### PR TITLE
Tighten the build options in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
     elif [ $TRAVIS_OS_NAME = osx ]; then
        brew outdated boost || brew upgrade boost;
     fi;
+    export CXXFLAGS="${CXXFLAGS} -Werror -Wno-unknown-attributes";
 env:
   global:
    - secure: "R+NxqtytOslIcQ/eCbLoZhImsgYdJnljfjANdieFQGune9ACPPQL0YanXkF49c9SWGBSxrAcute0egQzv2CU2+ivSQIX/xnMebKHiOmSPYBoxX+VgxLT3U1itUYlpYwixo9rF8UnGdlgXid6oENSiCvfWtNKoM2qOL0Ttw31J9E="


### PR DESCRIPTION
Hi,

This commit adds the `-Werror` flag to the compilation flags on travis, in order to treat warnings as errors. I realize it might not sound so great because there are warning that we know won't do any harm, but down the line I think it's worth it, as some errors might actually cause issues and would have otherwise been ignored (e.g. the 'no return in a function returning non-void' warning that currently stops the compilation).

I also wanted to compile using clang3.4 on travis, since that's the minimum version that is documented in the build requirements, but setting it up proved to be a hassle so I let 3.5 live for now.

HTH.