### PR TITLE
fix file YAML detection

### DIFF
--- a/rc/base/yaml.kak
+++ b/rc/base/yaml.kak
@@ -4,7 +4,7 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*[.](yaml) %{
+hook global BufCreate .*[.](ya?ml) %{
     set buffer filetype yaml
 }
 

--- a/rc/base/yaml.kak
+++ b/rc/base/yaml.kak
@@ -25,7 +25,7 @@ add-highlighter -group /yaml/code regex ^(\h*:\w*) 0:keyword
 add-highlighter -group /yaml/code regex \b(true|false|null)\b 0:value
 
 # Commands
-# ‾‾‾‾‾‾‾‾
+# ‾‾‾‾‾‾‾‾ 
 
 def -hidden yaml-filter-around-selections %{
     # remove trailing white spaces


### PR DESCRIPTION
If you look at for example the [wikipedia] page under Filename extension, you'll see `.yaml` and `.yml`
[wikipedia]: https://en.wikipedia.org/wiki/YAML