### PR TITLE
Improve the autowrap script

### DIFF
--- a/rc/autowrap.kak
+++ b/rc/autowrap.kak
@@ -1,9 +1,34 @@
+## Maximum amount of characters per line
 decl int autowrap_column 80
 
-def autowrap-enable %{
-    hook -group autowrap window InsertChar [^\n] %{ try %{ exec -draft "<a-h><a-k>.{%opt{autowrap_column},}<ret><a-;>bi<ret><esc>xX<a-k>[^\n]+\n[^\n]<ret>kx;d" } }
+## Automatically wrap the selection
+def autowrap-selection %{
+    try %{
+        ## <a-:><a-;>: ensure that the cursor is located after the anchor, then reverse the
+        ##             selection (make sure the cursor is at the beginning of the selection)
+        ## <a-k>(?=[^\n]*\h)(?=[^\n]*[^\h])[^\n]{%opt{autowrap_column},}[^\n]<ret>: make sure
+        ##             the selection is wrap-able (contains at least an horizontal space, any
+        ##             non-whitespace character, and at least "autowrap_column" characters)
+        ## %opt{autowrap_column}l: place the cursor on the "autowrap_column"th character
+        ## <a-i>w<a-;>;i<ret><esc>: move the cursor to the beginning of the word (if it overslaps
+        ##             the "autowrap_column"th column), or do nothing if the "autowrap_column"th
+        ##             character is a horizontal space, and insert a newline
+        ## kxXs\h+$<ret>d : select the line that we just made, as well as the one that was just
+        ##             wrapped, and remove any trailing horizontal space
+        exec -draft "<a-:><a-;><a-k>(?=[^\n]*\h)(?=[^\n]*[^\h])[^\n]{%opt{autowrap_column},}[^\n]<ret>%opt{autowrap_column}l<a-i>w<a-;>;i<ret><esc>kxXs\h+$<ret>d "
+    }
 }
 
+## Add a hook that will wrap the entire line every time a key is pressed
+def autowrap-enable %{
+    hook -group autowrap window InsertChar [^\n] %{
+        try %{
+            exec -draft "x:autowrap-selection<ret>"
+        }
+    }
+}
+
+## Disable the automatic line wrapping, autowrap-selection remains available though
 def autowrap-disable %{
     rmhooks window autowrap
 }


### PR DESCRIPTION
Hi,

I noticed several issues with the current autowrap, among which:
* lines were wrapped to a lesser amount of columns than the one specified in the `autowrap_column` option (e.g. 76 columns, when the entire line would have fit in 80)
* lines whose `autowrap_column`th character was a whitespace were not properly wrapped
* trailing whitespaces were not trimmed off the wrapped line

I had found one or two additional issues, but I didn't write them down and can't report them here. This patch hopefully fixes the above bullet points, and also add a `autowrap-selection` command that allows one to manually wrap a selection.

I also got rid of the bit, in the current implementation, that merges the newly created line and the one that follows it, I thought it was confusing and not so useful considering the timesink/resources whore that it was (if you still want to keep that feature though, you can recursively call the `autowrap-selection` command :)). The whole exec string is commented, that should help improve it if needs be.

Cheers.