### PR TITLE
Add nested ruby support to html. (e.g. hl in erb templates)

### DIFF
--- a/rc/base/html.kak
+++ b/rc/base/html.kak
@@ -8,6 +8,10 @@ hook global BufCreate .*\.html %{
     set buffer filetype html
 }
 
+hook global BufCreate .*\.html\..* %{
+    set buffer filetype html
+}
+
 hook global BufCreate .*\.xml %{
     set buffer filetype xml
 }
@@ -16,6 +20,7 @@ hook global BufCreate .*\.xml %{
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
 addhl -group / regions html                  \
+    ruby    <%        (?=%>)              '' \
     comment <!--     -->                  '' \
     tag     <          >                  '' \
     style   <style\b.*?>\K  (?=</style>)  '' \
@@ -25,6 +30,7 @@ addhl -group /html/comment fill comment
 
 addhl -group /html/style  ref css
 addhl -group /html/script ref javascript
+addhl -group /html/ruby   ref ruby
 
 addhl -group /html/tag regex </?(\w+) 1:keyword
 


### PR DESCRIPTION
This diff makes it so that the HTML filetype is also applied for filetypes that have the extension `.html.erb` and adds ruby highlighting to the `<%= %>` and `<% %>` tags in html files.

**before:**
<img width="793" alt="screen shot 2016-12-28 at 15 34 11" src="https://cloud.githubusercontent.com/assets/1220084/21524031/474d80e0-cd13-11e6-874b-568c603e5c2e.png">


**after:**
<img width="856" alt="screen shot 2016-12-28 at 15 32 58" src="https://cloud.githubusercontent.com/assets/1220084/21524022/3fb3f184-cd13-11e6-92c3-9ce66e7b23c8.png">
