### PR TITLE
Makefile: Add a hook that inserts tab characters in the implementations of targets

### DIFF
--- a/rc/base/makefile.kak
+++ b/rc/base/makefile.kak
@@ -28,12 +28,8 @@ addhl -group /makefile/content regex [+?:]= 0:operator
 
 def -hidden _makefile_fix_whitespaces %{
     try %{
-        exec -draft "
-            \%
-s^[^\s][^:\n]+:[^\n]*\n(^\h+[^\n]+\n?)+<ret>
-s {%opt{tabstop}}<ret>
-c<tab><esc>
-        "
+        exec -draft <esc>K <a-k>^\S[^:\v]*:[^:=]<ret>
+        exec <tab>
     }
 }
 
@@ -43,7 +39,7 @@ c<tab><esc>
 hook global WinSetOption filetype=makefile %{
     addhl ref makefile
 
-    hook buffer BufWritePre .* -group makefile-indent _makefile_fix_whitespaces
+    hook window InsertChar \n -group makefile-indent _makefile_fix_whitespaces
 
     set window comment_selection_chars ""
     set window comment_line_chars "#"
@@ -51,5 +47,5 @@ hook global WinSetOption filetype=makefile %{
 
 hook global WinSetOption filetype=(?!makefile).* %{
     rmhl makefile
-    rmhooks buffer makefile-indent
+    rmhooks window makefile-indent
 }

--- a/rc/base/makefile.kak
+++ b/rc/base/makefile.kak
@@ -23,13 +23,33 @@ addhl -group /makefile/content regex ^[\w.%]+\h*:\s 0:identifier
 addhl -group /makefile/content regex \b(ifeq|ifneq|else|endif)\b 0:keyword
 addhl -group /makefile/content regex [+?:]= 0:operator
 
+# Commands
+# ‾‾‾‾‾‾‾‾
+
+def -hidden _makefile_fix_whitespaces %{
+    try %{
+        exec -draft "
+            \%
+s^[^\s][^:\n]+:[^\n]*\n(^\h+[^\n]+\n?)+<ret>
+s {%opt{tabstop}}<ret>
+c<tab><esc>
+        "
+    }
+}
+
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
 hook global WinSetOption filetype=makefile %{
     addhl ref makefile
 
+    hook buffer BufWritePre .* -group makefile-indent _makefile_fix_whitespaces
+
     set window comment_selection_chars ""
     set window comment_line_chars "#"
 }
-hook global WinSetOption filetype=(?!makefile).* %{ rmhl makefile }
+
+hook global WinSetOption filetype=(?!makefile).* %{
+    rmhl makefile
+    rmhooks buffer makefile-indent
+}

--- a/rc/base/makefile.kak
+++ b/rc/base/makefile.kak
@@ -28,7 +28,7 @@ addhl -group /makefile/content regex [+?:]= 0:operator
 
 def -hidden _makefile_fix_whitespaces %{
     try %{
-        exec -draft <esc>K <a-k>^\S[^:\v]*:[^:=]<ret>
+        exec -draft <esc> K<a-i>p <a-k>^\S[^:\v]*:[^:=]<ret>
         exec <tab>
     }
 }

--- a/rc/base/makefile.kak
+++ b/rc/base/makefile.kak
@@ -5,7 +5,7 @@ hook global BufSetOption mimetype=text/x-makefile %{
     set buffer filetype makefile
 }
 
-hook global BufCreate [mM]akefile %{
+hook global BufCreate .*/?[mM]akefile %{
     set buffer filetype makefile
 }
 

--- a/rc/base/makefile.kak
+++ b/rc/base/makefile.kak
@@ -28,8 +28,13 @@ addhl -group /makefile/content regex [+?:]= 0:operator
 
 def -hidden _makefile_fix_whitespaces %{
     try %{
-        exec -draft <esc> K<a-i>p <a-k>^\S[^:\v]*:[^:=]<ret>
+        ## If the line above is a target or begins with a tab, then add another tab
+        exec -draft <esc> K <a-k>^(\S[^:\v]*:[^:=]|\t\S)<ret>
         exec <tab>
+    } catch %{
+        ## If we hit the return key twice while implementing a target,
+        ## we remove the tab character left alone on the previous line
+        try %{ exec -draft <esc> K s^\t$<ret>d }
     }
 }
 


### PR DESCRIPTION
Hi,

As mentioned by @somasis on IRC, it can be annoying to have to insert tabs in the right places when you indent with spaces.

This commit automatically replaces `tabstop` amount of spaces with a tab character in Makefile rules.

HTH.