### PR TITLE
Transform mimetype to a fallback option

### DIFF
--- a/rc/base/clojure.kak
+++ b/rc/base/clojure.kak
@@ -6,10 +6,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-clojure %{
-    set buffer filetype clojure
-}
-
 hook global BufCreate .*[.](cljs?) %{
     set buffer filetype clojure
 }

--- a/rc/base/css.kak
+++ b/rc/base/css.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-css %{
-    set buffer filetype css
-}
-
 hook global BufCreate .*[.](css) %{
     set buffer filetype css
 }

--- a/rc/base/d.kak
+++ b/rc/base/d.kak
@@ -5,7 +5,6 @@
 # ‾‾‾‾‾‾‾‾‾
 
 hook global BufCreate .*\.di? %{
-    set buffer mimetype ""
     set buffer filetype d
 }
 

--- a/rc/base/file.kak
+++ b/rc/base/file.kak
@@ -1,0 +1,13 @@
+decl str mimetype
+
+hook global BufOpen .* %{ %sh{
+    if [ -z "${kak_opt_filetype}" ]; then
+        mime=$(file -b --mime-type "${kak_buffile}")
+        printf %s\\n "${mime}" | grep -q '^text/x-'
+        if [ $? -eq 0 ]; then
+            printf "set buffer filetype '%s'\n" "${mime:7}"
+        else
+            printf "set buffer mimetype '%s'\n" "${mime}"
+        fi
+    fi
+} }

--- a/rc/base/file.kak
+++ b/rc/base/file.kak
@@ -3,9 +3,12 @@ decl str mimetype
 hook global BufOpen .* %{ %sh{
     if [ -z "${kak_opt_filetype}" ]; then
         mime=$(file -b --mime-type "${kak_buffile}")
-        printf %s\\n "${mime}" | grep -q '^text/x-'
-        if [ $? -eq 0 ]; then
-            printf "set buffer filetype '%s'\n" "${mime:7}"
+        case "${mime}" in
+            text/x-*) filetype="${mime#text/x-}" ;;
+            text/*)   filetype="${mime#text/}" ;;
+        esac
+        if [ -n "${filetype}" ]; then
+            printf "set buffer filetype '%s'\n" "${filetype}"
         else
             printf "set buffer mimetype '%s'\n" "${mime}"
         fi

--- a/rc/base/fish.kak
+++ b/rc/base/fish.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-fish %{
-    set buffer filetype fish
-}
-
 hook global BufCreate .*[.](fish) %{
     set buffer filetype fish
 }

--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -5,7 +5,6 @@
 # ‾‾‾‾‾‾‾‾‾
 
 hook global BufCreate .*\.go %{
-    set buffer mimetype ""
     set buffer filetype go
 }
 

--- a/rc/base/haskell.kak
+++ b/rc/base/haskell.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-haskell %{
-    set buffer filetype haskell
-}
-
 hook global BufCreate .*[.](hs) %{
     set buffer filetype haskell
 }

--- a/rc/base/java.kak
+++ b/rc/base/java.kak
@@ -2,10 +2,6 @@ hook global BufCreate .*\.java %{
     set buffer filetype java
 }
 
-hook global BufSetOption mimetype=text/java %{
-    set buffer filetype java
-}
-
 addhl -group / regions -default code java \
     string %{(?<!')"} %{(?<!\\)(\\\\)*"} '' \
     comment /\* \*/ '' \

--- a/rc/base/javascript.kak
+++ b/rc/base/javascript.kak
@@ -1,10 +1,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-javascript %{
-    set buffer filetype javascript
-}
-
 hook global BufCreate .*[.](js) %{
     set buffer filetype javascript
 }

--- a/rc/base/json.kak
+++ b/rc/base/json.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-json %{
-    set buffer filetype json
-}
-
 hook global BufCreate .*[.](json) %{
     set buffer filetype json
 }

--- a/rc/base/lisp.kak
+++ b/rc/base/lisp.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-lisp %{
-    set buffer filetype lisp
-}
-
 hook global BufCreate .*[.](lisp) %{
     set buffer filetype lisp
 }

--- a/rc/base/lua.kak
+++ b/rc/base/lua.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-lua %{
-    set buffer filetype lua
-}
-
 hook global BufCreate .*[.](lua) %{
     set buffer filetype lua
 }

--- a/rc/base/mail.kak
+++ b/rc/base/mail.kak
@@ -1,4 +1,10 @@
-hook global BufSetOption mimetype=message/rfc822 %{ set buffer filetype mail }
+hook global BufCreate .+\.eml %{
+    set buffer filetype mail
+}
+
+hook global BufSetOption mimetype=message/rfc822 %{
+    set buffer filetype mail
+}
 
 addhl -group / group mail
 addhl -group /mail regex ^(From|To|Cc|Bcc|Subject|Reply-To|In-Reply-To):([^\n]*(?:\n\h+[^\n]+)*)$ 1:keyword 2:attribute

--- a/rc/base/markdown.kak
+++ b/rc/base/markdown.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-markdown %{
-    set buffer filetype markdown
-}
-
 hook global BufCreate .*[.](markdown|md|mkd) %{
     set buffer filetype markdown
 }

--- a/rc/base/mime.kak
+++ b/rc/base/mime.kak
@@ -1,5 +1,0 @@
-decl str mimetype "text/plain"
-
-hook global BufOpen .* %{
-     set buffer mimetype %sh{file -b --mime-type "${kak_buffile}" }
-}

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-perl %{
-    set buffer filetype perl
-}
-
 hook global BufCreate .*\.pl %{
     set buffer filetype perl
 }

--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-ruby %{
-    set buffer filetype ruby
-}
-
 hook global BufCreate .*(([.](rb))|(irbrc)|(pryrc)|(Capfile|[.]cap)|(Gemfile)|(Guardfile)|(Rakefile|[.]rake)|(Thorfile|[.]thor)|(Vagrantfile)) %{
     set buffer filetype ruby
 }

--- a/rc/base/rust.kak
+++ b/rc/base/rust.kak
@@ -4,13 +4,8 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-rust %{
-    set buffer filetype rust
-}
-
 hook global BufCreate .*[.](rust|rs) %{
     set buffer filetype rust
-    set buffer mimetype ''
 }
 
 # Highlighters

--- a/rc/base/scala.kak
+++ b/rc/base/scala.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-scala %{
-    set buffer filetype scala
-}
-
 hook global BufCreate .*[.](scala) %{
     set buffer filetype scala
 }

--- a/rc/base/yaml.kak
+++ b/rc/base/yaml.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-yaml %{
-    set buffer filetype yaml
-}
-
 hook global BufCreate .*[.](yaml) %{
     set buffer filetype yaml
 }

--- a/rc/core/asciidoc.kak
+++ b/rc/core/asciidoc.kak
@@ -4,7 +4,9 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*\.asciidoc %{ set buffer filetype asciidoc }
+hook global BufCreate .+\.(a(scii)?doc|asc) %{
+    set buffer filetype asciidoc
+}
 
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -1,11 +1,13 @@
 hook global BufCreate .*\.(cc|cpp|cxx|C|hh|hpp|hxx|H)$ %{
     set buffer filetype cpp
-    set buffer mimetype ''
+}
+
+hook global BufSetOption filetype=c\+\+ %{
+    set buffer filetype cpp
 }
 
 hook global BufCreate .*\.c$ %{
     set buffer filetype c
-    set buffer mimetype ''
 }
 
 hook global BufCreate .*\.h$ %{
@@ -15,23 +17,9 @@ hook global BufCreate .*\.h$ %{
     } catch %{
         set buffer filetype c
     }
-    set buffer mimetype ''
-}
-
-hook global BufSetOption mimetype=text/x-c %{
-    set buffer filetype c
-}
-
-hook global BufSetOption mimetype=text/x-c\+\+ %{
-    set buffer filetype cpp
 }
 
 hook global BufCreate .*\.m %{
-    set buffer filetype objc
-    set buffer mimetype ''
-}
-
-hook global BufSetOption mimetype=text/x-objc %{
     set buffer filetype objc
 }
 

--- a/rc/core/makefile.kak
+++ b/rc/core/makefile.kak
@@ -1,10 +1,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-makefile %{
-    set buffer filetype makefile
-}
-
 hook global BufCreate .*/?[mM]akefile %{
     set buffer filetype makefile
 }

--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-python %{
-    set buffer filetype python
-}
-
 hook global BufCreate .*[.](py) %{
     set buffer filetype python
 }

--- a/rc/core/sh.kak
+++ b/rc/core/sh.kak
@@ -2,10 +2,6 @@ hook global BufCreate .*\.(z|ba|c|k)?sh(rc|_profile)? %{
     set buffer filetype sh
 }
 
-hook global BufSetOption mimetype=text/x-shellscript %{
-    set buffer filetype sh
-}
-
 addhl -group / regions -default code sh \
     double_string  %{(?<!\\)(\\\\)*\K"} %{(?<!\\)(\\\\)*"} '' \
     single_string %{(?<!\\)(\\\\)*\K'} %{'} '' \

--- a/rc/extra/cabal.kak
+++ b/rc/extra/cabal.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-cabal %{
-    set buffer filetype cabal
-}
-
 hook global BufCreate .*[.](cabal) %{
     set buffer filetype cabal
 }

--- a/rc/extra/coffee.kak
+++ b/rc/extra/coffee.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-coffee %{
-    set buffer filetype coffee
-}
-
 hook global BufCreate .*[.](coffee) %{
     set buffer filetype coffee
 }

--- a/rc/extra/cucumber.kak
+++ b/rc/extra/cucumber.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-cucumber %{
-    set buffer filetype cucumber
-}
-
 hook global BufCreate .*[.](feature|story) %{
     set buffer filetype cucumber
 }

--- a/rc/extra/haml.kak
+++ b/rc/extra/haml.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-haml %{
-    set buffer filetype haml
-}
-
 hook global BufCreate .*[.](haml) %{
     set buffer filetype haml
 }

--- a/rc/extra/latex.kak
+++ b/rc/extra/latex.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-tex %{
-    set buffer filetype latex
-}
-
 hook global BufCreate .*\.tex %{
     set buffer filetype latex
 }

--- a/rc/extra/modeline.kak
+++ b/rc/extra/modeline.kak
@@ -52,7 +52,6 @@ def -hidden _modeline-parse %{
                 autowrap_column
                 eolformat
                 filetype
-                mimetype
                 BOM
             )
 

--- a/rc/extra/moon.kak
+++ b/rc/extra/moon.kak
@@ -4,12 +4,8 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-moon %{
-    set buffer filetype moon
-}
-
 hook global BufCreate .*[.](moon) %{
-    set buffer mimetype text/x-moon
+    set buffer filetype moon
 }
 
 # Highlighters

--- a/rc/extra/pug.kak
+++ b/rc/extra/pug.kak
@@ -8,10 +8,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-pug %{
-    set buffer filetype pug
-}
-
 hook global BufCreate .*[.](pug|jade) %{
     set buffer filetype pug
 }

--- a/rc/extra/ragel.kak
+++ b/rc/extra/ragel.kak
@@ -6,10 +6,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-ragel %{
-    set buffer filetype ragel
-}
-
 hook global BufCreate .*[.](ragel|rl) %{
     set buffer filetype ragel
 }

--- a/rc/extra/sass.kak
+++ b/rc/extra/sass.kak
@@ -4,10 +4,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-sass %{
-    set buffer filetype sass
-}
-
 hook global BufCreate .*[.](sass) %{
     set buffer filetype sass
 }

--- a/rc/extra/scss.kak
+++ b/rc/extra/scss.kak
@@ -6,10 +6,6 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufSetOption mimetype=text/x-scss %{
-    set buffer filetype scss
-}
-
 hook global BufCreate .*[.](scss) %{
     set buffer filetype scss
 }

--- a/rc/extra/taskpaper.kak
+++ b/rc/extra/taskpaper.kak
@@ -5,7 +5,6 @@
 # ‾‾‾‾‾‾‾‾‾
 
 hook global BufCreate .*\.taskpaper %{
-    set buffer mimetype ""
     set buffer filetype taskpaper
 } 
 

--- a/rc/extra/tupfile.kak
+++ b/rc/extra/tupfile.kak
@@ -5,7 +5,6 @@
 # ‾‾‾‾‾‾‾‾‾
 
 hook global BufCreate (.+/)?[Tt]upfile %{
-    set buffer mimetype ""
     set buffer filetype tupfile
 }
 


### PR DESCRIPTION
The option is now used as a fallback when detection by extension fails. Some scripts like `base/mail.kak` and `base/html.kak` still rely heavily on it.

This PR collides with #878.