### PR TITLE
Fix the calls to unalias, add new characters to Go's commenting class…

### DIFF
--- a/rc/dlang.kak
+++ b/rc/dlang.kak
@@ -22,8 +22,8 @@ addhl -group / regions -default code dlang \
     comment '//' $ ''
 
 addhl -group /dlang/string fill string
-addhl -group /dlang/verbatim_string fill rgb:FF40D4
-addhl -group /dlang/verbatim_string_prefixed fill rgb:FF40D4
+addhl -group /dlang/verbatim_string fill magenta
+addhl -group /dlang/verbatim_string_prefixed fill magenta
 addhl -group /dlang/token fill meta
 addhl -group /dlang/disabled fill rgb:777777
 addhl -group /dlang/comment fill comment
@@ -93,7 +93,7 @@ hook global WinSetOption filetype=dlang %{
     hook window InsertChar \{ -group dlang-indent _dlang-indent-on-opening-curly-brace
     hook window InsertChar \} -group dlang-indent _dlang-indent-on-closing-curly-brace
 
-    alias buffer format-code dlang-format-dfmt
+    alias window format-code dlang-format-dfmt
 }
 
 hook global WinSetOption filetype=(?!dlang).* %{
@@ -102,5 +102,5 @@ hook global WinSetOption filetype=(?!dlang).* %{
     rmhooks window dlang-hooks
     rmhooks window dlang-indent
 
-    unalias buffer format-code
+    unalias window format-code dlang-format-dfmt
 }

--- a/rc/golang.kak
+++ b/rc/golang.kak
@@ -16,6 +16,7 @@ addhl -group / regions -default code golang \
     back_string '`' '`' '' \
     double_string '"' (?<!\\)(\\\\)*" '' \
     single_string "'" (?<!\\)(\\\\)*' '' \
+    comment /\* \*/ '' \
     comment '//' $ ''
 
 addhl -group /golang/back_string fill string
@@ -83,7 +84,7 @@ hook global WinSetOption filetype=golang %{
     hook window InsertChar \{ -group golang-indent _golang-indent-on-opening-curly-brace
     hook window InsertChar \} -group golang-indent _golang-indent-on-closing-curly-brace
 
-    alias buffer format-code golang-format-gofmt
+    alias window format-code golang-format-gofmt
 }
 
 hook global WinSetOption filetype=(?!golang).* %{
@@ -92,5 +93,5 @@ hook global WinSetOption filetype=(?!golang).* %{
     rmhooks window golang-hooks
     rmhooks window golang-indent
 
-    unalias buffer format-code
+    unalias window format-code golang-format-gofmt
 }


### PR DESCRIPTION
…, use a default color for D's verbatim strings