### PR TITLE
Introduce the `builtin` face, modify scripts accordingly

### DIFF
--- a/colors/base16.kak
+++ b/colors/base16.kak
@@ -27,6 +27,7 @@
         face attribute ${orange_dark}
         face comment ${grey_dark}
         face meta ${orange_light}
+        face builtin default+b
     "
 
     ## markup

--- a/colors/default.kak
+++ b/colors/default.kak
@@ -10,6 +10,7 @@ face operator yellow
 face attribute green
 face comment cyan
 face meta magenta
+face builtin default+b
 
 # For markup
 face title blue

--- a/colors/github.kak
+++ b/colors/github.kak
@@ -13,6 +13,7 @@ face operator yellow
 face attribute rgb:A71D5D
 face comment rgb:AAAAAA
 face meta rgb:183691
+face builtin default+b
 
 ## markup
 face title blue

--- a/colors/lucius.kak
+++ b/colors/lucius.kak
@@ -33,6 +33,7 @@
         face attribute ${lucius_light_blue}
         face comment ${lucius_grey}
         face meta ${lucius_purple}
+        face builtin default+b
 
         # and markup
         face title ${lucius_light_blue}

--- a/colors/reeder.kak
+++ b/colors/reeder.kak
@@ -31,6 +31,7 @@
         face attribute  ${green}
         face comment    ${brown_light}
         face meta       ${brown_dark}
+        face builtin   default+b
 
         # and markup
         face title      ${orange}+b

--- a/colors/solarized.kak
+++ b/colors/solarized.kak
@@ -31,6 +31,7 @@
         face attribute  ${violet}
         face comment    ${base01}
         face meta       ${orange}
+        face builtin   default+b
 
         # and markup
         face title      ${yellow}

--- a/colors/zenburn.kak
+++ b/colors/zenburn.kak
@@ -38,6 +38,7 @@
         face attribute ${zenstatement}
         face comment ${zencomment}
         face meta ${zenspecial}
+        face builtin default+b
 
         # and markup
         face title ${zenkeyword}

--- a/rc/base/d.kak
+++ b/rc/base/d.kak
@@ -35,26 +35,36 @@ addhl -group /d/code regex "\b(this)\b\s*[^(]" 1:value
 
 %sh{
     # Grammar
-    keywords="alias|asm|assert|body|cast|class|delegate|delete|enum|function"
-    keywords="${keywords}|import|in|interface|invariant|is|lazy|mixin|module"
-    keywords="${keywords}|new|out|pragma|struct|super|typeid|typeof|union"
-    keywords="${keywords}|unittest|__parameters|__traits|__vector|break|case"
-    keywords="${keywords}|catch|continue|default|do|else|finally|for|foreach"
-    keywords="${keywords}|foreach_reverse|goto|if|return|switch|throw|try|with|while"
+
+    keywords="abstract|alias|align|asm|assert|auto|body|break|case|cast"
+    keywords="${keywords}|catch|cent|class|const|continue|debug"
+    keywords="${keywords}|default|delegate|delete|deprecated|do|else|enum|export|extern"
+    keywords="${keywords}|final|finally|for|foreach|foreach_reverse|function|goto"
+    keywords="${keywords}|if|immutable|import|in|inout|interface|invariant"
+    keywords="${keywords}|is|lazy|macro|mixin|module|new|nothrow|out|override"
+    keywords="${keywords}|package|pragma|private|protected|public|pure|ref|return|scope"
+    keywords="${keywords}|shared|static|struct|super|switch|synchronized|template"
+    keywords="${keywords}|throw|try|typedef|typeid|typeof|union"
+    keywords="${keywords}|unittest|version|volatile|while|with"
     attributes="abstract|align|auto|const|debug|deprecated|export|extern|final"
     attributes="${attributes}|immutable|inout|nothrow|package|private|protected"
-    attributes="${attributes}|public|pure|ref|override|scope|shared|static|synchronized|version|__gshared"
-    types="bool|byte|cdouble|cfloat|char|creal|dchar|double|dstring|float"
+    attributes="${attributes}|public|pure|ref|override|scope|shared|static|synchronized|version"
+    attributes="${attributes}|__gshared|__traits|__vector|__parameters"
+    types="bool|byte|cdouble|cent|cfloat|char|creal|dchar|double|dstring|float"
     types="${types}|idouble|ifloat|int|ireal|long|ptrdiff_t|real|size_t|short"
-    types="${types}|string|ubyte|uint|ulong|ushort|void|wchar|wstring"
-    values="true|false|null|__FILE__|__MODULE__|__LINE__|__FUNCTION__"
-    values="${values}|__PRETTY_FUNCTION__|__DATE__|__EOF__|__TIME__"
-    values="${values}|__TIMESTAMP__|__VENDOR__|__VERSION__"
+    types="${types}|string|ubyte|ucent|uint|ulong|ushort|void|wchar|wstring"
+    values="true|false|null"
+    tokens="__FILE__|__MODULE__|__LINE__|__FUNCTION__"
+    tokens="${tokens}|__PRETTY_FUNCTION__|__DATE__|__EOF__|__TIME__"
+    tokens="${tokens}|__TIMESTAMP__|__VENDOR__|__VERSION__|#line"
+    properties="this|init|sizeof|alignof|mangleof|stringof|infinity|nan|dig|epsilon|mant_dig"
+    properties="${properties}|max_10_exp|min_exp|max|min_normal|re|im|classinfo"
+    properties="${properties}|length|dup|keys|values|rehash|clear"
     decorators="disable|property|nogc|safe|trusted|system"
 
     # Add the language's grammar to the static completion list
     printf %s\\n "hook global WinSetOption filetype=d %{
-        set window static_words '${keywords}:${attributes}:${types}:${values}:${decorators}'
+        set window static_words '${keywords}:${attributes}:${types}:${values}:${decorators}:${properties}'
     }" | sed 's,|,:,g'
 
     # Highlight keywords
@@ -64,6 +74,8 @@ addhl -group /d/code regex "\b(this)\b\s*[^(]" 1:value
         addhl -group /d/code regex \b(${types})\b 0:type
         addhl -group /d/code regex \b(${values})\b 0:value
         addhl -group /d/code regex @(${decorators})\b 0:attribute
+        addhl -group /d/code regex \b(${tokens})\b 0:builtin
+        addhl -group /d/code regex \.(${properties})\b 1:builtin
     "
 }
 

--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -28,17 +28,17 @@ addhl -group /go/code regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9]+|0[xX][0-9a-fA-F]+)
 
 %sh{
     # Grammar
-    keywords="break|default|defer|else|fallthrough|for|func|go|goto|if|import"
-    keywords="${keywords}|make|new|package|range|return|select|case|switch|type|continue"
-    keywords="${keywords}|append|cap|close|complex|copy|delete|imag|len|panic|print|println|real|recover"
-    attributes="const|var"
+    keywords="break|default|func|interface|select|case|defer|go|map|struct"
+    keywords="${keywords}|chan|else|goto|package|switch|const|fallthrough|if|range|type"
+    keywords="${keywords}|continue|for|import|return|var"
     types="bool|byte|chan|complex128|complex64|float32|float64|int|int16|int32"
     types="${types}|int64|int8|interface|intptr|map|rune|string|struct|uint|uint16|uint32|uint64|uint8"
-    values="false|true|nil"
+    values="false|true|nil|iota"
+    functions="append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover"
 
     # Add the language's grammar to the static completion list
     printf %s\\n "hook global WinSetOption filetype=go %{
-        set window static_words '${keywords}:${attributes}:${types}:${values}'
+        set window static_words '${keywords}:${attributes}:${types}:${values}:${functions}'
     }" | sed 's,|,:,g'
 
     # Highlight keywords
@@ -47,6 +47,7 @@ addhl -group /go/code regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9]+|0[xX][0-9a-fA-F]+)
         addhl -group /go/code regex \b(${attributes})\b 0:attribute
         addhl -group /go/code regex \b(${types})\b 0:type
         addhl -group /go/code regex \b(${values})\b 0:value
+        addhl -group /go/code regex \b(${functions})\b 0:builtin
     "
 }
 

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -150,16 +150,17 @@ def -hidden _c-family-insert-on-newline %[ eval -draft %[
 }
 
 # c specific
-addhl -group /c/code regex %{\bNULL\b|\b-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[^'\\])'} 0:value
+addhl -group /c/code regex %{\b-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[^'\\])'} 0:value
 %sh{
     # Grammar
     keywords="while|for|if|else|do|switch|case|default|goto|asm|break|continue|return|sizeof"
     attributes="const|auto|register|inline|static|volatile|struct|enum|union|typedef|extern|restrict"
     types="void|char|short|int|long|signed|unsigned|float|double|size_t"
+    values="NULL"
 
     # Add the language's grammar to the static completion list
     printf %s\\n "hook global WinSetOption filetype=c %{
-        set window static_words '${keywords}:${attributes}:${types}'
+        set window static_words '${keywords}:${attributes}:${types}:${values}'
     }" | sed 's,|,:,g'
 
     # Highlight keywords
@@ -167,6 +168,7 @@ addhl -group /c/code regex %{\bNULL\b|\b-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[
         addhl -group /c/code regex \b(${keywords})\b 0:keyword
         addhl -group /c/code regex \b(${attributes})\b 0:attribute
         addhl -group /c/code regex \b(${types})\b 0:type
+        addhl -group /c/code regex \b(${values})\b 0:value
     "
 }
 
@@ -198,6 +200,16 @@ addhl -group /cpp/code regex %{\b-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[^'\\])'
         addhl -group /cpp/code regex \b(${attributes})\b 0:attribute
         addhl -group /cpp/code regex \b(${types})\b 0:type
         addhl -group /cpp/code regex \b(${values})\b 0:value
+    "
+}
+
+# c and c++ compiler macros
+%sh{
+    gcc_macros="__cplusplus|__STDC_HOSTED__|__FILE__|__LINE__|__DATE__|__TIME__|__STDCPP_DEFAULT_NEW_ALIGNMENT__"
+
+    printf %s "
+        addhl -group /c/code regex \b(${gcc_macros})\b 0:builtin
+        addhl -group /cpp/code regex \b(${gcc_macros})\b 0:builtin
     "
 }
 

--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -31,12 +31,22 @@ addhl -group /python/comment       fill comment
     values="True|False|None"
     meta="import|from"
     # Keyword list is collected using `keyword.kwlist` from `keyword`
-    keywords="and|as|assert|break|class|continue|def|del|elif|else|except|exec|finally|for|global|if|in|is|lambda|not|or|pass|print|raise|return|try|while|with|yield"
-    types="bool|buffer|bytearray|complex|dict|file|float|frozenset|int|list|long|memoryview|object|set|str|tuple|unicode|xrange"
+    keywords="and|as|assert|break|class|continue|def|del|elif|else|except|exec"
+    keywords="${keywords}|finally|for|global|if|in|is|lambda|not|or|pass|print"
+    keywords="${keywords}|raise|return|try|while|with|yield"
+    types="bool|buffer|bytearray|bytes|complex|dict|file|float|frozenset|int"
+    types="${types}|list|long|memoryview|object|set|str|tuple|unicode|xrange"
+    functions="abs|all|any|ascii|bin|callable|chr|classmethod|compile|complex"
+    functions="${functions}|delattr|dict|dir|divmod|enumerate|eval|exec|filter"
+    functions="${functions}|format|frozenset|getattr|globals|hasattr|hash|help"
+    functions="${functions}|hex|id|__import__|input|isinstance|issubclass|iter"
+    functions="${functions}|len|locals|map|max|memoryview|min|next|oct|open|ord"
+    functions="${functions}|pow|print|property|range|repr|reversed|round"
+    functions="${functions}|setattr|slice|sorted|staticmethod|sum|super|type|vars|zip"
 
     # Add the language's grammar to the static completion list
     printf %s\\n "hook global WinSetOption filetype=python %{
-        set window static_words '${values}:${meta}:${keywords}:${types}'
+        set window static_words '${values}:${meta}:${keywords}:${types}:${functions}'
     }" | sed 's,|,:,g'
 
     # Highlight keywords
@@ -44,10 +54,14 @@ addhl -group /python/comment       fill comment
         addhl -group /python/code regex '\b(${values})\b' 0:value
         addhl -group /python/code regex '\b(${meta})\b' 0:meta
         addhl -group /python/code regex '\b(${keywords})\b' 0:keyword
+        addhl -group /python/code regex '\b(${functions})\b\(' 1:builtin
     "
 
-    # Highlight types, when they are not used as constructors
-    printf %s "addhl -group /python/code regex '\b(${types})\b[^(]' 1:type"
+    # Highlight types and attributes
+    printf %s "
+        addhl -group /python/code regex '\b(${types})\b' 0:type
+        addhl -group /python/code regex '@[\w_]+\b' 0:attribute
+    "
 }
 
 # Commands


### PR DESCRIPTION
Hi,

The `function` face was defined as just bold text, it should work fine with most themes. I used it to highlight keywords in several languages (C, C++, D, Go, Python) that have default symbols that are not quite keywords, but still need to be highlighted as they're predefined by the standard.

The C/C++ case is special, I only highlighted macros defined by the preprocessor or the compilers.

HTH.