### PR TITLE
Run tests loading kakrc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,4 @@ addons:
     build_command: "make -j4"
     branch_pattern: coverity-scan
 
-script: cd src && make && make test
+script: export POSIXLY_CORRECT=1 && cd src && make && make test && make test-kakrc

--- a/src/Makefile
+++ b/src/Makefile
@@ -84,6 +84,9 @@ kak : $(objects)
 
 test:
 	cd ../test && ./run
+	
+test-kakrc:
+	cd ../test && ./run -l
 tags:
 	ctags -R
 man: ../doc/kak.1.gz

--- a/test/README.asciidoc
+++ b/test/README.asciidoc
@@ -26,3 +26,5 @@ Usage
 To test, just type +run [test]+ in the +test+ directory.
 It will print each passing test.  If a test fails, a {unified-context-diff}[unified context diff]
 is printed showing the test’s expected output and the actual output.
+
+Pass the -l switch as the first argument to load the kakrc for the unit tests

--- a/test/run
+++ b/test/run
@@ -1,8 +1,12 @@
 #!/bin/sh
 
 # Main ├────────────────────────────────────────────────────────────────────────
-
 main() {
+  if [ "$1" = "-l" ]; then
+    load_kakrc=true
+    shift
+  fi
+
   number_tests=0
   number_failures=0
   dirs="${@:-.}"
@@ -27,7 +31,13 @@ main() {
     else
       number_tests=$(($number_tests + 1))
       touch in; cp in out
+      if [ -z $load_kakrc ]; then
+        load_kakrc_command=""
+      else
+        load_kakrc_command="source $test/../share/kak/kakrc"
+      fi
       kak_commands="
+        $load_kakrc_command
         set global autoreload yes
         set global autoinfo ''
         set global autoshowcompl false


### PR DESCRIPTION
The test/run script can optionally omit the -n flag setting the env
variable TEST_LOAD_KAKRC. This is useful to check that the default kak scripts
are actually correct and don't break kakoune's behaviour.