### PR TITLE
Removed useless softlink creation that blocked reinstallation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -62,7 +62,7 @@ install: kak
 	mkdir -p $(sharedir)/rc
 	install -m 0644 ../share/kak/kakrc $(sharedir)
 	install -m 0644 ../rc/* $(sharedir)/rc
-	ln -s rc $(sharedir)/autoload
+	[ -e $(sharedir)/autoload ] || ln -s rc $(sharedir)/autoload
 	mkdir -p $(sharedir)/colors
 	install -m 0644 ../colors/* $(sharedir)/colors
 	mkdir -p $(docdir)


### PR DESCRIPTION
I don't know why that recursive softlink was created, but it only works when Kakoune isn't already installed.