### PR TITLE
Makefile: don't hardcode ncursesw path in CPPFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@ else ifneq (,$(findstring CYGWIN,$(os)))
     LIBS += -lncursesw -lboost_regex -ldbghelp
 else
     LIBS += -lncursesw -lboost_regex
-    CPPFLAGS += -I/usr/include/ncursesw
+    CPPFLAGS += -Incursesw
     LDFLAGS += -rdynamic
 endif
 


### PR DESCRIPTION
The hardcoded path seems pointless since it should be found by CPP through searching the system's include directory. In addition this would probably help with some cross compilation issues.