### PR TITLE
prevent infinite recursion in on_assert_failed

### DIFF
--- a/src/assert.cc
+++ b/src/assert.cc
@@ -26,7 +26,26 @@ private:
 void on_assert_failed(const char* message)
 {
     String debug_info = "pid: " + to_string(getpid());
-    write_debug("assert failed: '"_str + message + "' " + debug_info);
+
+    thread_local static unsigned int nesting_level = 0;
+
+    if (nesting_level > 0)
+    {
+        throw assert_failed(message);
+    }
+
+    nesting_level++;
+
+    try
+    {
+        write_debug("assert failed: '"_str + message + "' " + debug_info);
+    }
+    catch (assert_failed&)
+    {
+        // TODO: can we fall back to something else?
+    }
+
+    nesting_level--;
 
     const auto msg = message + "\n[Debug Infos]\n"_str + debug_info;
 #if defined(__CYGWIN__)


### PR DESCRIPTION
While playing with kakoune I found that `kak -h` segfaults. It turns out to be because:
- the `-h` causes an `assert` to fail
- `on_assert_failed` tries to write to a debug buffer
- it's not possible to create a debug buffer because kakoune isn't initialised yet, so another `assert` fails
- `on_assert_failed` gets called again
- `kak` goes into an infinite recursion and runs out of stack space.

Here's a fix.
