### PR TITLE
rc: simplify/POSIXify the `autorestore.kak` script

### DIFF
--- a/rc/extra/autorestore.kak
+++ b/rc/extra/autorestore.kak
@@ -4,28 +4,19 @@ decl bool autorestore_purge_restored true
 ## Insert the content of the backup file into the current buffer, if a suitable one is found
 def autorestore-restore-buffer -docstring "Restore the backup for the current file if it exists" %{
     %sh{
-        test ! -f "${kak_buffile}" && exit
-
-        buffer_basename=$(basename "${kak_buffile}")
+        buffer_basename="${kak_buffile##*/}"
         buffer_dirname=$(dirname "${kak_buffile}")
 
         ## Find the name of the latest backup created for the buffer that was open
-        ## The backup file has to have been last modified more recently than the file we are editing
-        ## Other backups are removed
-        backup_path=$(find "${buffer_dirname}" -maxdepth 1 -type f -name "\.${buffer_basename}\.kak\.*" \
-                           \( \( -newer "${kak_buffile}" -exec ls -1t {} + \) -o \( -exec rm {} \; \) \) 2>/dev/null)
+        backup_path=$(ls -1t ."${kak_bufname}".kak.* | head -n 1)
 
         if [ -z "${backup_path}" ]; then
             exit
         fi
 
-        # Only get the most recent one
-        backup_path=$(ls -t $backup_path | head -n1)
-
         printf %s\\n "
             ## Replace the content of the buffer with the content of the backup file
             exec -draft %{ %d!cat<space>${backup_path}<ret>d }
-            eval -client %val{client} echo -color Information 'Backup restored'
 
             ## If the backup file has to be removed, issue the command once
             ## the current buffer has been saved
@@ -34,7 +25,9 @@ def autorestore-restore-buffer -docstring "Restore the backup for the current fi
             hook -group autorestore buffer BufWritePost '${kak_buffile}' %{
                 nop %sh{
                     if [ \"\${kak_opt_autorestore_purge_restored}\" = true ]; then
-                        rm -f '${backup_path}'
+                        ls -1 '${buffer_dirname}'/.'${buffer_basename}'.kak.* | while read -r f; do
+                            rm -f \"\${f}\"
+                        done
                     fi
                 }
             }
@@ -45,12 +38,16 @@ def autorestore-restore-buffer -docstring "Restore the backup for the current fi
 ## Remove all the backups that have been created for the current buffer
 def autorestore-purge-backups -docstring "Remove all the backups of the current buffer" %{
     nop %sh{
-        test ! -f "${kak_buffile}" && exit
+        if [ ! -f "${kak_buffile}" ]; then
+            exit
+        fi
 
-        buffer_basename=$(basename "${kak_bufname}")
+        buffer_basename="${kak_bufname##*/}"
         buffer_dirname=$(dirname "${kak_bufname}")
 
-        find "${buffer_dirname}" -maxdepth 1 -type f -readable -name "\.${buffer_basename}\.kak\.*" -delete 2>/dev/null
+        ls -1 "${buffer_dirname}"/."${buffer_basename}".kak.* | while read -r f; do
+            rm -f "${f}"
+        done
     }
     echo -color Information 'Backup files removed'
 }
@@ -60,4 +57,4 @@ def autorestore-disable -docstring "Disable automatic backup recovering" %{
     remove-hooks global autorestore
 }
 
-hook -group autorestore global BufOpenFile .* %{ autorestore-restore-buffer }
+hook -group autorestore global BufCreate .* %{ autorestore-restore-buffer }


### PR DESCRIPTION
This commit allows buffers that were not previously written to disk to
be restored if a backup has been generated in their name. Consequently,
we got rid of a few non-POSIX calls to `find` (using `-maxdepth` or
`-delete`), and of the logic that detected the newest backup (which
didn't seem a good reason enough to steer away from a portable command).

Fixes #1236