### PR TITLE
Change the message when entering insert mode while readonly

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1005,8 +1005,8 @@ public:
 
         if (context().has_client() and
             context().options()["readonly"].get<bool>())
-            context().print_status({ "Entering insert mode while readonly",
-                                     get_face("Information") });
+            context().print_status({ "Warning: This buffer is readonly",
+                                     get_face("Error") });
     }
 
     ~Insert()


### PR DESCRIPTION
I thought the original message wasn't distinctive enough. This really is a warning to the user, not just telling them that something happened, because inserting into a readonly buffer is unlikely to be intentional.