### PR TITLE
[POC] Add `m4` support to the string expansions

### DIFF
--- a/colors/base16.kak
+++ b/colors/base16.kak
@@ -2,68 +2,62 @@
 ## base16.kak by lenormf
 ##
 
-%sh{
-    black_lighterer='rgb:383838'
-    black_lighter='rgb:2D2D2D'
-    black_light='rgb:1C1C1C'
-    cyan_light='rgb:7CB0FF'
-    green_dark='rgb:A1B56C'
-    grey_dark='rgb:585858'
-    grey_light='rgb:D8D8D8'
-    magenta_dark='rgb:AB4642'
-    magenta_light='rgb:AB4434'
-    orange_dark='rgb:DC9656'
-    orange_light='rgb:F7CA88'
-    purple_dark='rgb:BA8BAF'
+%m4{
+    define(`black_lighterer', `rgb:383838')dnl
+    define(`black_lighter', `rgb:2D2D2D')dnl
+    define(`black_light', `rgb:1C1C1C')dnl
+    define(`cyan_light', `rgb:7CB0FF')dnl
+    define(`green_dark', `rgb:A1B56C')dnl
+    define(`grey_dark', `rgb:585858')dnl
+    define(`grey_light', `rgb:D8D8D8')dnl
+    define(`magenta_dark', `rgb:AB4642')dnl
+    define(`magenta_light', `rgb:AB4434')dnl
+    define(`orange_dark', `rgb:DC9656')dnl
+    define(`orange_light', `rgb:F7CA88')dnl
+    define(`purple_dark', `rgb:BA8BAF')dnl
 
     ## code
-    echo "
-        face value ${orange_dark}+b
-        face type ${orange_light}
-        face identifier ${magenta_dark}
-        face string ${green_dark}
-        face error ${grey_light},${magenta_light}
-        face keyword ${purple_dark}+b
-        face operator ${grey_light}
-        face attribute ${orange_dark}
-        face comment ${grey_dark}
-        face meta ${orange_light}
-    "
+    face value              orange_dark+b
+    face type               orange_light
+    face identifier         magenta_dark
+    face string             green_dark
+    face error              grey_light,magenta_light
+    face keyword            purple_dark+b
+    face operator           grey_light
+    face attribute          orange_dark
+    face comment            grey_dark
+    face meta               orange_light
 
     ## markup
-    echo "
-        face title blue
-        face header ${cyan_light}
-        face bold ${orange_light}
-        face italic ${orange_dark}
-        face mono ${green_dark}
-        face block ${orange_dark}
-        face link blue
-        face bullet ${magenta_light}
-        face list ${magenta_dark}
-    "
+    face title              blue
+    face header             cyan_light
+    face bold               orange_light
+    face italic             orange_dark
+    face mono               green_dark
+    face block              orange_dark
+    face link               blue
+    face bullet             magenta_light
+    face list               magenta_dark
 
     ## builtin
-    echo "
-        face Default ${grey_light},${black_lighter}
-        face PrimarySelection white,blue
-        face SecondarySelection black,blue
-        face PrimaryCursor black,white
-        face SecondaryCursor black,white
-        face LineNumbers ${grey_light},${black_lighter}
-        face LineNumberCursor ${grey_light},rgb:282828+b
-        face MenuForeground ${grey_light},blue
-        face MenuBackground blue,${grey_light}
-        face MenuInfo ${cyan_light}
-        face Information ${black_light},${cyan_light}
-        face Error ${grey_light},${magenta_light}
-        face StatusLine ${grey_light},${black_lighterer}
-        face StatusLineMode ${orange_dark}
-        face StatusLineInfo ${cyan_light}
-        face StatusLineValue ${green_dark}
-        face StatusCursor ${black_lighterer},${cyan_light}
-        face Prompt ${black_light},${cyan_light}
-        face MatchingChar ${cyan_light},${black_light}+b
-        face BufferPadding ${cyan_light},${black_lighter}
-    "
+    face Default            grey_light,black_lighter
+    face PrimarySelection   white,blue
+    face SecondarySelection black,blue
+    face PrimaryCursor      black,white
+    face SecondaryCursor    black,white
+    face LineNumbers        grey_light,black_lighter
+    face LineNumberCursor   grey_light,rgb:282828+b
+    face MenuForeground     grey_light,blue
+    face MenuBackground     blue,grey_light
+    face MenuInfo           cyan_light
+    face Information        black_light,cyan_light
+    face Error              grey_light,magenta_light
+    face StatusLine         grey_light,black_lighterer
+    face StatusLineMode     orange_dark
+    face StatusLineInfo     cyan_light
+    face StatusLineValue    green_dark
+    face StatusCursor       black_lighterer,cyan_light
+    face Prompt             black_light,cyan_light
+    face MatchingChar       cyan_light,black_light+b
+    face BufferPadding      cyan_light,black_lighter
 }

--- a/src/command_manager.hh
+++ b/src/command_manager.hh
@@ -69,6 +69,7 @@ struct Token
         RawQuoted,
         RawEval,
         ShellExpand,
+        MfourExpand,
         RegisterExpand,
         OptionExpand,
         ValExpand,

--- a/src/main.cc
+++ b/src/main.cc
@@ -20,6 +20,7 @@
 #include "remote.hh"
 #include "scope.hh"
 #include "shell_manager.hh"
+#include "scope_manager.hh"
 #include "string.hh"
 #include "unit_tests.hh"
 #include "window.hh"
@@ -143,8 +144,12 @@ void register_env_vars()
     } };
 
     ShellManager& shell_manager = ShellManager::instance();
+    ScopeManager& scope_manager = ScopeManager::instance();
     for (auto& env_var : env_vars)
+    {
         shell_manager.register_env_var(env_var.name, env_var.prefix, env_var.func);
+        scope_manager.register_env_var(env_var.name, env_var.prefix, env_var.func);
+    }
 }
 
 void register_registers()
@@ -485,6 +490,7 @@ int run_server(StringView session, StringView init_command,
     EventManager        event_manager;
     GlobalScope         global_scope;
     ShellManager        shell_manager;
+    ScopeManager        scope_manager;
     CommandManager      command_manager;
     RegisterManager     register_manager;
     HighlighterRegistry highlighter_registry;
@@ -616,6 +622,7 @@ int run_filter(StringView keystr, StringView commands, ConstArrayView<StringView
     GlobalScope     global_scope;
     EventManager    event_manager;
     ShellManager    shell_manager;
+    ScopeManager    scope_manager;
     CommandManager  command_manager;
     RegisterManager register_manager;
     ClientManager   client_manager;

--- a/src/scope_manager.hh
+++ b/src/scope_manager.hh
@@ -1,0 +1,32 @@
+#ifndef scope_manager_hh_INCLUDED
+#define scope_manager_hh_INCLUDED
+
+#include "shell_manager.hh"
+
+namespace Kakoune
+{
+
+class ScopeManager : public Singleton<ScopeManager>
+{
+public:
+    ScopeManager();
+
+    std::pair<String, int> eval(char const *prog_binary,
+                                StringView cmdline,
+                                const Context& context,
+                                ShellManager::Flags flags = ShellManager::Flags::WaitForStdout,
+                                const ShellContext& shell_context = {});
+
+    void register_env_var(StringView str, bool prefix, EnvVarRetriever retriever);
+    String get_val(StringView name, const Context& context) const;
+
+    CandidateList complete_env_var(StringView prefix, ByteCount cursor_pos) const;
+
+private:
+    struct EnvVarDesc { String str; bool prefix; EnvVarRetriever func; };
+    Vector<EnvVarDesc> m_env_vars;
+};
+
+}
+
+#endif // scope_manager_hh_INCLUDED

--- a/src/shell_manager.hh
+++ b/src/shell_manager.hh
@@ -7,6 +7,7 @@
 #include "string.hh"
 #include "utils.hh"
 #include "completion.hh"
+#include "event_manager.hh"
 
 namespace Kakoune
 {
@@ -30,6 +31,27 @@ public:
     {
         None = 0,
         WaitForStdout = 1
+    };
+
+    struct Pipe
+    {
+        Pipe(bool create = true);
+        ~Pipe();
+
+        int read_fd() const { return m_fd[0]; }
+        int write_fd() const { return m_fd[1]; }
+
+        void close_read_fd() { close_fd(m_fd[0]); }
+        void close_write_fd() { close_fd(m_fd[1]); }
+
+    private:
+        void close_fd(int& fd);
+        int m_fd[2];
+    };
+
+    struct PipeReader : FDWatcher
+    {
+        PipeReader(Pipe& pipe, String& contents);
     };
 
     std::pair<String, int> eval(StringView cmdline, const Context& context,


### PR DESCRIPTION
Hi,

Despite what the numerous changes to the code seem to suggest, this PR is less about adding arbitrary scopes in a generic manner than it is about a not very well known tool, `m4`. The following changeset adds the `%m4{}` scope to the already supported string expansions, and since I was more interested into the results than the changes themselves, I just duplicated code that worked for the shell and patched it (hence the `POC` tag in the title).

**About `m4`**

It's a GNU pre-processor that's included by default into most (all?) distributions, and allows simple macro replacements, functions, execution of shell commands, and much more.

**Why we're interested in it**

There are some cases where, when we develop a kak script, the only feature we're interested in is variable replacement, such as with color schemes. And the current way of implementing those scripts is to spawn a shell, so we can use the variables syntax, which is quite heavy/unecessary.

Using `m4` is a good replacement in those cases, as it's way faster than an entire shell, doesn't leave big memory footprints, and makes the scripts more readable (check out [my modified base16 theme](https://github.com/lenormf/kakoune/blob/be3ae4d468c863ca5c4db9d9b9f5e4d531755326/colors/base16.kak)). And it might even be possible to use `m4` in cases where we need more advanced features (a couple functions, mathematical evaluations, file inclusions, shell commands, …).

**Gains**

I haven't made any benchmarking or anything, but I wouldn't be surprised if we gained a good second during startup by simply replacing the `%sh` scopes with `%m4` ones in the color schemes. And as stated before, the features of this pre-processor go beyond simple symbol substitution, so changing a few shell scopes here and there in default kak scripts as well could improve things even further.

The `m4` syntax is based on defines, like `cpp`, and even though it's not much different from the regular shell script syntax, using it removes some clutter such as dollar signs and braces. Not everything has to be enclosed in double quotes either, which makes syntax highlighting slightly better.

This tool is also installed by default on all distributions I could try (it has a cygwin package as well, but I haven't checked whether it's installed by default), which means it's a very good trade if we use it.

**Documentation**

For more info about `m4`'s features, refer to the [documentation](https://www.gnu.org/software/m4/manual/m4.html).