### PR TITLE
src: Implement a `write!` command

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -676,8 +676,10 @@ command `q!` has to be used).
  * `e[dit][!] <filename> [<line> [<column>]]`: open buffer on file, go to given
      line and column. If file is already opened, just switch to this file.
      use edit! to force reloading.
- * `w[rite] [<filename>]`: write buffer to <filename> or use it's name if
-     filename is not given.
+ * `w[rite][!] [<filename>]`: write buffer to <filename> or use it's name if
+     filename is not given. If the file is write-protected, its
+     permissions are temporarily changed to allow saving the buffer and
+     restored afterwards when the write! command is used.
  * `w[rite]a[ll]`: write all buffers that are associated to a file.
  * `q[uit][!]`: exit Kakoune, use quit! to force quitting even if there is some
      unsaved buffers remaining.

--- a/doc/manpages/commands.asciidoc
+++ b/doc/manpages/commands.asciidoc
@@ -24,8 +24,11 @@ command *q!* has to be used).
 	open buffer on file, go to given line and column. If file is already
 	opened, just switch to this file. Use edit! to force reloading
 
-*w[rite]* [<filename>]::
-	write buffer to <filename> or use it's name if filename is not given
+*w[rite][!]* [<filename>]::
+	write buffer to <filename> or use it's name if filename is not
+	given. If the file is write-protected, its permissions are temporarily
+	changed to allow saving the buffer and restored afterwards when
+	the write! command is used.
 
 *w[rite]a[ll]*::
 	write all buffers that are associated to a file

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -309,6 +309,7 @@ const CommandDesc force_edit_cmd = {
     edit<true>
 };
 
+template<bool force = false>
 void write_buffer(const ParametersParser& parser, Context& context, const ShellContext&)
 {
     Buffer& buffer = context.buffer();
@@ -326,7 +327,7 @@ void write_buffer(const ParametersParser& parser, Context& context, const ShellC
                     buffer.name() : parse_filename(parser[0]);
 
     context.hooks().run_hook("BufWritePre", filename, context);
-    write_buffer_to_file(buffer, filename);
+    write_buffer_to_file(buffer, filename, force);
     context.hooks().run_hook("BufWritePost", filename, context);
 }
 
@@ -340,6 +341,18 @@ const CommandDesc write_cmd = {
     CommandHelper{},
     filename_completer,
     write_buffer,
+};
+
+const CommandDesc force_write_cmd = {
+    "write!",
+    "w!",
+    "write [filename]: write the current buffer to its file "
+    "or to [filename] if specified, even when the file is write protected",
+    single_optional_param,
+    CommandFlags::None,
+    CommandHelper{},
+    filename_completer,
+    write_buffer<true>,
 };
 
 void write_all_buffers(Context& context)
@@ -2102,6 +2115,7 @@ void register_commands()
     register_command(edit_cmd);
     register_command(force_edit_cmd);
     register_command(write_cmd);
+    register_command(force_write_cmd);
     register_command(write_all_cmd);
     register_command(write_all_quit_cmd);
     register_command(kill_cmd);

--- a/src/file.hh
+++ b/src/file.hh
@@ -49,7 +49,7 @@ struct MappedFile
     struct stat st {};
 };
 
-void write_buffer_to_file(Buffer& buffer, StringView filename);
+void write_buffer_to_file(Buffer& buffer, StringView filename, bool force = false);
 void write_buffer_to_fd(Buffer& buffer, int fd);
 void write_buffer_to_backup_file(Buffer& buffer);
 


### PR DESCRIPTION
This commit allows "forced" writes to a write-protected file, by
attempting to temporarily grant the current user write permissions on
it. After the buffer has been written, the previous permissions are
restored if the file existed, or set to 0644 otherwise.