### PR TITLE
Support xml based code in `html.kak`

### DIFF
--- a/rc/base/html.kak
+++ b/rc/base/html.kak
@@ -4,11 +4,11 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-html %{
+hook global BufSetOption mimetype=(text/((x-)?html|xml)|application/((\w+\+)?xml)) %{
     set buffer filetype html
 }
 
-hook global BufCreate .*[.](html) %{
+hook global BufCreate .*\.(html|xml) %{
     set buffer filetype html
 }
 


### PR DESCRIPTION
This commit extends the range of mimetypes detected in `html.kak` to the
following:
* text/html
* text/x-html
* text/xml
* application/xml
* application/…+xml (e.g. xhtml, rss)

Static .xml file will also be highlighted as HTML.

In the future we might want an `xml.kak`, from which `html.kak` can use regions.