### PR TITLE
Regex doc

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -472,6 +472,9 @@ A multiselection can also be obtained with `S`, which splits the current
 selection according to the regex entered. To split a comma separated list,
 use `S` then ', *'
 
+The regex syntax supported by Kakoune is the Perl one and is describe  
+here <<Regex syntax>>.
+
 `s` and `S` share the search pattern with `/`, and hence entering an empty
 pattern uses the last one.
 
@@ -986,6 +989,18 @@ begins and/or ends at word boundaries and set the search pattern accordingly.
 
 with `alt-*` you can set the search pattern to the current seletion without
 Kakoune trying to be smart.
+
+Regex syntax
+~~~~~~~~~~~~
+
+The regex syntax supported by Kakoune is the Perl syntax currently provided 
+by Boost :
+http://www.boost.org/doc/libs/release/libs/regex/doc/html/boost_regex/syntax/perl_syntax.html[Perl Regular Expression Syntax].
+
+Tips
+^^^^
+
+* It is possible to make case insensitive regex by prefixing expression with `(?i)`
 
 Exec and Eval
 ~~~~~~~~~~~~~

--- a/doc/coding-style.asciidoc
+++ b/doc/coding-style.asciidoc
@@ -7,7 +7,7 @@ Kakoune is written in C++11, here are the main coding style points:
 
    - That means avoid depending on boost, it is only allowed for the regex
      implementation. The reference for the current regex support is available under
-     http://www.boost.org/doc/libs/1_59_0/libs/regex/doc/html/boost_regex/syntax/perl_syntax.html[Perl Regular Expression Syntax].
+     http://www.boost.org/doc/libs/release/libs/regex/doc/html/boost_regex/syntax/perl_syntax.html[Perl Regular Expression Syntax].
 
  * 4 spaces for indentation, no tabs
 


### PR DESCRIPTION
Small addition to main doc to clarify supported regex syntax. Use an URL to latest release of Boost.Regex (and not a fixed one)