### PR TITLE
Update rust.kak to post-1.0 rust

### DIFF
--- a/rc/base/rust.kak
+++ b/rc/base/rust.kak
@@ -19,19 +19,22 @@ hook global BufCreate .*[.](rust|rs) %{
 addhl -group / regions -default code rust \
     string  '"' (?<!\\)(\\\\)*"        '' \
     comment //   $                     '' \
-    comment /\* \*/                   /\* \
-    macro  ^\h*?\K# (?<!\\)\n          ''
+    comment /\* \*/                   /\*
 
 addhl -group /rust/string  fill string
 addhl -group /rust/comment fill comment
-addhl -group /rust/macro   fill meta
 
-addhl -group /rust/code regex \<(self|true|false)\> 0:value
-addhl -group /rust/code regex \<(&&|\|\|)\> 0:operator
-addhl -group /rust/code regex \<(match|if|else|as|assert|fail|yield|break|box|continue|extern|for|in|if|impl|let|loop|once|priv|pub|return|unsafe|while|use|fn|proc)\> 0:keyword
-addhl -group /rust/code regex \<(mod|trait|struct|enum|type|mut|ref|static|const|alignof|be|do|offsetof|pure|sizeof|typeof)\> 0:attribute
-addhl -group /rust/code regex \<(int|uint|float|char|bool|u8|u16|u32|u64|f32|f64|i8|i16|i32|i64|str)\> 0:type
-addhl -group /rust/code regex \<(Share|Copy|Send|Sized|Add|Sub|Mul|Div|Rem|Neg|Not|BitAnd|BitOr|BitXor|Drop|Shl|Shr|Index|Option|Some|None|Result|Ok|Err|Any|AnyOwnExt|AnyRefExt|AnyMutRefExt|Ascii|AsciiCast|OwnedAsciiCast|AsciiStr|IntoBytes|ToCStr|Char|Clone|Eq|Ord|TotalEq|TotalOrd|Ordering|Equiv|Less|Equal|Greater|Container|Mutable|Map|MutableMap|Set|MutableSet|FromIterator|Extendable|Iterator|DoubleEndedIterator|RandomAccessIterator|CloneableIterator|OrdIterator|MutableDoubleEndedIterator|ExactSize|Num|NumCast|CheckedAdd|CheckedSub|CheckedMul|Signed|Unsigned|Round|Primitive|Int|Float|ToPrimitive|FromPrimitive|GenericPath|Path|PosixPath|WindowsPath|RawPtr|Buffer|Writer|Reader|Seek|Str|StrVector|StrSlice|OwnedStr|IntoMaybeOwned|StrBuf|ToStr|IntoStr|Tuple1|Tuple2|Tuple3|Tuple4|Tuple5|Tuple6|Tuple7|Tuple8|Tuple9|Tuple10|Tuple11|Tuple12|ImmutableEqVector|ImmutableTotalOrdVector|ImmutableCloneableVector|OwnedVector|OwnedCloneableVector|OwnedEqVector|MutableVector|MutableTotalOrdVector|Vector|VectorVector|CloneableVector|ImmutableVector)\> 0:identifier
+addhl -group /rust/code regex \<[A-z0-9_]+! 0:meta
+# the number literals syntax is defined here:
+# https://doc.rust-lang.org/reference.html#number-literals
+addhl -group /rust/code regex \<(?:self|true|false|[0-9][_0-9]*(?:\.[0-9][_0-9]*|(?:\.[0-9][_0-9]*)?E[\+\-][_0-9]+)(?:f(?:32|64))?|(?:0x[_0-9a-fA-F]+|0o[_0-7]+|0b[_01]+|[0-9][_0-9]*)(?:(?:i|u)(?:8|16|32|64|size))?)\> 0:value
+addhl -group /rust/code regex \<(?:&&|\|\|)\> 0:operator
+# the language keywords are defined here, but many of them are reserved and unused yet:
+# https://doc.rust-lang.org/grammar.html#keywords
+addhl -group /rust/code regex \<(?:crate|use|extern)\> 0:meta
+addhl -group /rust/code regex \<(?:let|as|fn|return|match|if|else|loop|for|in|while|break|continue|move|box|where|impl|pub|unsafe)\> 0:keyword
+addhl -group /rust/code regex \<(?:mod|trait|struct|enum|type|mut|ref|static|const)\> 0:attribute
+addhl -group /rust/code regex \<(?:u8|u16|u32|u64|usize|i8|i16|i32|i64|isize|f32|f64|bool|char|str|Self)\> 0:type
 
 # Commands
 # ‾‾‾‾‾‾‾‾
@@ -53,10 +56,6 @@ def -hidden _rust_indent_on_new_line %~
         try %[ exec -draft k <a-x> <a-k> [{(]\h*$ <ret> j <a-gt> ]
         # align to opening paren of previous line
         try %{ exec -draft [( <a-k> \`\([^\n]+\n[^\n]*\n?\' <ret> s \`\(\h*.|.\' <ret> & }
-        # indent after visibility specifier
-        try %[ exec -draft k <a-x> <a-k> ^\h*(public|private|protected):\h*$ <ret> j <a-gt> ]
-        # indent after if|else|while|for
-        try %[ exec -draft <space> <a-F> ) M B <a-k> \`(if|else|while|for)\h*\(.*\)\h*\n\h*\n?\' <ret> s \`|.\' <ret> 1<a-&> 1<a-space> <a-gt> ]
     >
 ~
 
@@ -71,8 +70,6 @@ def -hidden _rust_indent_on_closing_curly_brace %[
     eval -draft -itersel %_
         # align to opening curly brace when alone on a line
         try %[ exec -draft <a-h> <a-k> ^\h+\}$ <ret> h m s \`|.\' <ret> 1<a-&> ]
-        # add ; after } if class or struct definition
-        try %[ exec -draft h m <space> <a-?> (class|struct) <ret> <a-k> \`(class|struct)[^{}\n]+(\n)?\s*\{\' <ret> <a-space> m a \; <esc> ]
     _
 ]
 


### PR DESCRIPTION
Hi,
The rust syntax highlighting was quite outdated and predated the 1.0 release so I've cleaned it up a bit.
I've considered adding highlighters for basic types from the standard library (Option, Result, Vec...)
but it got a bit too colorful, and it seems like you don't usually highlight things related to standard library so I've left it out.
The number literals regex has one false negative that I know of, which are the float ending in '.' (so '1.' or '01_.') but I suppose it's acceptable. The word boundary matching makes this awkward to handle.
I've removed a *lot* from the 'identifier' group, but it contained a lot of unrelated things (which were also not identifiers) and it didn't provide much value in my opinion.
Since @alexherbo2 introduced this and @jkonecny12 also committed to it, I would like to have their input.