### PR TITLE
 Allow setting custom make error pattern

### DIFF
--- a/rc/core/make.kak
+++ b/rc/core/make.kak
@@ -1,5 +1,5 @@
 decl str makecmd make
-decl str make_error_pattern "[0-9]+: (?:fatal )?error:"
+decl str make_error_pattern " (?:fatal )?error:"
 
 decl str toolsclient
 decl -hidden int _make_current_error_line
@@ -61,7 +61,7 @@ def -hidden make-jump %{
 def make-next -docstring 'Jump to the next make error' %{
     eval -collapse-jumps -try-client %opt{jumpclient} %{
         buffer '*make*'
-        exec "%opt{_make_current_error_line}g<a-l>/%opt{make_error_pattern}<ret>"
+        exec "%opt{_make_current_error_line}g<a-l>/(?:\w:)?[^:]+:\d+:(?:\d+:)?%opt{make_error_pattern}<ret>"
         make-jump
     }
     try %{ eval -client %opt{toolsclient} %{ exec %opt{_make_current_error_line}g } }
@@ -70,7 +70,7 @@ def make-next -docstring 'Jump to the next make error' %{
 def make-prev -docstring 'Jump to the previous make error' %{
     eval -collapse-jumps -try-client %opt{jumpclient} %{
         buffer '*make*'
-        exec "%opt{_make_current_error_line}g<a-h><a-/>%opt{make_error_pattern}<ret>"
+        exec "%opt{_make_current_error_line}g<a-h><a-/>(?:\w:)?[^:]+:\d+:(?:\d+:)?%opt{make_error_pattern}<ret>"
         make-jump
     }
     try %{ eval -client %opt{toolsclient} %{ exec %opt{_make_current_error_line}g } }

--- a/rc/core/make.kak
+++ b/rc/core/make.kak
@@ -1,4 +1,6 @@
 decl str makecmd make
+decl str make_error_pattern "[0-9]+: (?:fatal )?error:"
+
 decl str toolsclient
 decl -hidden int _make_current_error_line
 
@@ -59,7 +61,7 @@ def -hidden make-jump %{
 def make-next -docstring 'Jump to the next make error' %{
     eval -collapse-jumps -try-client %opt{jumpclient} %{
         buffer '*make*'
-        exec "%opt{_make_current_error_line}g<a-l>/[0-9]+: (?:fatal )?error:<ret>"
+        exec "%opt{_make_current_error_line}g<a-l>/%opt{make_error_pattern}<ret>"
         make-jump
     }
     try %{ eval -client %opt{toolsclient} %{ exec %opt{_make_current_error_line}g } }
@@ -68,7 +70,7 @@ def make-next -docstring 'Jump to the next make error' %{
 def make-prev -docstring 'Jump to the previous make error' %{
     eval -collapse-jumps -try-client %opt{jumpclient} %{
         buffer '*make*'
-        exec "%opt{_make_current_error_line}g<a-h><a-/>[0-9]+: (?:fatal )?error:<ret>"
+        exec "%opt{_make_current_error_line}g<a-h><a-/>%opt{make_error_pattern}<ret>"
         make-jump
     }
     try %{ eval -client %opt{toolsclient} %{ exec %opt{_make_current_error_line}g } }


### PR DESCRIPTION
The current pattern used by the commands `make-next` and `make-prev` 
to find error messages are not suitable for all usages:

For example the go compiler will not suffix error lines with `error: ` and is
not usable with these functions.

This change allows the user to define a custom error pattern, instead of
having to work around the error (for example using sed to insert the 
`error: ` suffix).

What do you think of this? I have not followed the current convention
of having options without separators (like `makecmd`) because it has 
a verbose name. 

Also this does not feel to be the right solution because the pattern has 
to be set at global level.

