### PR TITLE
workaround for debmake problems

### DIFF
--- a/contrib/make_deb.bash
+++ b/contrib/make_deb.bash
@@ -3,7 +3,7 @@
 ## make_deb.bash for kakoune
 ## by lenormf
 ##
-## Dependencies: build-essential, devscripts, debmake
+## Dependencies: build-essential, devscripts, debmake, asciidoc
 ## Guidelines for making binary packages: https://www.debian.org/doc/debian-policy/ch-binary.html
 
 set -e
@@ -72,6 +72,10 @@ function main {
         echo "No maintainer full name detected, set one using the '-f' flag"
         exit
     fi
+
+## os.getlogin() does not always work, e.g. in docker
+    export DEBEMAIL="${maintainer_email}"
+    export DEBFULLNAME="${maintainer_fullname}"
 
     readonly PATH_KAKOUNE=$(readlink -e $(dirname $(readlink -f "$0"))/..)
     readonly PATH_DIR_TMP=$(mktemp -d)


### PR DESCRIPTION
For some reason `debmake` does not honor the `-e` and `-f` parameters, which causes it to try to "guess" the values, and `os.getlogin()` does not always work (in docker).

    Package maintainer info: Mikael Goransson (github@mgor.se)
    Path to the license file:
    Initializing package creation
    I: set parameters
    Traceback (most recent call last):
      File "/usr/bin/debmake", line 28, in <module>
         debmake.main()
       File "/usr/lib/python3/dist-packages/debmake/__init__.py", line 105, in main
         para = debmake.para.para(para)
       File "/usr/lib/python3/dist-packages/debmake/para.py", line 44, in para
         debmail = os.getlogin() + '@localhost'
    FileNotFoundError: [Errno 2] No such file or directory

As a workaround set and export `DEBEMAIL` and `DEBFULLNAME`.

Showing that `os.getlogin()` doesn't always work:

    root@kakoune-builder:/usr/local/src/kakoune/doc# python
    Python 2.7.12+ (default, Sep 17 2016, 12:08:02) 
    [GCC 6.2.0 20160914] on linux2
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import os
    >>> os.getlogin()
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    OSError: [Errno 2] No such file or directory
    >>> 

Also added `asciidoc` (which provides `a2x`) to the list of dependencies (which is a huge dependency).