### PR TITLE
Extend python higlighter

### DIFF
--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -47,18 +47,63 @@ add-highlighter -group /python/comment       fill comment
 
     # Highlight keywords
     printf %s "
-        add-highlighter -group /python/code regex '\b(${values})\b' 0:value
-        add-highlighter -group /python/code regex '\b(${meta})\b' 0:meta
-        add-highlighter -group /python/code regex '\b(${keywords})\b' 0:keyword
-        add-highlighter -group /python/code regex '\b(${functions})\b\(' 1:builtin
+        add-highlighter -group /python/code regex '\b(${values})\b' 1:value
+        add-highlighter -group /python/code regex '(?:^|[^.])\b(${meta})\b' 1:meta
+        add-highlighter -group /python/code regex '(?:^|[^.])\b(${keywords})\b' 1:keyword
+        add-highlighter -group /python/code regex '(?:^|[^.])\b(${functions})\b\(' 1:builtin
     "
 
     # Highlight types and attributes
     printf %s "
-        add-highlighter -group /python/code regex '\b(${types})\b' 0:type
+        add-highlighter -group /python/code regex '\b(${types})\b' 1:type
         add-highlighter -group /python/code regex '@[\w_]+\b' 0:attribute
     "
 }
+
+# extended syntax
+
+%sh{
+    values="self"
+    # attributes and methods list based on https://docs.python.org/3/reference/datamodel.html
+    attributes="__annotations__|__closure__|__code__|__defaults__|__dict__|__doc__"
+    attributes="${attributes}|__globals__|__kwdefaults__|__module__|__name__|__qualname__"
+    methods="__abs__|__add__|__aenter__|__aexit__|__aiter__|__and__|__anext__"
+    methods="${methods}|__await__|__bool__|__bytes__|__call__|__complex__|__contains__"
+    methods="${methods}|__del__|__delattr__|__delete__|__delitem__|__dir__|__divmod__"
+    methods="${methods}|__enter__|__eq__|__exit__|__float__|__floordiv__|__format__"
+    methods="${methods}|__ge__|__get__|__getattr__|__getattribute__|__getitem__"
+    methods="${methods}|__gt__|__hash__|__iadd__|__iand__|__ifloordiv__|__ilshift__"
+    methods="${methods}|__imatmul__|__imod__|__imul__|__index__|__init__"
+    methods="${methods}|__init_subclass__|__int__|__invert__|__ior__|__ipow__"
+    methods="${methods}|__irshift__|__isub__|__iter__|__itruediv__|__ixor__|__le__"
+    methods="${methods}|__len__|__length_hint__|__lshift__|__lt__|__matmul__"
+    methods="${methods}|__missing__|__mod__|__mul__|__ne__|__neg__|__new__|__or__"
+    methods="${methods}|__pos__|__pow__|__radd__|__rand__|__rdivmod__|__repr__"
+    methods="${methods}|__reversed__|__rfloordiv__|__rlshift__|__rmatmul__|__rmod__"
+    methods="${methods}|__rmul__|__ror__|__round__|__rpow__|__rrshift__|__rshift__"
+    methods="${methods}|__rsub__|__rtruediv__|__rxor__|__set__|__setattr__"
+    methods="${methods}|__setitem__|__set_name__|__slots__|__str__|__sub__"
+    methods="${methods}|__truediv__|__xor__"
+
+    printf %s "
+        add-highlighter -group /python/code regex '\b(${values})\b' 1:variable
+        add-highlighter -group /python/code regex '\.(${attributes})[^(]' 1:attribute
+        add-highlighter -group /python/code regex '(def\s+|\.)(${methods})\(' 2:function
+    "
+}
+
+# Integer formats
+add-highlighter -group /python/code regex '\b0[bB][01]+[lL]?\b' 0:value
+add-highlighter -group /python/code regex '\b0[xX][\da-fA-F]+[lL]?\b' 0:value
+add-highlighter -group /python/code regex '\b0[oO]?[0-7]+[lL]?\b' 0:value
+add-highlighter -group /python/code regex '\b([1-9]\d*|0)[lL]?\b' 0:value
+# Float formats
+add-highlighter -group /python/code regex '(\h|\v|[({[])(-((\d+\.\d+)|(\d+\.)|(\.\d+)))([eE][+-]?\d+)?(\h|\v|[)}\]])' 2:value
+add-highlighter -group /python/code regex '\b\d+[eE][+-]?\d+\b' 0:value
+# Imaginary formats
+add-highlighter -group /python/code regex '\b\d+[jJ]\b' 0:value
+add-highlighter -group /python/code regex '(\h|\v|[({[])(-((\d+\.\d+)|(\d+\.)|(\.\d+)))([eE][+-]?\d+)?[jJ](\h|\v|[)}\]])' 2:value
+add-highlighter -group /python/code regex '\b\d+[eE][+-]?\d+[jJ]\b' 0:value
 
 # Commands
 # ‾‾‾‾‾‾‾‾

--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -11,6 +11,9 @@ hook global BufCreate .*[.](py) %{
 # Highlighters & Completion
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
+declare-option -docstring "when enable more builtin symbols are highlighted for python" \
+    bool python_use_extended_syntax yes
+
 add-highlighter -group / regions -default code python \
     double_string '"""' '"""'            '' \
     single_string "'''" "'''"            '' \
@@ -62,7 +65,7 @@ add-highlighter -group /python/comment       fill comment
 
 # extended syntax
 
-%sh{
+%sh{ if [ "$kak_opt_python_use_extended_syntax" = "true" ]; then
     values="self"
     # attributes and methods list based on https://docs.python.org/3/reference/datamodel.html
     attributes="__annotations__|__closure__|__code__|__defaults__|__dict__|__doc__"
@@ -90,7 +93,7 @@ add-highlighter -group /python/comment       fill comment
         add-highlighter -group /python/code regex '\.(${attributes})[^(]' 1:attribute
         add-highlighter -group /python/code regex '(def\s+|\.)(${methods})\(' 2:function
     "
-}
+fi }
 
 # Integer formats
 add-highlighter -group /python/code regex '\b0[bB][01]+[lL]?\b' 0:value


### PR DESCRIPTION
Adds highlight for:
- `self`
- builtin attributes
- builtin methods
- numbers

The symbol lists are based on the online python3's documentation.
The new rules (except for the numbers) can be disabled with an option since it was a concern for certain users, cf seconde commit message.

Some problem remains: 
- [ ] handle weird number formats like `.12`, `1.e2j`

cc @danr 