### PR TITLE
Add `-group <lang>-highlight` to highlighters

### DIFF
--- a/rc/base/clojure.kak
+++ b/rc/base/clojure.kak
@@ -31,10 +31,9 @@ def -hidden _clojure_indent_on_new_line       _lisp_indent_on_new_line
 
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+hook -group clojure-highlight global WinSetOption filetype=clojure %{ addhl ref clojure }
 
 hook global WinSetOption filetype=clojure %[
-    addhl ref clojure
-
     hook window InsertEnd  .* -group clojure-hooks  _clojure_filter_around_selections
     hook window InsertChar \n -group clojure-indent _clojure_indent_on_new_line
 ]

--- a/rc/base/css.kak
+++ b/rc/base/css.kak
@@ -66,9 +66,9 @@ def -hidden _css_indent_on_closing_curly_brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=css %[
-    addhl ref css
+hook -group css-highlight global WinSetOption filetype=css %{ addhl ref css }
 
+hook global WinSetOption filetype=css %[
     hook window InsertEnd  .* -group css-hooks  _css_filter_around_selections
     hook window InsertChar \n -group css-indent _css_indent_on_new_line
     hook window InsertChar \} -group css-indent _css_indent_on_closing_curly_brace

--- a/rc/base/dlang.kak
+++ b/rc/base/dlang.kak
@@ -102,9 +102,9 @@ def -hidden _dlang-indent-on-closing-curly-brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=dlang %{
-    addhl ref dlang
+hook -group dlang-highlight global WinSetOption filetype=dlang %{ addhl ref dlang }
 
+hook global WinSetOption filetype=dlang %{
     # cleanup trailing whitespaces when exiting insert mode
     hook window InsertEnd .* -group dlang-hooks %{ try %{ exec -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group dlang-indent _dlang-indent-on-new-line

--- a/rc/base/etc.kak
+++ b/rc/base/etc.kak
@@ -17,7 +17,7 @@ addhl -group / group etc-resolv-conf
 addhl -group /etc-resolv-conf regex ^#.*?$ 0:comment
 addhl -group /etc-resolv-conf regex ^(nameserver|server|domain|sortlist|options)[\s\t]+(.*?)$ 1:type 2:attribute
 
-hook global WinSetOption filetype=etc-resolv-conf       %{ addhl ref etc-resolv-conf }
+hook -group etc-resolv-conf-highlight global WinSetOption filetype=etc-resolv-conf %{ addhl ref etc-resolv-conf }
 hook global WinSetOption filetype=(?!etc-resolv-conf).* %{ rmhl etc-resolv-conf }
 
 ## /etc/hosts
@@ -25,42 +25,42 @@ addhl -group / group etc-hosts
 addhl -group /etc-hosts regex ^(.+?)[\s\t]+?(.*?)$ 1:type 2:attribute
 addhl -group /etc-hosts regex \#.*?$ 0:comment
 
-hook global WinSetOption filetype=etc-hosts             %{ addhl ref etc-hosts }
-hook global WinSetOption filetype=(?!etc-hosts).*       %{ rmhl etc-hosts }
+hook -group etc-hosts-highlight global WinSetOption filetype=etc-hosts %{ addhl ref etc-hosts }
+hook global WinSetOption filetype=(?!etc-hosts).* %{ rmhl etc-hosts }
 
 ## /etc/fstab
 addhl -group / group etc-fstab
 addhl -group /etc-fstab regex ^(\S{1,})\s+?(\S{1,})\s+?(\S{1,})\s+?(\S{1,})\s+?(\S{1,})\s+?(\S{1,})(?:\s+)?$ 1:keyword 2:value 3:type 4:string 5:attribute 6:attribute
 addhl -group /etc-fstab regex \#.*?$ 0:comment
 
-hook global WinSetOption filetype=etc-fstab             %{ addhl ref etc-fstab }
-hook global WinSetOption filetype=(?!etc-fstab).*       %{ rmhl etc-fstab }
+hook -group etc-fstab-highlight global WinSetOption filetype=etc-fstab %{ addhl ref etc-fstab }
+hook global WinSetOption filetype=(?!etc-fstab).* %{ rmhl etc-fstab }
 
 ## /etc/group
 addhl -group / group etc-group
 addhl -group /etc-group regex ^(\S+?):(\S+?)?:(\S+?)?:(\S+?)?$ 1:keyword 2:type 3:value 4:string
 
-hook global WinSetOption filetype=etc-group             %{ addhl ref etc-group }
-hook global WinSetOption filetype=(?!etc-group).*       %{ rmhl etc-group }
+hook -group etc-group-highlight global WinSetOption filetype=etc-group %{ addhl ref etc-group }
+hook global WinSetOption filetype=(?!etc-group).* %{ rmhl etc-group }
 
 ## /etc/gshadow
 addhl -group / group etc-gshadow
 addhl -group /etc-gshadow regex ^(\S+?):(\S+?)?:(\S+?)?:(\S+?)?$ 1:keyword 2:type 3:value 4:string
 
-hook global WinSetOption filetype=etc-gshadow           %{ addhl ref etc-gshadow }
-hook global WinSetOption filetype=(?!etc-gshadow).*     %{ rmhl etc-gshadow }
+hook -group etc-gshadow-highlight global WinSetOption filetype=etc-gshadow %{ addhl ref etc-gshadow }
+hook global WinSetOption filetype=(?!etc-gshadow).* %{ rmhl etc-gshadow }
 
 ## /etc/shadow
 addhl -group / group etc-shadow
 addhl -group /etc-shadow regex ^(\S+?):(\S+?):([0-9]+?):([0-9]+?)?:([0-9]+?)?:([0-9]+?)?:([0-9]+?)?:([0-9]+?)?:(.*?)?$ 1:keyword 2:type 3:value 4:value 5:value 6:value 7:value 8:value
 
-hook global WinSetOption filetype=etc-shadow            %{ addhl ref etc-shadow }
-hook global WinSetOption filetype=(?!etc-shadow).*      %{ rmhl etc-shadow }
+hook -group etc-shadow-highlight global WinSetOption filetype=etc-shadow %{ addhl ref etc-shadow }
+hook global WinSetOption filetype=(?!etc-shadow).* %{ rmhl etc-shadow }
 
 ## /etc/passwd
 addhl -group / group etc-passwd
 addhl -group /etc-passwd regex ^(\S+?):(\S+?):([0-9]+?):([0-9]+?):(.*?)?:(.+?):(.+?)$ 1:keyword 2:type 3:value 4:value 5:string 6:attribute 7:attribute
 
-hook global WinSetOption filetype=etc-passwd            %{ addhl ref etc-passwd }
-hook global WinSetOption filetype=(?!etc-passwd).*      %{ rmhl etc-passwd }
+hook -group etc-passwd-highlight global WinSetOption filetype=etc-passwd %{ addhl ref etc-passwd }
+hook global WinSetOption filetype=(?!etc-passwd).* %{ rmhl etc-passwd }
 

--- a/rc/base/fish.kak
+++ b/rc/base/fish.kak
@@ -63,9 +63,9 @@ def -hidden _fish_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=fish %{
-    addhl ref fish
+hook -group fish-highlight global WinSetOption filetype=fish %{ addhl ref fish }
 
+hook global WinSetOption filetype=fish %{
     hook window InsertEnd  .* -group fish-hooks  _fish_filter_around_selections
     hook window InsertChar .* -group fish-indent _fish_indent_on_char
     hook window InsertChar \n -group fish-indent _fish_indent_on_new_line

--- a/rc/base/gas.kak
+++ b/rc/base/gas.kak
@@ -85,9 +85,9 @@ def -hidden _gas_indent_on_new_line %~
     >
 ~
 
-hook global WinSetOption filetype=gas %{
-    addhl ref gas
+hook -group gas-highlight global WinSetOption filetype=gas %{ addhl ref gas }
 
+hook global WinSetOption filetype=gas %{
     hook window InsertChar \n -group gas-indent _gas_indent_on_new_line
 }
 

--- a/rc/base/git.kak
+++ b/rc/base/git.kak
@@ -2,7 +2,7 @@ hook global BufCreate .*COMMIT_EDITMSG %{
     set buffer filetype git-commit
 }
 
-hook global WinSetOption filetype=git-commit %{
+hook -group git-commit-highlight global WinSetOption filetype=git-commit %{
     addhl group git-commit-highlight
     addhl -group git-commit-highlight regex "\`[^\n]{1,50}" 0:yellow
     addhl -group git-commit-highlight regex "\`[^\n]*\n\h*(?!#)([^\n]*)\n?" 1:default,red
@@ -19,7 +19,7 @@ hook global BufCreate .*git-rebase-todo %{
     set buffer filetype git-rebase
 }
 
-hook global WinSetOption filetype=git-rebase %{
+hook -group git-rebase-highlight global WinSetOption filetype=git-rebase %{
     addhl group git-rebase-highlight
     addhl -group git-rebase-highlight regex "#[^\n]*\n" 0:cyan,default
     addhl -group git-rebase-highlight regex "^(pick|edit|reword|squash|fixup|exec|[persfx]) (\w+)" 1:green 2:magenta

--- a/rc/base/haskell.kak
+++ b/rc/base/haskell.kak
@@ -58,9 +58,9 @@ def -hidden _haskell_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=haskell %{
-    addhl ref haskell
+hook -group haskell-highlight global WinSetOption filetype=haskell %{ addhl ref haskell }
 
+hook global WinSetOption filetype=haskell %{
     hook window InsertEnd  .* -group haskell-hooks  _haskell_filter_around_selections
     hook window InsertChar \n -group haskell-indent _haskell_indent_on_new_line
 }

--- a/rc/base/html.kak
+++ b/rc/base/html.kak
@@ -63,9 +63,9 @@ def -hidden _html_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=html %{
-    addhl ref html
+hook -group html-highlight global WinSetOption filetype=html %{ addhl ref html }
 
+hook global WinSetOption filetype=html %{
     hook window InsertEnd  .* -group html-hooks  _html_filter_around_selections
     hook window InsertChar .* -group html-indent _html_indent_on_char
     hook window InsertChar \n -group html-indent _html_indent_on_new_line

--- a/rc/base/ini.kak
+++ b/rc/base/ini.kak
@@ -2,18 +2,13 @@ hook global BufCreate .*\.(repo|service|target|socket|ini|cfg) %{
     set buffer filetype ini
 }
 
-addhl -group / regions -default code ini-highlighter \
+addhl -group / regions -default code ini \
     comment (^|\h)\K\# $ ''
 
-addhl -group /ini-highlighter/code regex "^\h*\[[^\]]*\]" 0:title
-addhl -group /ini-highlighter/code regex "^\h*([^\[][^=\n]*=)([^\n]*)" 1:identifier 2:value
+addhl -group /ini/code regex "^\h*\[[^\]]*\]" 0:title
+addhl -group /ini/code regex "^\h*([^\[][^=\n]*=)([^\n]*)" 1:identifier 2:value
 
-addhl -group /ini-highlighter/comment fill comment
+addhl -group /ini/comment fill comment
 
-hook global WinSetOption filetype=ini %{
-    addhl ref ini-highlighter
-}
-
-hook global WinSetOption filetype=(?!ini).* %{
-    rmhl ini-highlighter
-}
+hook -group ini-highlight global WinSetOption filetype=ini %{ addhl ref ini }
+hook global WinSetOption filetype=(?!ini).* %{ rmhl ini }

--- a/rc/base/java.kak
+++ b/rc/base/java.kak
@@ -19,10 +19,5 @@ addhl -group /java/code regex "\b(void|int|char|unsigned|float|boolean|double)\b
 addhl -group /java/code regex "\b(while|for|if|else|do|static|switch|case|default|class|interface|goto|break|continue|return|import|try|catch|throw|new|package|extends|implements)\b" 0:keyword
 addhl -group /java/code regex "\b(final|public|protected|private|abstract)\b" 0:attribute
 
-hook global WinSetOption filetype=java %{
-    addhl ref java
-}
-
-hook global WinSetOption filetype=(?!java).* %{
-    rmhl java
-}
+hook -group java-highlight global WinSetOption filetype=java %{ addhl ref java }
+hook global WinSetOption filetype=(?!java).* %{ rmhl java }

--- a/rc/base/javascript.kak
+++ b/rc/base/javascript.kak
@@ -66,9 +66,9 @@ def -hidden _javascript_indent_on_new_line %<
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=javascript %{
-    addhl ref javascript
+hook -group javascript-highlight global WinSetOption filetype=javascript %{ addhl ref javascript }
 
+hook global WinSetOption filetype=javascript %{
     hook window InsertEnd  .* -group javascript-hooks  _javascript_filter_around_selections
     hook window InsertChar .* -group javascript-indent _javascript_indent_on_char
     hook window InsertChar \n -group javascript-indent _javascript_indent_on_new_line

--- a/rc/base/json.kak
+++ b/rc/base/json.kak
@@ -51,9 +51,9 @@ def -hidden _json_indent_on_new_line %<
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=json %{
-    addhl ref json
+hook -group json-highlight global WinSetOption filetype=json %{ addhl ref json }
 
+hook global WinSetOption filetype=json %{
     hook window InsertEnd  .* -group json-hooks  _json_filter_around_selections
     hook window InsertChar .* -group json-indent _json_indent_on_char
     hook window InsertChar \n -group json-indent _json_indent_on_new_line

--- a/rc/base/julia.kak
+++ b/rc/base/julia.kak
@@ -26,5 +26,5 @@ addhl -group /julia/code regex \b(Number|Real|BigInt|Integer|UInt|UInt8|UInt16|U
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=julia %{ addhl ref julia }
+hook -group julia-highlight global WinSetOption filetype=julia %{ addhl ref julia }
 hook global WinSetOption filetype=(?!julia).* %{ rmhl julia }

--- a/rc/base/lisp.kak
+++ b/rc/base/lisp.kak
@@ -47,9 +47,9 @@ def -hidden _lisp_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=lisp %{
-    addhl ref lisp
+hook -group lisp-highlight global WinSetOption filetype=lisp %{ addhl ref lisp }
 
+hook global WinSetOption filetype=lisp %{
     hook window InsertEnd  .* -group lisp-hooks  _lisp_filter_around_selections
     hook window InsertChar \n -group lisp-indent _lisp_indent_on_new_line
 }

--- a/rc/base/lua.kak
+++ b/rc/base/lua.kak
@@ -95,9 +95,9 @@ def -hidden _lua_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=lua %{
-    addhl ref lua
+hook -group lua-highlight global WinSetOption filetype=lua %{ addhl ref lua }
 
+hook global WinSetOption filetype=lua %{
     hook window InsertEnd  .* -group lua-hooks  _lua_filter_around_selections
     hook window InsertChar .* -group lua-indent _lua_indent_on_char
     hook window InsertChar \n -group lua-indent _lua_indent_on_new_line

--- a/rc/base/mail.kak
+++ b/rc/base/mail.kak
@@ -5,5 +5,5 @@ addhl -group /mail regex ^(From|To|Cc|Bcc|Subject|Reply-To|In-Reply-To):([^\n]*(
 addhl -group /mail regex <[^@>]+@.*?> 0:string
 addhl -group /mail regex ^>.*?$ 0:comment
 
-hook global WinSetOption filetype=mail %{ addhl ref mail }
+hook -group mail-highlight global WinSetOption filetype=mail %{ addhl ref mail }
 hook global WinSetOption filetype=(?!mail).* %{ rmhl mail }

--- a/rc/base/markdown.kak
+++ b/rc/base/markdown.kak
@@ -62,8 +62,9 @@ def -hidden _markdown_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
+hook -group markdown-highlight global WinSetOption filetype=markdown %{ addhl ref markdown }
+
 hook global WinSetOption filetype=markdown %{
-    addhl ref markdown
     hook window InsertChar \n -group markdown-indent _markdown_indent_on_new_line
 }
 

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -109,9 +109,9 @@ def -hidden _perl-indent-on-closing-curly-brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=perl %{
-    addhl ref perl
+hook -group perl-highlight global WinSetOption filetype=perl %{ addhl ref perl }
 
+hook global WinSetOption filetype=perl %{
     # cleanup trailing whitespaces when exiting insert mode
     hook window InsertEnd .* -group perl-hooks %{ try %{ exec -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group perl-indent _perl-indent-on-new-line

--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -150,9 +150,9 @@ def -hidden _ruby_insert_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=ruby %{
-    addhl ref ruby
+hook -group ruby-highlight global WinSetOption filetype=ruby %{ addhl ref ruby }
 
+hook global WinSetOption filetype=ruby %{
     hook window InsertChar .* -group ruby-indent _ruby_indent_on_char
     hook window InsertChar \n -group ruby-indent _ruby_indent_on_new_line
     hook window InsertChar \n -group ruby-insert _ruby_insert_on_new_line

--- a/rc/base/rust.kak
+++ b/rc/base/rust.kak
@@ -76,9 +76,9 @@ def -hidden _rust_indent_on_closing_curly_brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=rust %[
-    addhl ref rust
+hook -group rust-highlight global WinSetOption filetype=rust %{ addhl ref rust }
 
+hook global WinSetOption filetype=rust %[
     hook window InsertEnd  .* -group rust-hooks  _rust_filter_around_selections
     hook window InsertChar \n -group rust-indent _rust_indent_on_new_line
     hook window InsertChar \{ -group rust-indent _rust_indent_on_opening_curly_brace

--- a/rc/base/scala.kak
+++ b/rc/base/scala.kak
@@ -66,9 +66,9 @@ def -hidden _scala_indent_on_closing_curly_brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=scala %[
-    addhl ref scala
+hook -group scala-highlight global WinSetOption filetype=scala %{ addhl ref scala }
 
+hook global WinSetOption filetype=scala %[
     hook window InsertEnd  .* -group scala-hooks  _scala_filter_around_selections
     hook window InsertChar \n -group scala-indent _scala_indent_on_new_line
     hook window InsertChar \} -group scala-indent _scala_indent_on_closing_curly_brace

--- a/rc/base/swift.kak
+++ b/rc/base/swift.kak
@@ -23,10 +23,5 @@ addhl -group /swift/code regex "\<(Bool|String|UInt|UInt16|UInt32|UInt64|UInt8)\
 addhl -group /swift/code regex "\<(IBAction|IBOutlet)\>" 0:attribute
 addhl -group /swift/code regex "@\w+\>" 0:attribute
 
-hook global WinSetOption filetype=swift %{
-    addhl ref swift
-}
-
-hook global WinSetOption filetype=(?!swift).* %{
-    rmhl swift
-}
+hook -group swift-highlight global WinSetOption filetype=swift %{ addhl ref swift }
+hook global WinSetOption filetype=(?!swift).* %{ rmhl swift }

--- a/rc/base/yaml.kak
+++ b/rc/base/yaml.kak
@@ -52,9 +52,9 @@ def -hidden _yaml_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=yaml %{
-    addhl ref yaml
+hook -group yaml-highlight global WinSetOption filetype=yaml %{ addhl ref yaml }
 
+hook global WinSetOption filetype=yaml %{
     hook window InsertEnd  .* -group yaml-hooks  _yaml_filter_around_selections
     hook window InsertChar \n -group yaml-indent _yaml_indent_on_new_line
 }

--- a/rc/core/asciidoc.kak
+++ b/rc/core/asciidoc.kak
@@ -28,5 +28,5 @@ addhl -group /asciidoc regex ^:[-\w]+: 0:meta
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 #
-hook global WinSetOption filetype=asciidoc %{ addhl ref asciidoc }
+hook -group asciidoc-highlight global WinSetOption filetype=asciidoc %{ addhl ref asciidoc }
 hook global WinSetOption filetype=(?!asciidoc).* %{ rmhl asciidoc }

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -252,13 +252,13 @@ hook global WinSetOption filetype=(?!(c|cpp|objc)$).* %[
     unalias window alt c-family-alternative-file
 ]
 
-hook global WinSetOption filetype=c %[ addhl ref c ]
+hook -group c-highlight global WinSetOption filetype=c %[ addhl ref c ]
 hook global WinSetOption filetype=(?!c$).* %[ rmhl c ]
 
-hook global WinSetOption filetype=cpp %[ addhl ref cpp ]
+hook -group cpp-highlight global WinSetOption filetype=cpp %[ addhl ref cpp ]
 hook global WinSetOption filetype=(?!cpp$).* %[ rmhl cpp ]
 
-hook global WinSetOption filetype=objc %[ addhl ref objc ]
+hook -group objc-highlight global WinSetOption filetype=objc %[ addhl ref objc ]
 hook global WinSetOption filetype=(?!objc$).* %[ rmhl objc ]
 
 decl str c_include_guard_style "ifdef"

--- a/rc/core/diff.kak
+++ b/rc/core/diff.kak
@@ -7,5 +7,5 @@ addhl -group /diff regex "^\+[^\n]*\n" 0:green,default
 addhl -group /diff regex "^-[^\n]*\n" 0:red,default
 addhl -group /diff regex "^@@[^\n]*@@" 0:cyan,default
 
-hook global WinSetOption filetype=diff %{ addhl ref diff }
+hook -group diff-highlight global WinSetOption filetype=diff %{ addhl ref diff }
 hook global WinSetOption filetype=(?!diff).* %{ rmhl diff }

--- a/rc/core/grep.kak
+++ b/rc/core/grep.kak
@@ -23,14 +23,20 @@ def -params .. -file-completion \
            }"
 }}
 
-hook global WinSetOption filetype=grep %{
+hook -group grep-highlight global WinSetOption filetype=grep %{
     addhl group grep
     addhl -group grep regex "^((?:\w:)?[^:]+):(\d+):(\d+)?" 1:cyan 2:green 3:green
     addhl -group grep line %{%opt{_grep_current_line}} default+b
+}
+
+hook global WinSetOption filetype=grep %{
     hook buffer -group grep-hooks NormalKey <ret> grep-jump
 }
 
-hook global WinSetOption filetype=(?!grep).* %{ rmhl grep; rmhooks buffer grep-hooks }
+hook global WinSetOption filetype=(?!grep).* %{
+    rmhl grep
+    rmhooks buffer grep-hooks
+}
 
 decl str jumpclient
 

--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -37,5 +37,5 @@ addhl -group /kakrc/single_string fill string
 addhl -group /kakrc/comment fill comment
 addhl -group /kakrc/shell ref sh
 
-hook global WinSetOption filetype=kak %{ addhl ref kakrc }
+hook -group kak-highlight global WinSetOption filetype=kak %{ addhl ref kakrc }
 hook global WinSetOption filetype=(?!kak).* %{ rmhl kakrc }

--- a/rc/core/make.kak
+++ b/rc/core/make.kak
@@ -22,8 +22,9 @@ addhl -group / group make
 addhl -group /make regex "^((?:\w:)?[^:\n]+):(\d+):(?:(\d+):)?\h+(?:((?:fatal )?error)|(warning)|(note)|(required from(?: here)?))?.*?$" 1:cyan 2:green 3:green 4:red 5:yellow 6:blue 7:yellow
 addhl -group /make line %{%opt{_make_current_error_line}} default+b
 
+hook -group make-highlight global WinSetOption filetype=make %{ addhl ref make }
+
 hook global WinSetOption filetype=make %{
-    addhl ref make
     hook buffer -group make-hooks NormalKey <ret> make-jump
 }
 

--- a/rc/core/makefile.kak
+++ b/rc/core/makefile.kak
@@ -54,9 +54,9 @@ def -hidden _makefile-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=makefile %{
-    addhl ref makefile
+hook -group makefile-highlight global WinSetOption filetype=makefile %{ addhl ref makefile }
 
+hook global WinSetOption filetype=makefile %{
     hook window InsertChar \n -group makefile-indent _makefile-indent-on-new-line
 
     set window comment_selection_chars ""

--- a/rc/core/man.kak
+++ b/rc/core/man.kak
@@ -2,7 +2,7 @@ decl str docsclient
 
 decl -hidden str _manpage
 
-hook global WinSetOption filetype=man %{
+hook -group man-highlight global WinSetOption filetype=man %{
     addhl group man-highlight
     # Sections
     addhl -group man-highlight regex ^\S.*?$ 0:blue
@@ -12,7 +12,9 @@ hook global WinSetOption filetype=man %{
     addhl -group man-highlight regex '^ {7}-[^\s,]+(,\s+-[^\s,]+)*' 0:yellow
     # References to other manpages
     addhl -group man-highlight regex [-a-zA-Z0-9_.]+\(\d\) 0:green
+}
 
+hook global WinSetOption filetype=man %{
     hook -group man-hooks window WinResize .* %{
         _man %opt{_manpage}
     }

--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -69,8 +69,9 @@ def -hidden _python_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
+hook -group python-highlight global WinSetOption filetype=python %{ addhl ref python }
+
 hook global WinSetOption filetype=python %{
-    addhl ref python
     hook window InsertChar \n -group python-indent _python_indent_on_new_line
     # cleanup trailing whitespaces on current line insert end
     hook window InsertEnd .* -group python-indent %{ try %{ exec -draft \; <a-x> s ^\h+$ <ret> d } }

--- a/rc/core/sh.kak
+++ b/rc/core/sh.kak
@@ -39,5 +39,5 @@ addhl -group /sh/code regex ^\h*(\w+)\h*\(\) 1:identifier
 addhl -group /sh/code regex \$(\w+|\{.+?\}|#|@|\?|\$|!|-|\*) 0:identifier
 addhl -group /sh/double_string regex \$(\w+|\{.+?\}) 0:identifier
 
-hook global WinSetOption filetype=sh %{ addhl ref sh }
+hook -group sh-highlight global WinSetOption filetype=sh %{ addhl ref sh }
 hook global WinSetOption filetype=(?!sh).* %{ rmhl sh }

--- a/rc/extra/cabal.kak
+++ b/rc/extra/cabal.kak
@@ -63,9 +63,9 @@ def -hidden _cabal_indent_on_closing_curly_brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=cabal %[
-    addhl ref cabal
+hook -group cabal-highlight global WinSetOption filetype=cabal %{ addhl ref cabal }
 
+hook global WinSetOption filetype=cabal %[
     hook window InsertEnd  .* -group cabal-hooks  _cabal_filter_around_selections
     hook window InsertChar \n -group cabal-indent _cabal_indent_on_new_line
     hook window InsertChar \{ -group cabal-indent _cabal_indent_on_opening_curly_brace

--- a/rc/extra/coffee.kak
+++ b/rc/extra/coffee.kak
@@ -75,9 +75,9 @@ def -hidden _coffee_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=coffee %{
-    addhl ref coffee
+hook -group coffee-highlight global WinSetOption filetype=coffee %{ addhl ref coffee }
 
+hook global WinSetOption filetype=coffee %{
     hook window InsertEnd  .* -group coffee-hooks  _coffee_filter_around_selections
     hook window InsertChar \n -group coffee-indent _coffee_indent_on_new_line
 

--- a/rc/extra/cucumber.kak
+++ b/rc/extra/cucumber.kak
@@ -81,9 +81,9 @@ def -hidden _cucumber_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=cucumber %{
-    addhl ref cucumber
+hook -group cucumber-highlight global WinSetOption filetype=cucumber %{ addhl ref cucumber }
 
+hook global WinSetOption filetype=cucumber %{
     hook window InsertEnd  .* -group cucumber-hooks  _cucumber_filter_around_selections
     hook window InsertChar \n -group cucumber-indent _cucumber_indent_on_new_line
 }

--- a/rc/extra/dockerfile.kak
+++ b/rc/extra/dockerfile.kak
@@ -38,10 +38,5 @@ addhl -group /dockerfile/comment fill comment
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=dockerfile %{
-    addhl ref dockerfile
-}
-
-hook global WinSetOption filetype=(?!dockerfile).* %{
-    rmhl dockerfile
-}
+hook -group dockerfile-highlight global WinSetOption filetype=dockerfile %{ addhl ref dockerfile }
+hook global WinSetOption filetype=(?!dockerfile).* %{ rmhl dockerfile }

--- a/rc/extra/exherbo.kak
+++ b/rc/extra/exherbo.kak
@@ -34,7 +34,7 @@ addhl -group /exheres-0-metadata regex ^(?:[\s\t]+)?[\S]+[\s\t]+=[\s\t]+\[.+?[\s
 addhl -group /exheres-0-metadata regex ^(?:[\s\t]+)?(\S+)\s\[\[$ 0:type
 addhl -group /exheres-0-metadata regex ^(?:[\s\t]+)?\]\]$ 0:type
 
-hook global WinSetOption filetype=exheres-0-metadata %{ addhl ref exheres-0-metadata }
+hook -group exheres-0-metadata-highlight global WinSetOption filetype=exheres-0-metadata %{ addhl ref exheres-0-metadata }
 hook global WinSetOption filetype=(?!exheres-0-metadata).* %{ rmhl exheres-0-metadata }
 
 ## exheres-0 options descriptions
@@ -44,7 +44,7 @@ addhl -group /exheres-0-options-descriptions regex ^(?:[\s\t]+)?[\S]+[\s\t]+-[\s
 addhl -group /exheres-0-options-descriptions regex ^(?:[\s\t]+)?(\S+)\s\[\[$ 0:type
 addhl -group /exheres-0-options-descriptions regex ^(?:[\s\t]+)?\]\]$ 0:type
 
-hook global WinSetOption filetype=exheres-0-options-descriptions %{ addhl ref exheres-0-options-descriptions }
+hook -group exheres-0-options-descriptions-highlight global WinSetOption filetype=exheres-0-options-descriptions %{ addhl ref exheres-0-options-descriptions }
 hook global WinSetOption filetype=(?!exheres-0-options-descriptions).* %{ rmhl exheres-0-options-descriptions }
 
 ## metadata/licence_groups.conf
@@ -53,7 +53,7 @@ addhl -group /exheres-0-licence-groups regex [\s\t]+(\S+(?:[\s\t]+))*$ 0:attribu
 addhl -group /exheres-0-licence-groups regex ^(\S+) 0:type
 addhl -group /exheres-0-licence-groups regex ^#.*?$ 0:comment
 
-hook global WinSetOption filetype=exheres-0-licence-groups %{ addhl ref exheres-0-licence-groups }
+hook -group exheres-0-licence-groups-highlight global WinSetOption filetype=exheres-0-licence-groups %{ addhl ref exheres-0-licence-groups }
 hook global WinSetOption filetype=(?!exheres-0-licence-groups).* %{ rmhl exheres-0-licence-groups }
 
 ## Paludis configurations
@@ -67,7 +67,7 @@ addhl -group /paludis-options-conf regex [\s\t](-\S+)(.*?) 1:red
 addhl -group /paludis-options-conf regex ^(\S+/\S+) 0:type
 addhl -group /paludis-options-conf regex ^#.*?$ 0:comment
 
-hook global WinSetOption filetype=paludis-options-conf %{ addhl ref paludis-options-conf }
+hook -group paludis-options-conf-highlight global WinSetOption filetype=paludis-options-conf %{ addhl ref paludis-options-conf }
 hook global WinSetOption filetype=(?!paludis-options-conf).* %{ rmhl paludis-options-conf }
 
 ## general.conf, repository.template
@@ -75,7 +75,7 @@ addhl -group / group paludis-key-value-conf
 addhl -group /paludis-key-value-conf regex ^[\s\t]?(\S+)[\s\t+]=[\s\t+](.*?)$ 1:attribute 2:value
 addhl -group /paludis-key-value-conf regex ^#.*?$ 0:comment
 
-hook global WinSetOption filetype=paludis-key-value-conf %{ addhl ref paludis-key-value-conf }
+hook -group paludis-key-value-conf-highlight global WinSetOption filetype=paludis-key-value-conf %{ addhl ref paludis-key-value-conf }
 hook global WinSetOption filetype=(?!paludis-key-value-conf).* %{ rmhl paludis-key-value-conf }
 
 ## mirrors.conf
@@ -83,7 +83,7 @@ addhl -group / group paludis-mirrors-conf
 addhl -group /paludis-mirrors-conf regex ^[\s\t+]?(\S+)[\s\t+](.*?)$ 1:type 2:value
 addhl -group /paludis-mirrors-conf regex ^#.*?$ 0:comment
 
-hook global WinSetOption filetype=paludis-mirrors-conf %{ addhl ref paludis-mirrors-conf }
+hook -group paludis-mirrors-conf-highlight global WinSetOption filetype=paludis-mirrors-conf %{ addhl ref paludis-mirrors-conf }
 hook global WinSetOption filetype=(?!paludis-mirrors-conf).* %{ rmhl paludis-mirrors-conf }
 
 ## package_(unmask|mask).conf, platforms.conf
@@ -92,7 +92,7 @@ addhl -group /paludis-specs-conf regex [\s\t]+(\S+(?:[\s\t]+))*$ 0:attribute
 addhl -group /paludis-specs-conf regex ^(\S+/\S+) 0:type
 addhl -group /paludis-specs-conf regex ^#.*?$ 0:comment
 
-hook global WinSetOption filetype=paludis-specs-conf %{ addhl ref paludis-specs-conf }
+hook -group paludis-specs-conf-highlight global WinSetOption filetype=paludis-specs-conf %{ addhl ref paludis-specs-conf }
 hook global WinSetOption filetype=(?!paludis-specs-conf).* %{ rmhl paludis-specs-conf }
 
 ## News items (GLEP42)
@@ -101,5 +101,5 @@ addhl -group /glep42 regex ^(Title|Author|Translator|Content-Type|Posted|Revisio
 addhl -group /glep42 regex <[^@>]+@.*?> 0:string
 addhl -group /glep42 regex ^>.*?$ 0:comment
 
-hook global WinSetOption filetype=glep42 %{ addhl ref glep42 }
+hook -group glep42-highlight global WinSetOption filetype=glep42 %{ addhl ref glep42 }
 hook global WinSetOption filetype=(?!glep42).* %{ rmhl glep42 }

--- a/rc/extra/git-tools.kak
+++ b/rc/extra/git-tools.kak
@@ -1,6 +1,6 @@
 decl str docsclient
 
-hook global WinSetOption filetype=git-log %{
+hook -group git-log-highlight global WinSetOption filetype=git-log %{
     addhl group git-log-highlight
     addhl -group git-log-highlight regex '^(commit) ([0-9a-f]+)$' 1:yellow 2:red
     addhl -group git-log-highlight regex '^([a-zA-Z_-]+:) (.*?)$' 1:green 2:magenta
@@ -11,7 +11,7 @@ hook global WinSetOption filetype=(?!git-log).* %{
     rmhl git-log-highlight
 }
 
-hook global WinSetOption filetype=git-status %{
+hook -group git-status-highlight global WinSetOption filetype=git-status %{
     addhl group git-status-highlight
     addhl -group git-status-highlight regex '^\h+(?:((?:both )?modified:)|(added:|new file:)|(deleted(?: by \w+)?:)|(renamed:)|(copied:))(?:.*?)$' 1:yellow 2:green 3:red 4:cyan 5:blue 6:magenta
 }

--- a/rc/extra/haml.kak
+++ b/rc/extra/haml.kak
@@ -58,9 +58,9 @@ def -hidden _haml_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=haml %{
-    addhl ref haml
+hook -group haml-highlight global WinSetOption filetype=haml %{ addhl ref haml }
 
+hook global WinSetOption filetype=haml %{
     hook window InsertEnd  .* -group haml-hooks  _haml_filter_around_selections
     hook window InsertChar \n -group haml-indent _haml_indent_on_new_line
 }

--- a/rc/extra/kickstart.kak
+++ b/rc/extra/kickstart.kak
@@ -26,10 +26,5 @@ addhl -group /kickstart/shell regex '^\h*%end\b' 0:type
 addhl -group /kickstart/shell ref sh
 
 
-hook global WinSetOption filetype=kickstart %{
-    addhl ref kickstart
-}
-
-hook global WinSetOption filetype=(?!kickstart).* %{
-    rmhl kickstart
-}
+hook -group kickstart-highlight global WinSetOption filetype=kickstart %{ addhl ref kickstart }
+hook global WinSetOption filetype=(?!kickstart).* %{ rmhl kickstart }

--- a/rc/extra/latex.kak
+++ b/rc/extra/latex.kak
@@ -33,9 +33,9 @@ addhl -group /latex/content regex '\\textbf\{([^}]+)\}' 1:default+b
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=latex %{
-    addhl ref latex
+hook -group latex-highlight global WinSetOption filetype=latex %{ addhl ref latex }
 
+hook global WinSetOption filetype=latex %{
     set window comment_line_chars '%'
 }
 

--- a/rc/extra/moon.kak
+++ b/rc/extra/moon.kak
@@ -98,9 +98,9 @@ def -hidden _moon_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=moon %{
-    addhl ref moon
+hook -group moon-highlight global WinSetOption filetype=moon %{ addhl ref moon }
 
+hook global WinSetOption filetype=moon %{
     hook window InsertEnd  .* -group moon-hooks  _moon_filter_around_selections
     hook window InsertChar .* -group moon-indent _moon_indent_on_char
     hook window InsertChar \n -group moon-indent _moon_indent_on_new_line

--- a/rc/extra/pug.kak
+++ b/rc/extra/pug.kak
@@ -69,9 +69,9 @@ def -hidden _pug_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=pug %{
-    addhl ref pug
+hook -group pug-highlight global WinSetOption filetype=pug %{ addhl ref pug }
 
+hook global WinSetOption filetype=pug %{
     hook window InsertEnd  .* -group pug-hooks  _pug_filter_around_selections
     hook window InsertChar \n -group pug-indent _pug_indent_on_new_line
 }

--- a/rc/extra/ragel.kak
+++ b/rc/extra/ragel.kak
@@ -62,9 +62,9 @@ def -hidden _ragel_indent_on_new_line %<
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=ragel %{
-    addhl ref ragel
+hook -group ragel-highlight global WinSetOption filetype=ragel %{ addhl ref ragel }
 
+hook global WinSetOption filetype=ragel %{
     hook window InsertEnd  .* -group ragel-hooks  _ragel_filter_around_selections
     hook window InsertChar .* -group ragel-indent _ragel_indent_on_char
     hook window InsertChar \n -group ragel-indent _ragel_indent_on_new_line

--- a/rc/extra/sass.kak
+++ b/rc/extra/sass.kak
@@ -54,9 +54,9 @@ def -hidden _sass_indent_on_new_line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=sass %{
-    addhl ref sass
+hook -group sass-highlight global WinSetOption filetype=sass %{ addhl ref sass }
 
+hook global WinSetOption filetype=sass %{
     hook window InsertEnd  .* -group sass-hooks  _sass_filter_around_selections
     hook window InsertChar \n -group sass-indent _sass_indent_on_new_line
 }

--- a/rc/extra/scss.kak
+++ b/rc/extra/scss.kak
@@ -33,9 +33,9 @@ def -hidden _scss_indent_on_closing_curly_brace _css_indent_on_closing_curly_bra
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=scss %[
-    addhl ref scss
+hook -group scss-highlight global WinSetOption filetype=scss %{ addhl ref scss }
 
+hook global WinSetOption filetype=scss %[
     hook window InsertEnd  .* -group scss-hooks  _scss_filter_around_selections
     hook window InsertChar \n -group scss-indent _scss_indent_on_new_line
     hook window InsertChar \} -group scss-indent _scss_indent_on_closing_curly_brace

--- a/rc/extra/tupfile.kak
+++ b/rc/extra/tupfile.kak
@@ -29,10 +29,5 @@ addhl -group /tupfile/code regex "\b(\&?[\w_]+)\s*[:+]?=" 1:keyword
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=tupfile %{
-    addhl ref tupfile
-}
-
-hook global WinSetOption filetype=(?!tupfile).* %{
-    rmhl tupfile
-}
+hook -group tupfile-highlight global WinSetOption filetype=tupfile %{ addhl ref tupfile }
+hook global WinSetOption filetype=(?!tupfile).* %{ rmhl tupfile }


### PR DESCRIPTION
Closes #814, this makes it easy to disable all highlighting with just `set global disabled_hooks '.+-highlight'`.

Note, this PR is still WIP, as denoted by the `todo` file, there are still files I want to do stuff with before merging this PR.

In the meanwhile, the PR is open for review, in case people want to fix any errors.