### PR TITLE
Add dash and underscore text objects

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -527,6 +527,8 @@ object you want.
  * `"`: select the enclosing double quoted string
  * `'`: select the enclosing single quoted string
  * ```: select the enclosing grave quoted string
+ * `-` or `d`: select the enclosing kebab-case word
+ * `_` or `l`: select the enclosing snake_case word
  * `w`: select the whole word
  * `W`: select the whole WORD
  * `s`: select the sentence

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -986,6 +986,8 @@ void select_object(Context& context, NormalParams params)
             { "\"", "\"", 'Q' },
             { "'", "'", 'q' },
             { "`", "`", 'g' },
+            { "-", "-", 'd' },
+            { "_", "_", 'l' },
         };
         for (auto& sur : surrounding_pairs)
         {
@@ -1004,6 +1006,8 @@ void select_object(Context& context, NormalParams params)
     "\",Q:  double quote string\n"
     "',q:  single quote string\n"
     "`,g:  grave quote string \n"
+    "-,d:  dash               \n"
+    "_,l:  underscore         \n"
     "w:    word               \n"
     "W:    WORD               \n"
     "s:    sentence           \n"


### PR DESCRIPTION
Hi

Those text objects are quite useful when dealing with:
- `kebab-case-variable-name` as it's usually the case in LISP languages
- `snake_case_variable_name` as found in Ruby or Markdown for example

The `d` letter stands for **d**ash, the letter u was already taken, so `l` stands for **l**ow dash