### PR TITLE
Add 'extend' to ruby grammar (meta)

### DIFF
--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -56,7 +56,7 @@ addhl -group /ruby/code regex \b([A-Za-z]\w*:(?=[^:]))|([$@][A-Za-z]\w*)|((?<=[^
     keywords="${keywords}|rescue|retry|return|self|super|then|true|undef|unless|until|when|while|yield"
     attributes="attr_reader|attr_writer|attr_accessor"
     values="false|true|nil"
-    meta="require|include"
+    meta="require|include|extend"
 
     # Add the language's grammar to the static completion list
     printf %s\\n "hook global WinSetOption filetype=ruby %{


### PR DESCRIPTION
Technically `include` and `extend` are both just methods on `Module` and `Object`, respectively, but I think we should have both.