### PR TITLE
Addendum to #715a19f

### DIFF
--- a/rc/golang.kak
+++ b/rc/golang.kak
@@ -59,6 +59,16 @@ def -hidden _golang-indent-on-closing-curly-brace %[
     try %[ exec -itersel -draft <a-h><a-k>^\h+\}$<ret>hms\`|.\'<ret>1<a-&> ]
 ]
 
+def golang-enable-gofmt %{
+    hook buffer -group golang-formatter BufWritePre .* %{
+        exec -draft %{%|"gofmt"<ret>}
+    }
+}
+
+def golang-disable-gofmt %{
+	rmhooks buffer golang-formatter
+}
+
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
@@ -74,4 +84,7 @@ hook global WinSetOption filetype=golang %{
 
 hook global WinSetOption filetype=(?!golang).* %{
     rmhl golang
+
+    rmhooks window golang-indent
+    rmhooks window golang-hooks
 }


### PR DESCRIPTION
```
Remove hooks when the filetype changes while editing a Go buffer, add an option to auto-format the buffer on write.
```

This commit follows up commit 715a19f - it makes sure the hooks are correctly removed when they have to be disabled, and enables the standard auto-formatter for Go `gofmt`.