### PR TITLE
Spell: fix the ranges highlighter, factorize parsing code

### DIFF
--- a/rc/spell.kak
+++ b/rc/spell.kak
@@ -16,15 +16,11 @@ def spell %{
             while read line; do
                 case $line in
                    \&*)
-                       word=$(printf %s "$line" | cut -d ' ' -f 2)
                        begin=$(printf %s "$line" | cut -d ' ' -f 4 | sed 's/:$//')
-                       end=$((begin + ${#word}))
-                       # echo "echo -debug -- line: $line_num, word: $word, begin: $begin, end: $end"
-                       regions="$regions:$line_num.$begin,$line_num.$end|Error"
-                       ;;
+                       ;&
                    '#'*)
                        word=$(printf %s "$line" | cut -d ' ' -f 2)
-                       begin=$(printf %s "$line" | cut -d ' ' -f 3)
+                       begin=${begin:-$(printf %s "$line" | cut -d ' ' -f 3)}
                        end=$((begin + ${#word}))
                        # echo "echo -debug -- line: $line_num, word: $word, begin: $begin, end: $end"
                        regions="$regions:$line_num.$begin,$line_num.$end|Error"

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -1024,7 +1024,7 @@ HighlighterAndId create_ranges_highlighter(HighlighterParameters params)
         }
     };
 
-    return {"hlranges_" + params[1], make_simple_highlighter(func) };
+    return {"hlranges_" + params[0], make_simple_highlighter(func) };
 }
 
 HighlighterAndId create_highlighter_group(HighlighterParameters params)


### PR DESCRIPTION
Hi,

The `spell` command doesn't currently work, due to a typo in the code that handles the `ranges` highlighters. The `spell.kak` support script also contained two chunks of code that were similar except for a single line, so I factorized them.