### PR TITLE
Use braille characters to mark whitespaces

### DIFF
--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -683,7 +683,7 @@ void show_whitespaces(const Context& context, HighlightFlags flags, DisplayBuffe
                         atom_it->replace("→" + String(' ', count-1));
                     }
                     else if (c == ' ')
-                        atom_it->replace("·");
+                        atom_it->replace("⠐");
                     else if (c == '\n')
                         atom_it->replace("¬");
                     break;


### PR DESCRIPTION
Replaced the dots to mark whitespace with appropriate braille characters.
Now we can finally distinguish dots and whitespaces.