### PR TITLE
src: Make the cursor character an opening delimiter

### DIFF
--- a/src/selectors.cc
+++ b/src/selectors.cc
@@ -295,7 +295,7 @@ find_surrounding(Iterator begin, Iterator end,
     const bool nestable = opening != closing;
 
     auto first = pos;
-    if (to_begin)
+    if (to_begin and opening != *pos)
     {
         using RevIt = std::reverse_iterator<Iterator>;
         auto res = find_closing(RevIt{pos+1}, RevIt{begin},


### PR DESCRIPTION
This commit allows the editor to consider the character under the cursor
as an opening delimiter when using an object selector, instead of
ignoring it and looking for one before the cursor.