### PR TITLE
Print "utf8" or "none" for BOM option in extra/editorconfig.kak

### DIFF
--- a/rc/extra/editorconfig.kak
+++ b/rc/extra/editorconfig.kak
@@ -28,7 +28,7 @@ def editorconfig-load -docstring "Set indentation options according to editorcon
                         print "error"
                 }
                 if (charset)
-                    print "set buffer BOM" (charset == "utf-8-bom" ? true : false)
+                    print "set buffer BOM " (charset == "utf-8-bom" ? "utf8" : "none")
             }
         '
     }


### PR DESCRIPTION
It looks like [this commit](https://github.com/mawww/kakoune/commit/d88d0bac42aa447c5635556e4a7c48bce625489b#diff-d906744a971a2fc6920535c7cf327795R31) broke the "set buffer BOM ..." part.  It just outputs `set buffer BOM` and nothing else.  This causes the following error to show up in the *debug* buffer when calling `editorconfig-load`:

> `error running hook BufOpen(/Users/foo/bar.js)/: 1:1: 'editorconfig-load' 3:1: 'set-option' wrong argument count`

This PR just restores the behavior of outputing `set buffer BOM utf8` or `set buffer BOM none`.  I think this is correct, and seems to be working in my testing.  Apologies if I'm solving it at the wrong level though.