### PR TITLE
Buffer padding

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -920,6 +920,7 @@ There are some builtins faces used by internal Kakoune functionalities:
  * `Prompt`: face used prompt displayed on the status line
  * `MatchingChar`: face used by the show_matching highlighter
  * `Search`: face used to highlight search results
+ * `BufferPadding`: face applied on the characters that follow the last line of a buffer
 
 Advanced topics
 ---------------

--- a/colors/base16.kak
+++ b/colors/base16.kak
@@ -64,5 +64,6 @@
         face StatusCursor ${black_lighterer},${cyan_light}
         face Prompt ${black_light},${cyan_light}
         face MatchingChar ${cyan_light},${black_light}+b
+        face BufferPadding ${cyan_light},${black_lighter}
     "
 }

--- a/colors/default.kak
+++ b/colors/default.kak
@@ -43,3 +43,4 @@ face StatusLineValue green,default
 face StatusCursor black,cyan
 face Prompt yellow,default
 face MatchingChar default,default+b
+face BufferPadding blue,default

--- a/colors/github.kak
+++ b/colors/github.kak
@@ -43,3 +43,4 @@ face StatusCursor rgb:434343,rgb:CDCDFD
 face Prompt rgb:F8F8FF,rgb:4078C0
 face MatchingChar rgb:F8F8FF,rgb:4078C0+b
 face Search default,default+u
+face BufferPadding rgb:A0A0A0,rgb:F8F8FF

--- a/colors/lucius.kak
+++ b/colors/lucius.kak
@@ -66,5 +66,6 @@
         face StatusCursor default,${lucius_blue}
         face Prompt ${lucius_lighter_grey}
         face MatchingChar ${lucius_lighter_grey},${lucius_bright_green}
+        face BufferPadding ${lucius_green},${lucius_darker_grey}
     "
 }

--- a/colors/reeder.kak
+++ b/colors/reeder.kak
@@ -64,6 +64,6 @@
         face StatusCursor       ${orange},${white_light}
         face Prompt             ${black_light}
         face MatchingChar       default+b
-        face BufferPadding		${grey_dark},${white}
+        face BufferPadding      ${grey_dark},${white}
     "
 }

--- a/colors/reeder.kak
+++ b/colors/reeder.kak
@@ -64,5 +64,6 @@
         face StatusCursor       ${orange},${white_light}
         face Prompt             ${black_light}
         face MatchingChar       default+b
+        face BufferPadding		${grey_dark},${white}
     "
 }

--- a/colors/solarized.kak
+++ b/colors/solarized.kak
@@ -64,5 +64,6 @@
         face StatusCursor       ${base00},${base3}
         face Prompt             yellow
         face MatchingChar       default+b
+        face BufferPadding		${base01},${base03}
     "
 }

--- a/colors/solarized.kak
+++ b/colors/solarized.kak
@@ -64,6 +64,6 @@
         face StatusCursor       ${base00},${base3}
         face Prompt             yellow
         face MatchingChar       default+b
-        face BufferPadding		${base01},${base03}
+        face BufferPadding      ${base01},${base03}
     "
 }

--- a/colors/zenburn.kak
+++ b/colors/zenburn.kak
@@ -67,5 +67,6 @@
         face StatusCursor ${zencursor}
         face Prompt yellow
         face MatchingChar default+b
+        face BufferPadding ${zenkeyword},${zenbackground}
     "
 }

--- a/doc/manpages/faces.asciidoc
+++ b/doc/manpages/faces.asciidoc
@@ -94,3 +94,6 @@ areas of the user interface:
 
 *Search*::
 	face used to highlight search results
+
+*BufferPadding*::
+	face applied on the characters that follow the last line of a buffer

--- a/src/client.cc
+++ b/src/client.cc
@@ -166,7 +166,7 @@ void Client::redraw_ifn()
 
     const bool needs_redraw = window.needs_redraw(context());
     if (needs_redraw)
-        ui.draw(window.update_display_buffer(context()), get_face("Default"));
+        ui.draw(window.update_display_buffer(context()), get_face("Default"), get_face("BufferPadding"));
 
     DisplayLine mode_line = generate_mode_line();
     if (needs_redraw or

--- a/src/face_registry.cc
+++ b/src/face_registry.cc
@@ -121,7 +121,7 @@ FaceRegistry::FaceRegistry()
         { "StatusCursor", Face{ Color::Black, Color::Cyan } },
         { "Prompt", Face{ Color::Yellow, Color::Default } },
         { "MatchingChar", Face{ Color::Default, Color::Default, Attribute::Bold } },
-        { "BufferPadding", Face{ Color::Blue, Color::Default, Attribute::Bold } },
+        { "BufferPadding", Face{ Color::Blue, Color::Default } },
       }
 {}
 

--- a/src/face_registry.cc
+++ b/src/face_registry.cc
@@ -121,6 +121,7 @@ FaceRegistry::FaceRegistry()
         { "StatusCursor", Face{ Color::Black, Color::Cyan } },
         { "Prompt", Face{ Color::Yellow, Color::Default } },
         { "MatchingChar", Face{ Color::Default, Color::Default, Attribute::Bold } },
+        { "BufferPadding", Face{ Color::Blue, Color::Default, Attribute::Bold } },
       }
 {}
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -251,7 +251,9 @@ void register_options()
                        "    ncurses_set_title             bool\n"
                        "    ncurses_enable_mouse          bool\n"
                        "    ncurses_wheel_up_button       int\n"
-                       "    ncurses_wheel_down_button     int\n",
+                       "    ncurses_wheel_down_button     int\n"
+                       "    ncurses_buffer_padding_str           str\n"
+                       "    ncurses_buffer_padding_type          fill|single|off\n",
                        UserInterface::Options{});
     reg.declare_option("modelinefmt", "format string used to generate the modeline",
                        "%val{bufname} %val{cursor_line}:%val{cursor_char_column} "_str);
@@ -292,7 +294,7 @@ std::unique_ptr<UserInterface> create_local_ui(bool dummy_ui)
         void info_show(StringView, StringView, CharCoord, Face, InfoStyle) override {}
         void info_hide() override {}
 
-        void draw(const DisplayBuffer&, const Face&) override {}
+        void draw(const DisplayBuffer&, const Face&, const Face&) override {}
         void draw_status(const DisplayLine&, const DisplayLine&, const Face&) override {}
         CharCoord dimensions() override { return {24,80}; }
         bool is_key_available() override { return false; }

--- a/src/main.cc
+++ b/src/main.cc
@@ -252,8 +252,8 @@ void register_options()
                        "    ncurses_enable_mouse          bool\n"
                        "    ncurses_wheel_up_button       int\n"
                        "    ncurses_wheel_down_button     int\n"
-                       "    ncurses_buffer_padding_str           str\n"
-                       "    ncurses_buffer_padding_type          fill|single|off\n",
+                       "    ncurses_buffer_padding_str    str\n"
+                       "    ncurses_buffer_padding_type   fill|single|off\n",
                        UserInterface::Options{});
     reg.declare_option("modelinefmt", "format string used to generate the modeline",
                        "%val{bufname} %val{cursor_line}:%val{cursor_char_column} "_str);

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -7,7 +7,6 @@
 #include "keys.hh"
 #include "register_manager.hh"
 #include "utf8_iterator.hh"
-#include "face_registry.hh"
 
 #include <algorithm>
 
@@ -361,7 +360,7 @@ void NCursesUI::draw(const DisplayBuffer& display_buffer,
         ++line_index;
     }
 
-    set_face(m_window, { Color::Blue, Color::Default }, padding_face);
+    set_face(m_window, padding_face, default_face);
 
     const DisplayLine padding_line = m_buffer_padding_str;
     const DisplayLine* padding_line_ptr = m_buffer_padding_type != BufferPaddingType::None ?

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -7,6 +7,7 @@
 #include "keys.hh"
 #include "register_manager.hh"
 #include "utf8_iterator.hh"
+#include "face_registry.hh"
 
 #include <algorithm>
 
@@ -341,8 +342,11 @@ void NCursesUI::draw_line(NCursesWin* window, const DisplayLine& line,
     }
 }
 
+static const DisplayLine empty_line = String(" ");
+
 void NCursesUI::draw(const DisplayBuffer& display_buffer,
-                     const Face& default_face)
+                     const Face& default_face,
+                     const Face& padding_face)
 {
     wbkgdset(m_window, COLOR_PAIR(get_color_pair(default_face)));
 
@@ -357,12 +361,18 @@ void NCursesUI::draw(const DisplayBuffer& display_buffer,
         ++line_index;
     }
 
-    set_face(m_window, { Color::Blue, Color::Default }, default_face);
+    set_face(m_window, { Color::Blue, Color::Default }, padding_face);
+
+    const DisplayLine padding_line = m_buffer_padding_str;
+    const DisplayLine* padding_line_ptr = m_buffer_padding_type != BufferPaddingType::None ?
+                                            &padding_line : &empty_line;
     while (line_index < m_dimensions.line + (m_status_on_top ? 1 : 0))
     {
         wmove(m_window, (int)line_index++, 0);
         wclrtoeol(m_window);
-        waddch(m_window, '~');
+        draw_line(m_window, *padding_line_ptr, 0, m_dimensions.column, padding_face);
+        if (m_buffer_padding_type == BufferPaddingType::Single)
+            padding_line_ptr = &empty_line;
     }
 
     m_dirty = true;
@@ -980,6 +990,20 @@ void NCursesUI::set_ui_options(const Options& options)
         auto wheel_down_it = options.find("ncurses_wheel_down_button");
         m_wheel_down_button = wheel_down_it != options.end() ?
             str_to_int_ifp(wheel_down_it->value).value_or(5) : 5;
+    }
+
+    {
+        auto padding_str_it = options.find("ncurses_buffer_padding_str");
+        m_buffer_padding_str = padding_str_it == options.end() or !padding_str_it->value.length() ?
+                                "~" : padding_str_it->value;
+
+        auto padding_type_it = options.find("ncurses_buffer_padding_type");
+        if (padding_type_it == options.end() or padding_type_it->value == "fill")
+            m_buffer_padding_type = BufferPaddingType::Fill;
+        else if (padding_type_it->value == "single")
+            m_buffer_padding_type = BufferPaddingType::Single;
+        else
+            m_buffer_padding_type = BufferPaddingType::None;
     }
 }
 

--- a/src/ncurses_ui.hh
+++ b/src/ncurses_ui.hh
@@ -13,6 +13,8 @@ namespace Kakoune
 
 struct NCursesWin;
 
+enum BufferPaddingType { None, Single, Fill };
+
 class NCursesUI : public UserInterface
 {
 public:
@@ -23,7 +25,8 @@ public:
     NCursesUI& operator=(const NCursesUI&) = delete;
 
     void draw(const DisplayBuffer& display_buffer,
-              const Face& default_face) override;
+              const Face& default_face,
+              const Face& padding_face) override;
 
     void draw_status(const DisplayLine& status_line,
                      const DisplayLine& mode_line,
@@ -120,6 +123,9 @@ private:
     bool m_mouse_enabled = false;
     int m_wheel_up_button = 4;
     int m_wheel_down_button = 5;
+
+    String		  	  m_buffer_padding_str = "~";
+    BufferPaddingType m_buffer_padding_type = BufferPaddingType::None;
 
     bool m_set_title = true;
 

--- a/src/ncurses_ui.hh
+++ b/src/ncurses_ui.hh
@@ -124,7 +124,7 @@ private:
     int m_wheel_up_button = 4;
     int m_wheel_down_button = 5;
 
-    String		  	  m_buffer_padding_str = "~";
+    String            m_buffer_padding_str = "~";
     BufferPaddingType m_buffer_padding_type = BufferPaddingType::None;
 
     bool m_set_title = true;

--- a/src/remote.cc
+++ b/src/remote.cc
@@ -249,7 +249,8 @@ public:
     void info_hide() override;
 
     void draw(const DisplayBuffer& display_buffer,
-              const Face& default_face) override;
+              const Face& default_face,
+              const Face& padding_face) override;
 
     void draw_status(const DisplayLine& status_line,
                      const DisplayLine& mode_line,
@@ -334,12 +335,14 @@ void RemoteUI::info_hide()
 }
 
 void RemoteUI::draw(const DisplayBuffer& display_buffer,
-                    const Face& default_face)
+                    const Face& default_face,
+                    const Face& padding_face)
 {
     Message msg(m_socket_watcher.fd());
     msg.write(RemoteUIMsg::Draw);
     msg.write(display_buffer);
     msg.write(default_face);
+    msg.write(padding_face);
 }
 
 void RemoteUI::draw_status(const DisplayLine& status_line,
@@ -504,7 +507,8 @@ void RemoteClient::process_next_message()
     {
         auto display_buffer = read<DisplayBuffer>(socket);
         auto default_face = read<Face>(socket);
-        m_ui->draw(display_buffer, default_face);
+        auto padding_face = read<Face>(socket);
+        m_ui->draw(display_buffer, default_face, padding_face);
         break;
     }
     case RemoteUIMsg::DrawStatus:

--- a/src/user_interface.hh
+++ b/src/user_interface.hh
@@ -53,7 +53,8 @@ public:
     virtual void info_hide() = 0;
 
     virtual void draw(const DisplayBuffer& display_buffer,
-                      const Face& default_face) = 0;
+                      const Face& default_face,
+                      const Face& padding_face) = 0;
 
     virtual void draw_status(const DisplayLine& status_line,
                              const DisplayLine& mode_line,


### PR DESCRIPTION
Hi,

The following commits add options that control how buffers are padded in a window (the dead space between the last line of a file and the bottom side of the window, currently filled with blue `~` signs).

The user can now chose to add a single string of his choosing after the last line of the buffers, fill the dead space with that same string, or do nothing.

There's also a `BufferPadding` face that comes with it, applied on the padding string (as of now, it's the same blue on black `~` sign, and that doesn't fare so well with certain themes).

I didn't think much about the names, maybe someone will think of something more appropriate.