### PR TITLE
Introduce `formatter.kak` to handle formatting.

### DIFF
--- a/rc/c-family.kak
+++ b/rc/c-family.kak
@@ -68,17 +68,6 @@ def -hidden _c-family-indent-on-closing-curly-brace %[
     try %[ exec -draft "hm;<a-?>(class|struct|union)<ret><a-k>\`(class|struct|union)[^{}\n]+(\n)?\s*\{\'<ret><a-;>ma;<esc>" ]
 ]
 
-decl str c_astyle_options ""
-def c-format-astyle -docstring "Format C/C++/Obj-C code using the astyle utility" %{
-    %sh{
-        readonly x=$((kak_cursor_column - 1))
-        readonly y="${kak_cursor_line}"
-
-        echo "exec -draft %{%|astyle<space>${kak_opt_c_astyle_options// /<space>}<ret>}"
-        echo "exec gg ${y}g ${x}l"
-    }
-}
-
 # Regions definition are the same between c++ and objective-c
 %sh{
     for ft in c cpp objc; do
@@ -135,7 +124,7 @@ hook global WinSetOption filetype=(c|cpp|objc) %[
     alias window comment-selection c-family-comment-selection
     alias window comment-line c-family-comment-line
 
-    alias window format-code c-format-astyle
+    set window formatcmd "astyle"
 ]
 
 hook global WinSetOption filetype=(?!(c|cpp|objc)$).* %[
@@ -145,8 +134,6 @@ hook global WinSetOption filetype=(?!(c|cpp|objc)$).* %[
     unalias window alt c-family-alternative-file
     unalias window comment-selection c-family-comment-selection
     unalias window comment-line c-family-comment-line
-
-    unalias window format-code c-format-astyle
 ]
 
 hook global WinSetOption filetype=c %[ addhl ref c ]

--- a/rc/dlang.kak
+++ b/rc/dlang.kak
@@ -70,17 +70,6 @@ def -hidden _dlang-indent-on-closing-curly-brace %[
     try %[ exec -itersel -draft <a-h><a-k>^\h+\}$<ret>hms\`|.\'<ret>1<a-&> ]
 ]
 
-decl str dlang_dfmt_options ""
-def dlang-format-dfmt -docstring "Format the code using the dfmt utility" %{
-    %sh{
-        readonly x=$((kak_cursor_column - 1))
-        readonly y="${kak_cursor_line}"
-
-        echo "exec -draft %{%|dfmt<space>${kak_opt_dlang_dfmt_options// /<space>}<ret>}"
-        echo "exec gg ${y}g ${x}l"
-    }
-}
-
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
@@ -93,7 +82,7 @@ hook global WinSetOption filetype=dlang %{
     hook window InsertChar \{ -group dlang-indent _dlang-indent-on-opening-curly-brace
     hook window InsertChar \} -group dlang-indent _dlang-indent-on-closing-curly-brace
 
-    alias window format-code dlang-format-dfmt
+    set window formatcmd "dfmt"
 }
 
 hook global WinSetOption filetype=(?!dlang).* %{
@@ -101,6 +90,4 @@ hook global WinSetOption filetype=(?!dlang).* %{
 
     rmhooks window dlang-hooks
     rmhooks window dlang-indent
-
-    unalias window format-code dlang-format-dfmt
 }

--- a/rc/formatter.kak
+++ b/rc/formatter.kak
@@ -1,0 +1,14 @@
+decl str formatcmd ""
+def format -docstring "Format the entire buffer with an external utility" %{
+    %sh{
+        if [ ! -z "${kak_opt_formatcmd}" ]; then
+            ## Save the current position of the cursor
+            readonly x=$((kak_cursor_column - 1))
+            readonly y="${kak_cursor_line}"
+
+            echo "exec -draft %{%|${kak_opt_formatcmd// /<space>}<ret>}"
+            ## Try to restore the position of the cursor as it was prior to formatting
+            echo "exec gg ${y}g ${x}l"
+        fi
+    }
+}

--- a/rc/golang.kak
+++ b/rc/golang.kak
@@ -62,16 +62,6 @@ def -hidden _golang-indent-on-closing-curly-brace %[
     try %[ exec -itersel -draft <a-h><a-k>^\h+\}$<ret>hms\`|.\'<ret>1<a-&> ]
 ]
 
-def golang-format-gofmt -docstring "Format the code using the gofmt utility" %{
-    %sh{
-        readonly x=$((kak_cursor_column - 1))
-        readonly y="${kak_cursor_line}"
-
-        echo "exec -draft %{%|gofmt<ret>}"
-        echo "exec gg ${y}g ${x}l"
-    }
-}
-
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
@@ -84,7 +74,7 @@ hook global WinSetOption filetype=golang %{
     hook window InsertChar \{ -group golang-indent _golang-indent-on-opening-curly-brace
     hook window InsertChar \} -group golang-indent _golang-indent-on-closing-curly-brace
 
-    alias window format-code golang-format-gofmt
+    set window formatcmd "gofmt"
 }
 
 hook global WinSetOption filetype=(?!golang).* %{
@@ -92,6 +82,4 @@ hook global WinSetOption filetype=(?!golang).* %{
 
     rmhooks window golang-hooks
     rmhooks window golang-indent
-
-    unalias window format-code golang-format-gofmt
 }


### PR DESCRIPTION
The modified files used to handle formatting code with the same code, and a
different command, the process is now centralized into a single file. Language
support files should set the `formatcmd` string to whatever formatter is the
most popular in their respective community, eventually with default options.