### PR TITLE
rc/sh: support single brackets

### DIFF
--- a/rc/sh.kak
+++ b/rc/sh.kak
@@ -16,7 +16,7 @@ addhl -group /sh/single_string fill string
 addhl -group /sh/comment fill comment
 
 addhl -group /sh/code regex \<(alias|bind|builtin|caller|case|cd|command|coproc|declare|do|done|echo|elif|else|enable|esac|exit|fi|for|function|help|if|in|let|local|logout|mapfile|printf|read|readarray|readonly|return|select|set|shift|source|test|then|time|type|typeset|ulimit|unalias|until|while)\> 0:keyword
-addhl -group /sh/code regex [\[\]\(\)&|]{2} 0:operator
+addhl -group /sh/code regex ([\[\]\(\)&|]{2}|\[?\[\s|\s\]\]?) 0:operator
 addhl -group /sh/code regex (\w+)= 1:identifier
 addhl -group /sh/code regex ^\h*(\w+)\h*\(\) 1:identifier
 


### PR DESCRIPTION
This adds support for things like `if [ -e "$file" ]` whereas without this, only `if [[ -e "$fille" ]]` would get highlighted.