### PR TITLE
Add 'cfg' extension to 'ini-file' filetype

### DIFF
--- a/rc/ini.kak
+++ b/rc/ini.kak
@@ -1,4 +1,4 @@
-hook global BufCreate .*\.(repo|service|target|socket|ini) %{
+hook global BufCreate .*\.(repo|service|target|socket|ini|cfg) %{
     set buffer filetype ini-file
 }
 


### PR DESCRIPTION
'cfg' is another common file extension for ini like files. My use case is about
http://www.buildout.org/ config files.