### PR TITLE
Fix bad highlighting of parameters with '-' in kickstart

### DIFF
--- a/rc/kickstart.kak
+++ b/rc/kickstart.kak
@@ -10,7 +10,7 @@ addhl -group / regions -default code kickstart \
     shell '^\h*\K%(pre|pre-install|post)\>' '^\h*\K%end\>' ''
 
 addhl -group /kickstart/code regex "^\h*\<(auth|authconfig|autopart|autostep|bootloader|btrfs|clearpart|cmdline|device|dmraid|driverdisk|fcoe|firewall|firstboot|group|graphical|halt|ignoredisk|install|cdrom|harddrive|liveimg|nfs|url|iscsi|iscsiname|keyboard|lang|logvol|logging|mediacheck|monitor|multipath|network|part|partition|poweroff|raid|realm|reboot|repo|rescue|rootpw|selinux|services|shutdown|sshkey|sshpw|skipx|text|timezone|updates|upgrade|user|vnc|volgroup|xconfig|zerombr|zfcp)\>" 1:keyword
-addhl -group /kickstart/code regex '(--\w+=? ?)([^-"\n][^\h\n]*)?' 1:attribute 2:string
+addhl -group /kickstart/code regex '(--[\w-]+=? ?)([^-"\n][^\h\n]*)?' 1:attribute 2:string
 addhl -group /kickstart/code regex '%(include|ksappend)\>' 0:keyword
 
 addhl -group /kickstart/comment fill comment


### PR DESCRIPTION
Parameters like ``ignoredisk --only-use=sda`` badly highlighted only first part of ``--only-use``.