### PR TITLE
Fix shell highlighter for comments and variables

### DIFF
--- a/rc/sh.kak
+++ b/rc/sh.kak
@@ -9,7 +9,7 @@ hook global BufSetOption mimetype=text/x-shellscript %{
 addhl -group / regions -default code sh \
     double_string  %{"} %{(?<!\\)(\\\\)*"} '' \
     single_string %{'} %{(?<!\\)(\\\\)*'} '' \
-    comment '#' '$' ''
+    comment '(?<!\$)#' '$' ''
 
 addhl -group /sh/double_string fill string
 addhl -group /sh/single_string fill string
@@ -20,7 +20,7 @@ addhl -group /sh/code regex [\[\]\(\)&|]{2} 0:operator
 addhl -group /sh/code regex (\w+)= 1:identifier
 addhl -group /sh/code regex ^\h*(\w+)\h*\(\) 1:identifier
 
-addhl -group /sh/code regex \$(\w+|\{.+?\}) 0:identifier
+addhl -group /sh/code regex \$(\w+|\{.+?\}|#|@|\?|\$|!|-|\*) 0:identifier
 addhl -group /sh/double_string regex \$(\w+|\{.+?\}) 0:identifier
 
 hook global WinSetOption filetype=sh %{ addhl ref sh }


### PR DESCRIPTION
Fix $# was processed as comment but it's variable.
Add highlighting for ``$#``,``$$``,``$!``,``$@``,``$?``,``$-``,``$*`` as variables too.