### PR TITLE
Add missing Go keyword

### DIFF
--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -30,7 +30,7 @@ addhl -group /go/code regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9]+|0[xX][0-9a-fA-F]+)
     # Grammar
     keywords="break|default|defer|else|fallthrough|for|func|go|goto|if|import"
     keywords="${keywords}|interface|make|new|package|range|return|select|case|switch|type|continue"
-    keywords="${keywords}|var|const"
+    attributes="const|var"
     types="bool|byte|chan|complex128|complex64|float32|float64|int|int16|int32"
     types="${types}|int64|int8|interface|intptr|map|rune|string|struct|uint|uint16|uint32|uint64|uint8"
     values="false|true|nil"

--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -30,7 +30,7 @@ addhl -group /go/code regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9]+|0[xX][0-9a-fA-F]+)
     # Grammar
     keywords="break|default|defer|else|fallthrough|for|func|go|goto|if|import"
     keywords="${keywords}|interface|make|new|package|range|return|select|case|switch|type|continue"
-    attributes="var|const"
+    keywords="${keywords}|var|const"
     types="bool|byte|chan|complex128|complex64|float32|float64|int|int16|int32"
     types="${types}|int64|int8|interface|intptr|map|rune|string|struct|uint|uint16|uint32|uint64|uint8"
     values="false|true|nil"

--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -30,7 +30,7 @@ addhl -group /go/code regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9]+|0[xX][0-9a-fA-F]+)
     # Grammar
     keywords="break|default|defer|else|fallthrough|for|func|go|goto|if|import"
     keywords="${keywords}|interface|make|new|package|range|return|select|case|switch|type|continue"
-    attributes="const"
+    attributes="var|const"
     types="bool|byte|chan|complex128|complex64|float32|float64|int|int16|int32"
     types="${types}|int64|int8|interface|intptr|map|rune|string|struct|uint|uint16|uint32|uint64|uint8"
     values="false|true|nil"


### PR DESCRIPTION
Add `var` to the keywords, per https://golang.org/ref/spec#Keywords.