### PR TITLE
Add a scrolloffalways option

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -186,6 +186,9 @@ void register_options()
     reg.declare_option("scrolloff",
                        "number of lines and columns to keep visible main cursor when scrolling",
                        CharCoord{0,0});
+    reg.declare_option("scrolloffalways",
+                       "always keep lines visible, even when at the end of the buffer",
+                       false);
     reg.declare_option("eolformat", "end of line format: 'crlf' or 'lf'", "lf"_str);
     reg.declare_option("BOM", "insert a byte order mark when writing buffer",
                        "no"_str);


### PR DESCRIPTION
Gives the option of always having ```scrolloff``` work, even when near the end of the buffer.

Also fixes a crash bug when the cursor is near the end of the window, the end of the buffer and the beginning of the buffer and ```scrolloff``` is set to something greater than 0.