### PR TITLE
rc/base/etc: Use a more efficient expression

### DIFF
--- a/rc/base/etc.kak
+++ b/rc/base/etc.kak
@@ -30,8 +30,8 @@ hook global WinSetOption filetype=(?!etc-hosts).*       %{ rmhl etc-hosts }
 
 ## /etc/fstab
 addhl -group / group etc-fstab
+addhl -group /etc-fstab regex ^(\S{1,})\s+?(\S{1,})\s+?(\S{1,})\s+?(\S{1,})\s+?(\S{1,})\s+?(\S{1,})(?:\s+)?$ 1:keyword 2:value 3:type 4:string 5:attribute 6:attribute
 addhl -group /etc-fstab regex \#.*?$ 0:comment
-addhl -group /etc-fstab regex ^(\S+)\s+(\S+)\s+(\S+)\s+(?:(\S+,?)+)\s+([0-9])\s+([0-9]) 1:keyword 2:value 3:type 4:string 5:attribute 6:attribute
 
 hook global WinSetOption filetype=etc-fstab             %{ addhl ref etc-fstab }
 hook global WinSetOption filetype=(?!etc-fstab).*       %{ rmhl etc-fstab }


### PR DESCRIPTION
I was hitting a stack size issue with the previous regular expression used
to match filesystem lines, so I decided to rewrite it. Admittedly I don't
know entirely if this has better performance, but it seems to work well
and additionally isn't too greedy with matching like the previous one.