### PR TITLE
Suppress warnings when compiling with clang

### DIFF
--- a/src/string.hh
+++ b/src/string.hh
@@ -168,7 +168,9 @@ public:
     };
     ZeroTerminatedString zstr() const { return {begin(), end()}; }
 
+#ifndef __clang__
     [[gnu::optimize(3)]] // this is recursive for constexpr reason
+#endif
     static constexpr ByteCount strlen(const char* s)
     {
         return *s == 0 ? 0 : strlen(s+1) + 1;


### PR DESCRIPTION
Super small nit pick. clang complains as per function optimizations have not been implemented yet. Added simple macro check to suppress the warning.

There has been some talk about adding the feature [here](http://clang-developers.42468.n3.nabble.com/PROPOSAL-per-function-optimization-level-control-td4031670.html).