### PR TITLE
Remove `formatcmd` and comment options from default scripts, fix `commenting.kak`

### DIFF
--- a/rc/base/css.kak
+++ b/rc/base/css.kak
@@ -72,8 +72,6 @@ hook global WinSetOption filetype=css %[
     hook window InsertEnd  .* -group css-hooks  _css_filter_around_selections
     hook window InsertChar \n -group css-indent _css_indent_on_new_line
     hook window InsertChar \} -group css-indent _css_indent_on_closing_curly_brace
-
-    set comment_line_chars ""
 ]
 
 hook -group css-highlight global WinSetOption filetype=(?!css).* %{ rmhl css }

--- a/rc/base/d.kak
+++ b/rc/base/d.kak
@@ -110,8 +110,6 @@ hook global WinSetOption filetype=d %{
     hook window InsertChar \n -group d-indent _d-indent-on-new-line
     hook window InsertChar \{ -group d-indent _d-indent-on-opening-curly-brace
     hook window InsertChar \} -group d-indent _d-indent-on-closing-curly-brace
-
-    set window comment_selection_chars "/+:+/"
 }
 
 hook -group d-highlight global WinSetOption filetype=(?!d).* %{ rmhl d }

--- a/rc/base/d.kak
+++ b/rc/base/d.kak
@@ -111,7 +111,6 @@ hook global WinSetOption filetype=d %{
     hook window InsertChar \{ -group d-indent _d-indent-on-opening-curly-brace
     hook window InsertChar \} -group d-indent _d-indent-on-closing-curly-brace
 
-    set window formatcmd "dfmt"
     set window comment_selection_chars "/+:+/"
 }
 

--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -92,8 +92,6 @@ hook global WinSetOption filetype=go %{
     hook window InsertChar \n -group go-indent _go-indent-on-new-line
     hook window InsertChar \{ -group go-indent _go-indent-on-opening-curly-brace
     hook window InsertChar \} -group go-indent _go-indent-on-closing-curly-brace
-
-    set window formatcmd "gofmt"
 }
 
 hook -group go-highlight global WinSetOption filetype=(?!go).* %{ rmhl go }

--- a/rc/base/html.kak
+++ b/rc/base/html.kak
@@ -69,8 +69,6 @@ hook global WinSetOption filetype=html %{
     hook window InsertEnd  .* -group html-hooks  _html_filter_around_selections
     hook window InsertChar .* -group html-indent _html_indent_on_char
     hook window InsertChar \n -group html-indent _html_indent_on_new_line
-
-    set window comment_selection_chars '<!--:-->'
 }
 
 hook -group html-highlight global WinSetOption filetype=(?!html).* %{ rmhl html }

--- a/rc/base/lua.kak
+++ b/rc/base/lua.kak
@@ -1,8 +1,6 @@
 # http://lua.org
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-# require commenting.kak
-
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
@@ -103,9 +101,6 @@ hook global WinSetOption filetype=lua %{
     hook window InsertChar \n -group lua-indent _lua_indent_on_new_line
 
     alias window alt lua-alternative-file
-
-    set window comment_line_chars '--'
-    set window comment_selection_chars '\Q--[[:]]'
 }
 
 hook -group lua-highlight global WinSetOption filetype=(?!lua).* %{ rmhl lua }

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -117,9 +117,6 @@ hook global WinSetOption filetype=perl %{
     hook window InsertChar \n -group perl-indent _perl-indent-on-new-line
     hook window InsertChar \{ -group perl-indent _perl-indent-on-opening-curly-brace
     hook window InsertChar \} -group perl-indent _perl-indent-on-closing-curly-brace
-
-    set window comment_selection_chars ""
-    set window comment_line_chars "#"
 }
 
 hook -group perl-highlight global WinSetOption filetype=(?!perl).* %{ rmhl perl }

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -118,7 +118,6 @@ hook global WinSetOption filetype=perl %{
     hook window InsertChar \{ -group perl-indent _perl-indent-on-opening-curly-brace
     hook window InsertChar \} -group perl-indent _perl-indent-on-closing-curly-brace
 
-    set window formatcmd "perltidy"
     set window comment_selection_chars ""
     set window comment_line_chars "#"
 }

--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -1,8 +1,6 @@
 # http://ruby-lang.org
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-# require commenting.kak
-
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
@@ -158,9 +156,6 @@ hook global WinSetOption filetype=ruby %{
     hook window InsertChar \n -group ruby-insert _ruby_insert_on_new_line
 
     alias window alt ruby-alternative-file
-
-    set window comment_line_chars '#'
-    set window comment_selection_chars '^begin=:^=end'
 }
 
 hook -group ruby-highlight global WinSetOption filetype=(?!ruby).* %{ rmhl ruby }

--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -161,11 +161,6 @@ hook global WinSetOption filetype=ruby %{
 
     set window comment_line_chars '#'
     set window comment_selection_chars '^begin=:^=end'
-
-    # Rubocop requires a filepath that will be used when generating the errors summary,
-    # even though it's reading anonymous data on stdin
-    # It also leaves an ugly separator on the first line on the output
-    set window formatcmd 'rubocop --auto-correct --stdin - -o /dev/null | sed 1d'
 }
 
 hook -group ruby-highlight global WinSetOption filetype=(?!ruby).* %{ rmhl ruby }

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -240,8 +240,6 @@ hook global WinSetOption filetype=(c|cpp|objc) %[
     hook -group c-family-insert window InsertChar \n _c-family-insert-on-newline
 
     alias window alt c-family-alternative-file
-
-    set window formatcmd "astyle"
 ]
 
 hook global WinSetOption filetype=(?!(c|cpp|objc)$).* %[

--- a/rc/core/commenting.kak
+++ b/rc/core/commenting.kak
@@ -1,21 +1,48 @@
-## Characters that will be used to surround a selection with
-decl str-list comment_selection_chars "/*:*/"
-
 ## Characters that will be inserted at the beginning of a line to comment
-decl str comment_line_chars "//"
+decl str comment_line_chars "#"
+
+## Characters that will be used to surround a selection with
+decl str-list comment_selection_chars ""
 
 ## Default characters for all languages
+hook global BufSetOption filetype=asciidoc %{
+    set buffer comment_selection_chars '///:///'
+}
+
+hook global BufSetOption filetype=(c|cpp|go|java|javascript|objc|sass|scala|scss|swift) %{
+    set buffer comment_line_chars '//'
+    set buffer comment_selection_chars '/*:*/'
+}
+
+hook global BufSetOption filetype=(cabal|haskell|moon) %{
+    set buffer comment_line_chars '--'
+}
+
+hook global BufSetOption filetype=clojure %{
+    set buffer comment_line_chars '#_ '
+    set buffer comment_selection_chars '(comment :)'
+}
+
 hook global BufSetOption filetype=coffee %{
-    set buffer comment_line_chars '#'
     set buffer comment_selection_chars '###:###'
 }
 
 hook global BufSetOption filetype=css %{
     set buffer comment_line_chars ''
+    set buffer comment_selection_chars '/*:*/'
 }
 
 hook global BufSetOption filetype=d %{
+    set buffer comment_line_chars '//'
     set buffer comment_selection_chars '/+:+/'
+}
+
+hook global BufSetOption filetype=(gas|ini) %{
+    set buffer comment_line_chars ';'
+}
+
+hook global BufSetOption filetype=haml %{
+    set buffer comment_line_chars '-#'
 }
 
 hook global BufSetOption filetype=html %{
@@ -25,7 +52,11 @@ hook global BufSetOption filetype=html %{
 
 hook global BufSetOption filetype=latex %{
     set buffer comment_line_chars '%'
-    set buffer comment_selection_chars ''
+}
+
+hook global BufSetOption filetype=lisp %{
+    set buffer comment_line_chars ';'
+    set buffer comment_selection_chars '#|:|#'
 }
 
 hook global BufSetOption filetype=lua %{
@@ -33,18 +64,29 @@ hook global BufSetOption filetype=lua %{
     set buffer comment_selection_chars '--[[:]]'
 }
 
-hook global BufSetOption filetype=moon %{
-    set buffer comment_line_chars '--'
-    set buffer comment_selection_chars ''
+hook global BufSetOption filetype=markdown %{
+    set buffer comment_line_chars ''
+    set buffer comment_selection_chars '[//]: # (:)'
 }
 
-hook global BufSetOption filetype=(perl|makefile) %{
-    set buffer comment_line_chars '#'
-    set buffer comment_selection_chars ''
+hook global BufSetOption filetype=perl %{
+    set buffer comment_selection_chars '#[:]'
+}
+
+hook global BufSetOption filetype=(pug|rust) %{
+    set buffer comment_line_chars '//'
+}
+
+hook global BufSetOption filetype=python %{
+    set buffer comment_selection_chars '""":"""'
+}
+
+hook global BufSetOption filetype=ragel %{
+    set buffer comment_line_chars '%%'
+    set buffer comment_selection_chars '%%{:}%%'
 }
 
 hook global BufSetOption filetype=ruby %{
-    set buffer comment_line_chars '#'
     set buffer comment_selection_chars '^begin=:^=end'
 }
 
@@ -55,7 +97,7 @@ def comment-selection -docstring "Comment/uncomment the current selection" %{
             printf %s\\n "$@" | sed 's,<,<lt>,g'
         }
 
-        readonly opening=$(exec_proof "${kak_opt_comment_selection_chars%%:*}")
+        readonly opening=$(exec_proof "${kak_opt_comment_selection_chars%:*}")
         readonly closing=$(exec_proof "${kak_opt_comment_selection_chars##*:}")
 
         if [ -z "${opening}" ] || [ -z "${closing}" ]; then

--- a/rc/core/commenting.kak
+++ b/rc/core/commenting.kak
@@ -4,6 +4,50 @@ decl str-list comment_selection_chars "/*:*/"
 ## Characters that will be inserted at the beginning of a line to comment
 decl str comment_line_chars "//"
 
+## Default characters for all languages
+hook global BufSetOption filetype=coffee %{
+    set buffer comment_line_chars '#'
+    set buffer comment_selection_chars '###:###'
+}
+
+hook global BufSetOption filetype=css %{
+    set buffer comment_line_chars ''
+}
+
+hook global BufSetOption filetype=d %{
+    set buffer comment_selection_chars '/+:+/'
+}
+
+hook global BufSetOption filetype=html %{
+    set buffer comment_line_chars ''
+    set buffer comment_selection_chars '<!--:-->'
+}
+
+hook global BufSetOption filetype=latex %{
+    set buffer comment_line_chars '%'
+    set buffer comment_selection_chars ''
+}
+
+hook global BufSetOption filetype=lua %{
+    set buffer comment_line_chars '--'
+    set buffer comment_selection_chars '--[[:]]'
+}
+
+hook global BufSetOption filetype=moon %{
+    set buffer comment_line_chars '--'
+    set buffer comment_selection_chars ''
+}
+
+hook global BufSetOption filetype=(perl|makefile) %{
+    set buffer comment_line_chars '#'
+    set buffer comment_selection_chars ''
+}
+
+hook global BufSetOption filetype=ruby %{
+    set buffer comment_line_chars '#'
+    set buffer comment_selection_chars '^begin=:^=end'
+}
+
 def comment-selection -docstring "Comment/uncomment the current selection" %{
     %sh{
         function exec_proof {

--- a/rc/core/commenting.kak
+++ b/rc/core/commenting.kak
@@ -50,7 +50,7 @@ hook global BufSetOption filetype=ruby %{
 
 def comment-selection -docstring "Comment/uncomment the current selection" %{
     %sh{
-        function exec_proof {
+        exec_proof() {
             ## Replace the '<' sign that is interpreted differently in `exec`
             printf %s\\n "$@" | sed 's,<,<lt>,g'
         }
@@ -63,51 +63,52 @@ def comment-selection -docstring "Comment/uncomment the current selection" %{
             exit
         fi
 
-        printf %s\\n "try %{
+        printf %s\\n "eval -draft %{ try %{
             ## The selection is empty
-            exec -draft %{<a-K>\A[\h\v\n]*\z<ret>}
+            exec <a-K>\\A[\\h\\v\\n]*\\z<ret>
 
             try %{
                 ## The selection has already been commented
-                exec -draft %{<a-K>\A\Q${opening}\E.*\Q${closing}\E\z<ret>}
+                exec %{<a-K>\\A\\Q${opening}\\E.*\\Q${closing}\\E\\n*\\z<ret>}
 
                 ## Comment the selection
-                exec %{a${closing}<esc>i${opening}<esc>${#opening}H}
+                exec -draft %{a${closing}<esc>i${opening}}
             } catch %{
                 ## Uncomment the commented selection
-                exec -draft %{s(\A\Q${opening}\E)|(\Q${closing}\E\z)<ret>d}
+                exec -draft %{s(\\A\\Q${opening}\\E)|(\\Q${closing}\\E\\n*\\z)<ret>d}
             }
-        }"
+        } }"
     }
 }
 
 def comment-line -docstring "Comment/uncomment the current line" %{
     %sh{
         readonly opening="${kak_opt_comment_line_chars}"
-        readonly opening_escaped="\Q${opening}\E"
+        readonly opening_escaped="\\Q${opening}\\E"
 
         if [ -z "${opening}" ]; then
             echo "echo -debug 'The \`comment_line_chars\` variable is empty, could not comment the line'"
             exit
         fi
 
-        printf %s\\n "
-        ## Select the content of the line, without indentation
-        exec %{I<esc><a-l>}
-
-        try %{
-            ## There's no text on the line
-            exec -draft %{<a-K>\A[\h\v\n]*\z<ret>}
+        printf %s\\n "eval -draft %{
+            ## Select the content of the line, without indentation
+            exec I<esc><a-l>
 
             try %{
-                ## The line has already been commented
-                exec -draft %{<a-K>\A${opening_escaped}<ret>}
+                ## There's no text on the line
+                exec <a-K>\\A[\\h\\v\\n]*\\z<ret>
 
-                ## Comment the line
-                exec %{i${opening}<esc>${#opening}H}
-            } catch %{
-                ## Uncomment the line
-                exec -draft %{s\A${opening_escaped}\h*<ret>d}
+                try %{
+                    ## The line has already been commented
+                    exec %{<a-K>\\A${opening_escaped}<ret>}
+
+                    ## Comment the line
+                    exec -draft %{i${opening}}
+                } catch %{
+                    ## Uncomment the line
+                    exec -draft %{s\\A${opening_escaped}\\h*<ret>d}
+                }
             }
         }"
     }

--- a/rc/core/makefile.kak
+++ b/rc/core/makefile.kak
@@ -58,9 +58,6 @@ hook -group makefile-highlight global WinSetOption filetype=makefile %{ addhl re
 
 hook global WinSetOption filetype=makefile %{
     hook window InsertChar \n -group makefile-indent _makefile-indent-on-new-line
-
-    set window comment_selection_chars ""
-    set window comment_line_chars "#"
 }
 
 hook -group makefile-highlight global WinSetOption filetype=(?!makefile).* %{ rmhl makefile }

--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -75,8 +75,6 @@ hook global WinSetOption filetype=python %{
     hook window InsertChar \n -group python-indent _python_indent_on_new_line
     # cleanup trailing whitespaces on current line insert end
     hook window InsertEnd .* -group python-indent %{ try %{ exec -draft \; <a-x> s ^\h+$ <ret> d } }
-
-    set window formatcmd "autopep8 -"
 }
 
 hook -group python-highlight global WinSetOption filetype=(?!python).* %{ rmhl python }

--- a/rc/extra/coffee.kak
+++ b/rc/extra/coffee.kak
@@ -1,8 +1,6 @@
 # http://coffeescript.org
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-# require commenting.kak
-
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
@@ -80,9 +78,6 @@ hook -group coffee-highlight global WinSetOption filetype=coffee %{ addhl ref co
 hook global WinSetOption filetype=coffee %{
     hook window InsertEnd  .* -group coffee-hooks  _coffee_filter_around_selections
     hook window InsertChar \n -group coffee-indent _coffee_indent_on_new_line
-
-    set window comment_line_chars '#'
-    set window comment_selection_chars '###:###'
 }
 
 hook -group coffee-highlight global WinSetOption filetype=(?!coffee).* %{ rmhl coffee }

--- a/rc/extra/latex.kak
+++ b/rc/extra/latex.kak
@@ -35,8 +35,4 @@ addhl -group /latex/content regex '\\textbf\{([^}]+)\}' 1:default+b
 
 hook -group latex-highlight global WinSetOption filetype=latex %{ addhl ref latex }
 
-hook global WinSetOption filetype=latex %{
-    set window comment_line_chars '%'
-}
-
 hook -group latex-highlight global WinSetOption filetype=(?!latex).* %{ rmhl latex }

--- a/rc/extra/moon.kak
+++ b/rc/extra/moon.kak
@@ -1,8 +1,6 @@
 # http://moonscript.org
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-# require commenting.kak
-
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
@@ -106,9 +104,6 @@ hook global WinSetOption filetype=moon %{
     hook window InsertChar \n -group moon-indent _moon_indent_on_new_line
 
     alias window alt moon-alternative-file
-
-    set window comment_line_chars '--'
-    set window comment_selection_chars ''
 }
 
 hook -group moon-highlight global WinSetOption filetype=(?!moon).* %{ rmhl moon }

--- a/test/regression/860-python-incorrect-commenting/rc
+++ b/test/regression/860-python-incorrect-commenting/rc
@@ -1,4 +1,3 @@
 source "%val{runtime}/colors/default.kak"
-source "%val{runtime}/rc/core/formatter.kak"
 source "%val{runtime}/rc/core/python.kak"
 set buffer filetype python


### PR DESCRIPTION
Hi,

The details are in the commits. Now the next big question is: do we declare default formatters in `formatting.kak`, as we do for commenting sequences in `commenting.kak`? The two cases are similar despite this major difference: commenting sequences in languages do not change, but users have a choice between several formatters, so do we take the liberty of giving a default value?