### PR TITLE
Fix compile warnings on OSX that could actually be errors

### DIFF
--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -32,7 +32,7 @@ Buffer::Buffer(String name, Flags flags, BufferLines lines,
 
     for (auto& line : lines)
     {
-        kak_assert(not line->length == 0 and line->data()[line->length-1] == '\n');
+        kak_assert(not (line->length == 0) and line->data()[line->length-1] == '\n');
     }
     static_cast<BufferLines&>(m_lines) = std::move(lines);
 
@@ -174,7 +174,7 @@ void Buffer::reload(BufferLines lines, time_t fs_timestamp)
     for (size_t l = 0; l < lines.size(); ++l)
     {
         auto& line = lines[l];
-        kak_assert(not line->length == 0 and line->data()[line->length-1] == '\n');
+        kak_assert(not (line->length == 0) and line->data()[line->length-1] == '\n');
         if (not (m_flags & Flags::NoUndo))
             m_current_undo_group.emplace_back(
                 Modification::Insert, LineCount{(int)l}, SharedString{line});


### PR DESCRIPTION
c++ -std=gnu++11 -g -Wall -Wno-reorder -Wno-sign-compare -pedantic -DKAK_DEBUG -MD -MP -MF .buffer.d -c -o .buffer.o buffer.cc
buffer.cc:35:20: warning: logical not is only applied to the left hand side of this comparison
      [-Wlogical-not-parentheses]
        kak_assert(not line->length == 0 and line->data()[line->length-1] == '\n');
                   ^                ~~
./assert.hh:17:18: note: expanded from macro 'kak_assert'
        if (not (condition)) \
                 ^
buffer.cc:35:20: note: add parentheses after the '!' to evaluate the comparison first
./assert.hh:17:18: note: expanded from macro 'kak_assert'
        if (not (condition)) \
                 ^
buffer.cc:35:20: note: add parentheses around left hand side expression to silence this warning
./assert.hh:17:18: note: expanded from macro 'kak_assert'
        if (not (condition)) \
                 ^
buffer.cc:177:20: warning: logical not is only applied to the left hand side of this comparison
      [-Wlogical-not-parentheses]
        kak_assert(not line->length == 0 and line->data()[line->length-1] == '\n');
                   ^                ~~
./assert.hh:17:18: note: expanded from macro 'kak_assert'
        if (not (condition)) \
                 ^
buffer.cc:177:20: note: add parentheses after the '!' to evaluate the comparison first
./assert.hh:17:18: note: expanded from macro 'kak_assert'
        if (not (condition)) \
                 ^
buffer.cc:177:20: note: add parentheses around left hand side expression to silence this warning
./assert.hh:17:18: note: expanded from macro 'kak_assert'
        if (not (condition)) \
                 ^
2 warnings generated.