### PR TITLE
Fix python comment chars

### DIFF
--- a/rc/core/commenting.kak
+++ b/rc/core/commenting.kak
@@ -78,7 +78,8 @@ hook global BufSetOption filetype=(pug|rust) %{
 }
 
 hook global BufSetOption filetype=python %{
-    set buffer comment_selection_chars '""":"""'
+    set buffer comment_line_chars '#'
+    set buffer comment_selection_chars '\'\'\':\'\'\''
 }
 
 hook global BufSetOption filetype=ragel %{

--- a/rc/core/commenting.kak
+++ b/rc/core/commenting.kak
@@ -78,7 +78,6 @@ hook global BufSetOption filetype=(pug|rust) %{
 }
 
 hook global BufSetOption filetype=python %{
-    set buffer comment_line_chars '#'
     set buffer comment_selection_chars '\'\'\':\'\'\''
 }
 


### PR DESCRIPTION
Add line chars and fix selection chars (`"""` is for docstrings).