### PR TITLE
go: error is a type not a keyword

### DIFF
--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -28,10 +28,10 @@ addhl -group /go/code regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9]+|0[xX][0-9a-fA-F]+)
 
 %sh{
     # Grammar
-    keywords="break|default|error|func|interface|select|case|defer|go|map|struct"
+    keywords="break|default|func|interface|select|case|defer|go|map|struct"
     keywords="${keywords}|chan|else|goto|package|switch|const|fallthrough|if|range|type"
     keywords="${keywords}|continue|for|import|return|var"
-    types="bool|byte|chan|complex128|complex64|float32|float64|int|int16|int32"
+    types="bool|byte|chan|complex128|complex64|error|float32|float64|int|int16|int32"
     types="${types}|int64|int8|interface|intptr|map|rune|string|struct|uint|uint16|uint32|uint64|uint8"
     values="false|true|nil|iota"
     functions="append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover"


### PR DESCRIPTION
@mawww sorry for the extra work

cc: #941 