### PR TITLE
Always use quotes with sh/bash

### DIFF
--- a/rc/base/mime.kak
+++ b/rc/base/mime.kak
@@ -1,5 +1,5 @@
 decl str mimetype "text/plain"
 
 hook global BufOpen .* %{
-     set buffer mimetype %sh{file -b --mime-type ${kak_buffile} }
+     set buffer mimetype %sh{file -b --mime-type "${kak_buffile}" }
 }


### PR DESCRIPTION
Fixes opening of files with spaces in them:
```
*** This is the debug buffer, where debug info will be written ***            
error running hook BufOpen(/tmp/hey ho/bz z)/: 2:6: 'set' wrong argument count
```