### PR TITLE
src: Fix the `distclean` Makefile target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -103,7 +103,8 @@ clean:
 	rm -f .*.o .*.d
 
 distclean: clean
-	rm -f kak
+	rm -f kak kak$(suffix)
+	find ../doc -type f -name \*\\.gz -exec rm -f '{}' +
 
 installdirs:
 	install -d $(bindir) \


### PR DESCRIPTION
Have the Makefile remove the actual binaries and generated documentation
when called with the `distclean` target