### PR TITLE
Ensure that at least one character follows a ',' or a '+' sign in a face

### DIFF
--- a/src/face_registry.cc
+++ b/src/face_registry.cc
@@ -9,15 +9,15 @@ namespace Kakoune
 
 static Face parse_face(StringView facedesc)
 {
-    const String invalid_face_error = "invalid face description, expected <fg>[,<bg>][+<attr>]";
+    constexpr StringView invalid_face_error = "invalid face description, expected <fg>[,<bg>][+<attr>]";
     auto bg_it = find(facedesc, ',');
     auto attr_it = find(facedesc, '+');
     if (bg_it != facedesc.end()
         and (attr_it < bg_it or (bg_it + 1) == facedesc.end()))
-        throw runtime_error(invalid_face_error);
+        throw runtime_error(invalid_face_error.str());
     if (attr_it != facedesc.end()
         and (attr_it + 1) == facedesc.end())
-        throw runtime_error(invalid_face_error);
+        throw runtime_error(invalid_face_error.str());
     Face res;
     res.fg = attr_it != facedesc.begin() ?
         str_to_color({facedesc.begin(), std::min(attr_it, bg_it)}) : Color::Default;

--- a/src/face_registry.cc
+++ b/src/face_registry.cc
@@ -9,10 +9,15 @@ namespace Kakoune
 
 static Face parse_face(StringView facedesc)
 {
+    const String invalid_face_error = "invalid face description, expected <fg>[,<bg>][+<attr>]";
     auto bg_it = find(facedesc, ',');
     auto attr_it = find(facedesc, '+');
-    if (bg_it != facedesc.end() and attr_it < bg_it)
-        throw runtime_error("invalid face description, expected <fg>[,<bg>][+<attr>]");
+    if (bg_it != facedesc.end()
+        and (attr_it < bg_it or (bg_it + 1) == facedesc.end()))
+        throw runtime_error(invalid_face_error);
+    if (attr_it != facedesc.end()
+        and (attr_it + 1) == facedesc.end())
+        throw runtime_error(invalid_face_error);
     Face res;
     res.fg = attr_it != facedesc.begin() ?
         str_to_color({facedesc.begin(), std::min(attr_it, bg_it)}) : Color::Default;


### PR DESCRIPTION
description (respectively a background color and attributes).