### PR TITLE
Adds tomorrow-night theme and include and included faces.

### DIFF
--- a/colors/base16.kak
+++ b/colors/base16.kak
@@ -27,6 +27,8 @@
         face attribute ${orange_dark}
         face comment ${grey_dark}
         face meta ${orange_light}
+        face include default
+        face included default
         face builtin default+b
     "
 

--- a/colors/default.kak
+++ b/colors/default.kak
@@ -10,6 +10,8 @@ face operator yellow
 face attribute green
 face comment cyan
 face meta magenta
+face include default
+face included default
 face builtin default+b
 
 # For markup

--- a/colors/github.kak
+++ b/colors/github.kak
@@ -13,6 +13,8 @@ face operator yellow
 face attribute rgb:A71D5D
 face comment rgb:AAAAAA
 face meta rgb:183691
+face include default
+face included default
 face builtin default+b
 
 ## markup

--- a/colors/lucius.kak
+++ b/colors/lucius.kak
@@ -33,6 +33,8 @@
         face attribute ${lucius_light_blue}
         face comment ${lucius_grey}
         face meta ${lucius_purple}
+        face include default
+        face included default
         face builtin default+b
 
         # and markup

--- a/colors/reeder.kak
+++ b/colors/reeder.kak
@@ -31,7 +31,9 @@
         face attribute  ${green}
         face comment    ${brown_light}
         face meta       ${brown_dark}
-        face builtin   default+b
+        face include    default
+        face included   default
+        face builtin    default+b
 
         # and markup
         face title      ${orange}+b

--- a/colors/solarized.kak
+++ b/colors/solarized.kak
@@ -31,7 +31,9 @@
         face attribute  ${violet}
         face comment    ${base01}
         face meta       ${orange}
-        face builtin   default+b
+        face include    default
+        face included   default
+        face builtin    default+b
 
         # and markup
         face title      ${yellow}

--- a/colors/tomorrow-night.kak
+++ b/colors/tomorrow-night.kak
@@ -1,0 +1,78 @@
+##
+## Tomorrow-night, adapted by nicholastmosher
+##
+
+%sh{
+    foreground='rgb:c5c8c6'
+    background='rgb:272727'
+    selection='rgb:373b41'
+    window='rgb:383838'
+    text='rgb:D8D8D8'
+    text_light='rgb:4E4E4E'
+    line='rgb:282a2e'
+    comment='rgb:969896'
+    red='rgb:cc6666'
+    orange='rgb:d88860'
+    yellow='rgb:f0c674'
+    green='rgb:b5bd68'
+    green_dark='rgb:a1b56c'
+    blue='rgb:81a2be'
+    aqua='rgb:87afaf'
+    magenta='rgb:ab4642'
+    purple='rgb:b294bb'
+    include=${aqua}
+    included=${green}
+
+    ## code
+    echo "
+        face value ${orange}
+        face type ${yellow}
+        face identifier ${magenta}
+        face string ${green_dark}
+        face keyword ${purple}
+        face operator ${aqua}
+        face attribute ${purple}
+        face comment ${comment}
+        face meta ${purple}
+        face include ${include}
+        face included ${included}
+        face builtin ${orange}
+    "
+
+    ## markup
+    echo "
+        face title blue
+        face header ${aqua}
+        face bold ${yellow}
+        face italic ${orange}
+        face mono ${green_dark}
+        face block ${orange}
+        face link blue
+        face bullet ${red}
+        face list ${red}
+    "
+
+    ## builtin
+    echo "
+        face Default ${text},${background}
+        face PrimarySelection default,${selection}
+        face SecondarySelection default,${selection}
+        face PrimaryCursor black,${aqua}
+        face SecondaryCursor black,${aqua}
+        face LineNumbers ${text_light},${background}
+        face LineNumberCursor ${yellow},rgb:282828+b
+        face MenuForeground ${text_light},blue
+        face MenuBackground ${aqua},${window}
+        face MenuInfo ${aqua}
+        face Information white,${window}
+        face Error white,${red}
+        face StatusLine ${text},${window}
+        face StatusLineMode ${yellow}+b
+        face StatusLineInfo ${aqua}
+        face StatusLineValue ${green_dark}
+        face StatusCursor ${window},${aqua}
+        face Prompt ${background},${aqua}
+        face MatchingChar ${yellow},${background}+b
+        face BufferPadding ${aqua},${background}
+    "
+}

--- a/colors/zenburn.kak
+++ b/colors/zenburn.kak
@@ -38,6 +38,8 @@
         face attribute ${zenstatement}
         face comment ${zencomment}
         face meta ${zenspecial}
+        face include default
+        face included default
         face builtin default+b
 
         # and markup

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -194,10 +194,14 @@ add-highlighter -group /cpp/code regex %{\b-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)
 # c and c++ compiler macros
 %sh{
     builtin_macros="__cplusplus|__STDC_HOSTED__|__FILE__|__LINE__|__DATE__|__TIME__|__STDCPP_DEFAULT_NEW_ALIGNMENT__"
+    builtin_macros="${builtin_macros}|EXIT_SUCCESS|EXIT_FAILURE"
+    includes="\h*(#include)\h+(\"[^\"]+?\"|<[^>]+?>)"
 
     printf %s "
         add-highlighter -group /c/code regex \b(${builtin_macros})\b 0:builtin
         add-highlighter -group /cpp/code regex \b(${builtin_macros})\b 0:builtin
+        add-highlighter -group /c/macro regex ${includes} 1:include 2:included
+        add-highlighter -group /cpp/macro regex ${includes} 1:include 2:included
     "
 }
 


### PR DESCRIPTION
I made a colorscheme modeled after my favorite vim theme, tomorrow-night. As a side effect of the new theme, I created two new faces for use with the colorschemes, `include` and `included`. The intent is to be able to uniquely highlight a language's "include" statement (or whichever variation of an import keyword) and the header or package or whatever's being "included".

![capture](https://cloud.githubusercontent.com/assets/4210949/22538256/02eb9ee0-e8df-11e6-9c20-8f7e08eaa143.png)