### PR TITLE
man.kak: Remove ascii codes from man output

### DIFF
--- a/rc/core/man.kak
+++ b/rc/core/man.kak
@@ -20,7 +20,7 @@ hook global WinSetOption filetype=(?!man).* %{
 def -hidden -params .. _man %{ %sh{
     manout=$(mktemp /tmp/kak-man-XXXXXX)
     colout=$(mktemp /tmp/kak-man-XXXXXX)
-    MANWIDTH=${kak_window_width} man "$@" > $manout
+    MANWIDTH=${kak_window_width} man "$@" | sed -r 's/\x1B\[([0-9]*?)?[m|K]//g' > $manout
     retval=$?
     col -b -x > ${colout} < ${manout}
     rm ${manout}


### PR DESCRIPTION
Some implementations of man do not output pages stripped of color
codes and such, even if the stdout isn't a tty.