### PR TITLE
Make ctags.kak work without coreutils

### DIFF
--- a/rc/base/ctags.kak
+++ b/rc/base/ctags.kak
@@ -7,9 +7,12 @@ decl str-list ctagsfiles 'tags'
 
 def -params ..1 \
     -shell-candidates '
+        realpath() {
+            echo $(cd -P -- "$(dirname -- "$1")" && echo "$(pwd -P)/$(basename -- "$1")")
+        }
         printf %s\\n "$kak_opt_ctagsfiles" | tr \':\' \'\n\' |
         while read -r candidate; do
-            [ -f "$candidate" ] && readlink -f "$candidate"
+            [ -f "$candidate" ] && realpath "$candidate"
         done | awk \'!x[$0]++\' | # remove duplicates
         while read -r tags; do
             namecache="${tags%/*}/.kak.${tags##*/}.namecache"
@@ -22,13 +25,16 @@ def -params ..1 \
 If no symbol is passed then the current selection is used as symbol name} \
     tag \
     %{ %sh{
+        realpath() {
+            echo $(cd -P -- "$(dirname -- "$1")" && echo "$(pwd -P)/$(basename -- "$1")")
+        }
         export tagname=${1:-${kak_selection}}
         printf %s\\n "$kak_opt_ctagsfiles" | tr ':' '\n' |
         while read -r candidate; do
-            [ -f "$candidate" ] && readlink -f "$candidate"
+            [ -f "$candidate" ] && realpath "$candidate"
         done | awk '!x[$0]++' | # remove duplicates
         while read -r tags; do
-            printf '!TAGROOT\t%s\n' "$(readlink -f "${tags%/*}")/"
+            printf '!TAGROOT\t%s\n' "$(realpath "${tags%/*}")/"
             readtags -t "$tags" $tagname
         done | awk -F '\t|\n' '
         /^!TAGROOT\t/ { tagroot=$2 }

--- a/rc/base/ctags.kak
+++ b/rc/base/ctags.kak
@@ -8,7 +8,7 @@ decl str-list ctagsfiles 'tags'
 def -params ..1 \
     -shell-candidates '
         realpath() {
-            echo $(cd -P -- "$(dirname -- "$1")" && echo "$(pwd -P)/$(basename -- "$1")")
+            printf %s\\n "$(cd -P -- "$(dirname -- "$1")" && printf %s\\n "$PWD/${1##*/}")"
         }
         printf %s\\n "$kak_opt_ctagsfiles" | tr \':\' \'\n\' |
         while read -r candidate; do
@@ -26,7 +26,7 @@ If no symbol is passed then the current selection is used as symbol name} \
     tag \
     %{ %sh{
         realpath() {
-            echo $(cd -P -- "$(dirname -- "$1")" && echo "$(pwd -P)/$(basename -- "$1")")
+            printf %s\\n "$(cd -P -- "$(dirname -- "$1")" && printf %s\\n "$PWD/${1##*/}")"
         }
         export tagname=${1:-${kak_selection}}
         printf %s\\n "$kak_opt_ctagsfiles" | tr ':' '\n' |


### PR DESCRIPTION
This is not the prettiest fix but with this you don't need GNU readlink to use ctags. I've used it for some time on macOS and Archlinux.