### PR TITLE
fix(README): remove <register> from prompt and onkey commands

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1508,12 +1508,11 @@ Kakoune state:
 
 Some helper commands can be used to define composite commands:
 
- * `prompt <prompt> <register> <command>`: Prompt the user for a string, when
-     the user validates, store the result in given <register> and run <commmand>.
-     the -init <str> switch allows setting initial content and -password allow
-     not to show the entered text (and clears the register after command execution).
- * `onkey <register> <command>`: Wait for next key from user, writes it into given
-     <register> and execute commands.
+ * `prompt <prompt> <command>`: prompt the user for a string, when the user validates,
+     executes <command>. The entered text is available in the `text` value
+     accessible through `$kak_text` in shells or `%val{text}` in commands.
+ * `onkey <command>`: wait for next key from user, then execute <command>,
+     the key is available through the `key` value, accessible through `$kak_key`.
  * `menu <label1> <commands1> <label2> <commands2>...`: display a menu using
      labels, the selected label's commands are executed.
      `menu` can take a -auto-single argument, to automatically run commands


### PR DESCRIPTION
Hi

man pages were updated, but not the README