### PR TITLE
Name JSON resize parameters explicitely

### DIFF
--- a/doc/json_ui.asciidoc
+++ b/doc/json_ui.asciidoc
@@ -44,4 +44,4 @@ Here are the requests that can be written by the json ui on stdout:
 The requests that the json ui can interpret on stdin are:
 
 * keys(String key1, String key2...): keystrokes
-* resize(int x, int y): notify ui resize
+* resize(int rows, int columns): notify ui resize


### PR DESCRIPTION
I find that x, y can be easily confused with the classic width/height