### PR TITLE
Update the minimum version of `gcc` required to build

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -99,7 +99,7 @@ Building
 
 Kakoune dependencies are:
 
- * A C++11 compliant compiler (GCC >= 4.8 or clang >= 3.4)
+ * A C++11 compliant compiler (GCC >= 5 or clang >= 3.4)
  * boost (>= 1.50)
  * ncurses with wide-characters support (>= 5.3, generally referred to as libncursesw)
  * asciidoc (for the `a2k` tool), to generate man pages


### PR DESCRIPTION
Not sure about the `clang` version though, TBD.