### PR TITLE
Introduce the `commenting.kak` file

### DIFF
--- a/rc/c-family.kak
+++ b/rc/c-family.kak
@@ -121,8 +121,6 @@ hook global WinSetOption filetype=(c|cpp|objc) %[
     hook window InsertChar \} -group c-family-indent _c-family-indent-on-closing-curly-brace
 
     alias window alt c-family-alternative-file
-    alias window comment-selection c-family-comment-selection
-    alias window comment-line c-family-comment-line
 
     set window formatcmd "astyle"
 ]
@@ -132,8 +130,6 @@ hook global WinSetOption filetype=(?!(c|cpp|objc)$).* %[
     rmhooks window c-family-indent
 
     unalias window alt c-family-alternative-file
-    unalias window comment-selection c-family-comment-selection
-    unalias window comment-line c-family-comment-line
 ]
 
 hook global WinSetOption filetype=c %[ addhl ref c ]
@@ -188,42 +184,3 @@ def c-family-alternative-file -docstring "Jump to the alternate file (header/imp
        echo "echo -color Error 'alternative file not found'"
     fi
 }}
-
-def c-family-comment-selection -docstring "Comment the current selection" %{
-    try %{
-        ## The selection is empty
-        exec -draft %{<a-K>\A[\h\v\n]*\z<ret>}
-
-        try %{
-            ## The selection has already been commented
-            exec -draft %{<a-K>\A/\*.*\*/\z<ret>}
-
-            ## Comment the selection
-            exec %{a */<esc>i/* <esc>3H}
-        } catch %{
-            ## Uncomment the commented selection
-            exec -draft %{s(\A/\* )|( \*/\z)<ret>d}
-        }
-    }
-}
-
-def c-family-comment-line -docstring "Comment the current line" %{
-    ## Select the content of the line, without indentation
-    exec %{I<esc><a-l>}
-
-    try %{
-        ## There's no text on the line
-        exec -draft %{<a-K>\A[\h\v\n]*\z<ret>}
-
-        try %{
-            ## The line has already been commented
-            exec -draft %{<a-K>^//<ret>}
-
-            ## Comment the line
-            exec %{i// <esc>3H}
-        } catch %{
-            ## Uncomment the line
-            exec -draft %{s^//\h*<ret>d}
-        }
-    }
-}

--- a/rc/commenting.kak
+++ b/rc/commenting.kak
@@ -1,0 +1,77 @@
+## Characters that will be used to surround a selection with
+decl str-list comment_selection_chars "/*:*/"
+
+## Characters that will be inserted at the beginning of a line to comment
+decl str comment_line_chars "//"
+
+def comment-selection -docstring "Comment/uncomment the current selection" %{
+    %sh{
+        function escape_regex_chars {
+            ## Escape characters that can be interpreted as modifiers/repetitors by the regex engine
+            sed -r 's,(\*|\+|\[|\]|\{\}|\||\(|\)|\?),\\\1,g' <<< "$@"
+        }
+
+        readonly opening="${kak_opt_comment_selection_chars%%:*}"
+        readonly closing="${kak_opt_comment_selection_chars##*:}"
+        readonly opening_escaped=$(escape_regex_chars "${opening}")
+        readonly closing_escaped=$(escape_regex_chars "${closing}")
+
+        if [ -z "${opening}" -o -z "${closing}" ]; then
+            echo "The \`comment_selection_chars\` variable is empty, couldn't comment the selection" >&2
+            exit
+        fi
+
+        echo "try %{
+            ## The selection is empty
+            exec -draft %{<a-K>\A[\h\v\n]*\z<ret>}
+
+            try %{
+                ## The selection has already been commented
+                exec -draft %{<a-K>\A${opening_escaped}.*${closing_escaped}\z<ret>}
+
+                ## Comment the selection
+                exec %{a ${closing}<esc>i${opening} <esc>$((${#opening} + 1))H}
+            } catch %{
+                ## Uncomment the commented selection
+                exec -draft %{s(\A${opening_escaped} )|( ${closing_escaped}\z)<ret>d}
+            }
+        }"
+    }
+}
+
+def comment-line -docstring "Comment/uncomment the current line" %{
+    %sh{
+        function escape_regex_chars {
+            ## Escape characters that can be interpreted as modifiers/repetitors by the regex engine
+            sed -r 's,(\*|\+|\[|\]|\{\}|\||\(|\)|\?),\\\1,g' <<< "$@"
+        }
+
+        readonly opening="${kak_opt_comment_line_chars}"
+        readonly opening_escaped=$(escape_regex_chars "${opening}")
+
+        if [ -z "${opening}" ]; then
+            echo "The \`comment_line_chars\` variable is empty, couldn't comment the line" >&2
+            exit
+        fi
+
+        echo "
+        ## Select the content of the line, without indentation
+        exec %{I<esc><a-l>}
+
+        try %{
+            ## There's no text on the line
+            exec -draft %{<a-K>\A[\h\v\n]*\z<ret>}
+
+            try %{
+                ## The line has already been commented
+                exec -draft %{<a-K>^${opening_escaped}<ret>}
+
+                ## Comment the line
+                exec %{i${opening} <esc>$((${#opening} + 1))H}
+            } catch %{
+                ## Uncomment the line
+                exec -draft %{s^${opening_escaped}\h*<ret>d}
+            }
+        }"
+    }
+}

--- a/rc/css.kak
+++ b/rc/css.kak
@@ -75,6 +75,8 @@ hook global WinSetOption filetype=css %[
     hook window InsertEnd  .* -group css-hooks  _css_filter_around_selections
     hook window InsertChar \n -group css-indent _css_indent_on_new_line
     hook window InsertChar \} -group css-indent _css_indent_on_closing_curly_brace
+
+    set comment_line_chars ""
 ]
 
 hook global WinSetOption filetype=(?!css).* %{

--- a/rc/dlang.kak
+++ b/rc/dlang.kak
@@ -83,6 +83,7 @@ hook global WinSetOption filetype=dlang %{
     hook window InsertChar \} -group dlang-indent _dlang-indent-on-closing-curly-brace
 
     set window formatcmd "dfmt"
+    set window comment_selection_chars "/+:+/"
 }
 
 hook global WinSetOption filetype=(?!dlang).* %{

--- a/rc/makefile.kak
+++ b/rc/makefile.kak
@@ -26,5 +26,10 @@ addhl -group /makefile/content regex [+?:]= 0:operator
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=makefile %{ addhl ref makefile }
+hook global WinSetOption filetype=makefile %{
+    addhl ref makefile
+
+    set window comment_selection_chars ""
+    set window comment_line_chars "#"
+}
 hook global WinSetOption filetype=(?!makefile).* %{ rmhl makefile }

--- a/rc/perl.kak
+++ b/rc/perl.kak
@@ -108,6 +108,8 @@ hook global WinSetOption filetype=perl %{
     hook window InsertChar \} -group perl-indent _perl-indent-on-closing-curly-brace
 
     set window formatcmd "perltidy"
+    set window comment_selection_chars ""
+    set window comment_line_chars "#"
 }
 
 hook global WinSetOption filetype=(?!perl).* %{


### PR DESCRIPTION
Centralize commenting functions into a single file, and declare
variables used by those functions in language support files. The
functions are `comment-selection` and `comment-line`, users should bind
those functions to the keys of their liking for easy access.