### PR TITLE
Remove the option that excludes the `-pedantic` flag from `CXXFLAGS`

### DIFF
--- a/contrib/Tupfile
+++ b/contrib/Tupfile
@@ -12,12 +12,11 @@
 
 debug    = yes
 static   = no
-pedantic = yes
 
 suffix   = .opt
 
 CXX      = g++
-CXXFLAGS = -std=gnu++11 -Wall -Wno-reorder -Wno-sign-compare -Wno-address
+CXXFLAGS = -pedantic -std=gnu++11 -Wall -Wno-reorder -Wno-sign-compare -Wno-address
 CPPFLAGS =
 LDFLAGS  =
 LIBS     =
@@ -33,10 +32,6 @@ endif
 ifeq ($(static),yes)
 	LIBS += -ltinfo -lgpm
 	LDFLAGS += -static -pthread
-endif
-
-ifeq ($(pedantic),yes)
-	CXXFLAGS += -pedantic
 endif
 
 ifeq (@(TUP_PLATFORM),macosx)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,5 @@
 debug ?= yes
 static ?= no
-pedantic ?= yes
 
 ifeq ($(debug),yes)
     CPPFLAGS += -DKAK_DEBUG
@@ -12,10 +11,6 @@ else
     else
         $(error debug should be either yes or no)
     endif
-endif
-
-ifeq ($(pedantic),yes)
-    CXXFLAGS += -pedantic
 endif
 
 sources := $(wildcard *.cc)
@@ -64,7 +59,7 @@ ifeq ($(static),yes)
     LDFLAGS += -static -pthread
 endif
 
-CXXFLAGS += -std=gnu++11 -g -Wall -Wno-reorder -Wno-sign-compare -Wno-address
+CXXFLAGS += -pedantic -std=gnu++11 -g -Wall -Wno-reorder -Wno-sign-compare -Wno-address
 
 all : kak
 kak : $(objects)


### PR DESCRIPTION
Allowing compilation without the `-pedantic` flag was a temporary trick
to work around a bug involving `libstdc++` and `musl`. A fix has been
pushed for the issue in the appropriate repositories, we no longer need
the optional non-pedantic compilation option.