### PR TITLE
base/markdown: Correct italic/bold detection regex

### DIFF
--- a/rc/base/markdown.kak
+++ b/rc/base/markdown.kak
@@ -113,8 +113,10 @@ addhl -group /markdown/content regex ^(#+)(\h+)([^\n]+) 1:header
 addhl -group /markdown/content regex ^\h?+((?:[\s\t]+)?[-\*])\h+[^\n]*(\n\h+[^-\*]\S+[^\n]*\n)*$ 0:list 1:bullet
 addhl -group /markdown/content regex ^([-=~]+)\n[^\n\h].*?\n\1$ 0:block
 addhl -group /markdown/content regex \B\+[^\n]+?\+\B 0:mono
+addhl -group /markdown/content regex \B\*[^\n]+?\*\B 0:italic
 addhl -group /markdown/content regex \b_[^\n]+?_\b 0:italic
-addhl -group /markdown/content regex \B\*[^\n]+?\*\B 0:bold
+addhl -group /markdown/content regex \B\*\*[^\n]+?\*\*\B 0:bold
+addhl -group /markdown/content regex \B__[^\n]+?__\B 0:bold
 addhl -group /markdown/content regex <(([a-z]+://.*?)|((mailto:)?[\w+-]+@[a-z]+[.][a-z]+))> 0:link
 addhl -group /markdown/content regex ^\h*(>\h*)+ 0:comment
 addhl -group /markdown/content regex \H\K\h\h$ 0:PrimarySelection


### PR DESCRIPTION
As specified at <https://daringfireball.net/projects/markdown/syntax#em>,
italics are made with either single asterisks/underscores, and bold is
double asterisks/underscores. Before this, single asterisks were
understood as bold, and only underscores were understood as italics;
both of which behaviors are incorrect.