### PR TITLE
Avoid problems when the message contains comas

### DIFF
--- a/rc/base/lint.kak
+++ b/rc/base/lint.kak
@@ -81,7 +81,7 @@ def lint-next -docstring "Jump to the next line that contains an error" %{ %sh{
         while read -r line
         do
             # get line,column pair
-            coords="${line%,*}"
+            coords=$(printf %s "$line" | cut -d, -f1,2)
             candidate="${coords%,*}"
             if [ "$candidate" -gt "$kak_cursor_line" ]
             then


### PR DESCRIPTION
Explanation:
`echo "10,36,note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]" | cut -d, -f1,2` returns `10,36`
whereas
`coords="${line%,*}` with `line="10,36,note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]"` results in `coords` -> `10,36,note: Expressions don't expand in single quotes`