### PR TITLE
Document the non inclusiveness of the end column in range faces options

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -824,7 +824,8 @@ Options are typed, their type can be
  * `range-faces`: a `:` separated list of a pairs of a buffer range
    (`<begin line>.<begin column>,<end line>.<end column>`) and  a face
    (separated by `|`), except for the first element which is just the
-   timestamp of the buffer.
+   timestamp of the buffer. Note that the end column is not inclusive,
+   meaning that it has to be strictly greater than the begin column
  * `completions`: a `:` separated list of `<text>|<docstring>|<menu text>`
    candidates, except for the first element which follows the
    `<line>.<column>[+<length>]@<timestamp>` format to define where the

--- a/doc/manpages/options.asciidoc
+++ b/doc/manpages/options.asciidoc
@@ -26,7 +26,8 @@ Types
 	a `:` separated list of a pairs of a buffer range
 	(`<begin line>.<begin column>,<end line>.<end column>`) and  a face
 	(separated by `|`), except for the first element which is just the
-	timestamp of the buffer.
+	timestamp of the buffer. Note that the end column is not inclusive,
+	meaning that it has to be strictly greater than the begin column
 *completions*::
 	a `:` separated list of `<text>|<docstring>|<menu text>`
 	candidates, except for the first element which follows the


### PR DESCRIPTION
Changing the behavior of the option in the code would imply changes in scripts, so I just documented this behavior.

Maybe it will change later on, but that's not too important for now as this behavior exists because of the translation between data and C++ iterators (it's not a random mistake).

Closes #864 