### PR TITLE
Fix Makefile for Fedora packaging system

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -59,7 +59,7 @@ install: kak
 	mkdir -p $(sharedir)/rc
 	install -m 0644 ../share/kak/kakrc $(sharedir)
 	install -m 0644 ../rc/* $(sharedir)/rc
-	ln -s $(sharedir)/rc $(sharedir)/autoload
+	ln -r -s $(sharedir)/rc $(sharedir)/autoload
 	mkdir -p $(docdir)
 	install -m 0644 ../README.asciidoc $(docdir)
 	install -m 0644 ../doc/* $(docdir)


### PR DESCRIPTION
There was a problem with absolute path for symlink.
I think most of the packaging systems will be affected by this problem.

This happens because packaging build to special folder and after that it will create package from that folder. This means that the package is created with bad absolute symlink.