### PR TITLE
Add autowrap to git-commit

### DIFF
--- a/rc/git.kak
+++ b/rc/git.kak
@@ -8,6 +8,9 @@ hook global WinSetOption filetype=git-commit %{
     addhl -group git-commit-highlight regex "\`[^\n]*\n\h*(?!#)([^\n]*)\n?" 1:default,red
     addhl -group git-commit-highlight regex "^\h*#[^\n]*\n" 0:cyan,default
     addhl -group git-commit-highlight regex "\<(?:(modified)|(deleted)|(new file)|(renamed)):([^\n]*)\n" 1:yellow 2:red 3:green 4:blue 5:magenta
+
+    set buffer autowrap_column 72
+    autowrap-enable
 }
 
 hook global WinSetOption filetype=(?!git-commit).* %{


### PR DESCRIPTION
Git message is recommended to be wrapped to 72 characters.
[Source](http://chris.beams.io/posts/git-commit/#wrap-72)

This is a kind of RFC I want to ask everyone if we want this as opt-in or opt-out solution.

And @lenormf thank you for fixing the ``autorwrap-enable`` function.