### PR TITLE
src: Support the `-help` flag

### DIFF
--- a/doc/kak.1.txt
+++ b/doc/kak.1.txt
@@ -7,7 +7,7 @@ kak - a vim inspired, selection oriented code editor
 
 SYNOPSIS
 --------
-*kak* [-q] [-n] [-l] [-ro] [-clear] [-ui ui_type] [-e command] [-f keys] [-p session_id] [-c session_id|[[-d] -s session_id] [+line[:column]] file ...
+*kak* [-help] [-q] [-n] [-l] [-ro] [-clear] [-ui ui_type] [-e command] [-f keys] [-p session_id] [-c session_id|[[-d] -s session_id] [+line[:column]|+:] file ...
 
 DESCRIPTION
 -----------
@@ -26,6 +26,9 @@ stays fixed and the cursor one moves around.
 
 OPTIONS
 -------
+-help::
+	display a help message and quit
+
 -n::
 	do not load resource files on startup ('kakrc', 'autoload', 'rc' etc)
 
@@ -63,7 +66,8 @@ OPTIONS
 	enter in 'readonly mode', all the buffers opened will not be written to disk
 
 +line[:column]::
-	specify a target line and column for the first file
+	specify a target line and column for the first file; when the plus sign is followed by only a colon,
+	then the cursor is sent to the last line of the file
 
 file::
 	one or more files to edit

--- a/src/main.cc
+++ b/src/main.cc
@@ -801,11 +801,32 @@ int main(int argc, char* argv[])
                    { "ui", { true, "set the type of user interface to use (ncurses, dummy, or json)" } },
                    { "l", { false, "list existing sessions" } },
                    { "clear", { false, "clear dead sessions" } },
-                   { "ro", { false, "readonly mode" } } }
+                   { "ro", { false, "readonly mode" } },
+                   { "help", { false, "display a help message and quit" } } }
     };
+
     try
     {
+        auto show_usage = [&]()
+        {
+            write_stdout(format("Usage: {} [options] [file]... [+<line>[:<col>]|+:]\n\n"
+                    "Options:\n"
+                    "{}\n"
+                    "Prefixing a positional argument with a plus (`+`) sign will place the\n"
+                    "cursor at a given set of coordinates, or the end of the buffer if the plus\n"
+                    "sign is followed only by a colon (`:`)\n",
+                    argv[0], generate_switches_doc(param_desc.switches)));
+            return 0;
+        };
+
+        if (contains(ConstArrayView<char*>{argv+1, (size_t)argc-1}, StringView{"--help"}))
+            return show_usage();
+
         ParametersParser parser(params, param_desc);
+
+        const bool show_help_message = (bool)parser.get_switch("help");
+        if (show_help_message)
+            return show_usage();
 
         const bool list_sessions = (bool)parser.get_switch("l");
         const bool clear_sessions = (bool)parser.get_switch("clear");


### PR DESCRIPTION
Output:

```
> ./kak -help
Usage: ./kak [options] [file]... [+<line>[:<col>]|+:]

Options:
 -c <arg>: connect to given session
 -e <arg>: execute argument on initialisation
 -n : do not source kakrc files on startup
 -s <arg>: set session name
 -d : run as a headless session (requires -s)
 -p <arg>: just send stdin as commands to the given session
 -f <arg>: act as a filter, executing given keys on given files
 -q : in filter mode, be quiet about errors applying keys
 -ui <arg>: set the type of user interface to use (ncurses, dummy, or json)
 -l : list existing sessions
 -clear : clear dead sessions
 -ro : readonly mode
 -help : display a help message

Prefixing a positional argument with a plus (`+`) sign will place the
cursor at a given set of coordinates, or the end of the buffer if the plus
sign is followed only by a colon (`:`)
```
