### PR TITLE
Fix editorconfig specification

### DIFF
--- a/rc/extra/editorconfig.kak
+++ b/rc/extra/editorconfig.kak
@@ -14,7 +14,7 @@ def editorconfig-load -docstring "Set indentation options according to editorcon
                     print "set buffer indentwidth 0"
                     print "set buffer aligntab true"
                 }
-                if (indent_style == "spaces") {
+                if (indent_style == "space") {
                     print "set buffer indentwidth " (indent_size == "tab" ? 4 : indent_size)
                     print "set buffer aligntab false"
                 }

--- a/rc/extra/editorconfig.kak
+++ b/rc/extra/editorconfig.kak
@@ -28,7 +28,7 @@ def editorconfig-load -docstring "Set indentation options according to editorcon
                         print "error"
                 }
                 if (charset)
-                    print "set buffer BOM" (charset == "utf-8-bom" ? true : false)
+                    print "set buffer BOM" (charset == "utf-8" ? true : false)
             }
         '
     }


### PR DESCRIPTION
I believe that kakoune was looking for the incorrect values for "indent_style" and "charset". For "indent_style" it appears to be looking for "spaces" instead of "space" and for "charset" it appears to be looking for "utf-8-bom" instead of "utf-8". I've linked the relevant sections of the spec for others to confirm my suspicions.

https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#indent_style
https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#charset