### PR TITLE
Adding support for DragonFlyBSD.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,6 +30,10 @@ ifeq ($(os),Darwin)
     LIBS += -lncurses -lboost_regex-mt
 else ifeq ($(os),Haiku)
     LIBS += -lncursesw -lboost_regex -lnetwork -lbe
+else ifeq ($(os),DragonFly)
+    LIBS += -lncursesw -lboost_regex
+    CPPFLAGS += -I/usr/local/include
+    LDFLAGS += -L/usr/local/lib
 else ifneq (,$(findstring CYGWIN,$(os)))
     LIBS += -lncursesw -lboost_regex -ldbghelp
 else

--- a/src/file.cc
+++ b/src/file.cc
@@ -505,6 +505,11 @@ String get_kak_binary_path()
     kak_assert(status == B_OK);
     BPath path(&info.ref);
     return path.Path();
+#elif defined(__DragonFly__)
+    ssize_t res = readlink("/proc/curproc/file", buffer, 2048);
+    kak_assert(res != -1);
+    buffer[res] = '\0';
+    return buffer;
 #else
 # error "finding executable path is not implemented on this platform"
 #endif


### PR DESCRIPTION
This makes it possible to compile kakoune and run it on DragonFlyBSD. I have some kind of UTF problem when running kakoune however, to be investigated.