### PR TITLE
Updated readme to include sudo make install

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -18,6 +18,7 @@ TL;DR
 git clone http://github.com/mawww/kakoune.git
 cd kakoune/src
 make
+sudo make install
 ./kak
 ---------------------------------------------
 


### PR DESCRIPTION
Currently you need to run `sudo make install` to get the install the kak command to your path and for syntax highlighting to work. I'd say 99% of people using this will want to do that immediately, and otherwise they will be quickly confused. This was not included in the README tldr, so I added it.