### PR TITLE
Fix for contrib/make_deb.bash on Ubuntu 16.04

### DIFF
--- a/contrib/make_deb.bash
+++ b/contrib/make_deb.bash
@@ -113,7 +113,7 @@ function main {
 
 ## FIXME: make a patch
     echo "Disabling copying the README file to the doc directory"
-    sed -r -i 's,(install -m [0-9]+ \.\./README\.asciidoc .+),#\1,' "${DIR_KAKOUNE}/Makefile"
+    sed -r -i 's,(install.*\.\./README\.asciidoc.+),#\1,' "${DIR_KAKOUNE}/Makefile"
 
 ## FIXME: make a patch
     echo "Setting the prefix of the installation procedure"


### PR DESCRIPTION
The Makefile had tabs in a few places, which tripped up sed. This
version should still work in debian, while also working in Xenial.