### PR TITLE
Add ncurses to Homebrew formula

### DIFF
--- a/contrib/kakoune.rb
+++ b/contrib/kakoune.rb
@@ -6,6 +6,7 @@ class Kakoune < Formula
 
   depends_on 'boost'
   depends_on 'docbook-xsl' => :build
+  depends_on 'ncurses' => [:build, :recommended]
   depends_on 'asciidoc' => [:build, 'with-docbook-xsl']
 
   def install


### PR DESCRIPTION
as a build and recommended dependency. Generates a `--without-ncurses` option to disable it. See https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md#specifying-other-formulae-as-dependencies