### PR TITLE
Basic support for TaskPaper

### DIFF
--- a/rc/extra/taskpaper.kak
+++ b/rc/extra/taskpaper.kak
@@ -1,0 +1,47 @@
+# https://www.taskpaper.com
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+# Detection
+# ‾‾‾‾‾‾‾‾‾
+
+hook global BufCreate .*\.taskpaper %{
+    set buffer mimetype ""
+    set buffer filetype taskpaper
+} 
+
+# Highlighters
+# ‾‾‾‾‾‾‾‾‾‾‾‾
+
+addhl -group / group taskpaper
+
+addhl -group /taskpaper regex ^\h*([^:\n]+):\h*\n 1:header
+addhl -group /taskpaper regex \h@\w+(?:\(([^)]*)\))? 0:identifier 1:value
+addhl -group /taskpaper regex ^\h*([^-:\n]+)\n 1:+i
+addhl -group /taskpaper regex ^\h*-\h+[^\n]*@done[^\n]* 0:+d
+addhl -group /taskpaper regex (([a-z]+://\S+)|((mailto:)[\w+-]+@\S+)) 0:link
+
+# Commands
+# ‾‾‾‾‾‾‾‾
+
+def -hidden _taskpaper-indent-on-new-line %{
+    eval -draft -itersel %{
+        # preserve previous line indent
+        try %{ exec -draft \;K<a-&> }
+        ## If the line above is a project indent with a tab
+        try %{ exec -draft Z k<a-x> <a-k>^\h*([^:\n]+):<ret> z i<tab> }
+        # cleanup trailing white spaces on previous line
+        try %{ exec -draft k<a-x> s \h+$ <ret>d }
+    }
+}
+
+# Initialization
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+hook -group taskpaper-highlight global WinSetOption filetype=taskpaper %{
+    addhl ref taskpaper
+    hook window InsertChar \n -group taskpaper-indent _taskpaper-indent-on-new-line
+}
+hook -group taskpaper-highlight global WinSetOption filetype=(?!taskpaper).* %{
+    rmhl taskpaper
+    rmhooks window taskpaper-indent
+}


### PR DESCRIPTION
This adds syntax highlight and indent hook for TaskPaper files. See https://www.taskpaper.com.

Although this is a MacOS app the format is simple and plain text. It also has good support in [other editors/apps](http://support.hogbaysoftware.com/t/what-other-apps-support-taskpapers-file-format/1114).

Examples in _default_ and _base16_ themes:
<img width="1116" alt="screen shot 2016-10-21 at 20 46 52" src="https://cloud.githubusercontent.com/assets/879004/19608162/9815c43e-97cf-11e6-884e-a07bb54778d0.png">
<img width="1116" alt="screen shot 2016-10-21 at 20 47 00" src="https://cloud.githubusercontent.com/assets/879004/19608163/9834af7a-97cf-11e6-83b2-f6224e1c59de.png">

edit: add screenshots