### PR TITLE
[RFC] CLI front-end restructuring

### DIFF
--- a/doc/kak.1.txt
+++ b/doc/kak.1.txt
@@ -7,7 +7,7 @@ kak - a vim inspired, selection oriented code editor
 
 SYNOPSIS
 --------
-*kak* [-n] [-l] [-e command] [-mode filter -ks command [-q]] [-s session_name] [-c -s session_name]|[-mode daemon -s session_name] file ...
+*kak* [-n] [-l] [-e command] [-f keystrokes [-q]] [-s session_name] [-c session_name]|[-mode daemon|dummy|json|ncurses|stdin] -s session_name] file ...
 
 DESCRIPTION
 -----------
@@ -27,7 +27,7 @@ stays fixed and the cursor one moves around.
 OPTIONS
 -------
 
--nc::
+--norc::
 	do not source kakrc files on startup
 
 -l::
@@ -40,9 +40,9 @@ OPTIONS
 	execute argument on initialisation
 
 -s <session_name>::
-	set session name
+	set session name for new sessions
 
--c -s <session_name>::
+-c <session_name>::
 	connect to given session
 
 -mode daemon::
@@ -57,14 +57,11 @@ OPTIONS
 -mode dummy::
 	use a dummy user interface, for testing purposes
 
--mode filter::
-	run kak on files in a scriptable fashion
-
--ks <keystrokes>::
-	in filter mode (-mode filter), keystrokes to send to kak for given files
+-f <keystrokes>::
+	run kak as a script on given files, accepts keystrokes to send to kak
 
 -q::
-	in filter mode (-mode filter), be quiet about errors applying keys
+	(with -f mode only), be quiet about errors applying keys
 
 file::
 	one or more files to edit
@@ -87,7 +84,7 @@ kak /path/to/file::
 kak ./file1.txt /path/to/file2.c::
 	Edit multiple files (multiple buffers will be created)
 
-kak -mode filter -f "ggO// kak: tabstop=8<esc>" *.c::
+kak -f "ggO// kak: tabstop=8<esc>" *.c::
 	Insert a modeline that sets the tabstop variable at the beginning of several source code files
 
 kak -e "man dup2"::

--- a/doc/kak.1.txt
+++ b/doc/kak.1.txt
@@ -7,7 +7,7 @@ kak - a vim inspired, selection oriented code editor
 
 SYNOPSIS
 --------
-*kak* [-q] [-u] [-n] [-l] [-e command] [-f command] [-p session_id] [-c session_id|[[-d] -s session_id] file ...
+*kak* [-n] [-l] [-e command] [-mode filter -ks command [-q]] [-s session_name] [-c -s session_name]|[-mode daemon -s session_name] file ...
 
 DESCRIPTION
 -----------
@@ -26,35 +26,45 @@ stays fixed and the cursor one moves around.
 
 OPTIONS
 -------
--q::
-	in filter mode, be quiet about errors applying keys
 
--u::
-	use a dummy user interface, for testing purposes
-
--n::
+-nc::
 	do not source kakrc files on startup
 
 -l::
 	list existing sessions
 
--d::
-	run as a headless session (requires -s)
+-prune::
+	prune dead / stale sessions
 
 -e <command>::
 	execute argument on initialisation
 
--f <command>::
-	act as a filter, executing given keys on given files
+-s <session_name>::
+	set session name
 
--p <session_id>::
-	just send stdin as commands to the given session
-
--c <session_id>::
+-c -s <session_name>::
 	connect to given session
 
--s <session_id>::
-	set session name
+-mode daemon::
+	run as a headless session (requires -s)
+
+-mode stdin -s <session_name>::
+	just send stdin as commands to the given session
+
+-mode json -s <session_name>::
+	open json-rpc connection to session
+
+-mode dummy::
+	use a dummy user interface, for testing purposes
+
+-mode filter::
+	run kak on files in a scriptable fashion
+
+-ks <keystrokes>::
+	in filter mode (-mode filter), keystrokes to send to kak for given files
+
+-q::
+	in filter mode (-mode filter), be quiet about errors applying keys
 
 file::
 	one or more files to edit
@@ -77,7 +87,7 @@ kak /path/to/file::
 kak ./file1.txt /path/to/file2.c::
 	Edit multiple files (multiple buffers will be created)
 
-kak -f "ggO// kak: tabstop=8<esc>" *.c::
+kak -mode filter -f "ggO// kak: tabstop=8<esc>" *.c::
 	Insert a modeline that sets the tabstop variable at the beginning of several source code files
 
 kak -e "man dup2"::

--- a/src/main.cc
+++ b/src/main.cc
@@ -278,6 +278,8 @@ enum class UIType
     NCurses,
     Json,
     Dummy,
+    Stdin,
+    Filter,
 };
 
 static Client* local_client = nullptr;
@@ -680,7 +682,7 @@ int run_filter(StringView keystr, StringView commands, ConstArrayView<StringView
     return 0;
 }
 
-int run_pipe(StringView session)
+int run_pipe(const StringView session)
 {
     char buf[512];
     String command;
@@ -721,19 +723,23 @@ int main(int argc, char* argv[])
     for (size_t i = 1; i < argc; ++i)
         params.push_back(argv[i]);
 
-    const ParameterDesc param_desc{
-        SwitchMap{ { "c", { true,  "connect to given session" } },
-                   { "e", { true,  "execute argument on initialisation" } },
-                   { "n", { false, "do not source kakrc files on startup" } },
-                   { "s", { true,  "set session name" } },
-                   { "d", { false, "run as a headless session (requires -s)" } },
-                   { "p", { true,  "just send stdin as commands to the given session" } },
-                   { "f", { true,  "act as a filter, executing given keys on given files" } },
-                   { "q", { false, "in filter mode, be quiet about errors applying keys" } },
-                   { "ui", { true, "set the type of user interface to use (ncurses, dummy, or json)" } },
-                   { "l", { false, "list existing sessions" } },
-                   { "clear", { false, "clear dead sessions" } } }
-    };
+    const ParameterDesc param_desc{SwitchMap{
+        {"m",
+         {true,
+          "Mode to run. Accepted options: "
+          "json, dummy, stdin, filter, daemon (headless), ncurses (default)"}},
+        {"c", {false, "connect to a running session"}},
+        {"s",
+         {true,
+          "specify session name when creating or connecting to sessions"}},
+        {"e", {true, "execute argument on initialisation"}},
+        {"nc", {false, "do not source kakrc files on startup"}},
+        {"l", {false, "list existing sessions"}},
+        {"prune", {false, "prune dead / stale sessions"}},
+        {"q", {false, "(filter-mode) run in quiet mode"}},
+        {"ks", {false, "(filter-mode) keystrokes to run in filter session"}},
+        {"h", {false, "print this help message"}},
+    }};
     try
     {
         std::sort(keymap.begin(), keymap.end(),
@@ -742,9 +748,14 @@ int main(int argc, char* argv[])
 
         ParametersParser parser(params, param_desc);
 
+        if ((bool)parser.get_switch('h')) {
+            write_stdout(generate_switches_doc(param_desc.switches));
+            return 0;
+        }
+
         const bool list_sessions = (bool)parser.get_switch("l");
-        const bool clear_sessions = (bool)parser.get_switch("clear");
-        if (list_sessions or clear_sessions)
+        const bool prune_sessions = (bool)parser.get_switch("prune");
+        if (list_sessions or prune_sessions)
         {
             StringView username = getpwuid(geteuid())->pw_name;
             for (auto& session : list_files(format("/tmp/kakoune/{}/", username)))
@@ -752,7 +763,7 @@ int main(int argc, char* argv[])
                 const bool valid = check_session(session);
                 if (list_sessions)
                     write_stdout(format("{}{}\n", session, valid ? "" : " (dead)"));
-                if (not valid and clear_sessions)
+                if (not valid and prune_sessions)
                 {
                     char socket_file[128];
                     format_to(socket_file, "/tmp/kakoune/{}/{}", username, session);
@@ -762,44 +773,41 @@ int main(int argc, char* argv[])
             return 0;
         }
 
-        if (auto session = parser.get_switch("p"))
+        const StringView session = parser.get_switch("s").value_or(StringView{});
+        auto init_command = parser.get_switch("e").value_or(StringView{});
+        auto ui_name = parser.get_switch("m").value_or("ncurses");
+
+        if (ui_name == "stdin")
         {
-            for (auto opt : { "c", "n", "s", "d", "e" })
-            {
-                if (parser.get_switch(opt))
-                {
-                    write_stderr(format("error: -{} makes not sense with -p\n", opt));
-                    return -1;
-                }
-            }
-            return run_pipe(*session);
+            return run_pipe(session);
         }
 
-        auto init_command = parser.get_switch("e").value_or(StringView{});
-        auto ui_name = parser.get_switch("ui").value_or("ncurses");
         UIType ui_type;
         if (ui_name == "ncurses") ui_type = UIType::NCurses;
         else if (ui_name == "json") ui_type = UIType::Json;
         else if (ui_name == "dummy") ui_type = UIType::Dummy;
+        else if (ui_name == "daemon" || ui_name == "filter" || ui_name == "stdin" ) ;
         else
         {
             write_stderr(format("error: unknown ui type: '{}'", ui_name));
             return -1;
         }
 
-
-        if (auto keys = parser.get_switch("f"))
+        if (ui_name == "filter") 
         {
-            Vector<StringView> files;
-            for (size_t i = 0; i < parser.positional_count(); ++i)
-                files.emplace_back(parser[i]);
+            if (auto keys = parser.get_switch("ks"))
+            {
+                Vector<StringView> files;
+                for (size_t i = 0; i < parser.positional_count(); ++i)
+                    files.emplace_back(parser[i]);
 
-            return run_filter(*keys, init_command, files, (bool)parser.get_switch("q"));
+                return run_filter(*keys, init_command, files, (bool)parser.get_switch("q"));
+            }
         }
 
-        if (auto server_session = parser.get_switch("c"))
+        if ((bool)parser.get_switch("c"))
         {
-            for (auto opt : { "n", "s", "d" })
+            for (auto opt : { "nc" })
             {
                 if (parser.get_switch(opt))
                 {
@@ -811,7 +819,7 @@ int main(int argc, char* argv[])
             for (auto name : parser)
                 new_files += format("edit '{}';", escape(real_path(name), "'", '\\'));
 
-            return run_client(*server_session, new_files + init_command, ui_type);
+            return run_client(session, new_files + init_command, ui_type);
         }
         else
         {
@@ -835,12 +843,11 @@ int main(int argc, char* argv[])
                 files.emplace_back(name);
             }
 
-            StringView session = parser.get_switch("s").value_or(StringView{});
             try
             {
                 return run_server(session, init_command,
-                                  (bool)parser.get_switch("n"),
-                                  (bool)parser.get_switch("d"),
+                                  (bool)parser.get_switch("nc"),
+                                  ui_name == "daemon",
                                   ui_type, files, target_coord);
             }
             catch (convert_to_client_mode& convert)

--- a/src/main.cc
+++ b/src/main.cc
@@ -279,7 +279,6 @@ enum class UIType
     Json,
     Dummy,
     Stdin,
-    Filter,
 };
 
 static Client* local_client = nullptr;
@@ -727,7 +726,7 @@ int main(int argc, char* argv[])
         {"m",
          {true,
           "Mode to run. Accepted options: "
-          "json, dummy, stdin, filter, daemon (headless), ncurses (default)"}},
+          "json, dummy, stdin, daemon (headless), ncurses (default)"}},
         {"c", {true, "connect to a running session"}},
         {"s", {true, "specify session name"}},
         {"e", {true, "execute argument on initialisation"}},

--- a/test/run
+++ b/test/run
@@ -53,7 +53,7 @@ main() {
       "
       session="kak-test-$(printf '%s' "$dir" | sed -e 's+^\./++; s+/+-+g')"
       rm -f /tmp/kakoune/$USER/$session
-      ${test}/../src/kak out -n -s "$session" -ui json -e "$kak_commands" > display
+      ${test}/../src/kak out -nc -s "$session" -m json -e "$kak_commands" > display
       retval=$?
       if [ $should_fail -eq 0 ]; then
         if [ $retval -ne 0 ]; then

--- a/test/run
+++ b/test/run
@@ -53,7 +53,7 @@ main() {
       "
       session="kak-test-$(printf '%s' "$dir" | sed -e 's+^\./++; s+/+-+g')"
       rm -f /tmp/kakoune/$USER/$session
-      ${test}/../src/kak out -nc -s "$session" -m json -e "$kak_commands" > display
+      ${test}/../src/kak out --norc -s "$session" -m json -e "$kak_commands" > display
       retval=$?
       if [ $should_fail -eq 0 ]; then
         if [ $retval -ne 0 ]; then


### PR DESCRIPTION
I'm playing around with cleaning up the front end for end-users. This PR introduces the concept of using kak in a "mode" to compromise what was formerly -d (daemon), -ui ncurses, -ui dummy, -ui json, -p (stdin) and -f (filter). I believe that its important to give more clarity the many ways kak's editing functionality can be started.

While I did this I observed what other applications did (tmux, vim, etc). I had a few other choices. VIM has modes, while not used often, that still have their own options. I don't think the approach works best long term, as it takes up valuable real estate of options each time a mode is added (this freed up -d, -p, n, -f and -m). Also, I also believe that in the future users may like to have mode-specific option and help dialogs / docs, so options don't clutter up the main space.

I considered making this larger than an end-user PR (and doing more changes inside of parameters_parser) but felt I could have the effect I wanted with a smaller commit

Replace the options of -f, -ui, -d and -p with -m (mode).

While stdin, filter and daemon don't represent a UI, they do relate
to how the app is process is executed to the user.

To start application in various modes:

    $ kak  # defaults to ncurses
    $ kak -m daemon
    $ kak -m json
    $ kak -m filter
    $ kak -m stdin

-f (required for -mode filter) has been renamed to -ks

-n (no kakrc files) has been renamed -nc

-s is now required for -c

-clear has been replaced with -prune

add -h (help) to print option docs