### PR TITLE
add alt-n commands to (replace|append) previous match

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -145,7 +145,8 @@ Basic Movement
  * _?_: search (extend to next match)
  * _n_: select next match
  * _N_: add a new selection with next match
- * _alt-n_: replace main selection with next match (preserving the others)
+ * _alt-n_: select previous match
+ * _alt-N_: add a new selection with previous match
 
  * _pageup_: scroll up
  * _pagedown_: scroll down

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1319,8 +1319,9 @@ KeyMap keymap =
     { alt('/'), search<SelectMode::Replace, Backward> },
     { alt('?'), search<SelectMode::Extend, Backward> },
     { 'n', search_next<SelectMode::Replace, Forward> },
-    { alt('n'), search_next<SelectMode::ReplaceMain, Forward> },
     { 'N', search_next<SelectMode::Append, Forward> },
+    { alt('n'), search_next<SelectMode::Replace, Backward> },
+    { alt('N'), search_next<SelectMode::Append, Backward> },
     { '*', use_selection_as_search_pattern<true> },
     { alt('*'), use_selection_as_search_pattern<false> },
 


### PR DESCRIPTION
Note: alt-n command were used to replace main selection with next match
      (preserving the others)
