### PR TITLE
Fix the autowrap script, use an external tool to wrap paragraphs

### DIFF
--- a/rc/base/autowrap.kak
+++ b/rc/base/autowrap.kak
@@ -5,7 +5,7 @@ decl int autowrap_column 80
 # This can potentially break formatting of documents containing markup (e.g. markdown)
 decl bool autowrap_format_paragraph yes
 # Command to which the paragraphs to wrap will be passed, all occurences of '%c' are replaced with `autowrap_column`
-decl str autowrap_fmtcmd 'fmt -s -w %c'
+decl str autowrap_fmtcmd 'fold -s -w %c'
 
 def -hidden autowrap-cursor %{ eval -draft %{
     try %{


### PR DESCRIPTION
Hi,

Following a discussion on IRC about the implementation of autowrapping support, I decided to put an end to the current implementation (raw kakoune scripting) and leave complex indenting to a dedicated tool, `fmt` (part of the coreutils).

Here is how it works:
* the script will break lines as you type words, i.e. when you append words to a sentence at the end of a line
* the `fmt` utility will indent the entire paragraph around the cursor if you insert characters in the middle of a sentence, making the line larger than `autowrap_column`

You can also disable that last feature if you're writing a document in a particularly formatted style (e.g. markdown, html etc) by setting the `autowrap_format_paragraph` variable to `no`, in which case only simple line breaks will be inserted if you type a word after the maximum amount of columns allowed.

Cheers.