### PR TITLE
Make autoload scripts more robust

### DIFF
--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -36,7 +36,7 @@ def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
     autoload() {
         dir=$1
         for rcfile in ${dir}/*.kak; do
-            echo "try %{ source '${rcfile}' } catch %{ }";
+            echo "try %{ source '${rcfile}' } catch %{ echo -debug Autoload: could not load '${rcfile}' }";
         done
         for subdir in ${dir}/*; do
             if [ -d "$subdir" ]; then

--- a/src/Makefile
+++ b/src/Makefile
@@ -72,10 +72,6 @@ clean:
 
 XDG_CONFIG_HOME ?= $(HOME)/.config
 
-userconfig:
-	mkdir -p $(XDG_CONFIG_HOME)/kak/autoload
-	ln -s $(CURDIR)/../rc/*.kak $(XDG_CONFIG_HOME)/kak/autoload/
-
 install: kak
 	mkdir -p $(bindir)
 	install -m 0755 kak $(bindir)
@@ -89,4 +85,4 @@ install: kak
 	install -m 0644 ../README.asciidoc $(docdir)
 	install -m 0644 ../doc/* $(docdir)
 
-.PHONY: tags userconfig install
+.PHONY: tags install


### PR DESCRIPTION
I had moved my kakoune installation folder and the links in ~/.config/kak were still pointing to the old scripts.
This pull request updates those links on 'make userconfig' and adds a little debug message in case one cannot be loaded.