### PR TITLE
Add the -version option to print the version

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -66,6 +66,25 @@ endif
 
 CXXFLAGS += -std=gnu++11 -g -Wall -Wno-reorder -Wno-sign-compare -Wno-address
 
+
+# Version number handling. This save the current version number to a file and
+# rebuilds version.cc iff the version number has actually changed.
+version := $(shell git describe --always --dirty 2>/dev/null)
+version_old = $(shell cat .version 2>/dev/null)
+
+ifneq ($(version_old),$(version))
+# Mark version.cc for rebuild. Do not use .PHONY because this needs to be
+# persistent if make is interrupted. Do not use the $(file) function as it
+# segfaults in GNU Make 4.0
+$(shell touch version.cc)
+$(file > .version,$(version))
+endif
+
+# Special treatment for version.cc: define KAK_VERSION
+# This needs to be an "=" rather than ":=" to be expanded in rule context
+version_cppflag = $(if $(filter version.cc,$<),-DKAK_VERSION=\"$(version)\")
+
+
 all : kak
 kak : $(objects)
 	$(CXX) $(LDFLAGS) $(CXXFLAGS) $(objects) $(LIBS) -o $@
@@ -73,7 +92,8 @@ kak : $(objects)
 -include $(deps)
 
 .%$(suffix).o: %.cc
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -MD -MP -MF $(addprefix ., $(<:.cc=$(suffix).d)) -c -o $@ $<
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(version_cppflag) \
+	    -MD -MP -MF $(addprefix ., $(<:.cc=$(suffix).d)) -c -o $@ $<
 
 # Generate the man page
 ../doc/kak.1.gz: ../doc/kak.1.txt
@@ -138,3 +158,4 @@ uninstall:
 
 .PHONY: check TAGS clean distclean installdirs install install-strip uninstall
 .PHONY: tags test man doc
+

--- a/src/main.cc
+++ b/src/main.cc
@@ -24,6 +24,7 @@
 #include "shell_manager.hh"
 #include "string.hh"
 #include "unit_tests.hh"
+#include "version.hh"
 #include "window.hh"
 
 #include <fcntl.h>
@@ -747,7 +748,8 @@ int main(int argc, char* argv[])
                    { "ui", { true, "set the type of user interface to use (ncurses, dummy, or json)" } },
                    { "l", { false, "list existing sessions" } },
                    { "clear", { false, "clear dead sessions" } },
-                   { "ro", { false, "readonly mode" } } }
+                   { "ro", { false, "readonly mode" } },
+                   { "version", { false, "print version and exit" } } }
     };
     try
     {
@@ -756,6 +758,13 @@ int main(int argc, char* argv[])
                   { return lhs.key < rhs.key; });
 
         ParametersParser parser(params, param_desc);
+
+        const bool print_version = (bool)parser.get_switch("version");
+        if (print_version)
+        {
+            write_stdout(format("Kakoune {}\n", Kakoune::version));
+            return 0;
+        }
 
         const bool list_sessions = (bool)parser.get_switch("l");
         const bool clear_sessions = (bool)parser.get_switch("clear");

--- a/src/version.cc
+++ b/src/version.cc
@@ -1,0 +1,3 @@
+#include "version.hh"
+
+const char* const Kakoune::version = KAK_VERSION;

--- a/src/version.hh
+++ b/src/version.hh
@@ -1,0 +1,11 @@
+#ifndef version_hh_INCLUDED
+#define version_hh_INCLUDED
+
+namespace Kakoune
+{
+
+extern const char* const version;
+
+}
+
+#endif // version_hh_INCLUDED


### PR DESCRIPTION
The version is obtained from the command "git describe --always --dirty".

A bit of Makefile magic is used to generate a "version.cc" that is only
recompiled when the output of "git describe" changes.

In the event of a release outside of Git, the code could be modified to use git
when available and to fall back on a hard-coded version number. The current
fall back is the empty string.