### PR TITLE
Expose cursor_byte_offset env variable

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -712,6 +712,7 @@ Some of Kakoune state is available through environment variables:
  * `kak_cursor_line`: line of the end of the main selection
  * `kak_cursor_column`: column of the end of the main selection (in byte)
  * `kak_cursor_char_column`: column of the end of the main selection (in character)
+ * `kak_cursor_byte_offset`: offset of the main selection from the beginning of the buffer (in byte).
  * `kak_window_width`: width of the current kakoune window
  * `kak_window_height`: height of the current kakoune window
  * `kak_hook_param`: filtering text passed to the currently executing hook

--- a/src/main.cc
+++ b/src/main.cc
@@ -115,6 +115,11 @@ void register_env_vars()
             { auto coord = context.selections().main().cursor();
               return to_string(context.buffer()[coord.line].char_count_to(coord.column) + 1); }
         }, {
+            "cursor_byte_offset", false,
+            [](StringView name, const Context& context) -> String
+            { auto cursor = context.selections().main().cursor();
+              return to_string(context.buffer().distance(context.buffer().begin().coord(), cursor)); }
+        }, {
             "selection_desc", false,
             [](StringView name, const Context& context)
             { return selection_to_string(context.selections().main()); }


### PR DESCRIPTION
Expose a new environment variable `cursor_byte_offset` which is the position of the cursor in bytes from the start of the buffer.

It can be used to integrate third party tools like `godef`, for example:

```
def -allow-override godef %{
	%sh{
		output=$(mktemp -d -t kak-temp-XXXXXXXX)/fifo
		mkfifo ${output}
		(godef -t -f ${kak_buffile} -o ${kak_cursor_byte_offset} > ${output}) > /dev/null 2>&1 < /dev/null &
		result=$(cat $output | grep -v '^/')
		echo "info -anchor ${kak_cursor_line}.${kak_cursor_column} -placement above %{ $result }"
        }
}
```