### PR TITLE
Use a wrapper for sigaction instead of signal

### DIFF
--- a/src/event_manager.cc
+++ b/src/event_manager.cc
@@ -133,4 +133,14 @@ void EventManager::force_signal(int fd)
     FD_SET(fd, &m_forced_fd);
 }
 
+SignalHandler set_signal_wrapper(int signum, SignalHandler handler)
+{
+    struct sigaction new_action, old_action;
+
+    sigemptyset(&new_action.sa_mask);
+    new_action.sa_handler = handler;
+    new_action.sa_flags = SA_RESTART;
+    sigaction(signum, &new_action, &old_action);
+    return old_action.sa_handler;
+}
 }

--- a/src/event_manager.hh
+++ b/src/event_manager.hh
@@ -14,6 +14,8 @@
 namespace Kakoune
 {
 
+typedef void(*SignalHandler)(int);
+
 enum class EventMode
 {
     Normal,
@@ -91,6 +93,8 @@ private:
 
     TimePoint        m_last;
 };
+
+SignalHandler set_signal_wrapper(int signum, SignalHandler handler);
 
 }
 

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -250,8 +250,8 @@ NCursesUI::NCursesUI()
 
     enable_mouse(true);
 
-    signal(SIGWINCH, on_term_resize);
-    signal(SIGCONT, on_term_resize);
+    set_signal_wrapper(SIGWINCH, on_term_resize);
+    set_signal_wrapper(SIGCONT, on_term_resize);
 
     check_resize(true);
 
@@ -262,8 +262,8 @@ NCursesUI::~NCursesUI()
 {
     enable_mouse(false);
     endwin();
-    signal(SIGWINCH, SIG_DFL);
-    signal(SIGCONT, SIG_DFL);
+    set_signal_wrapper(SIGWINCH, SIG_DFL);
+    set_signal_wrapper(SIGCONT, SIG_DFL);
 }
 
 void NCursesUI::Window::create(const CharCoord& p, const CharCoord& s)


### PR DESCRIPTION
Use a wrapper based on the function in Figure 10.18 of [Advanced Programming in the Unix Environment](http://poincare.matf.bg.ac.rs/~ivana//courses/ps/sistemi_knjige/pomocno/apue.pdf) pg. 391. The benefits of which are explained in the text prior to the figure. I didn't see an instance of SIGALRM and didn't implement an error handler if `sigaction` failed.