### PR TITLE
Add an option to auto-format Go buffers on write

### DIFF
--- a/rc/golang.kak
+++ b/rc/golang.kak
@@ -59,6 +59,16 @@ def -hidden _golang-indent-on-closing-curly-brace %[
     try %[ exec -itersel -draft <a-h><a-k>^\h+\}$<ret>hms\`|.\'<ret>1<a-&> ]
 ]
 
+def golang-enable-gofmt %{
+    hook buffer -group golang-formatter BufWritePre .* %{
+        exec -draft %{%|"gofmt"<ret>}
+    }
+}
+
+def golang-disable-gofmt %{
+	rmhooks buffer golang-formatter
+}
+
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
@@ -74,6 +84,6 @@ hook global WinSetOption filetype=golang %{
 
 hook global WinSetOption filetype=(?!golang).* %{
     rmhl golang
-    rmhooks window golang-hooks 
-    rmhooks window golang-indent 
+    rmhooks window golang-hooks
+    rmhooks window golang-indent
 }


### PR DESCRIPTION
Some trailing whitespaces were also inserted in the previous commit, this PR fixes that also.