### PR TITLE
racer: escape pipe from closure in the description

### DIFF
--- a/rc/extra/racer.kak
+++ b/rc/extra/racer.kak
@@ -31,6 +31,11 @@ def racer-complete -docstring "Complete the current selection with racer" %{
                         sub(word, "{default+e}" word "{default+d}", menu)
                         menu = "{default+d}" menu
                         word = word "("
+                    } else if (type == "Enum") {
+                        menu = substr(menu, 0, length(menu) - 2)
+                        sub(word, "{default+e}" word "{default+d}", menu)
+                        menu = "{default+d}" menu
+                        word = word "::"
                     } else {
                         menu = "{default+e}" word "{default+d} " menu
                     }

--- a/rc/extra/racer.kak
+++ b/rc/extra/racer.kak
@@ -22,6 +22,7 @@ def racer-complete -docstring "Complete the current selection with racer" %{
                     word = $2
                     type = $7
                     desc = substr($9, 2, length($9) - 2)
+                    gsub(/\|/, "\\|", desc)
                     gsub(/\\n/, "\n", desc)
                     menu = $8
                     sub(/^pub /, "", menu)


### PR DESCRIPTION
The rust documentation can be pretty extensive for stdlib containing for example... examples. This patch fixes the completion when there is a closure in this documentation.