### PR TITLE
Update Makefile for OSX build with homebrew ncurses

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -37,6 +37,8 @@ os := $(shell uname)
 
 ifeq ($(os),Darwin)
     LIBS += -lncurses -lboost_regex-mt
+    CPPFLAGS += -I/usr/local/opt/ncurses/include
+    LDFLAGS += -L/usr/local/opt/ncurses/lib
 else ifeq ($(os),FreeBSD)
     LIBS += -ltinfow -lncursesw -lboost_regex
     CPPFLAGS += -I/usr/local/include


### PR DESCRIPTION
This adds compilation flags to include the homebrew installed ncurses 6.0 library during compilation.

Closes #608