### PR TITLE
Allow files to be opened for editing through the :new command

### DIFF
--- a/rc/client.kak
+++ b/rc/client.kak
@@ -22,14 +22,20 @@ decl str termcmd %sh{
 }
 
 def -docstring 'create a new kak client for current session' \
+    -file-completion \
     -shell-params \
     new %{ %sh{
-            if [ -z "${kak_opt_termcmd}" ]; then
-               echo "echo -color Error 'termcmd option is not set'"
-               exit
-            fi
-            if [ $# -ne 0 ]; then kakoune_params="-e '$@'"; fi
-            setsid ${kak_opt_termcmd} "kak -c ${kak_session} ${kakoune_params}" < /dev/null > /dev/null 2>&1 &
+        if [ -z "${kak_opt_termcmd}" ]; then
+           echo "echo -color Error 'termcmd option is not set'"
+           exit
+        fi
+        ## if there is only one argument, and it's a filepath, then edit it in the new client
+        if [ $# -eq 1 -a -f "${1}" ]; then
+            kakoune_params="-e 'edit ${1}'"
+        else
+            kakoune_params="-e '$@'"
+        fi
+        setsid ${kak_opt_termcmd} "kak -c ${kak_session} ${kakoune_params}" < /dev/null > /dev/null 2>&1 &
 }}
 
 def -docstring 'focus given client' \


### PR DESCRIPTION
As it is tedious to always have to issue an ```edit``` command when opening a new kak client, this pull request modifies ```rc/client.kak``` so that when a path to a file is provided to the ```new``` command, the new kak client will automatically open it for editing.

File completion has also been enabled on the command, for conveniency's sake.