### PR TITLE
Patch to build on FreeBSD

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -28,6 +28,10 @@ os := $(shell uname)
 
 ifeq ($(os),Darwin)
     LIBS += -lncurses -lboost_regex-mt
+else ifeq ($(os),FreeBSD)
+    LIBS += -ltinfow -lncursesw -lboost_regex
+    CPPFLAGS += -I/usr/local/include
+    LDFLAGS += -L/usr/local/lib
 else ifeq ($(os),Haiku)
     LIBS += -lncursesw -lboost_regex -lnetwork -lbe
 else ifneq (,$(findstring CYGWIN,$(os)))

--- a/src/file.cc
+++ b/src/file.cc
@@ -12,6 +12,10 @@
 #include <unistd.h>
 #include <dirent.h>
 
+#if defined(__FreeBSD__)
+#include <sys/sysctl.h>
+#endif
+
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
 #define st_mtim st_mtimespec
@@ -490,6 +494,11 @@ String get_kak_binary_path()
     ssize_t res = readlink("/proc/self/exe", buffer, 2048);
     kak_assert(res != -1);
     buffer[res] = '\0';
+    return buffer;
+#elif defined(__FreeBSD__)
+    int mib[] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+    size_t res = sizeof(buffer);
+    sysctl(mib, 4, buffer, &res, NULL, 0);
     return buffer;
 #elif defined(__APPLE__)
     uint32_t bufsize = 2048;


### PR DESCRIPTION
Added a condition in file.cc `get_kak_binary_path()` for FreeBSD. Uses sysctl, which as far as I can tell is the standard way to get the binary's path on FreeBSD. Might not be applicable to other BSD systems.

The Makefile was a little tricky to get right and was mostly trial-and-error. Building it with gcc requires rebuilding boost with gcc and libstdc++ (which I didn't feel like doing), but clang seems to require libgcc_s to build kakoune, thus I included `-L/usr/local/lib/gcc48`, which of course won't exist if the user has a different gcc version. Nevertheless, I did manage to build it on my system (FreeBSD 10.1, clang 3.4.1) with this.