### PR TITLE
Misc: Add static completion suggestions to several languages

### DIFF
--- a/rc/base/dlang.kak
+++ b/rc/base/dlang.kak
@@ -35,25 +35,25 @@ addhl -group /dlang/code regex "\<(this)\>\s*[^(]" 1:value
 
 %sh{
     # Grammar
-    keywords="alias:asm:assert:body:cast:class:delegate:delete:enum:function"
-    keywords="${keywords}:import:in:interface:invariant:is:lazy:mixin:module"
-    keywords="${keywords}:new:out:pragma:struct:super:typeid:typeof:union"
-    keywords="${keywords}:unittest:__parameters:__traits:__vector:break:case"
-    keywords="${keywords}:catch:continue:default:do:else:finally:for:foreach"
-    keywords="${keywords}:foreach_reverse:goto:if:return:switch:throw:try:with:while"
-    attributes="abstract:align:auto:const:debug:deprecated:export:extern:final"
-    attributes="${attributes}:immutable:inout:nothrow:package:private:protected"
-    attributes="${attributes}:public:pure:ref:override:scope:shared:static:synchronized:version:__gshared"
-    types="bool:byte:cdouble:cfloat:char:creal:dchar:double:dstring:float"
-    types="${types}:idouble:ifloat:int:ireal:long:ptrdiff_t:real:size_t:short"
-    types="${types}:string:ubyte:uint:ulong:ushort:void:wchar:wstring"
-    values="true:false:null:__FILE__:__MODULE__:__LINE__:__FUNCTION__"
-    values="${values}:__PRETTY_FUNCTION__:__DATE__:__EOF__:__TIME__"
-    values="${values}:__TIMESTAMP__:__VENDOR__:__VERSION__"
-    decorators="disable:property:nogc:safe:trusted:system"
+    keywords="alias|asm|assert|body|cast|class|delegate|delete|enum|function"
+    keywords="${keywords}|import|in|interface|invariant|is|lazy|mixin|module"
+    keywords="${keywords}|new|out|pragma|struct|super|typeid|typeof|union"
+    keywords="${keywords}|unittest|__parameters|__traits|__vector|break|case"
+    keywords="${keywords}|catch|continue|default|do|else|finally|for|foreach"
+    keywords="${keywords}|foreach_reverse|goto|if|return|switch|throw|try|with|while"
+    attributes="abstract|align|auto|const|debug|deprecated|export|extern|final"
+    attributes="${attributes}|immutable|inout|nothrow|package|private|protected"
+    attributes="${attributes}|public|pure|ref|override|scope|shared|static|synchronized|version|__gshared"
+    types="bool|byte|cdouble|cfloat|char|creal|dchar|double|dstring|float"
+    types="${types}|idouble|ifloat|int|ireal|long|ptrdiff_t|real|size_t|short"
+    types="${types}|string|ubyte|uint|ulong|ushort|void|wchar|wstring"
+    values="true|false|null|__FILE__|__MODULE__|__LINE__|__FUNCTION__"
+    values="${values}|__PRETTY_FUNCTION__|__DATE__|__EOF__|__TIME__"
+    values="${values}|__TIMESTAMP__|__VENDOR__|__VERSION__"
+    decorators="disable|property|nogc|safe|trusted|system"
 
     # Add the language's grammar to the static completion list
-    echo "hook global WinSetOption filetype=dlang %{
+    sed 's,|,:,g' <<< "hook global WinSetOption filetype=dlang %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${types}'
@@ -63,11 +63,11 @@ addhl -group /dlang/code regex "\<(this)\>\s*[^(]" 1:value
 
     # Highlight keywords
     echo "
-        addhl -group /dlang/code regex \<(${keywords//:/|})\> 0:keyword
-        addhl -group /dlang/code regex \<(${attributes//:/|})\> 0:attribute
-        addhl -group /dlang/code regex \<(${types//:/|})\> 0:type
-        addhl -group /dlang/code regex \<(${values//:/|})\> 0:value
-        addhl -group /dlang/code regex @(${decorators//:/|})\> 0:attribute
+        addhl -group /dlang/code regex \<(${keywords})\> 0:keyword
+        addhl -group /dlang/code regex \<(${attributes})\> 0:attribute
+        addhl -group /dlang/code regex \<(${types})\> 0:type
+        addhl -group /dlang/code regex \<(${values})\> 0:value
+        addhl -group /dlang/code regex @(${decorators})\> 0:attribute
     "
 }
 

--- a/rc/base/dlang.kak
+++ b/rc/base/dlang.kak
@@ -53,16 +53,16 @@ addhl -group /dlang/code regex "\<(this)\>\s*[^(]" 1:value
     decorators="disable|property|nogc|safe|trusted|system"
 
     # Add the language's grammar to the static completion list
-    sed 's,|,:,g' <<< "hook global WinSetOption filetype=dlang %{
+    printf %s "hook global WinSetOption filetype=dlang %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${types}'
         set -add window static_words '${values}'
         set -add window static_words '${decorators}'
-    }"
+    }" | sed 's,|,:,g'
 
     # Highlight keywords
-    echo "
+    printf %s "
         addhl -group /dlang/code regex \<(${keywords})\> 0:keyword
         addhl -group /dlang/code regex \<(${attributes})\> 0:attribute
         addhl -group /dlang/code regex \<(${types})\> 0:type

--- a/rc/base/dlang.kak
+++ b/rc/base/dlang.kak
@@ -29,14 +29,47 @@ addhl -group /dlang/disabled fill rgb:777777
 addhl -group /dlang/comment fill comment
 
 addhl -group /dlang/string regex %{\\(x[0-9a-fA-F]{2}|[0-7]{1,3}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})\>} 0:value
-addhl -group /dlang/code regex %{\<(true|false|null|__FILE__|__MODULE__|__LINE__|__FUNCTION__|__PRETTY_FUNCTION__|__DATE__|__EOF__|__TIME__|__TIMESTAMP__|__VENDOR__|__VERSION__)\>|'((\\.)?|[^'\\])'} 0:value
+addhl -group /dlang/code regex %{'((\\.)?|[^'\\])'} 0:value
 addhl -group /dlang/code regex "-?([0-9_]*\.(?!0[xXbB]))?\<([0-9_]+|0[xX][0-9a-fA-F_]*\.?[0-9a-fA-F_]+|0[bb][01_]+)([ep]-?[0-9_]+)?[fFlLuUi]*\>" 0:value
 addhl -group /dlang/code regex "\<(this)\>\s*[^(]" 1:value
-addhl -group /dlang/code regex "\<(bool|byte|cdouble|cfloat|char|creal|dchar|double|dstring|float|idouble|ifloat|int|ireal|long|ptrdiff_t|real|size_t|short|string|ubyte|uint|ulong|ushort|void|wchar|wstring)\>" 0:type
-addhl -group /dlang/code regex "\<(alias|asm|assert|body|cast|class|delegate|delete|enum|function|import|in|interface|invariant|is|lazy|mixin|module|new|out|pragma|struct|super|typeid|typeof|union|unittest|__parameters|__traits|__vector)\>" 0:keyword
-addhl -group /dlang/code regex "\<(break|case|catch|continue|default|do|else|finally|for|foreach|foreach_reverse|goto|if|return|switch|throw|try|with|while)\>" 0:keyword
-addhl -group /dlang/code regex "\<(abstract|align|auto|const|debug|deprecated|export|extern|final|immutable|inout|nothrow|package|private|protected|public|pure|ref|override|scope|shared|static|synchronized|version|__gshared)\>" 0:attribute
-addhl -group /dlang/code regex "@(disable|property|nogc|safe|trusted|system)" 0:attribute
+
+%sh{
+    # Grammar
+    keywords="alias:asm:assert:body:cast:class:delegate:delete:enum:function"
+    keywords="${keywords}:import:in:interface:invariant:is:lazy:mixin:module"
+    keywords="${keywords}:new:out:pragma:struct:super:typeid:typeof:union"
+    keywords="${keywords}:unittest:__parameters:__traits:__vector:break:case"
+    keywords="${keywords}:catch:continue:default:do:else:finally:for:foreach"
+    keywords="${keywords}:foreach_reverse:goto:if:return:switch:throw:try:with:while"
+    attributes="abstract:align:auto:const:debug:deprecated:export:extern:final"
+    attributes="${attributes}:immutable:inout:nothrow:package:private:protected"
+    attributes="${attributes}:public:pure:ref:override:scope:shared:static:synchronized:version:__gshared"
+    types="bool:byte:cdouble:cfloat:char:creal:dchar:double:dstring:float"
+    types="${types}:idouble:ifloat:int:ireal:long:ptrdiff_t:real:size_t:short"
+    types="${types}:string:ubyte:uint:ulong:ushort:void:wchar:wstring"
+    values="true:false:null:__FILE__:__MODULE__:__LINE__:__FUNCTION__"
+    values="${values}:__PRETTY_FUNCTION__:__DATE__:__EOF__:__TIME__"
+    values="${values}:__TIMESTAMP__:__VENDOR__:__VERSION__"
+    decorators="disable:property:nogc:safe:trusted:system"
+
+    # Add the language's grammar to the static completion list
+    echo "hook global WinSetOption filetype=dlang %{
+        set window static_words '${keywords}'
+        set -add window static_words '${attributes}'
+        set -add window static_words '${types}'
+        set -add window static_words '${values}'
+        set -add window static_words '${decorators}'
+    }"
+
+    # Highlight keywords
+    echo "
+        addhl -group /dlang/code regex \<(${keywords//:/|})\> 0:keyword
+        addhl -group /dlang/code regex \<(${attributes//:/|})\> 0:attribute
+        addhl -group /dlang/code regex \<(${types//:/|})\> 0:type
+        addhl -group /dlang/code regex \<(${values//:/|})\> 0:value
+        addhl -group /dlang/code regex @(${decorators//:/|})\> 0:attribute
+    "
+}
 
 # Commands
 # ‾‾‾‾‾‾‾‾

--- a/rc/base/golang.kak
+++ b/rc/base/golang.kak
@@ -28,15 +28,15 @@ addhl -group /golang/code regex %{-?([0-9]*\.(?!0[xX]))?\<([0-9]+|0[xX][0-9a-fA-
 
 %sh{
     # Grammar
-    keywords="break:default:defer:else:fallthrough:for:func:go:goto:if:import"
-    keywords="${keywords}:interface:make:new:package:range:return:select:case:switch:type:continue"
+    keywords="break|default|defer|else|fallthrough|for|func|go|goto|if|import"
+    keywords="${keywords}|interface|make|new|package|range|return|select|case|switch|type|continue"
     attributes="const"
-    types="bool:byte:chan:complex128:complex64:float32:float64:int:int16:int32"
-    types="${types}:int64:int8:interface:intptr:map:rune:string:struct:uint:uint16:uint32:uint64:uint8"
-    values="false:true:nil"
+    types="bool|byte|chan|complex128|complex64|float32|float64|int|int16|int32"
+    types="${types}|int64|int8|interface|intptr|map|rune|string|struct|uint|uint16|uint32|uint64|uint8"
+    values="false|true|nil"
 
     # Add the language's grammar to the static completion list
-    echo "hook global WinSetOption filetype=golang %{
+    sed 's,|,:,g' <<< "hook global WinSetOption filetype=golang %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${types}'
@@ -45,10 +45,10 @@ addhl -group /golang/code regex %{-?([0-9]*\.(?!0[xX]))?\<([0-9]+|0[xX][0-9a-fA-
 
     # Highlight keywords
     echo "
-        addhl -group /golang/code regex \<(${keywords//:/|})\> 0:keyword
-        addhl -group /golang/code regex \<(${attributes//:/|})\> 0:attribute
-        addhl -group /golang/code regex \<(${types//:/|})\> 0:type
-        addhl -group /golang/code regex \<(${values//:/|})\> 0:value
+        addhl -group /golang/code regex \<(${keywords})\> 0:keyword
+        addhl -group /golang/code regex \<(${attributes})\> 0:attribute
+        addhl -group /golang/code regex \<(${types})\> 0:type
+        addhl -group /golang/code regex \<(${values})\> 0:value
     "
 }
 

--- a/rc/base/golang.kak
+++ b/rc/base/golang.kak
@@ -36,15 +36,15 @@ addhl -group /golang/code regex %{-?([0-9]*\.(?!0[xX]))?\<([0-9]+|0[xX][0-9a-fA-
     values="false|true|nil"
 
     # Add the language's grammar to the static completion list
-    sed 's,|,:,g' <<< "hook global WinSetOption filetype=golang %{
+    printf %s "hook global WinSetOption filetype=golang %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${types}'
         set -add window static_words '${values}'
-    }"
+    }" | sed 's,|,:,g'
 
     # Highlight keywords
-    echo "
+    printf %s "
         addhl -group /golang/code regex \<(${keywords})\> 0:keyword
         addhl -group /golang/code regex \<(${attributes})\> 0:attribute
         addhl -group /golang/code regex \<(${types})\> 0:type

--- a/rc/base/golang.kak
+++ b/rc/base/golang.kak
@@ -24,11 +24,33 @@ addhl -group /golang/double_string fill string
 addhl -group /golang/single_string fill string
 addhl -group /golang/comment fill comment
 
-addhl -group /golang/code regex %{\<(false|true|nil)\>} 0:value
 addhl -group /golang/code regex %{-?([0-9]*\.(?!0[xX]))?\<([0-9]+|0[xX][0-9a-fA-F]+)\.?([eE][+-]?[0-9]+)?i?\>} 0:value
-addhl -group /golang/code regex \<(break|default|defer|else|fallthrough|for|func|go|goto|if|import|interface|make|new|package|range|return|select|case|switch|type|continue)\> 0:keyword
-addhl -group /golang/code regex \<(bool|byte|chan|complex128|complex64|float32|float64|int|int16|int32|int64|int8|interface|intptr|map|rune|string|struct|uint|uint16|uint32|uint64|uint8)\> 0:type
-addhl -group /golang/code regex \<(const)\> 0:attribute
+
+%sh{
+    # Grammar
+    keywords="break:default:defer:else:fallthrough:for:func:go:goto:if:import"
+    keywords="${keywords}:interface:make:new:package:range:return:select:case:switch:type:continue"
+    attributes="const"
+    types="bool:byte:chan:complex128:complex64:float32:float64:int:int16:int32"
+    types="${types}:int64:int8:interface:intptr:map:rune:string:struct:uint:uint16:uint32:uint64:uint8"
+    values="false:true:nil"
+
+    # Add the language's grammar to the static completion list
+    echo "hook global WinSetOption filetype=golang %{
+        set window static_words '${keywords}'
+        set -add window static_words '${attributes}'
+        set -add window static_words '${types}'
+        set -add window static_words '${values}'
+    }"
+
+    # Highlight keywords
+    echo "
+        addhl -group /golang/code regex \<(${keywords//:/|})\> 0:keyword
+        addhl -group /golang/code regex \<(${attributes//:/|})\> 0:attribute
+        addhl -group /golang/code regex \<(${types//:/|})\> 0:type
+        addhl -group /golang/code regex \<(${values//:/|})\> 0:value
+    "
+}
 
 # Commands
 # ‾‾‾‾‾‾‾‾

--- a/rc/base/makefile.kak
+++ b/rc/base/makefile.kak
@@ -27,14 +27,12 @@ addhl -group /makefile/content regex [+?:]= 0:operator
     keywords="ifeq|ifneq|else|endif"
 
     # Add the language's grammar to the static completion list
-    sed 's,|,:,g' <<< "hook global WinSetOption filetype=makefile %{
+    printf %s "hook global WinSetOption filetype=makefile %{
         set window static_words '${keywords}'
-    }"
+    }" | sed 's,|,:,g'
 
     # Highlight keywords
-    echo "
-        addhl -group /makefile/content regex \<(${keywords})\> 0:keyword
-    "
+    printf %s "addhl -group /makefile/content regex \<(${keywords})\> 0:keyword"
 }
 
 # Commands

--- a/rc/base/makefile.kak
+++ b/rc/base/makefile.kak
@@ -24,16 +24,16 @@ addhl -group /makefile/content regex [+?:]= 0:operator
 
 %sh{
     # Grammar
-    keywords="ifeq:ifneq:else:endif"
+    keywords="ifeq|ifneq|else|endif"
 
     # Add the language's grammar to the static completion list
-    echo "hook global WinSetOption filetype=makefile %{
+    sed 's,|,:,g' <<< "hook global WinSetOption filetype=makefile %{
         set window static_words '${keywords}'
     }"
 
     # Highlight keywords
     echo "
-        addhl -group /makefile/content regex \<(${keywords//:/|})\> 0:keyword
+        addhl -group /makefile/content regex \<(${keywords})\> 0:keyword
     "
 }
 

--- a/rc/base/makefile.kak
+++ b/rc/base/makefile.kak
@@ -20,8 +20,22 @@ addhl -group /makefile/comment fill comment
 addhl -group /makefile/eval fill value
 
 addhl -group /makefile/content regex ^[\w.%]+\h*:\s 0:identifier
-addhl -group /makefile/content regex \b(ifeq|ifneq|else|endif)\b 0:keyword
 addhl -group /makefile/content regex [+?:]= 0:operator
+
+%sh{
+    # Grammar
+    keywords="ifeq:ifneq:else:endif"
+
+    # Add the language's grammar to the static completion list
+    echo "hook global WinSetOption filetype=makefile %{
+        set window static_words '${keywords}'
+    }"
+
+    # Highlight keywords
+    echo "
+        addhl -group /makefile/content regex \<(${keywords//:/|})\> 0:keyword
+    "
+}
 
 # Commands
 # ‾‾‾‾‾‾‾‾

--- a/rc/base/makefile.kak
+++ b/rc/base/makefile.kak
@@ -27,7 +27,7 @@ addhl -group /makefile/content regex [+?:]= 0:operator
     keywords="ifeq|ifneq|else|endif"
 
     # Add the language's grammar to the static completion list
-    printf %s "hook global WinSetOption filetype=makefile %{
+    printf %s\\n "hook global WinSetOption filetype=makefile %{
         set window static_words '${keywords}'
     }" | sed 's,|,:,g'
 

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -26,8 +26,38 @@ addhl -group /perl/double_string fill string
 addhl -group /perl/single_string fill string
 addhl -group /perl/comment fill comment
 
-addhl -group /perl/code regex \<__(DATA|END|FILE|LINE|PACKAGE)__\> 0:value
-addhl -group /perl/code regex \<(ARGV|STDERR|STDOUT|ARGVOUT|STDIN)\> 0:value
+%sh{
+    # Grammar
+    keywords="else:lock:qw:elsif:lt:qx:eq:exp:ne:sub:for:no:my:not:tr:goto:and:foreach:or:break:exit:unless:cmp:ge:package:until:continue:gt:while:if:qq:xor:do:le:qr:return"
+    attributes="END:AUTOLOAD:BEGIN:CHECK:UNITCHECK:INIT:DESTROY"
+    attributes="${attributes}:length:setpgrp:endgrent:link:setpriority:endhostent:listen:setprotoent:endnetent:local:setpwent"
+    attributes="${attributes}:endprotoent:localtime:setservent:endpwent:log:setsockopt:endservent:lstat:shift:eof:map:shmctl:eval:mkdir:shmget:exec:msgctl:shmread"
+    attributes="${attributes}:exists:msgget:shmwrite:msgrcv:shutdown:fcntl:msgsnd:sin:fileno:sleep:flock:next:socket:fork:socketpair:format:oct:sort"
+    attributes="${attributes}:formline:open:splice:getc:opendir:split:getgrent:ord:sprintf:getgrgid:our:sqrt:getgrnam:pack:srand:gethostbyaddr:pipe:stat:gethostbyname"
+    attributes="${attributes}:pop:state:gethostent:pos:study:getlogin:print:substr:getnetbyaddr:printf:symlink:abs:getnetbyname:prototype:syscall:accept:getnetent"
+    attributes="${attributes}:push:sysopen:alarm:getpeername:quotemeta:sysread:atan2:getpgrp:rand:sysseek:getppid:read:system:getpriority:readdir:syswrite:bind"
+    attributes="${attributes}:getprotobyname:readline:tell:binmode:getprotobynumber:readlink:telldir:bless:getprotoent:readpipe:tie:getpwent:recv:tied:caller"
+    attributes="${attributes}:getpwnam:redo:time:chdir:getpwuid:ref:times:getservbyname:rename:truncate:chmod:getservbyport:require:uc:chomp:getservent:reset:ucfirst"
+    attributes="${attributes}:chop:getsockname:umask:chown:getsockopt:reverse:undef:chr:glob:rewinddir:chroot:gmtime:rindex:unlink:close:rmdir:unpack"
+    attributes="${attributes}:closedir:grep:say:unshift:connect:hex:scalar:untie:cos:index:seek:use:crypt:seekdir:utime:dbmclose:int:select:values:dbmopen:ioctl:semctl"
+    attributes="${attributes}:vec:defined:join:semget:wait:delete:keys:semop:waitpid:kill:send:wantarray:die:last:setgrent:warn:dump:lc:sethostent:write:each:lcfirst:setnetent"
+    values="ARGV:STDERR:STDOUT:ARGVOUT:STDIN:__DATA__:__END__:__FILE__:__LINE__:__PACKAGE__"
+
+    # Add the language's grammar to the static completion list
+    echo "hook global WinSetOption filetype=perl %{
+        set window static_words '${keywords}'
+        set -add window static_words '${attributes}'
+        set -add window static_words '${values}'
+    }"
+
+    # Highlight keywords
+    echo "
+        addhl -group /perl/code regex \<(${keywords//:/|})\> 0:keyword
+        addhl -group /perl/code regex \<(${attributes//:/|})\> 0:attribute
+        addhl -group /perl/code regex \<(${values//:/|})\> 0:value
+    "
+}
+
 addhl -group /perl/code regex (?!\$)-?([0-9]*\.(?!0[xXbB]))?\<([0-9]+|0[xX][0-9a-fA-F]+|0[bb][01_]+)\.?([eE][+-]?[0-9]+)?i?\> 0:value
 addhl -group /perl/code regex %{\$!|\$"|\$#|\$\$|\$%|\$&|\$'|\$\(|\$\)|\$\*|\$\+|\$,|\$_|\$-|\$`|\$\.|\$/|\$:|\$;|\$<|\$=|\$>|\$\?|\$@|\$\[|\$\\|\$\]|\$\^|\$\||\$~|%!|@\+|@-|@_} 0:value
 addhl -group /perl/code regex (%ENV|%INC|%OVERLOAD|%SIG|@ARGV|@INC|@LAST_MATCH_START) 0:value
@@ -37,20 +67,6 @@ addhl -group /perl/code regex \$\^(RE_TRIE_MAXBUF|TAINT|UNICODE|UTF8LOCALE|WARNI
 
 addhl -group /perl/code regex \$[0-9]+ 0:attribute
 addhl -group /perl/code regex \<-(B|b|C|c|d|e|f|g|k|l|M|O|o|p|r|R|S|s|T|t|u|w|W|X|x|z)\> 0:attribute
-addhl -group /perl/code regex \<(END|AUTOLOAD|BEGIN|CHECK|UNITCHECK|INIT|DESTROY)\> 0:attribute
-addhl -group /perl/code regex \<(length|setpgrp|endgrent|link|setpriority|endhostent|listen|setprotoent|endnetent|local|setpwent)\> 0:attribute
-addhl -group /perl/code regex \<(endprotoent|localtime|setservent|endpwent|log|setsockopt|endservent|lstat|shift|eof|map|shmctl|eval|mkdir|shmget|exec|msgctl|shmread)\> 0:attribute
-addhl -group /perl/code regex \<(exists|msgget|shmwrite|msgrcv|shutdown|fcntl|msgsnd|sin|fileno|sleep|flock|next|socket|fork|socketpair|format|oct|sort)\> 0:attribute
-addhl -group /perl/code regex \<(formline|open|splice|getc|opendir|split|getgrent|ord|sprintf|getgrgid|our|sqrt|getgrnam|pack|srand|gethostbyaddr|pipe|stat|gethostbyname)\> 0:attribute
-addhl -group /perl/code regex \<(pop|state|gethostent|pos|study|getlogin|print|substr|getnetbyaddr|printf|symlink|abs|getnetbyname|prototype|syscall|accept|getnetent)\> 0:attribute
-addhl -group /perl/code regex \<(push|sysopen|alarm|getpeername|quotemeta|sysread|atan2|getpgrp|rand|sysseek|getppid|read|system|getpriority|readdir|syswrite|bind)\> 0:attribute
-addhl -group /perl/code regex \<(getprotobyname|readline|tell|binmode|getprotobynumber|readlink|telldir|bless|getprotoent|readpipe|tie|getpwent|recv|tied|caller)\> 0:attribute
-addhl -group /perl/code regex \<(getpwnam|redo|time|chdir|getpwuid|ref|times|getservbyname|rename|truncate|chmod|getservbyport|require|uc|chomp|getservent|reset|ucfirst)\> 0:attribute
-addhl -group /perl/code regex \<(chop|getsockname|umask|chown|getsockopt|reverse|undef|chr|glob|rewinddir|chroot|gmtime|rindex|unlink|close|rmdir|unpack)\> 0:attribute
-addhl -group /perl/code regex \<(closedir|grep|say|unshift|connect|hex|scalar|untie|cos|index|seek|use|crypt|seekdir|utime|dbmclose|int|select|values|dbmopen|ioctl|semctl)\> 0:attribute
-addhl -group /perl/code regex \<(vec|defined|join|semget|wait|delete|keys|semop|waitpid|kill|send|wantarray|die|last|setgrent|warn|dump|lc|sethostent|write|each|lcfirst|setnetent)\> 0:attribute
-
-addhl -group /perl/code regex \<(else|lock|qw|elsif|lt|qx|eq||exp|ne|sub|for|no|my|not|tr|goto|and|foreach|or|break|exit|unless|cmp|ge|package|until|continue|gt|while|if|qq|xor|do|le|qr|return)\> 0:keyword
 
 addhl -group /perl/code regex %{(?:\<[stqrmwy]+)?/[^\n/]*/([msixpodualngecr]+\>)?} 0:magenta
 addhl -group /perl/code regex %{(?:\<[stqrmwy]+)?/[^\n/]+/[^\n/]*/([msixpeodualngcr]+\>)?} 0:magenta

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -28,23 +28,23 @@ addhl -group /perl/comment fill comment
 
 %sh{
     # Grammar
-    keywords="else:lock:qw:elsif:lt:qx:eq:exp:ne:sub:for:no:my:not:tr:goto:and:foreach:or:break:exit:unless:cmp:ge:package:until:continue:gt:while:if:qq:xor:do:le:qr:return"
-    attributes="END:AUTOLOAD:BEGIN:CHECK:UNITCHECK:INIT:DESTROY"
-    attributes="${attributes}:length:setpgrp:endgrent:link:setpriority:endhostent:listen:setprotoent:endnetent:local:setpwent"
-    attributes="${attributes}:endprotoent:localtime:setservent:endpwent:log:setsockopt:endservent:lstat:shift:eof:map:shmctl:eval:mkdir:shmget:exec:msgctl:shmread"
-    attributes="${attributes}:exists:msgget:shmwrite:msgrcv:shutdown:fcntl:msgsnd:sin:fileno:sleep:flock:next:socket:fork:socketpair:format:oct:sort"
-    attributes="${attributes}:formline:open:splice:getc:opendir:split:getgrent:ord:sprintf:getgrgid:our:sqrt:getgrnam:pack:srand:gethostbyaddr:pipe:stat:gethostbyname"
-    attributes="${attributes}:pop:state:gethostent:pos:study:getlogin:print:substr:getnetbyaddr:printf:symlink:abs:getnetbyname:prototype:syscall:accept:getnetent"
-    attributes="${attributes}:push:sysopen:alarm:getpeername:quotemeta:sysread:atan2:getpgrp:rand:sysseek:getppid:read:system:getpriority:readdir:syswrite:bind"
-    attributes="${attributes}:getprotobyname:readline:tell:binmode:getprotobynumber:readlink:telldir:bless:getprotoent:readpipe:tie:getpwent:recv:tied:caller"
-    attributes="${attributes}:getpwnam:redo:time:chdir:getpwuid:ref:times:getservbyname:rename:truncate:chmod:getservbyport:require:uc:chomp:getservent:reset:ucfirst"
-    attributes="${attributes}:chop:getsockname:umask:chown:getsockopt:reverse:undef:chr:glob:rewinddir:chroot:gmtime:rindex:unlink:close:rmdir:unpack"
-    attributes="${attributes}:closedir:grep:say:unshift:connect:hex:scalar:untie:cos:index:seek:use:crypt:seekdir:utime:dbmclose:int:select:values:dbmopen:ioctl:semctl"
-    attributes="${attributes}:vec:defined:join:semget:wait:delete:keys:semop:waitpid:kill:send:wantarray:die:last:setgrent:warn:dump:lc:sethostent:write:each:lcfirst:setnetent"
-    values="ARGV:STDERR:STDOUT:ARGVOUT:STDIN:__DATA__:__END__:__FILE__:__LINE__:__PACKAGE__"
+    keywords="else|lock|qw|elsif|lt|qx|eq|exp|ne|sub|for|no|my|not|tr|goto|and|foreach|or|break|exit|unless|cmp|ge|package|until|continue|gt|while|if|qq|xor|do|le|qr|return"
+    attributes="END|AUTOLOAD|BEGIN|CHECK|UNITCHECK|INIT|DESTROY"
+    attributes="${attributes}|length|setpgrp|endgrent|link|setpriority|endhostent|listen|setprotoent|endnetent|local|setpwent"
+    attributes="${attributes}|endprotoent|localtime|setservent|endpwent|log|setsockopt|endservent|lstat|shift|eof|map|shmctl|eval|mkdir|shmget|exec|msgctl|shmread"
+    attributes="${attributes}|exists|msgget|shmwrite|msgrcv|shutdown|fcntl|msgsnd|sin|fileno|sleep|flock|next|socket|fork|socketpair|format|oct|sort"
+    attributes="${attributes}|formline|open|splice|getc|opendir|split|getgrent|ord|sprintf|getgrgid|our|sqrt|getgrnam|pack|srand|gethostbyaddr|pipe|stat|gethostbyname"
+    attributes="${attributes}|pop|state|gethostent|pos|study|getlogin|print|substr|getnetbyaddr|printf|symlink|abs|getnetbyname|prototype|syscall|accept|getnetent"
+    attributes="${attributes}|push|sysopen|alarm|getpeername|quotemeta|sysread|atan2|getpgrp|rand|sysseek|getppid|read|system|getpriority|readdir|syswrite|bind"
+    attributes="${attributes}|getprotobyname|readline|tell|binmode|getprotobynumber|readlink|telldir|bless|getprotoent|readpipe|tie|getpwent|recv|tied|caller"
+    attributes="${attributes}|getpwnam|redo|time|chdir|getpwuid|ref|times|getservbyname|rename|truncate|chmod|getservbyport|require|uc|chomp|getservent|reset|ucfirst"
+    attributes="${attributes}|chop|getsockname|umask|chown|getsockopt|reverse|undef|chr|glob|rewinddir|chroot|gmtime|rindex|unlink|close|rmdir|unpack"
+    attributes="${attributes}|closedir|grep|say|unshift|connect|hex|scalar|untie|cos|index|seek|use|crypt|seekdir|utime|dbmclose|int|select|values|dbmopen|ioctl|semctl"
+    attributes="${attributes}|vec|defined|join|semget|wait|delete|keys|semop|waitpid|kill|send|wantarray|die|last|setgrent|warn|dump|lc|sethostent|write|each|lcfirst|setnetent"
+    values="ARGV|STDERR|STDOUT|ARGVOUT|STDIN|__DATA__|__END__|__FILE__|__LINE__|__PACKAGE__"
 
     # Add the language's grammar to the static completion list
-    echo "hook global WinSetOption filetype=perl %{
+    sed 's,|,:,g' <<< "hook global WinSetOption filetype=perl %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${values}'
@@ -52,9 +52,9 @@ addhl -group /perl/comment fill comment
 
     # Highlight keywords
     echo "
-        addhl -group /perl/code regex \<(${keywords//:/|})\> 0:keyword
-        addhl -group /perl/code regex \<(${attributes//:/|})\> 0:attribute
-        addhl -group /perl/code regex \<(${values//:/|})\> 0:value
+        addhl -group /perl/code regex \<(${keywords})\> 0:keyword
+        addhl -group /perl/code regex \<(${attributes})\> 0:attribute
+        addhl -group /perl/code regex \<(${values})\> 0:value
     "
 }
 

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -44,14 +44,14 @@ addhl -group /perl/comment fill comment
     values="ARGV|STDERR|STDOUT|ARGVOUT|STDIN|__DATA__|__END__|__FILE__|__LINE__|__PACKAGE__"
 
     # Add the language's grammar to the static completion list
-    sed 's,|,:,g' <<< "hook global WinSetOption filetype=perl %{
+    printf %s "hook global WinSetOption filetype=perl %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${values}'
-    }"
+    }" | sed 's,|,:,g'
 
     # Highlight keywords
-    echo "
+    printf %s "
         addhl -group /perl/code regex \<(${keywords})\> 0:keyword
         addhl -group /perl/code regex \<(${attributes})\> 0:attribute
         addhl -group /perl/code regex \<(${values})\> 0:value

--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -54,17 +54,17 @@ addhl -group /ruby/code regex \<([A-Za-z]\w*:)|([$@][A-Za-z]\w*)|(\W\K:[A-Za-z]\
 
 %sh{
     # Grammar
-    # Keywords are collected searching for keyword_ at
+    # Keywords are collected searching for keywords at
     # https://github.com/ruby/ruby/blob/trunk/parse.y
-    keywords="alias:and:begin:break:case:class:def:defined:do:else:elsif:end"
-    keywords="${keywords}:ensure:false:for:if:in:module:next:nil:not:or:redo"
-    keywords="${keywords}:rescue:retry:return:self:super:then:true:undef:unless:until:when:while:yield"
-    attributes="attr_reader:attr_writer:attr_accessor"
-    values="false:true:nil"
-    meta="require:include"
+    keywords="alias|and|begin|break|case|class|def|defined|do|else|elsif|end"
+    keywords="${keywords}|ensure|false|for|if|in|module|next|nil|not|or|redo"
+    keywords="${keywords}|rescue|retry|return|self|super|then|true|undef|unless|until|when|while|yield"
+    attributes="attr_reader|attr_writer|attr_accessor"
+    values="false|true|nil"
+    meta="require|include"
 
     # Add the language's grammar to the static completion list
-    echo "hook global WinSetOption filetype=ruby %{
+    sed 's,|,:,g' <<< "hook global WinSetOption filetype=ruby %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${values}'
@@ -73,10 +73,10 @@ addhl -group /ruby/code regex \<([A-Za-z]\w*:)|([$@][A-Za-z]\w*)|(\W\K:[A-Za-z]\
 
     # Highlight keywords
     echo "
-        addhl -group /ruby/code regex \<(${keywords//:/|})\> 0:keyword
-        addhl -group /ruby/code regex \<(${attributes//:/|})\> 0:attribute
-        addhl -group /ruby/code regex \<(${values//:/|})\> 0:value
-        addhl -group /ruby/code regex \<(${meta//:/|})\> 0:meta
+        addhl -group /ruby/code regex \<(${keywords})\> 0:keyword
+        addhl -group /ruby/code regex \<(${attributes})\> 0:attribute
+        addhl -group /ruby/code regex \<(${values})\> 0:value
+        addhl -group /ruby/code regex \<(${meta})\> 0:meta
     "
 }
 

--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -51,12 +51,34 @@ addhl -group /ruby/comment fill comment
 addhl -group /ruby/literal fill meta
 
 addhl -group /ruby/code regex \<([A-Za-z]\w*:)|([$@][A-Za-z]\w*)|(\W\K:[A-Za-z]\w*[=?!]?) 0:identifier
-addhl -group /ruby/code regex \<(require|include)\> 0:meta
-addhl -group /ruby/code regex \<(attr_(reader|writer|accessor))\> 0:attribute
 
-# Keywords are collected searching for keyword_ at
-# https://github.com/ruby/ruby/blob/trunk/parse.y
-addhl -group /ruby/code regex \<(alias|and|begin|break|case|class|def|defined|do|else|elsif|end|ensure|false|for|if|in|module|next|nil|not|or|redo|rescue|retry|return|self|super|then|true|undef|unless|until|when|while|yield)\> 0:keyword
+%sh{
+    # Grammar
+    # Keywords are collected searching for keyword_ at
+    # https://github.com/ruby/ruby/blob/trunk/parse.y
+    keywords="alias:and:begin:break:case:class:def:defined:do:else:elsif:end"
+    keywords="${keywords}:ensure:false:for:if:in:module:next:nil:not:or:redo"
+    keywords="${keywords}:rescue:retry:return:self:super:then:true:undef:unless:until:when:while:yield"
+    attributes="attr_reader:attr_writer:attr_accessor"
+    values="false:true:nil"
+    meta="require:include"
+
+    # Add the language's grammar to the static completion list
+    echo "hook global WinSetOption filetype=ruby %{
+        set window static_words '${keywords}'
+        set -add window static_words '${attributes}'
+        set -add window static_words '${values}'
+        set -add window static_words '${meta}'
+    }"
+
+    # Highlight keywords
+    echo "
+        addhl -group /ruby/code regex \<(${keywords//:/|})\> 0:keyword
+        addhl -group /ruby/code regex \<(${attributes//:/|})\> 0:attribute
+        addhl -group /ruby/code regex \<(${values//:/|})\> 0:value
+        addhl -group /ruby/code regex \<(${meta//:/|})\> 0:meta
+    "
+}
 
 # Commands
 # ‾‾‾‾‾‾‾‾

--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -64,15 +64,15 @@ addhl -group /ruby/code regex \<([A-Za-z]\w*:)|([$@][A-Za-z]\w*)|(\W\K:[A-Za-z]\
     meta="require|include"
 
     # Add the language's grammar to the static completion list
-    sed 's,|,:,g' <<< "hook global WinSetOption filetype=ruby %{
+    printf %s "hook global WinSetOption filetype=ruby %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${values}'
         set -add window static_words '${meta}'
-    }"
+    }" | sed 's,|,:,g'
 
     # Highlight keywords
-    echo "
+    printf %s "
         addhl -group /ruby/code regex \<(${keywords})\> 0:keyword
         addhl -group /ruby/code regex \<(${attributes})\> 0:attribute
         addhl -group /ruby/code regex \<(${values})\> 0:value

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -94,23 +94,94 @@ def -hidden _c-family-indent-on-closing-curly-brace %[
 
 # c specific
 addhl -group /c/code regex %{\<NULL\>|\<-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[^'\\])'} 0:value
-addhl -group /c/code regex "\<(void|char|short|int|long|signed|unsigned|float|double|size_t)\>" 0:type
-addhl -group /c/code regex "\<(while|for|if|else|do|switch|case|default|goto|asm|break|continue|return|sizeof)\>" 0:keyword
-addhl -group /c/code regex "\<(const|auto|register|inline|static|volatile|struct|enum|union|typedef|extern|restrict)\>" 0:attribute
+%sh{
+    # Grammar
+    keywords="while:for:if:else:do:switch:case:default:goto:asm:break:continue:return:sizeof"
+    attributes="const:auto:register:inline:static:volatile:struct:enum:union:typedef:extern:restrict"
+    types="void:char:short:int:long:signed:unsigned:float:double:size_t"
+
+    # Add the language's grammar to the static completion list
+    echo "hook global WinSetOption filetype=c %{
+        set window static_words '${keywords}'
+        set -add window static_words '${attributes}'
+        set -add window static_words '${types}'
+    }"
+
+    # Highlight keywords
+    echo "
+        addhl -group /c/code regex \<(${keywords//:/|})\> 0:keyword
+        addhl -group /c/code regex \<(${attributes//:/|})\> 0:attribute
+        addhl -group /c/code regex \<(${types//:/|})\> 0:type
+    "
+}
 
 # c++ specific
-addhl -group /cpp/code regex %{\<(this|true|false|NULL|nullptr|)\>|\<-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[^'\\])'} 0:value
-addhl -group /cpp/code regex "\<(void|char|short|int|long|signed|unsigned|float|double|size_t|bool)\>" 0:type
-addhl -group /cpp/code regex "\<(while|for|if|else|do|switch|case|default|goto|asm|break|continue|return|using|try|catch|throw|new|delete|and|and_eq|or|or_eq|not|operator|explicit|(?:reinterpret|const|static|dynamic)_cast|sizeof|alignof|alignas|decltype)\>" 0:keyword
-addhl -group /cpp/code regex "\<(const|constexpr|mutable|auto|noexcept|namespace|inline|static|volatile|class|struct|enum|union|public|protected|private|template|typedef|virtual|friend|extern|typename|override|final)\>" 0:attribute
+addhl -group /cpp/code regex %{\<-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[^'\\])'} 0:value
+
+%sh{
+    # Grammar
+    keywords="while:for:if:else:do:switch:case:default:goto:asm:break:continue"
+    keywords="${keywords}:return:using:try:catch:throw:new:delete:and:and_eq:or"
+    keywords="${keywords}:or_eq:not:operator:explicit:reinterpret_cast"
+    keywords="${keywords}:const_cast:static_cast:dynamic_cast:sizeof:alignof"
+    keywords="${keywords}:alignas:decltype"
+    attributes="const:constexpr:mutable:auto:noexcept:namespace:inline:static"
+    attributes="${attributes}:volatile:class:struct:enum:union:public:protected"
+    attributes="${attributes}:private:template:typedef:virtual:friend:extern"
+    attributes="${attributes}:typename:override:final"
+    types="void:char:short:int:long:signed:unsigned:float:double:size_t:bool"
+    values="this:true:false:NULL:nullptr"
+
+    # Add the language's grammar to the static completion list
+    echo "hook global WinSetOption filetype=cpp %{
+        set window static_words '${keywords}'
+        set -add window static_words '${attributes}'
+        set -add window static_words '${types}'
+        set -add window static_words '${values}'
+    }"
+
+    # Highlight keywords
+    echo "
+        addhl -group /cpp/code regex \<(${keywords//:/|})\> 0:keyword
+        addhl -group /cpp/code regex \<(${attributes//:/|})\> 0:attribute
+        addhl -group /cpp/code regex \<(${types//:/|})\> 0:type
+        addhl -group /cpp/code regex \<(${values//:/|})\> 0:value
+    "
+}
 
 # objective-c specific
-addhl -group /objc/code regex %{\<(self|nil|id|super|TRUE|FALSE|YES|NO|NULL)\>|\<-?\d+[fdiu]?|'((\\.)?|[^'\\])'} 0:value
-addhl -group /objc/code regex "\<(void|char|short|int|long|signed|unsigned|float|bool|size_t|instancetype|BOOL|NSInteger|NSUInteger|CGFloat|NSString)\>" 0:type
-addhl -group /objc/code regex "\<(while|for|if|else|do|switch|case|default|goto|break|continue|return)\>" 0:keyword
-addhl -group /objc/code regex "\<(const|auto|inline|static|volatile|struct|enum|union|typedef|extern|__block|nonatomic|assign|copy|strong|retain|weak|readonly)\>" 0:attribute
-addhl -group /objc/code regex "@(property|synthesize|interface|implementation|protocol|end|selector|autoreleasepool|try|catch|class|synchronized)\>" 0:attribute
-addhl -group /objc/code regex "\<(IBAction|IBOutlet)\>" 0:attribute
+addhl -group /objc/code regex %{\<-?\d+[fdiu]?|'((\\.)?|[^'\\])'} 0:value
+
+%sh{
+    # Grammar
+    keywords="while:for:if:else:do:switch:case:default:goto:break:continue:return"
+    attributes="const:auto:inline:static:volatile:struct:enum:union:typedef"
+    attributes="${attributes}:extern:__block:nonatomic:assign:copy:strong"
+    attributes="${attributes}:retain:weak:readonly:IBAction:IBOutlet"
+    types="void:char:short:int:long:signed:unsigned:float:bool:size_t"
+    types="${types}:instancetype:BOOL:NSInteger:NSUInteger:CGFloat:NSString"
+    values="self:nil:id:super:TRUE:FALSE:YES:NO:NULL"
+    decorators="property:synthesize:interface:implementation:protocol:end"
+    decorators="${decorators}:selector:autoreleasepool:try:catch:class:synchronized"
+
+    # Add the language's grammar to the static completion list
+    echo "hook global WinSetOption filetype=objc %{
+        set window static_words '${keywords}'
+        set -add window static_words '${attributes}'
+        set -add window static_words '${types}'
+        set -add window static_words '${values}'
+        set -add window static_words '${decorators}'
+    }"
+
+    # Highlight keywords
+    echo "
+        addhl -group /objc/code regex \<(${keywords//:/|})\> 0:keyword
+        addhl -group /objc/code regex \<(${attributes//:/|})\> 0:attribute
+        addhl -group /objc/code regex \<(${types//:/|})\> 0:type
+        addhl -group /objc/code regex \<(${values//:/|})\> 0:value
+        addhl -group /objc/code regex @(${decorators//:/|})\> 0:attribute
+    "
+}
 
 hook global WinSetOption filetype=(c|cpp|objc) %[
     try %{ # we might be switching from one c-family language to another
@@ -128,7 +199,6 @@ hook global WinSetOption filetype=(c|cpp|objc) %[
     alias window alt c-family-alternative-file
 
     set window formatcmd "astyle"
-    set window static_words "void:char:short:int:long:signed:unsigned:float:double:size_t:while:for:if:else:do:switch:case:default:goto:asm:break:continue:return:sizeof:const:auto:register:inline:static:volatile:struct:enum:union:typedef:extern:restrict"
 ]
 
 hook global WinSetOption filetype=(?!(c|cpp|objc)$).* %[

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -96,12 +96,12 @@ def -hidden _c-family-indent-on-closing-curly-brace %[
 addhl -group /c/code regex %{\<NULL\>|\<-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[^'\\])'} 0:value
 %sh{
     # Grammar
-    keywords="while:for:if:else:do:switch:case:default:goto:asm:break:continue:return:sizeof"
-    attributes="const:auto:register:inline:static:volatile:struct:enum:union:typedef:extern:restrict"
-    types="void:char:short:int:long:signed:unsigned:float:double:size_t"
+    keywords="while|for|if|else|do|switch|case|default|goto|asm|break|continue|return|sizeof"
+    attributes="const|auto|register|inline|static|volatile|struct|enum|union|typedef|extern|restrict"
+    types="void|char|short|int|long|signed|unsigned|float|double|size_t"
 
     # Add the language's grammar to the static completion list
-    echo "hook global WinSetOption filetype=c %{
+    sed 's,|,:,g' <<< "hook global WinSetOption filetype=c %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${types}'
@@ -109,9 +109,9 @@ addhl -group /c/code regex %{\<NULL\>|\<-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[
 
     # Highlight keywords
     echo "
-        addhl -group /c/code regex \<(${keywords//:/|})\> 0:keyword
-        addhl -group /c/code regex \<(${attributes//:/|})\> 0:attribute
-        addhl -group /c/code regex \<(${types//:/|})\> 0:type
+        addhl -group /c/code regex \<(${keywords})\> 0:keyword
+        addhl -group /c/code regex \<(${attributes})\> 0:attribute
+        addhl -group /c/code regex \<(${types})\> 0:type
     "
 }
 
@@ -120,20 +120,20 @@ addhl -group /cpp/code regex %{\<-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[^'\\])'
 
 %sh{
     # Grammar
-    keywords="while:for:if:else:do:switch:case:default:goto:asm:break:continue"
-    keywords="${keywords}:return:using:try:catch:throw:new:delete:and:and_eq:or"
-    keywords="${keywords}:or_eq:not:operator:explicit:reinterpret_cast"
-    keywords="${keywords}:const_cast:static_cast:dynamic_cast:sizeof:alignof"
-    keywords="${keywords}:alignas:decltype"
-    attributes="const:constexpr:mutable:auto:noexcept:namespace:inline:static"
-    attributes="${attributes}:volatile:class:struct:enum:union:public:protected"
-    attributes="${attributes}:private:template:typedef:virtual:friend:extern"
-    attributes="${attributes}:typename:override:final"
-    types="void:char:short:int:long:signed:unsigned:float:double:size_t:bool"
-    values="this:true:false:NULL:nullptr"
+    keywords="while|for|if|else|do|switch|case|default|goto|asm|break|continue"
+    keywords="${keywords}|return|using|try|catch|throw|new|delete|and|and_eq|or"
+    keywords="${keywords}|or_eq|not|operator|explicit|reinterpret_cast"
+    keywords="${keywords}|const_cast|static_cast|dynamic_cast|sizeof|alignof"
+    keywords="${keywords}|alignas|decltype"
+    attributes="const|constexpr|mutable|auto|noexcept|namespace|inline|static"
+    attributes="${attributes}|volatile|class|struct|enum|union|public|protected"
+    attributes="${attributes}|private|template|typedef|virtual|friend|extern"
+    attributes="${attributes}|typename|override|final"
+    types="void|char|short|int|long|signed|unsigned|float|double|size_t|bool"
+    values="this|true|false|NULL|nullptr"
 
     # Add the language's grammar to the static completion list
-    echo "hook global WinSetOption filetype=cpp %{
+    sed 's,|,:,g' <<< "hook global WinSetOption filetype=cpp %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${types}'
@@ -142,10 +142,10 @@ addhl -group /cpp/code regex %{\<-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[^'\\])'
 
     # Highlight keywords
     echo "
-        addhl -group /cpp/code regex \<(${keywords//:/|})\> 0:keyword
-        addhl -group /cpp/code regex \<(${attributes//:/|})\> 0:attribute
-        addhl -group /cpp/code regex \<(${types//:/|})\> 0:type
-        addhl -group /cpp/code regex \<(${values//:/|})\> 0:value
+        addhl -group /cpp/code regex \<(${keywords})\> 0:keyword
+        addhl -group /cpp/code regex \<(${attributes})\> 0:attribute
+        addhl -group /cpp/code regex \<(${types})\> 0:type
+        addhl -group /cpp/code regex \<(${values})\> 0:value
     "
 }
 
@@ -154,18 +154,18 @@ addhl -group /objc/code regex %{\<-?\d+[fdiu]?|'((\\.)?|[^'\\])'} 0:value
 
 %sh{
     # Grammar
-    keywords="while:for:if:else:do:switch:case:default:goto:break:continue:return"
-    attributes="const:auto:inline:static:volatile:struct:enum:union:typedef"
-    attributes="${attributes}:extern:__block:nonatomic:assign:copy:strong"
-    attributes="${attributes}:retain:weak:readonly:IBAction:IBOutlet"
-    types="void:char:short:int:long:signed:unsigned:float:bool:size_t"
-    types="${types}:instancetype:BOOL:NSInteger:NSUInteger:CGFloat:NSString"
-    values="self:nil:id:super:TRUE:FALSE:YES:NO:NULL"
-    decorators="property:synthesize:interface:implementation:protocol:end"
-    decorators="${decorators}:selector:autoreleasepool:try:catch:class:synchronized"
+    keywords="while|for|if|else|do|switch|case|default|goto|break|continue|return"
+    attributes="const|auto|inline|static|volatile|struct|enum|union|typedef"
+    attributes="${attributes}|extern|__block|nonatomic|assign|copy|strong"
+    attributes="${attributes}|retain|weak|readonly|IBAction|IBOutlet"
+    types="void|char|short|int|long|signed|unsigned|float|bool|size_t"
+    types="${types}|instancetype|BOOL|NSInteger|NSUInteger|CGFloat|NSString"
+    values="self|nil|id|super|TRUE|FALSE|YES|NO|NULL"
+    decorators="property|synthesize|interface|implementation|protocol|end"
+    decorators="${decorators}|selector|autoreleasepool|try|catch|class|synchronized"
 
     # Add the language's grammar to the static completion list
-    echo "hook global WinSetOption filetype=objc %{
+    sed 's,|,:,g' <<< "hook global WinSetOption filetype=objc %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${types}'
@@ -175,11 +175,11 @@ addhl -group /objc/code regex %{\<-?\d+[fdiu]?|'((\\.)?|[^'\\])'} 0:value
 
     # Highlight keywords
     echo "
-        addhl -group /objc/code regex \<(${keywords//:/|})\> 0:keyword
-        addhl -group /objc/code regex \<(${attributes//:/|})\> 0:attribute
-        addhl -group /objc/code regex \<(${types//:/|})\> 0:type
-        addhl -group /objc/code regex \<(${values//:/|})\> 0:value
-        addhl -group /objc/code regex @(${decorators//:/|})\> 0:attribute
+        addhl -group /objc/code regex \<(${keywords})\> 0:keyword
+        addhl -group /objc/code regex \<(${attributes})\> 0:attribute
+        addhl -group /objc/code regex \<(${types})\> 0:type
+        addhl -group /objc/code regex \<(${values})\> 0:value
+        addhl -group /objc/code regex @(${decorators})\> 0:attribute
     "
 }
 

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -101,14 +101,14 @@ addhl -group /c/code regex %{\<NULL\>|\<-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[
     types="void|char|short|int|long|signed|unsigned|float|double|size_t"
 
     # Add the language's grammar to the static completion list
-    sed 's,|,:,g' <<< "hook global WinSetOption filetype=c %{
+    printf %s "hook global WinSetOption filetype=c %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${types}'
-    }"
+    }" | sed 's,|,:,g'
 
     # Highlight keywords
-    echo "
+    printf %s "
         addhl -group /c/code regex \<(${keywords})\> 0:keyword
         addhl -group /c/code regex \<(${attributes})\> 0:attribute
         addhl -group /c/code regex \<(${types})\> 0:type
@@ -133,15 +133,15 @@ addhl -group /cpp/code regex %{\<-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[^'\\])'
     values="this|true|false|NULL|nullptr"
 
     # Add the language's grammar to the static completion list
-    sed 's,|,:,g' <<< "hook global WinSetOption filetype=cpp %{
+    printf %s "hook global WinSetOption filetype=cpp %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${types}'
         set -add window static_words '${values}'
-    }"
+    }" | sed 's,|,:,g'
 
     # Highlight keywords
-    echo "
+    printf %s "
         addhl -group /cpp/code regex \<(${keywords})\> 0:keyword
         addhl -group /cpp/code regex \<(${attributes})\> 0:attribute
         addhl -group /cpp/code regex \<(${types})\> 0:type
@@ -165,16 +165,16 @@ addhl -group /objc/code regex %{\<-?\d+[fdiu]?|'((\\.)?|[^'\\])'} 0:value
     decorators="${decorators}|selector|autoreleasepool|try|catch|class|synchronized"
 
     # Add the language's grammar to the static completion list
-    sed 's,|,:,g' <<< "hook global WinSetOption filetype=objc %{
+    printf %s "hook global WinSetOption filetype=objc %{
         set window static_words '${keywords}'
         set -add window static_words '${attributes}'
         set -add window static_words '${types}'
         set -add window static_words '${values}'
         set -add window static_words '${decorators}'
-    }"
+    }" | sed 's,|,:,g'
 
     # Highlight keywords
-    echo "
+    printf %s "
         addhl -group /objc/code regex \<(${keywords})\> 0:keyword
         addhl -group /objc/code regex \<(${attributes})\> 0:attribute
         addhl -group /objc/code regex \<(${types})\> 0:type

--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -10,21 +10,21 @@ addhl -group / regions -default code kakrc \
 
 %sh{
     # Grammar
-    keywords="hook:rmhooks:addhl:rmhl:exec:eval:source:runtime:def:alias"
-    keywords="${keywords}:unalias:decl:echo:edit:set:map:face:prompt:menu:info"
-    keywords="${keywords}:try:catch:nameclient:namebuf:cd:colorscheme"
-    values="default:black:red:green:yellow:blue:magenta:cyan:white"
+    keywords="hook|rmhooks|addhl|rmhl|exec|eval|source|runtime|def|alias"
+    keywords="${keywords}|unalias|decl|echo|edit|set|map|face|prompt|menu|info"
+    keywords="${keywords}|try|catch|nameclient|namebuf|cd|colorscheme"
+    values="default|black|red|green|yellow|blue|magenta|cyan|white"
 
     # Add the language's grammar to the static completion list
-    echo "hook global WinSetOption filetype=kak %{
+    sed 's,|,:,g' <<< "hook global WinSetOption filetype=kak %{
         set window static_words '${keywords}'
         set -add window static_words '${values}'
     }"
 
     # Highlight keywords
     echo "
-        addhl -group /kakrc/code regex \<(${keywords//:/|})\> 0:keyword
-        addhl -group /kakrc/code regex \<(${values//:/|})\> 0:value
+        addhl -group /kakrc/code regex \<(${keywords})\> 0:keyword
+        addhl -group /kakrc/code regex \<(${values})\> 0:value
     "
 }
 

--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -16,13 +16,13 @@ addhl -group / regions -default code kakrc \
     values="default|black|red|green|yellow|blue|magenta|cyan|white"
 
     # Add the language's grammar to the static completion list
-    sed 's,|,:,g' <<< "hook global WinSetOption filetype=kak %{
+    printf %s "hook global WinSetOption filetype=kak %{
         set window static_words '${keywords}'
         set -add window static_words '${values}'
-    }"
+    }" | sed 's,|,:,g'
 
     # Highlight keywords
-    echo "
+    printf %s "
         addhl -group /kakrc/code regex \<(${keywords})\> 0:keyword
         addhl -group /kakrc/code regex \<(${values})\> 0:value
     "

--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -8,8 +8,27 @@ addhl -group / regions -default code kakrc \
     single_string %{(^|\h)'} %{(?<!\\)(\\\\)*'} '' \
     shell '%sh\{' '\}' '\{'
 
-addhl -group /kakrc/code regex \<(hook|rmhooks|addhl|rmhl|exec|eval|source|runtime|def|alias|unalias|decl|echo|edit|set|map|face|prompt|menu|info|try|catch|nameclient|namebuf|cd|colorscheme)\> 0:keyword
-addhl -group /kakrc/code regex \<(default|black|red|green|yellow|blue|magenta|cyan|white|(?:rgb:[0-9a-fA-F]{6}))\> 0:value
+%sh{
+    # Grammar
+    keywords="hook:rmhooks:addhl:rmhl:exec:eval:source:runtime:def:alias"
+    keywords="${keywords}:unalias:decl:echo:edit:set:map:face:prompt:menu:info"
+    keywords="${keywords}:try:catch:nameclient:namebuf:cd:colorscheme"
+    values="default:black:red:green:yellow:blue:magenta:cyan:white"
+
+    # Add the language's grammar to the static completion list
+    echo "hook global WinSetOption filetype=kak %{
+        set window static_words '${keywords}'
+        set -add window static_words '${values}'
+    }"
+
+    # Highlight keywords
+    echo "
+        addhl -group /kakrc/code regex \<(${keywords//:/|})\> 0:keyword
+        addhl -group /kakrc/code regex \<(${values//:/|})\> 0:value
+    "
+}
+
+addhl -group /kakrc/code regex \<rgb:[0-9a-fA-F]{6}\> 0:value
 addhl -group /kakrc/code regex (?:\<hook)\h+(?:(global|buffer|window)|(\S+))\h+(\S+)\h+(\S+)? 1:attribute 2:error 3:identifier 4:string
 addhl -group /kakrc/code regex (?:\<set)\h+(?:(global|buffer|window)|(\S+))\h+(\S+)\h+(\S+)? 1:attribute 2:error 3:identifier 4:string
 addhl -group /kakrc/code regex (?:\<map)\h+(?:(global|buffer|window)|(\S+))\h+(?:(normal|insert|prompt|menu)|(\S+))\h+(\S+)\h+(\S+)? 1:attribute 2:error 3:attribute 4:error 5:identifier 6:string

--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -28,14 +28,14 @@ addhl -group /python/comment       fill comment
 
 %sh{
     # Grammar
-    values="True:False:None"
-    meta="import:from"
+    values="True|False|None"
+    meta="import|from"
     # Keyword list is collected using `keyword.kwlist` from `keyword`
-    keywords="and:as:assert:break:class:continue:def:del:elif:else:except:exec:finally:for:global:if:in:is:lambda:not:or:pass:print:raise:return:try:while:with:yield"
-    types="bool:buffer:bytearray:complex:dict:file:float:frozenset:int:list:long:memoryview:object:set:str:tuple:unicode:xrange"
+    keywords="and|as|assert|break|class|continue|def|del|elif|else|except|exec|finally|for|global|if|in|is|lambda|not|or|pass|print|raise|return|try|while|with|yield"
+    types="bool|buffer|bytearray|complex|dict|file|float|frozenset|int|list|long|memoryview|object|set|str|tuple|unicode|xrange"
 
     # Add the language's grammar to the static completion list
-    echo "hook global WinSetOption filetype=python %{
+    sed 's,|,:,g' <<< "hook global WinSetOption filetype=python %{
         set window static_words '${values}'
         set -add window static_words '${meta}'
         set -add window static_words '${keywords}'
@@ -44,13 +44,13 @@ addhl -group /python/comment       fill comment
 
     # Highlight keywords
     echo "
-        addhl -group /python/code regex '\<(${values//:/|})\>' 0:value
-        addhl -group /python/code regex '\<(${meta//:/|})\>' 0:meta
-        addhl -group /python/code regex '\<(${keywords//:/|})\>' 0:keyword
+        addhl -group /python/code regex '\<(${values})\>' 0:value
+        addhl -group /python/code regex '\<(${meta})\>' 0:meta
+        addhl -group /python/code regex '\<(${keywords})\>' 0:keyword
     "
 
     # Highlight types, when they are not used as constructors
-    echo "addhl -group /python/code regex '\<(${types//:/|})\>[^(]' 1:type"
+    echo "addhl -group /python/code regex '\<(${types})\>[^(]' 1:type"
 }
 
 # Commands

--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -35,22 +35,22 @@ addhl -group /python/comment       fill comment
     types="bool|buffer|bytearray|complex|dict|file|float|frozenset|int|list|long|memoryview|object|set|str|tuple|unicode|xrange"
 
     # Add the language's grammar to the static completion list
-    sed 's,|,:,g' <<< "hook global WinSetOption filetype=python %{
+    printf %s "hook global WinSetOption filetype=python %{
         set window static_words '${values}'
         set -add window static_words '${meta}'
         set -add window static_words '${keywords}'
         set -add window static_words '${types}'
-    }"
+    }" | sed 's,|,:,g'
 
     # Highlight keywords
-    echo "
+    printf %s "
         addhl -group /python/code regex '\<(${values})\>' 0:value
         addhl -group /python/code regex '\<(${meta})\>' 0:meta
         addhl -group /python/code regex '\<(${keywords})\>' 0:keyword
     "
 
     # Highlight types, when they are not used as constructors
-    echo "addhl -group /python/code regex '\<(${types})\>[^(]' 1:type"
+    printf %s "addhl -group /python/code regex '\<(${types})\>[^(]' 1:type"
 }
 
 # Commands

--- a/rc/core/sh.kak
+++ b/rc/core/sh.kak
@@ -24,7 +24,7 @@ addhl -group /sh/comment fill comment
     keywords="${keywords}|time|type|typeset|ulimit|unalias|until|while"
 
     # Add the language's grammar to the static completion list
-    printf %s "hook global WinSetOption filetype=sh %{
+    printf %s\\n "hook global WinSetOption filetype=sh %{
         set window static_words '${keywords}'
     }" | sed 's,|,:,g'
 

--- a/rc/core/sh.kak
+++ b/rc/core/sh.kak
@@ -24,14 +24,12 @@ addhl -group /sh/comment fill comment
     keywords="${keywords}|time|type|typeset|ulimit|unalias|until|while"
 
     # Add the language's grammar to the static completion list
-    sed 's,|,:,g' <<< "hook global WinSetOption filetype=sh %{
+    printf %s "hook global WinSetOption filetype=sh %{
         set window static_words '${keywords}'
-    }"
+    }" | sed 's,|,:,g'
 
     # Highlight keywords
-    echo "
-        addhl -group /sh/code regex \<(${keywords})\> 0:keyword
-    "
+    printf %s "addhl -group /sh/code regex \<(${keywords})\> 0:keyword"
 }
 
 addhl -group /sh/code regex [\[\]\(\)&|]{2}|\[\s|\s\] 0:operator

--- a/rc/core/sh.kak
+++ b/rc/core/sh.kak
@@ -17,20 +17,20 @@ addhl -group /sh/comment fill comment
 
 %sh{
     # Grammar
-    keywords="alias:bind:builtin:caller:case:cd:command:coproc:declare:do:done"
-    keywords="${keywords}:echo:elif:else:enable:esac:exit:fi:for:function:help"
-    keywords="${keywords}:if:in:let:local:logout:mapfile:printf:read:readarray"
-    keywords="${keywords}:readonly:return:select:set:shift:source:test:then"
-    keywords="${keywords}:time:type:typeset:ulimit:unalias:until:while"
+    keywords="alias|bind|builtin|caller|case|cd|command|coproc|declare|do|done"
+    keywords="${keywords}|echo|elif|else|enable|esac|exit|fi|for|function|help"
+    keywords="${keywords}|if|in|let|local|logout|mapfile|printf|read|readarray"
+    keywords="${keywords}|readonly|return|select|set|shift|source|test|then"
+    keywords="${keywords}|time|type|typeset|ulimit|unalias|until|while"
 
     # Add the language's grammar to the static completion list
-    echo "hook global WinSetOption filetype=sh %{
+    sed 's,|,:,g' <<< "hook global WinSetOption filetype=sh %{
         set window static_words '${keywords}'
     }"
 
     # Highlight keywords
     echo "
-        addhl -group /sh/code regex \<(${keywords//:/|})\> 0:keyword
+        addhl -group /sh/code regex \<(${keywords})\> 0:keyword
     "
 }
 

--- a/rc/core/sh.kak
+++ b/rc/core/sh.kak
@@ -15,7 +15,25 @@ addhl -group /sh/double_string fill string
 addhl -group /sh/single_string fill string
 addhl -group /sh/comment fill comment
 
-addhl -group /sh/code regex \<(alias|bind|builtin|caller|case|cd|command|coproc|declare|do|done|echo|elif|else|enable|esac|exit|fi|for|function|help|if|in|let|local|logout|mapfile|printf|read|readarray|readonly|return|select|set|shift|source|test|then|time|type|typeset|ulimit|unalias|until|while)\> 0:keyword
+%sh{
+    # Grammar
+    keywords="alias:bind:builtin:caller:case:cd:command:coproc:declare:do:done"
+    keywords="${keywords}:echo:elif:else:enable:esac:exit:fi:for:function:help"
+    keywords="${keywords}:if:in:let:local:logout:mapfile:printf:read:readarray"
+    keywords="${keywords}:readonly:return:select:set:shift:source:test:then"
+    keywords="${keywords}:time:type:typeset:ulimit:unalias:until:while"
+
+    # Add the language's grammar to the static completion list
+    echo "hook global WinSetOption filetype=sh %{
+        set window static_words '${keywords}'
+    }"
+
+    # Highlight keywords
+    echo "
+        addhl -group /sh/code regex \<(${keywords//:/|})\> 0:keyword
+    "
+}
+
 addhl -group /sh/code regex [\[\]\(\)&|]{2}|\[\s|\s\] 0:operator
 addhl -group /sh/code regex (\w+)= 1:identifier
 addhl -group /sh/code regex ^\h*(\w+)\h*\(\) 1:identifier


### PR DESCRIPTION
This commit also sets `autopep8` as the default python formatter.

I haven't modified the files that support languages I don't use, it was tedious enough to modify the ones in `core` and `base`.