### PR TITLE
src: Try to detect possible overflows properly

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -217,7 +217,16 @@ public:
             m_idle_timer.set_next_date(Clock::now() + get_idle_timeout(context()));
         else if (cp and isdigit(*cp))
         {
-            int new_val = m_params.count * 10 + *cp - '0';
+            const int n_cp = *cp - '0';
+            int new_val = -1;
+            if (m_params.count < std::numeric_limits<int>::max() / 10)
+            {
+                new_val = m_params.count * 10;
+                if (new_val < std::numeric_limits<int>::max() - n_cp)
+                    new_val += n_cp;
+                else
+                    new_val = -1;
+            }
             if (new_val < 0)
                 context().print_status({ "parameter overflowed", get_face("Error") });
             else


### PR DESCRIPTION
The previous check tried to catch the overflow after the fact, which
relied on the undefined behaviour of the operation.