### PR TITLE
Define extern char **environ for OSX, which doesn't define it in a header

### DIFF
--- a/src/env_vars.cc
+++ b/src/env_vars.cc
@@ -1,5 +1,9 @@
 #include "env_vars.hh"
 
+#if __APPLE__
+extern char **environ;
+#endif
+
 namespace Kakoune
 {
 


### PR DESCRIPTION
Not sure why. I see other headers defining it manually, e.g. php.h. In fact, PHP has it inside:

``` c
#if !defined(PHP_WIN32)
extern char **environ;
#endif
```
