### PR TITLE
Update Readme -- remove Fedora 20 support

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -120,7 +120,7 @@ brew install --HEAD https://raw.githubusercontent.com/mawww/kakoune/master/contr
 ====
 
 [TIP]
-.Fedora 20/21/22/Rawhide & Epel 7
+.Fedora 21/22/Rawhide & Epel 7
 ====
 Use the https://copr.fedoraproject.org/coprs/jkonecny/kakoune/[copr] repository.
 


### PR DESCRIPTION
Fedora 20 is now unsupported and copr starts to failing when building this one.