### PR TITLE
Use CPPFLAGS to specify flags for C++ preprocessor

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,13 +19,13 @@ else ifneq (,$(findstring CYGWIN,$(os)))
     LIBS += -lncursesw -lboost_regex -ldbghelp
 else
     LIBS += -lncursesw -lboost_regex
-    CXXFLAGS += -I/usr/include/ncursesw
+    CPPFLAGS += -I/usr/include/ncursesw
     LDFLAGS += -rdynamic
 endif
 
 debug ?= yes
 ifeq ($(debug),yes)
-    CXXFLAGS += -DKAK_DEBUG
+    CPPFLAGS += -DKAK_DEBUG
 else
     ifeq ($(debug),no)
         CXXFLAGS += -O3
@@ -40,7 +40,7 @@ kak : $(objects)
 -include $(deps)
 
 .%.o: %.cc
-	$(CXX) $(CXXFLAGS) -MD -MP -MF $(addprefix ., $(<:.cc=.d)) -c -o $@ $<
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -MD -MP -MF $(addprefix ., $(<:.cc=.d)) -c -o $@ $<
 
 test:
 	cd ../test && ./run


### PR DESCRIPTION
GNU make document says:

> <dl>
>   <dt><code>CXXFLAGS</code></dt>
>   <dd>Extra flags to give to the C++ compiler.</dd>
>  <dl>
>   <dt><code>CPPFLAGS</code></dt>
>   <dd>Extra flags to give to the C preprocessor and programs that use it (the C and Fortran compilers).</dd>
> </dl>

And, `CPPFLAGS` are also used by C++ preprocessing in GNU make's implicit rules.

In other case, homebrew set `CPPFLAGS` to specify C preprocessor flags (e.g. include path, macro definition).  So, please use `CPPFLAGS` in kakoune Makefile.