### PR TITLE
formatter.kak: Use sed rather than ${variable//string/replacement}

### DIFF
--- a/rc/core/formatter.kak
+++ b/rc/core/formatter.kak
@@ -2,11 +2,12 @@ decl str formatcmd ""
 def format -docstring "Format the entire buffer with an external utility" %{
     %sh{
         if [ ! -z "${kak_opt_formatcmd}" ]; then
+            readonly kak_opt_formatcmd=$(printf '%s' "${kak_opt_formatcmd}" | sed 's/ /<space>/g')
             ## Save the current position of the cursor
             readonly x=$((kak_cursor_column - 1))
             readonly y="${kak_cursor_line}"
 
-            printf %s\\n "exec -draft %{%|${kak_opt_formatcmd// /<space>}<ret>}"
+            printf %s\\n "exec -draft %{%|${kak_opt_formatcmd}<ret>}"
             ## Try to restore the position of the cursor as it was prior to formatting
             printf %s\\n "exec gg ${y}g ${x}l"
         fi


### PR DESCRIPTION
Using ${variable//string/replacement} is a bash extension, it is not part
of POSIX shell scripting.

http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02