### PR TITLE
Properly wrap `kak_assert` into a do-while scope

### DIFF
--- a/src/assert.hh
+++ b/src/assert.hh
@@ -17,12 +17,13 @@ void on_assert_failed(const char* message);
 #define TOSTRING(X) STRINGIFY(X)
 
 #ifdef KAK_DEBUG
-    #define kak_assert(...) \
+    #define kak_assert(...) do { \
         if (not (__VA_ARGS__)) \
             on_assert_failed("assert failed \"" #__VA_ARGS__ \
-                             "\" at " __FILE__ ":" TOSTRING(__LINE__))
+                             "\" at " __FILE__ ":" TOSTRING(__LINE__)); \
+    } while (0)
 #else
-    #define kak_assert(...)
+    #define kak_assert(...) do {} while (0)
 #endif
 
 


### PR DESCRIPTION
Expanding the `kak_assert` macro to either an `if` statement or nothing
leads to issues when the macro is used in a conditional statement that
doesn't use braces.

Example: ncurses_ui.cc:476, in non debug mode, the macro will expand to
an empty line, resulting in the `ungetch` call not being executed if the
`ioctl` call succeeds (line 448).