### PR TITLE
Fix for puppet tags

### DIFF
--- a/rc/base/ctags.kak
+++ b/rc/base/ctags.kak
@@ -16,8 +16,9 @@ def -params 0..1 \
         for tags in "$@"
         do
             [ -f "$tags" ] || continue
-            namecache="$(dirname "$tags")"/.kak."$(basename "$tags")".namecache
-            if [ "$namecache" -ot "$tags" ]; then
+            namecache="${tags%/*}"/.kak."${tags##*/}".namecache
+            if [ -z "$(find "$namecache" -prune -newer "$tags")" ]
+            then
                 cut -f1 "$tags" | grep -v \'^!_\' | uniq > "$namecache"
             fi
             cat "$namecache"

--- a/rc/base/ctags.kak
+++ b/rc/base/ctags.kak
@@ -28,7 +28,13 @@ def -params 0..1 \
                 out = out " %{" $2 " {MenuInfo}" re "} %{eval -collapse-jumps %{ try %{ edit %{" ENVIRON["tagroot"] $2 "}; exec %{/\\Q" keys "<ret>vc} } catch %{ echo %{unable to find tag} } } }"
             }
             /[^\t]+\t[^\t]+\t[0-9]+/ { out = out " %{" $2 ":" $3 "} %{eval -collapse-jumps %{ edit %{" ENVIRON["tagroot"] $2 "} %{" $3 "}}}" }
-            END { print length(out) == 0 ? "echo -color Error no such tag " ENVIRON["tagname"] : "menu -markup -auto-single " out }'
+            END {
+                if (length(out) == 0) {
+                    print "echo -color Error no such tag " ENVIRON["tagname"]
+                } else {
+                    print "menu -markup -auto-single " out 
+                }
+            }'
         done
     }}
 

--- a/rc/base/ctags.kak
+++ b/rc/base/ctags.kak
@@ -16,7 +16,7 @@ def -params 0..1 \
         for tags in "$@"
         do
             [ -f "$tags" ] || continue
-            namecache="${tags%/*}"/.kak."${tags##*/}".namecache
+            namecache="$(dirname "$tags")"/.kak."${tags##*/}".namecache
             if [ -z "$(find "$namecache" -prune -newer "$tags")" ]
             then
                 cut -f1 "$tags" | grep -v \'^!_\' | uniq > "$namecache"

--- a/rc/base/ctags.kak
+++ b/rc/base/ctags.kak
@@ -17,25 +17,36 @@ def -params 0..1 \
     -docstring 'Jump to tag definition' \
     tag \
     %{ %sh{
-        export tagname=${1:-${kak_selection}}
-        for tags in $(printf %s\\n "${kak_opt_ctagsfiles}" | tr ':' '\n'); do
-            export tagroot="$(readlink -f $(dirname "$tags"))/"
-            readtags -t "${tags}" ${tagname} | awk -F '\t|\n' '
-            /[^\t]+\t[^\t]+\t\/\^.*\$?\// {
-                re=$0;
-                sub(".*\t/\\^", "", re); sub("\\$?/$", "", re); gsub("(\\{|\\}|\\\\E).*$", "", re);
-                keys=re; gsub(/</, "<lt>", keys); gsub(/\t/, "<c-v><c-i>", keys);
-                out = out " %{" $2 " {MenuInfo}" re "} %{eval -collapse-jumps %{ try %{ edit %{" ENVIRON["tagroot"] $2 "}; exec %{/\\Q" keys "<ret>vc} } catch %{ echo %{unable to find tag} } } }"
-            }
-            /[^\t]+\t[^\t]+\t[0-9]+/ { out = out " %{" $2 ":" $3 "} %{eval -collapse-jumps %{ edit %{" ENVIRON["tagroot"] $2 "} %{" $3 "}}}" }
-            END {
-                if (length(out) == 0) {
-                    print "echo -color Error no such tag " ENVIRON["tagname"]
-                } else {
-                    print "menu -markup -auto-single " out 
-                }
-            }'
-        done
+        export tagname="${1:-$kak_selection}"
+
+        oldIFS="$IFS"
+        IFS=:
+        # $1=tag1, $2=tag2 ...
+        set -- $kak_opt_ctagsfiles
+        IFS="$oldIFS"
+
+        for tags in "$@"
+        do
+            if [ -f "$tags" ]
+            then
+                tagroot="$(readlink -f "$(dirname "$tags")")"
+                # Avoid reading the same tag twice
+                if [ "$tagroot" = "$PWD" ] || [ "$tagroot" = "$(pwd -P)" ]
+                then
+                    [ "$tags" != tags ] && continue
+                fi
+                echo -n "$tagroot/	"; readtags -t "$tags" "$tagname"
+            fi
+        done | awk -F '\t|\n' '
+        /[^\t]+\t[^\t]+\t\/\^.*\$?\// {
+            tagroot = $1
+            re=$0;
+            sub(".*\t/\\^", "", re); sub("\\$?/$", "", re); gsub("(\\{|\\}|\\\\E).*$", "", re);
+            keys=re; gsub(/</, "<lt>", keys); gsub(/\t/, "<c-v><c-i>", keys);
+            out = out " %{" re " {MenuInfo}" tagroot $3 "} %{eval -collapse-jumps %{ try %{ edit %{" tagroot $3 "}; exec %{/\\Q" keys "<ret>vc} } catch %{ echo %{unable to find tag} } } }"
+        }
+        /[^\t]+\t[^\t]+\t[0-9]+/ { out = out " %{" $3 ":" $4 "} %{eval -collapse-jumps %{ edit %{" tagroot $3 "} %{" $4 "}}}" }
+        END { print length(out) == 0 ? "echo -color Error no such tag " ENVIRON["tagname"] : "menu -markup -auto-single " out }'
     }}
 
 def tag-complete -docstring "Insert completion candidates for the current selection into the buffer's local variables" %{ eval -draft %{

--- a/rc/base/ctags.kak
+++ b/rc/base/ctags.kak
@@ -58,11 +58,11 @@ def -params 0..1 \
 
 def tag-complete -docstring "Insert completion candidates for the current selection into the buffer's local variables" %{ eval -draft %{
     exec <space>hb<a-k>^\w+$<ret>
-    %sh{ (
+    %sh{ {
         compl=$(readtags -p "$kak_selection" | cut -f 1 | sort | uniq | sed -e 's/:/\\:/g' | sed -e 's/\n/:/g' )
         compl="${kak_cursor_line}.${kak_cursor_column}+${#kak_selection}@${kak_timestamp}:${compl}"
         printf %s\\n "set buffer=$kak_bufname ctags_completions '${compl}'" | kak -p ${kak_session}
-    ) > /dev/null 2>&1 < /dev/null & }
+    } > /dev/null 2>&1 < /dev/null & }
 }}
 
 def ctags-funcinfo -docstring "Display ctags information about a selected function" %{
@@ -91,7 +91,7 @@ decl str ctagspaths "."
 
 def ctags-generate -docstring 'Generate tag file asynchronously' %{
     echo -color Information "launching tag generation in the background"
-    %sh{ (
+    %sh{ {
         while ! mkdir .tags.kaklock 2>/dev/null; do sleep 1; done
         trap 'rmdir .tags.kaklock' EXIT
 
@@ -103,11 +103,11 @@ def ctags-generate -docstring 'Generate tag file asynchronously' %{
         fi
 
         printf %s\\n "eval -client $kak_client echo -color Information '${msg}'" | kak -p ${kak_session}
-    ) > /dev/null 2>&1 < /dev/null & }
+    } > /dev/null 2>&1 < /dev/null & }
 }
 
 def update-tags -docstring 'Update tags for the given file' %{
-        %sh{ (
+        %sh{ {
             while ! mkdir .tags.kaklock 2>/dev/null; do sleep 1; done
 	        trap 'rmdir .tags.kaklock' EXIT
 
@@ -118,5 +118,5 @@ def update-tags -docstring 'Update tags for the given file' %{
             else
                 msg="tags update failed for $kak_bufname"
             fi
-        ) > /dev/null 2>&1 < /dev/null & }
+        } > /dev/null 2>&1 < /dev/null & }
 }

--- a/rc/base/ctags.kak
+++ b/rc/base/ctags.kak
@@ -8,11 +8,10 @@ decl str-list ctagsfiles 'tags'
 def -params 0..1 \
     -shell-candidates '
         {
-        oldIFS="$IFS"
         IFS=:
         # $1=tag1, $2=tag2 ...
         set -- $kak_opt_ctagsfiles
-        IFS="$oldIFS"
+        unset IFS
         for tags in "$@"
         do
             [ -f "$tags" ] || continue
@@ -29,10 +28,9 @@ def -params 0..1 \
     %{ %sh{
         export tagname="${1:-$kak_selection}"
 
-        oldIFS="$IFS"
         IFS=:
         set -- $kak_opt_ctagsfiles
-        IFS="$oldIFS"
+        unset IFS
 
         for tags in "$@"
         do


### PR DESCRIPTION
Use an
`if/else` vs
`.. ? .. : ..`
because puppet tags for instance are most of the time classes with colons in their names
