### PR TITLE
Add support for ES6 template literals to javascript highlighting

### DIFF
--- a/rc/base/javascript.kak
+++ b/rc/base/javascript.kak
@@ -11,6 +11,7 @@ hook global BufCreate .*[.](js) %{
 addhl -group / regions -default code javascript \
     double_string '"'  (?<!\\)(\\\\)*"        '' \
     single_string "'"  (?<!\\)(\\\\)*'        '' \
+    literal       "`"  (?<!\\)(\\\\)*`        '' \
     comment       //   '$'                    '' \
     comment       /\*  \*/                    ''
 
@@ -20,6 +21,8 @@ addhl -group / regions -default code javascript \
 addhl -group /javascript/double_string fill string
 addhl -group /javascript/single_string fill string
 addhl -group /javascript/comment       fill comment
+addhl -group /javascript/literal       fill string
+addhl -group /javascript/literal       regex \${.*?} 0:value
 
 addhl -group /javascript/code regex \$\w* 0:identifier
 addhl -group /javascript/code regex \b(document|false|null|parent|self|this|true|undefined|window)\b 0:value


### PR DESCRIPTION
Adds support for template literals to the javascript highlighter.

![screen shot 2017-01-05 at 7 36 10 pm](https://cloud.githubusercontent.com/assets/197222/21706747/4891e5d8-d37e-11e6-8ef4-785128316b91.png)

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals