### PR TITLE
editorconfig, fix indent options and add whitespaces ones

### DIFF
--- a/rc/extra/editorconfig.kak
+++ b/rc/extra/editorconfig.kak
@@ -18,10 +18,11 @@ def -hidden _editorconfig-bufwritepre-hook %{
     } }
 }
 
-def editorconfig-load -docstring "Set indentation options and whitespace behavior according to editorconfig" %{
+def editorconfig-load -params ..1 -docstring "editorconfig-load [file]: set formatting behavior according to editorconfig" %{
+    remove-hooks buffer editorconfig-hooks
     %sh{
-        command -v editorconfig >/dev/null 2>&1 || { echo 'echo -color Error The editorconfig tool could not be found'; exit 1; }
-        editorconfig "${kak_buffile}" | awk -F= -- '
+        command -v editorconfig >/dev/null 2>&1 || { echo 'echo -color Error editorconfig could not be found'; exit 1; }
+        editorconfig "${1:-$kak_buffile}" | awk -F= -- '
             /indent_style=/            { indent_style = $2 }
             /indent_size=/             { indent_size = $2 == "tab" ? 4 : $2  }
             /tab_width=/               { tab_width = $2 }

--- a/rc/extra/editorconfig.kak
+++ b/rc/extra/editorconfig.kak
@@ -2,21 +2,6 @@
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
 decl -hidden bool editorconfig_trim_trailing_whitespace false
-decl -hidden int  editorconfig_insert_final_newline     0
-
-def -hidden _editorconfig-bufwritepre-hook %{
-    hook buffer BufWritePre %val{buffile} -group editorconfig-hooks %{ %sh{
-        if [ ${kak_opt_editorconfig_trim_trailing_whitespace} = "true" ]; then
-            printf %s\\n "try %{ exec -draft %{ %s\h+$<ret>d } }"
-        fi
-        if [ ${kak_opt_editorconfig_insert_final_newline} -gt 0 ]; then
-            printf %s\\n "try %{ exec -draft %{ %s\v+\Z<ret>d } }"
-        fi
-        if [ ${kak_opt_editorconfig_insert_final_newline} -gt 1 ]; then
-            printf %s\\n "try %{ exec -draft %{ geo<esc> } }"
-        fi
-    } }
-}
 
 def editorconfig-load -params ..1 -docstring "editorconfig-load [file]: set formatting behavior according to editorconfig" %{
     remove-hooks buffer editorconfig-hooks
@@ -29,7 +14,6 @@ def editorconfig-load -params ..1 -docstring "editorconfig-load [file]: set form
             /end_of_line=/             { end_of_line = $2 }
             /charset=/                 { charset = $2 }
             /trim_trailing_whitespace/ { trim_trailing_whitespace = $2 }
-            /insert_final_newline/     { insert_final_newline = $2 }
 
             END {
                 if (indent_style == "tab") {
@@ -52,11 +36,12 @@ def editorconfig-load -params ..1 -docstring "editorconfig-load [file]: set form
                 if (trim_trailing_whitespace == "true") {
                     print "set buffer editorconfig_trim_trailing_whitespace true"
                 }
-                if (insert_final_newline) {
-                    print "set buffer editorconfig_insert_final_newline " (insert_final_newline == "true" ? 2 : 1)
-                }
             }
         '
     }
-    _editorconfig-bufwritepre-hook
+    hook buffer BufWritePre %val{buffile} -group editorconfig-hooks %{ %sh{
+        if [ ${kak_opt_editorconfig_trim_trailing_whitespace} = "true" ]; then
+            printf %s\\n "try %{ exec -draft %{ %s\h+$<ret>d } }"
+        fi
+    } }
 }

--- a/rc/extra/editorconfig.kak
+++ b/rc/extra/editorconfig.kak
@@ -18,7 +18,7 @@ def -hidden _editorconfig-bufwritepre-hook %{
     } }
 }
 
-def editorconfig-load -docstring "Set indentation optins and whitespace behavior according to editorconfig file" %{
+def editorconfig-load -docstring "Set indentation options and whitespace behavior according to editorconfig" %{
     %sh{
         command -v editorconfig >/dev/null 2>&1 || { echo 'echo -color Error The editorconfig tool could not be found'; exit 1; }
         editorconfig "${kak_buffile}" | awk -F= -- '

--- a/rc/extra/editorconfig.kak
+++ b/rc/extra/editorconfig.kak
@@ -46,7 +46,7 @@ def editorconfig-load -docstring "Set indentation options and whitespace behavio
                     print "set buffer eolformat " end_of_line
                 }
                 if (charset == "utf-8-bom") {
-                    print "set buffer BOM utf-8"
+                    print "set buffer BOM utf8"
                 }
                 if (trim_trailing_whitespace == "true") {
                     print "set buffer editorconfig_trim_trailing_whitespace true"

--- a/rc/extra/editorconfig.kak
+++ b/rc/extra/editorconfig.kak
@@ -1,35 +1,61 @@
-def editorconfig-load -docstring "Set indentation options according to editorconfig file" %{
+# http://editorconfig.org/#file-format-details
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+decl -hidden bool editorconfig_trim_trailing_whitespace false
+decl -hidden int  editorconfig_insert_final_newline     0
+
+def -hidden _editorconfig-bufwritepre-hook %{
+    hook buffer BufWritePre %val{buffile} -group editorconfig-hooks %{ %sh{
+        if [ ${kak_opt_editorconfig_trim_trailing_whitespace} = "true" ]; then
+            printf %s\\n "try %{ exec -draft %{ %s\h+$<ret>d } }"
+        fi
+        if [ ${kak_opt_editorconfig_insert_final_newline} -gt 0 ]; then
+            printf %s\\n "try %{ exec -draft %{ %s\v+\Z<ret>d } }"
+        fi
+        if [ ${kak_opt_editorconfig_insert_final_newline} -gt 1 ]; then
+            printf %s\\n "try %{ exec -draft %{ geo<esc> } }"
+        fi
+    } }
+}
+
+def editorconfig-load -docstring "Set indentation optins and whitespace behavior according to editorconfig file" %{
     %sh{
         command -v editorconfig >/dev/null 2>&1 || { echo 'echo -color Error The editorconfig tool could not be found'; exit 1; }
-        editorconfig $kak_buffile | awk -F= -- '
-            /indent_style=/ { indent_style = $2 }
-            /indent_size=/  { indent_size = $2 == "tab" ? 4 : $2  }
-            /tab_width=/    { tab_width = $2 }
-            /end_of_line=/  { end_of_line = $2 }
-            /charset=/      { charset = $2 }
+        editorconfig "${kak_buffile}" | awk -F= -- '
+            /indent_style=/            { indent_style = $2 }
+            /indent_size=/             { indent_size = $2 == "tab" ? 4 : $2  }
+            /tab_width=/               { tab_width = $2 }
+            /end_of_line=/             { end_of_line = $2 }
+            /charset=/                 { charset = $2 }
+            /trim_trailing_whitespace/ { trim_trailing_whitespace = $2 }
+            /insert_final_newline/     { insert_final_newline = $2 }
 
             END {
-                if (indent_style == "tab")
-                {
+                if (indent_style == "tab") {
                     print "set buffer indentwidth 0"
                     print "set buffer aligntab true"
                 }
-                if (indent_style == "spaces") {
+                if (indent_style == "space") {
                     print "set buffer indentwidth " (indent_size == "tab" ? 4 : indent_size)
                     print "set buffer aligntab false"
                 }
                 if (indent_size || tab_width) {
                     print "set buffer tabstop " (tab_width ? tab_width : indent_size)
                 }
-                if (end_of_line) {
-                    if (end_of_line == "lf" || end_of_line == "crlf")
-                        print "set buffer eolformat " end_of_line
-                    else
-                        print "error"
+                if (end_of_line == "lf" || end_of_line == "crlf") {
+                    print "set buffer eolformat " end_of_line
                 }
-                if (charset)
-                    print "set buffer BOM" (charset == "utf-8-bom" ? true : false)
+                if (charset == "utf-8-bom") {
+                    print "set buffer BOM utf-8"
+                }
+                if (trim_trailing_whitespace == "true") {
+                    print "set buffer editorconfig_trim_trailing_whitespace true"
+                }
+                if (insert_final_newline) {
+                    print "set buffer editorconfig_insert_final_newline " (insert_final_newline == "true" ? 2 : 1)
+                }
             }
         '
     }
+    _editorconfig-bufwritepre-hook
 }


### PR DESCRIPTION
I was just going to fix a syntax error but got carried away and refactored the whole script plus implemented some missing features for editorconfig.

Options reference: http://editorconfig.org/#file-format-details

- **indent_style**, **indent_size**, **tab_width**: follow the specification or default to 4 spaces when needed
- **end_of_line**: set `eolformat` to `lf` or `crlf`
- **charset**: set `BOM` to `utf8` if the value is `utf-8-bom`
- **trim_trailing_whitespace**: remove trailing whitespaces on save when set to `true`
- **insert_final_newline**: remove trailing empty lines when the value is `false`, leave only one empty line at the end of the file when the value is `true`, does nothing when the option is not present
