### PR TITLE
Add first and second line highlighting git-commit

### DIFF
--- a/rc/git.kak
+++ b/rc/git.kak
@@ -4,6 +4,8 @@ hook global BufCreate .*COMMIT_EDITMSG %{
 
 hook global WinSetOption filetype=git-commit %{
     addhl group git-commit-highlight
+    addhl -group git-commit-highlight regex "\`[^\n]{1,50}" 0:yellow
+    addhl -group git-commit-highlight regex "\`[^\n]*\n\h*(?!#)([^\n]*)\n?" 1:default,red
     addhl -group git-commit-highlight regex "^\h*#[^\n]*\n" 0:cyan,default
     addhl -group git-commit-highlight regex "\<(?:(modified)|(deleted)|(new file)|(renamed)):([^\n]*)\n" 1:yellow 2:red 3:green 4:blue 5:magenta
 }


### PR DESCRIPTION
First 50 characters are recommended for subject line. They are highlighted with yellow color.
The subject line wants an empty second line, so every characters (except for comments) on second line are highlighted with red background.

Source for the recommendations http://chris.beams.io/posts/git-commit/ .