### PR TITLE
rc/markdown: add another markdown extension (.mkd)

### DIFF
--- a/rc/markdown.kak
+++ b/rc/markdown.kak
@@ -8,7 +8,7 @@ hook global BufSetOption mimetype=text/x-markdown %{
     set buffer filetype markdown
 }
 
-hook global BufCreate .*[.](markdown|md) %{
+hook global BufCreate .*[.](markdown|md|mkd) %{
     set buffer filetype markdown
 }
 


### PR DESCRIPTION
`.mkd` is another common extension I see used often.