### PR TITLE
glep42: highlighting for Gentoo/Exherbo news items

### DIFF
--- a/rc/glep42.kak
+++ b/rc/glep42.kak
@@ -1,0 +1,11 @@
+hook global BufCreate .*/[0-9][0-9][0-9][0-9]-[0-3][0-9]-[0-9][0-9]-.*\.[a-z][a-z]\.txt %{
+    set buffer filetype glep42
+}
+
+addhl -group / group glep42
+addhl -group /glep42 regex ^(Title|Author|Translator|Content-Type|Posted|Revision|News-Item-Format|Display-If-Installed|Display-If-Keyword|Display-If-Profile):([^\n]*(?:\n\h+[^\n]+)*)$ 1:keyword 2:attribute
+addhl -group /glep42 regex <[^@>]+@.*?> 0:string
+addhl -group /glep42 regex ^>.*?$ 0:comment
+
+hook global WinSetOption filetype=glep42 %{ addhl ref glep42 }
+hook global WinSetOption filetype=(?!glep42).* %{ rmhl glep42 }


### PR DESCRIPTION
This adds a glep42.kak file which does syntax highlighting for GLEP-42 news items on Gentoo and Exherbo Linux. The format is close to the format of mail files, so I used that as a base.