### PR TITLE
Improved haskell comment regex

### DIFF
--- a/rc/base/haskell.kak
+++ b/rc/base/haskell.kak
@@ -12,10 +12,10 @@ hook global BufCreate .*[.](hs) %{
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
 add-highlighter -group / regions -default code haskell \
-    string   '"'     (?<!\\)(\\\\)*"      '' \
-    comment  (--) $                       '' \
-    comment \{-   -\}                    \{- \
-    macro   ^\h*?\K# (?<!\\)\n            ''
+    string   '"'      (?<!\\)(\\\\)*"      ''  \
+    comment  (--[^>]) $                    ''  \
+    comment \{-       -\}                  \{- \
+    macro   ^\h*?\K#  (?<!\\)\n            ''
 
 add-highlighter -group /haskell/string  fill string
 add-highlighter -group /haskell/comment fill comment


### PR DESCRIPTION
As title says, I tried to improve a bit the way kakoune highlights haskell comments, even if I'm not an haskell developer.

the following screen shows the difference

![09-30-2017-02-21_1366x768](https://cloud.githubusercontent.com/assets/10442548/23183712/4d3c8cea-f87d-11e6-8c23-6053e8804aff.png)
