### PR TITLE
Fix shell path detection

### DIFF
--- a/src/shell_manager.cc
+++ b/src/shell_manager.cc
@@ -27,7 +27,7 @@ ShellManager::ShellManager()
         auto size = confstr(_CS_PATH, 0, 0);
         String path; path.resize(size, 0);
         confstr(_CS_PATH, path.data(), size);
-        for (auto dir : StringView{path} | split<StringView>(':'))
+        for (auto dir : StringView{path.data(), (ByteCount)size} | split<StringView>(':'))
         {
             String candidate = format("{}/sh", dir);
             struct stat st;


### PR DESCRIPTION
When only one directory is returned from confstr, the StringView returned
by split() contained a null terminator which caused the shell path to
be truncated when call .c_str()