### PR TITLE
Fix boost linking on OSX for manual make

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -38,8 +38,8 @@ os := $(shell uname)
 
 ifeq ($(os),Darwin)
     LIBS += -lncurses -lboost_regex-mt
-    CPPFLAGS += -I/usr/local/opt/ncurses/include
-    LDFLAGS += -L/usr/local/opt/ncurses/lib
+    CPPFLAGS += -I/usr/local/opt/ncurses/include -I/usr/local/opt/boost/include
+    LDFLAGS += -L/usr/local/opt/ncurses/lib -L/usr/local/opt/boost/lib
 else ifeq ($(os),FreeBSD)
     LIBS += -ltinfow -lncursesw -lboost_regex
     CPPFLAGS += -I/usr/local/include


### PR DESCRIPTION
Adresses #974^W manual build using boost from homebrew. This PR adds explicit flags for homebrew's boost. My guess is that `brew` has some implicit `{LD,CPP}FLAGS`, so it shouldn't conflict. 

cc @nhooyr