### PR TITLE
Fix mark documentation

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -375,8 +375,8 @@ Marks
 ~~~~~
 
 Current selections position can be saved in a register and restored later on.
-`^` followed by a register will save the current selections in that register,
-`alt-^` followed by a register will restore the selections saved in it.
+`Z` followed by a register will save the current selections in that register,
+`z` followed by a register will restore the selections saved in it.
 
 Jump list
 ~~~~~~~~~


### PR DESCRIPTION
In Readme there was still the old way with ``^`` and ``alt-^``.
Now it's changed to ``z`` and ``Z``.