### PR TITLE
Removed the '-r' flag from the ln command in the install step of the …

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -62,7 +62,7 @@ install: kak
 	mkdir -p $(sharedir)/rc
 	install -m 0644 ../share/kak/kakrc $(sharedir)
 	install -m 0644 ../rc/* $(sharedir)/rc
-	ln -r -s $(sharedir)/rc $(sharedir)/autoload
+	ln -s $(sharedir)/rc $(sharedir)/autoload
 	mkdir -p $(docdir)
 	install -m 0644 ../README.asciidoc $(docdir)
 	install -m 0644 ../doc/* $(docdir)


### PR DESCRIPTION
…Makefile.  It is not a POSIX compliant option, therefore does not work on BSD or OS X.  Reference GH Issue#286.

Based on my understanding of this Makefile, the '-r' flag is unnecessary and didn't do anything additional.  The pathspec for both the source and target are explicit using a variable for a portion.
Will test via Homebrew following pushing this to my fork.