### PR TITLE
Man: fix a regression introduced in aa6f7c82.

### DIFF
--- a/rc/man.kak
+++ b/rc/man.kak
@@ -38,7 +38,7 @@ def -params .. \
     prefix=${1:0:${kak_pos_in_token}}
     for page in /usr/share/man/*/${prefix}*.[1-8]*; do
         candidate=$(basename ${page%%.[1-8]*})
-        pagenum=$(echo $page | sed 's/^.*\([1-8][a-z]*\)$/\1/')
+        pagenum=$(echo $page | sed -r 's,^.+/.+\.([1-8][^.]*)\..+$,\1,')
         case $candidate in
             *\*) ;;
             *) echo $candidate\($pagenum\);;


### PR DESCRIPTION
The regular expression changed, and returned the wrong page number to
the command completion.