### PR TITLE
Argument text object should no longer handle <>

### DIFF
--- a/src/selectors.cc
+++ b/src/selectors.cc
@@ -435,8 +435,8 @@ Selection select_argument(const Buffer& buffer, const Selection& selection,
     auto classify = [](Codepoint c) {
         switch (c)
         {
-        case '(': case '[': case '{': case '<': return Opening;
-        case ')': case ']': case '}': case '>': return Closing;
+        case '(': case '[': case '{': return Opening;
+        case ')': case ']': case '}': return Closing;
         case ',': case ';': return Delimiter;
         default: return None;
         }


### PR DESCRIPTION
It turns out that lists of the form \<a, b, c\> are far more rare than (a, b < c, d) and (a, b->c). The current implementation makes incorrect selections in the two latter cases.
This pull request solves the most frequent case by not recognizing <>.
An alternative approach would be to use some form of heuristic to determine if the angle brackets are part of a list or some other construct, but that would be significantly more complicated for little gain.