### PR TITLE
Update go keywords

### DIFF
--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -29,7 +29,8 @@ addhl -group /go/code regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9]+|0[xX][0-9a-fA-F]+)
 %sh{
     # Grammar
     keywords="break|default|defer|else|fallthrough|for|func|go|goto|if|import"
-    keywords="${keywords}|interface|make|new|package|range|return|select|case|switch|type|continue"
+    keywords="${keywords}|make|new|package|range|return|select|case|switch|type|continue"
+    keywords="${keywords}|append|cap|close|complex|copy|delete|imag|len|panic|print|println|real|recover"
     attributes="const|var"
     types="bool|byte|chan|complex128|complex64|float32|float64|int|int16|int32"
     types="${types}|int64|int8|interface|intptr|map|rune|string|struct|uint|uint16|uint32|uint64|uint8"


### PR DESCRIPTION
Add missing builtins and remove `interface` from the keywords since it is in the types already.

cf https://golang.org/pkg/builtin/