### PR TITLE
Add nested html support to javascript files. (For React components)

### DIFF
--- a/rc/base/javascript.kak
+++ b/rc/base/javascript.kak
@@ -12,7 +12,8 @@ addhl -group / regions -default code javascript \
     double_string '"'  (?<!\\)(\\\\)*"        '' \
     single_string "'"  (?<!\\)(\\\\)*'        '' \
     comment       //   '$'                    '' \
-    comment       /\*  \*/                    ''
+    comment       /\*  \*/                    '' \
+    tag          <       >                    ''
 
 # Regular expression flags are: g → global match, i → ignore case, m → multi-lines, y → sticky
 # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
@@ -26,6 +27,8 @@ addhl -group /javascript/code regex \b(document|false|null|parent|self|this|true
 addhl -group /javascript/code regex "-?[0-9]*\.?[0-9]+" 0:value
 addhl -group /javascript/code regex \b(Array|Boolean|Date|Function|Number|Object|RegExp|String)\b 0:type
 addhl -group /javascript/code regex (?<=\W)/[^\n/]+/[gimy]* 0:meta
+
+addhl -group /javascript/tag ref html
 
 # Keywords are collected at
 # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords


### PR DESCRIPTION
This diff adds nested HTML highlighting to javascript files. This is especially necessary for the increasing number of people that work with view frameworks such as React.


**before**:
<img width="729" alt="screen shot 2016-12-28 at 15 41 19" src="https://cloud.githubusercontent.com/assets/1220084/21524207/a3cbeb58-cd14-11e6-8339-b57920596517.png">

**after**:
<img width="740" alt="screen shot 2016-12-28 at 15 39 40" src="https://cloud.githubusercontent.com/assets/1220084/21524213/ad44cfa6-cd14-11e6-9ccd-6008ca39f489.png">
