### PR TITLE
Fix the EOL format detection

### DIFF
--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -34,6 +34,7 @@ static ParsedLines parse_lines(StringView data)
         pos = data.begin() + 3;
     }
 
+    res.eolformat = EolFormat::Crlf;
     while (pos < data.end())
     {
         const char* line_end = pos;
@@ -44,11 +45,13 @@ static ParsedLines parse_lines(StringView data)
 
         if (line_end+1 != data.end() and *line_end == '\r' and *(line_end+1) == '\n')
         {
-            res.eolformat = EolFormat::Crlf;
             pos = line_end + 2;
         }
         else
+        {
+            res.eolformat = EolFormat::Lf;
             pos = line_end + 1;
+        }
     }
 
     return res;


### PR DESCRIPTION
Only switch the end of line format to `CRLF` if all the lines in a
buffer end with a CRLF, as opposed to require only one.