### PR TITLE
Allow the autowrap command to break lines as many times as necessary

### DIFF
--- a/rc/autowrap.kak
+++ b/rc/autowrap.kak
@@ -1,8 +1,7 @@
 ## Maximum amount of characters per line
 decl int autowrap_column 80
 
-## Automatically wrap the selection
-def autowrap-selection -docstring "Wrap the selection" %{
+def -hidden _autowrap-break-line %{
     try %{
         ## <a-:><a-;>: ensure that the cursor is located after the anchor, then reverse the
         ##             selection (make sure the cursor is at the beginning of the selection)
@@ -10,21 +9,34 @@ def autowrap-selection -docstring "Wrap the selection" %{
         ##             the selection is wrap-able (contains at least an horizontal space, any
         ##             non-whitespace character, and at least "autowrap_column" characters)
         ## %opt{autowrap_column}l: place the cursor on the "autowrap_column"th character
-        ## <a-i>w<a-;>;i<ret><esc>: move the cursor to the beginning of the word (if it overslaps
+        ## <a-i>w<a-;>;i<ret><esc>: move the cursor to the beginning of the word (if it overlaps
         ##             the "autowrap_column"th column), or do nothing if the "autowrap_column"th
         ##             character is a horizontal space, and insert a newline
-        ## kxXs\h+$<ret>d : select the line that we just made, as well as the one that was just
-        ##             wrapped, and remove any trailing horizontal space
-        exec -draft "<a-:><a-;><a-k>(?=[^\n]*\h)(?=[^\n]*[^\h])[^\n]{%opt{autowrap_column},}[^\n]<ret>%opt{autowrap_column}l<a-i>w<a-;>;i<ret><esc>kxXs\h+$<ret>d "
+        ## <a-x>:_autowrap-break-line: select the second half of the buffer that was just split,
+        ##             and call itself recursively until all lines in the selection
+        ##             are correctly split
+        exec -draft "<a-:><a-;>
+                    <a-k>(?=[^\n]*\h)(?=[^\n]*[^\h])[^\n]{%opt{autowrap_column},}[^\n]<ret>
+                    %opt{autowrap_column}l
+                    <a-i>w<a-;>;i<ret><esc>
+                    <a-x>:_autowrap-break-line<ret>"
+    }
+}
+
+## Automatically wrap the selection
+def autowrap-selection -docstring "Wrap the selection" %{
+    eval -draft _autowrap-break-line
+
+    try %{
+        exec -draft "<a-k>^[^\n]*\h*\n\h*[^\n]+$<ret>
+                    s\h*\n\h*(?=[^\z])<ret>c<ret><esc>"
     }
 }
 
 ## Add a hook that will wrap the entire line every time a key is pressed
 def autowrap-enable -docstring "Wrap the lines in which characters are inserted" %{
     hook -group autowrap window InsertChar [^\n] %{
-        try %{
-            exec -draft "<a-x>:autowrap-selection<ret>"
-        }
+        exec -draft "<a-x>:autowrap-selection<ret>"
     }
 }
 


### PR DESCRIPTION
Quick note: I couldn't find a way, with this method of handling multiple line breaks, to squeeze in a way to merge single words on their own line with the rest of the paragraph. The `<a-k>` that would detect those cases that result in words being inserted in the middle of a long line (resulting in turn in the last word of the sentence to be brought back to the beginning of the line, to make it fit the maximum amount of columns) also prevents the recursion from happening.