### PR TITLE
Fix compilation on Mac OS Sierra

### DIFF
--- a/contrib/kakoune.rb
+++ b/contrib/kakoune.rb
@@ -5,7 +5,8 @@ class Kakoune < Formula
   head "https://github.com/mawww/kakoune.git"
 
   depends_on 'boost'
-  depends_on 'asciidoc' => :build
+  depends_on 'docbook-xsl' => :build
+  depends_on 'asciidoc' => [:build, 'with-docbook-xsl']
 
   def install
     cd 'src' do


### PR DESCRIPTION
The `xsltproc` utility is missing some xsl files, which are now
installed on the system by the `docbook-xsl` package.

Fixes #939