### PR TITLE
[WIP] src: Implement an highlighter that hints at long lines

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1053,6 +1053,7 @@ There are some builtins faces used by internal Kakoune functionalities:
  * `Search`: face used to highlight search results
  * `BufferPadding`: face applied on the characters that follow the last line of a buffer
  * `Whitespace`: face used by the show_whitespaces highlighter
+ * `LongLineHint`: face used by the show_long_line_hints highlighter
 
 Advanced topics
 ---------------

--- a/doc/manpages/faces.asciidoc
+++ b/doc/manpages/faces.asciidoc
@@ -109,3 +109,6 @@ areas of the user interface:
 
 *Whitespace*::
 	face used by the show_whitespaces highlighter
+
+*LongLineHint*::
+	face used by the show_long_line_hints highlighter

--- a/doc/manpages/highlighters.asciidoc
+++ b/doc/manpages/highlighters.asciidoc
@@ -70,6 +70,13 @@ General highlighters
 	*-tabpad* <separator>:::
 		a one character long separator that will be appended to tabulations to honor the *tabstop* option
 
+*show_long_line_hints* [options]::
+	display a dollar sign at the end of lines that are longer than the
+	window's width, with the following *options*:
+
+	*-hint* <character>:::
+		a one column wide character that will be displayed instead of the
+		default dollar sign
 
 *number_lines* [options]::
 	show line numbers, with the following *options*:

--- a/src/face_registry.cc
+++ b/src/face_registry.cc
@@ -121,6 +121,7 @@ FaceRegistry::FaceRegistry()
         { "MatchingChar", Face{ Color::Default, Color::Default, Attribute::Bold } },
         { "BufferPadding", Face{ Color::Blue, Color::Default } },
         { "Whitespace", Face{ Color::Default, Color::Default } },
+        { "LongLineHint", Face{ Color::Default, Color::Default, Attribute::Bold } },
       }
 {}
 


### PR DESCRIPTION
This commit introduces the `show_long_line_hints` highlighter which will
display a one-column wide hint character on the last column of the current
window, on lines that are longer than the window's column count.

The `-hint` parameter controls what character will be displayed (defaults
to a dollar sign), and the `LongLineHint` face dictates how the hint should
be displayed.