### PR TITLE
Allow modifying the characters used when highlighting whitespace

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1227,9 +1227,8 @@ general highlighters are:
        <option_name>.
  * `show_matching`: highlight matching char of the character under the selections
        cursor using `MatchingChar` face.
- * `show_whitespaces`: display symbols on top of whitespaces to make them more explicit
-       using the Whitespace face.
- * `number_lines \<-relative> \<-hlcursor> \<-separator <separator text> >`: show line numbers.
+ * `show_whitespaces \<-tab <separator> \<-tabpad <separator> \<-lf <separator> \<-spc <separator> \<-nbsp <separator>`: display symbols on top of whitespaces to make them more explicit using the Whitespace face.
+ * `number_lines \<-relative> \<-hlcursor> \<-separator <separator text>`: show line numbers.
        The -relative switch will show line numbers relative to the main cursor line, the
        -hlcursor switch will highlight the cursor line with a separate face. With the
        -separator switch one can specify a string to separate the line numbers column with

--- a/doc/manpages/highlighters.asciidoc
+++ b/doc/manpages/highlighters.asciidoc
@@ -51,9 +51,25 @@ General highlighters
 	highlight matching char of the character under the selections cursor
 	using MatchingChar face
 
-*show_whitespaces*::
+*show_whitespaces* [options]::
 	display symbols on top of whitespaces to make them more explicit
-	using the Whitespace face.
+	using the Whitespace face, with the following *options*:
+
+	*-lf* <separator>:::
+		a one character long separator that will replace line feeds
+
+	*-spc* <separator>:::
+		a one character long separator that will replace spaces
+
+	*-nbsp* <separator>:::
+		a one character long separator that will replace non breakable spaces
+
+	*-tab* <separator>:::
+		a one character long separator that will replace tabulations
+
+	*-tabpad* <separator>:::
+		a one character long separator that will be appended to tabulations to honor the *tabstop* option
+
 
 *number_lines* [options]::
 	show line numbers, with the following *options*:


### PR DESCRIPTION
This commit adds the following flags to the `show_whitespaces`
highlighter, with a one character long parameter:

 * `-lf`: character replacing line feeds
 * `-spc`: character replacing spaces
 * `-nbsp`: character replacing non breakable spaces
 * `-tab`: character replacing a tabulation
 * `-tabpad`: character used as padding after a tabulation to satisfy
              the `tabstop` option