### PR TITLE
Fix operators highlighting in shell scripts

### DIFF
--- a/rc/core/sh.kak
+++ b/rc/core/sh.kak
@@ -32,7 +32,7 @@ addhl -group /sh/comment fill comment
     printf %s "addhl -group /sh/code regex \b(${keywords})\b 0:keyword"
 }
 
-addhl -group /sh/code regex [\[\]\(\)&|]{2}|\[\s|\s\] 0:operator
+addhl -group /sh/code regex [\[\]\(\)&|]{1,2} 0:operator
 addhl -group /sh/code regex (\w+)= 1:identifier
 addhl -group /sh/code regex ^\h*(\w+)\h*\(\) 1:identifier
 


### PR DESCRIPTION
Hi,

This patch allows highlighting `[[` and `]]` keywords (which didn't work before), but is also highlightings other characters previously left untouched: ')', `&`, `|`. Those are operators too, but since they used not to be highlighted, it's good to mention it here.

HTH.