### PR TITLE
Possibly use __attribute__((constructor/destructor)) to remove some startup/cleanup code from main

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -643,8 +643,7 @@ int run_pipe(StringView session)
     return 0;
 }
 
-int main(int argc, char* argv[])
-{
+__attribute__((constructor(100))) void startup() {
     setlocale(LC_ALL, "");
 
     signal(SIGSEGV, signal_handler);
@@ -654,7 +653,11 @@ int main(int argc, char* argv[])
     signal(SIGPIPE, SIG_IGN);
     signal(SIGINT, [](int){});
     signal(SIGCHLD, [](int){});
+}
 
+
+int main(int argc, char* argv[])
+{
     Vector<String> params;
     for (size_t i = 1; i < argc; ++i)
         params.push_back(argv[i]);


### PR DESCRIPTION
This is more of a thought than a full fledged pull-request, but I'm pretty sure most compilers should support __attribute__((constructor/destructor)) by now. I'm sure clang and gcc do, but I'm definitely not sure about Windows. As a result, it could be possible to reduce the amount of "startup" code by using __attribute__((constructor)) and "cleanup" with __attribute__((destructor)). If I'm honest there are quite a few reasons to be weary of a pull request like this, as it has the potential to decrease portability and increase complexity. However, if handled appropriately it could actually reduce complexity and remove some boilerplate code. In addition, constructor/destructor priorities are a nice feature that could be used in the future as more code is needed. Again, this is just a thought that in some ways I'd suggest rejecting :smile: 