### PR TITLE
Allow unit tests to test for errors.

### DIFF
--- a/test/run
+++ b/test/run
@@ -15,11 +15,8 @@ main() {
     test_files=$(ls out selections state 2>/dev/null)
     cd $work/$dir;
     indent="$(echo "${dir}/" | sed -e 's|[^/]*/\+|  |g')"
-    name=$(echo ${PWD##*/} | sed 's/-fail^//')
-    should_fail=0
-    if [ ${PWD##*-} = fail ]; then
-      should_fail=1
-    fi
+    name=$(basename $PWD)
+    should_fail=$(test ! -e error; echo $?)
     if ! test -e cmd; then
       echo "$indent$name"
     elif test -x enabled && ! ./enabled; then
@@ -37,6 +34,10 @@ main() {
         } \
         catch %{
           exec gg
+        }
+        hook global RuntimeError .+ %{
+          nop %sh{echo '\$kak_hook_param' > stderr}
+          quit!
         }
         exec '$(cat cmd | sed -e s/\'/\\\\\'/g)'
         eval -buffer *debug* write debug
@@ -78,10 +79,16 @@ main() {
           fi
         done
       else
-        if [ $retval -eq 0 ]; then
-          color=red
+        color=green
+        if [ ! -e stderr ]; then
+          if [ $retval -eq 0 ]; then
+            color=red
+            number_failures=$(($number_failures + 1))
+          fi
+        elif [ -s error -a ! $(cmp -s error stderr) ]; then
+          color=yellow
         fi
-        color=${color:-green}
+
         echo "$indent$name" | colorize $color normal
       fi
     fi

--- a/test/run
+++ b/test/run
@@ -15,7 +15,11 @@ main() {
     test_files=$(ls out selections state 2>/dev/null)
     cd $work/$dir;
     indent="$(echo "${dir}/" | sed -e 's|[^/]*/\+|  |g')"
-    name=$(basename $PWD)
+    name=$(echo ${PWD##*/} | sed 's/-fail^//')
+    should_fail=0
+    if [ ${PWD##*-} = fail ]; then
+      should_fail=1
+    fi
     if ! test -e cmd; then
       echo "$indent$name"
     elif test -x enabled && ! ./enabled; then
@@ -46,32 +50,40 @@ main() {
       "
       ${test}/../src/kak out -n -u -e "$kak_commands"
       retval=$?
-      if [ $retval -ne 0 ]; then
+      if [ $should_fail = 0 ]; then
+        if [ $retval -ne 0 ]; then
           echo "Kakoune returned error $retval"
-      fi
-      for expect in $test_files; do
-        if cmp -s $test/$dir/$expect $expect; then
-          echo "$indent$name" | colorize green normal
-        else
-          number_failures=$(($number_failures + 1))
-          echo "$indent$name" | colorize red normal
-          echo
-          diff -u $test/$dir/$expect $expect | while read -r line; do
-            first_character=$(echo "$line" | cut -b 1)
-            case $first_character in
-              +) color=green ;;
-              -) color=red ;;
-              @) color=magenta ;;
-              *) color=none ;;
-            esac
-            echo "$line" | colorize $color normal
-          done
-          echo
-          echo "debug buffer:" | colorize yellow normal
-          cat debug
-          echo
         fi
-      done
+        for expect in $test_files; do
+          if cmp -s $test/$dir/$expect $expect; then
+            echo "$indent$name" | colorize green normal
+          else
+            number_failures=$(($number_failures + 1))
+            echo "$indent$name" | colorize red normal
+            echo
+            diff -u $test/$dir/$expect $expect | while read -r line; do
+              first_character=$(echo "$line" | cut -b 1)
+              case $first_character in
+                +) color=green ;;
+                -) color=red ;;
+                @) color=magenta ;;
+                *) color=none ;;
+              esac
+              echo "$line" | colorize $color normal
+            done
+            echo
+            echo "debug buffer:" | colorize yellow normal
+            cat debug
+            echo
+          fi
+        done
+      else
+        if [ $retval -eq 0 ]; then
+          color=red
+        fi
+        color=${color:-green}
+        echo "$indent$name" | colorize $color normal
+      fi
     fi
   done
   if expr $number_failures > 0; then


### PR DESCRIPTION
I would have made it so uncapitalized unit tests names test for failures and the rest behave like regular tests, but I don't think that would fare well with case insensitive filesystems (ntfs etc) so I went for the "-fail" suffix.