### PR TITLE
[WIP] contrib: Add a Dockerfile for CI builds

### DIFF
--- a/contrib/docker-build/Dockerfile
+++ b/contrib/docker-build/Dockerfile
@@ -1,0 +1,134 @@
+##
+## Dockerfile by lenormf
+##
+## Usage: docker build -t $USER/kakoune-build .
+## Once the image has been created: docker run --privileged $USER/kakoune-build [compiler]...
+## Privileges are needed in order to forward the host's /proc to the underlying chroot
+## By default the container will update to the latest HEAD of the upstream repository,
+## then start building in both release and debug mode the project with the following compilers:
+## clang-3.4, clang-3.5, clang-3.8, g++-5, g++-6
+## After the project has been sucessfully compiled, the test suite is run
+##
+
+FROM debian:stretch
+MAINTAINER Frank LENORMAND <lenormf@gmail.com>
+
+ENV LANG=en_US.UTF-8
+
+RUN \
+    apt-get update \
+    && apt-get install -y sudo multistrap
+
+RUN \
+    useradd -m build \
+    && echo build:build | chpasswd \
+    && echo '%build ALL=NOPASSWD:ALL' > /etc/sudoers.d/build \
+    && chmod 0440 /etc/sudoers.d/build
+
+COPY multistrap-* /root/multistrap/
+COPY entrypoint.sh /entrypoint.sh
+
+RUN \
+    chmod 755 /entrypoint.sh \
+    && chmod -R 755 /root/
+
+WORKDIR /home/build/
+USER build
+
+# clang-3.4, minimum supported version
+RUN \
+    rm -rf hooks conf \
+    && mkdir hooks conf \
+    && sed \
+        -e 's/{{suite}}/jessie/g' \
+        -e 's/{{pkg-compiler}}/clang-3.4/g' \
+        /root/multistrap/multistrap-compiler.conf \
+        > conf/clang-3.4.conf \
+    && cp /root/multistrap/multistrap-hook-dev_random.sh hooks/download-dev_urandom.sh \
+    && chmod 755 hooks/* \
+    && sudo multistrap -d clang-3.4 -f conf/clang-3.4.conf \
+    && sed \
+        -e 's/{{compiler}}/clang++-3.4/g' \
+        /root/multistrap/multistrap-config.sh \
+        | sudo tee clang-3.4/root/config.sh \
+    && sudo chmod 755 clang-3.4/root/config.sh \
+    && sudo chroot clang-3.4 /root/config.sh
+
+# clang-3.5, provided by the `clang` package on Debian:jessie
+RUN \
+    rm -rf hooks conf \
+    && mkdir hooks conf \
+    && sed \
+        -e 's/{{suite}}/jessie/g' \
+        -e 's/{{pkg-compiler}}/clang-3.5/g' \
+        /root/multistrap/multistrap-compiler.conf \
+        > conf/clang-3.5.conf \
+    && cp /root/multistrap/multistrap-hook-dev_random.sh hooks/download-dev_urandom.sh \
+    && chmod 755 hooks/* \
+    && sudo multistrap -d clang-3.5 -f conf/clang-3.5.conf \
+    && sed \
+        -e 's/{{compiler}}/clang++-3.5/g' \
+        /root/multistrap/multistrap-config.sh \
+        | sudo tee clang-3.5/root/config.sh \
+    && sudo chmod 755 clang-3.5/root/config.sh \
+    && sudo chroot clang-3.5 /root/config.sh
+
+# clang-3.8, provided by the `clang` package on Debian:stretch
+RUN \
+    rm -rf hooks conf \
+    && mkdir hooks conf \
+    && sed \
+        -e 's/{{suite}}/stretch/g' \
+        -e 's/{{pkg-compiler}}/clang-3.8/g' \
+        /root/multistrap/multistrap-compiler.conf \
+        > conf/clang-3.8.conf \
+    && cp /root/multistrap/multistrap-hook-dev_random.sh hooks/download-dev_urandom.sh \
+    && chmod 755 hooks/* \
+    && sudo multistrap -d clang-3.8 -f conf/clang-3.8.conf \
+    && sed \
+        -e 's/{{compiler}}/clang++-3.8/g' \
+        /root/multistrap/multistrap-config.sh \
+        | sudo tee clang-3.8/root/config.sh \
+    && sudo chmod 755 clang-3.8/root/config.sh \
+    && sudo chroot clang-3.8 /root/config.sh
+
+# g++-5, provided by the `c++-compiler` package on Debian:stretch
+RUN \
+    rm -rf hooks conf \
+    && mkdir hooks conf \
+    && sed \
+        -e 's/{{suite}}/sid/g' \
+        -e 's/{{pkg-compiler}}/g++-5/g' \
+        /root/multistrap/multistrap-compiler.conf \
+        > conf/g++-5.conf \
+    && cp /root/multistrap/multistrap-hook-dev_random.sh hooks/download-dev_urandom.sh \
+    && chmod 755 hooks/* \
+    && sudo multistrap -d g++-5 -f conf/g++-5.conf \
+    && sed \
+        -e 's/{{compiler}}/g++-5/g' \
+        /root/multistrap/multistrap-config.sh \
+        | sudo tee g++-5/root/config.sh \
+    && sudo chmod 755 g++-5/root/config.sh \
+    && sudo chroot g++-5 /root/config.sh
+
+# g++-6, provided by the `c++-compiler` package on Debian:stretch
+RUN \
+    rm -rf hooks conf \
+    && mkdir hooks conf \
+    && sed \
+        -e 's/{{suite}}/stretch/g' \
+        -e 's/{{pkg-compiler}}/g++-6/g' \
+        /root/multistrap/multistrap-compiler.conf \
+        > conf/g++-6.conf \
+    && cp /root/multistrap/multistrap-hook-dev_random.sh hooks/download-dev_urandom.sh \
+    && chmod 755 hooks/* \
+    && sudo multistrap -d g++-6 -f conf/g++-6.conf \
+    && sed \
+        -e 's/{{compiler}}/g++-6/g' \
+        /root/multistrap/multistrap-config.sh \
+        | sudo tee g++-6/root/config.sh \
+    && sudo chmod 755 g++-6/root/config.sh \
+    && sudo chroot g++-6 /root/config.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["clang-3.4", "clang-3.5", "clang-3.8", "g++-5", "g++-6"]

--- a/contrib/docker-build/entrypoint.sh
+++ b/contrib/docker-build/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+for compiler in "$@"; do
+    cd /home/build/
+
+    sudo mount -t proc /proc "${compiler}/proc"
+
+    for debug_mode in yes no; do
+        printf 'Compiling with compiler=%s, debug=%s\n' "${compiler}" "${debug_mode}"
+
+        if ! sudo chroot "${compiler}" /root/kakoune/run.sh "${debug_mode}"; then
+            echo "Build failed"
+        else
+            echo "Build passed"
+        fi
+
+        echo
+    done
+
+    sudo umount "${compiler}/proc"
+done

--- a/contrib/docker-build/multistrap-compiler.conf
+++ b/contrib/docker-build/multistrap-compiler.conf
@@ -1,0 +1,11 @@
+[General]
+include=/usr/share/multistrap/{{suite}}.conf
+debootstrap=Debian Base Compiler
+hookdir=/home/build/hooks/
+
+[Base]
+packages=locales ca-certificates
+packages=git libncursesw5-dev libboost-regex-dev make
+
+[Compiler]
+packages={{pkg-compiler}}

--- a/contrib/docker-build/multistrap-config.sh
+++ b/contrib/docker-build/multistrap-config.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+
+export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
+export LC_ALL=C LANGUAGE=C LANG=C
+/var/lib/dpkg/info/dash.preinst install
+
+echo en_US UTF-8 > /etc/locale.gen
+locale-gen
+echo export LANG=en_US.UTF-8 > /etc/profile.d/utf8.sh
+
+dpkg --configure -a
+
+echo nameserver 8.8.8.8 > /etc/resolv.conf
+
+(
+    cd /root
+    git clone https://github.com/mawww/kakoune.git
+    cat >kakoune/run.sh <<"EOF"
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")/src"
+git pull
+CXX="{{compiler}}" debug="${1:-no}" make clean all test
+EOF
+
+    chmod +x kakoune/run.sh
+)

--- a/contrib/docker-build/multistrap-hook-dev_random.sh
+++ b/contrib/docker-build/multistrap-hook-dev_random.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+mknod -m 666 "${1}/dev/random" c 1 8
+mknod -m 666 "${1}/dev/urandom" c 1 9
+chown root:root "${1}/dev/random" "${1}/dev/urandom"


### PR DESCRIPTION
Hi,

Travis doesn't offer much margin when it comes to software versions, so I came up with a `docker` image that allows to compile the project using different compilers.

Even though it takes more space because of base files duplication, I went with `multistrap` so that the build environments would be segregated, and also to let the door open to cross-compiling if we ever need it (an ARM build could be nice).

Not sure if this really belongs to `contrib`, but here it is. Read the commit message for more info.