### PR TITLE
Make sure no ANSI sequences are in the data returned by `man`

### DIFF
--- a/rc/core/doc.kak
+++ b/rc/core/doc.kak
@@ -8,7 +8,7 @@ def -hidden -params 1..2 doc-open %{
         export MANWIDTH=${kak_window_width}
 
         if man "$1" > "${manout}"; then
-            sed -ie $(printf 's/.\x8//g') "${manout}"
+            sed -i "" -e $(printf 's/.\x8//g') -e 's,\x1B\[[0-9;]*[a-zA-Z],,g' "${manout}"
 
             printf %s\\n "
                 edit! -scratch '*doc*'


### PR DESCRIPTION
The Debian implementation of `man-db` does not strip ANSI sequences out
of the file, even though the documentation says it would do so. The
commit that originally closed this issue wasn't related to the problem
experienced, this one hopefully addresses it.

This commit also addresses an issue with the `-i` flag in BSD `sed`
which expects an argument (the GNU implementation doesn't).

Fixes #1098