### PR TITLE
Fixes #995 Documentation rendering problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.o
 .*.d
 *.pyc
+*.1-r
 src/kak
 doc/kak.1.gz
 doc/manpages/*.gz

--- a/rc/core/doc.kak
+++ b/rc/core/doc.kak
@@ -9,7 +9,7 @@ def -hidden -params 1..2 _doc-open %{
         export MANWIDTH=${kak_window_width}
 
         if man "$1" > "${manout}"; then
-            sed -i 's/.\x8//g' "${manout}"
+            sed -ie $(printf 's/.\x8//g') "${manout}"
 
             printf %s\\n "
                 edit! -scratch '*doc*'


### PR DESCRIPTION
BSD sed doesn't accept ascii number with '\x', used printf to generate '\x8' as @lenormf suggested.