### PR TITLE
Fixed a typo in the documentation - "test" -> "text"

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1026,7 +1026,7 @@ Registers
 ~~~~~~~~~
 
 Registers are named lists of text. They are used for various purposes, like
-storing the last yanked test, or the captured groups associated with the
+storing the last yanked text, or the captured groups associated with the
 selections.
 
 Yanking and pasting uses the register `"`, however most commands using a register

--- a/doc/manpages/registers.asciidoc
+++ b/doc/manpages/registers.asciidoc
@@ -9,7 +9,7 @@ Description
 -----------
 Registers are named lists of text -instead of simply text- in order to interact
 well with multiselection.  They are used for various purposes, like storing
-the last yanked test, or the captured groups associated with the selections.
+the last yanked text, or the captured groups associated with the selections.
 
 Interacting
 -----------


### PR DESCRIPTION
Just another quick typo fix in the docs.  

Thanks for the making such an awesome editor @mawww !