### PR TITLE
Fix the build on Mac OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
       fi;
     elif [ $TRAVIS_OS_NAME = osx ]; then
        brew outdated boost || brew upgrade boost;
+       brew install homebrew/dupes/ncurses;
     fi;
 env:
   global:

--- a/src/insert_completer.hh
+++ b/src/insert_completer.hh
@@ -10,7 +10,7 @@
 namespace Kakoune
 {
 
-class SelectionList;
+struct SelectionList;
 struct Key;
 
 struct InsertCompleterDesc


### PR DESCRIPTION
Hi,

The `tiparm` function isn't available in the default ncurses package provided by Mac OS, so I got `homebrew` to install the ncurses dupe to fix that.

@jjthrash could you please fix the `contrib/kakoune.rb` recipe so that it installs the `homebrew/dupes/ncurses` dependency ? Not sure it needs fixing, but I wouldn't know since I can't test changes to that file.

Recent C++ standards also don't allow forward declaration of structures with the `class` keyword, so I got rid of the warning by using the `struct` one.

HTH.