### PR TITLE
[wip] gdb integration script

### DIFF
--- a/rc/extra/gdb.kak
+++ b/rc/extra/gdb.kak
@@ -80,7 +80,10 @@ define-command -hidden gdb-session-connect-internal %{
                 line = get(frame, "line=\"", "[0-9]+", "\"")
                 return line " \"" file "\""
             }
-            BEGIN { connected = 0 }
+            BEGIN {
+                connected = 0
+                printing = 0
+            }
             // {
                 if (!connected) {
                     connected = 1
@@ -131,7 +134,7 @@ define-command -hidden gdb-session-connect-internal %{
             /\^done/ {
                 if (printing) {
                     # trim trailing \n
-                    print_value = substr(print_value, 0, length(print_value) - 3)
+                    print_value = substr(print_value, 0, match(print_value, "(\n|\\\\n)*$") - 1)
                     # QUOTE => \\QUOTE
                     gsub("'\''", "\\\\'\''", print_value)
                     # eval -client $client QUOTE info  -- \QUOTE $string \QUOTE QUOTE

--- a/rc/extra/gdb.kak
+++ b/rc/extra/gdb.kak
@@ -1,0 +1,320 @@
+# script summary:
+# a long running shell process connects to an existing gdb session and handles input/output
+# input (common gdb commands) to the gdb session is done by writing to a fifo
+# output is converted into corresponding kak commands to update the presented information
+
+declare-option -hidden str gdb_dir
+
+# contains all known breakpoints in this format:
+# id|enabled|line|file:id|enabled|line|file|:...
+declare-option -hidden str-list gdb_breakpoints_info
+# if execution is currently stopped, contains the location in this format:
+# line|file
+declare-option -hidden str-list gdb_location_info
+# note that these variables may reference locations that are not in currently opened buffers
+
+# corresponding flags generated from the previous variables
+# these are only set on buffer scope
+declare-option -hidden line-flags gdb_breakpoints_flags
+declare-option -hidden line-flags gdb_location_flag
+
+set-face GdbBreakpoint red,default
+set-face GdbLocation blue,default
+
+add-highlighter -group / group -passes move gdb
+add-highlighter -group /gdb flag_lines GdbLocation gdb_location_flag
+add-highlighter -group /gdb flag_lines GdbBreakpoint gdb_breakpoints_flags
+
+hook global WinCreate .* %{
+    add-highlighter ref -passes move gdb
+}
+
+define-command -params .. -file-completion gdb-session-new %{
+    gdb-session-connect
+    %sh{
+        # can't connect until socat has created the pty thing
+        while [ ! -e "${kak_opt_gdb_dir}/pty" ]; do
+            sleep 1
+        done
+        {
+            setsid -w $kak_opt_termcmd " \
+              gdb $@ --init-eval-command=\"new-ui mi3 ${kak_opt_gdb_dir}/pty\""
+            printf gdb-session-stop\\n | kak -p "$kak_session"
+        } 2>/dev/null >/dev/null &
+    }
+}
+
+define-command gdb-session-connect %{
+    gdb-session-stop
+    %sh{
+        tmpdir=$(mktemp --tmpdir -d gdb_kak_XXX)
+        mkfifo "${tmpdir}/pipe"
+        {
+            tail -n +1 -f "${tmpdir}/pipe" | socat "pty,link=${tmpdir}/pty" STDIO,nonblock=1 | awk '
+            function send(what) {
+                cmd = "kak -p '"$kak_session"'"
+                print(what) | cmd
+                close(cmd)
+            }
+            function get(input, prefix, pattern, suffix) {
+                s = match(input, prefix pattern suffix)
+                return substr(input, s + length(prefix), RLENGTH - length(prefix) - length(suffix))
+            }
+            function breakpoint_info(breakpoint) {
+                id = get(breakpoint, "number=\"", "[0-9]+", "\"")
+                enabled = get(breakpoint, "enabled=\"", "[yn]", "\"")
+                line = get(breakpoint, "line=\"", "[0-9]+", "\"")
+                file = get(breakpoint, "fullname=\"", "[^\"]*", "\"")
+                return id " " enabled " " line " \"" file "\""
+            }
+            function frame_info(frame) {
+                file = get(frame, "fullname=\"", "[^\"]*", "\"")
+                line = get(frame, "line=\"", "[0-9]+", "\"")
+                return line " \"" file "\""
+            }
+            BEGIN { connected = 0 }
+            // {
+                if (!connected) {
+                    connected = 1
+                    print("-break-list") >> "'"$tmpdir/pipe"'"
+                    print("-stack-info-frame") >> "'"$tmpdir/pipe"'"
+                    close("'"$tmpdir/pipe"'")
+                }
+            }
+            /\*running/ {
+                send("gdb-clear-location")
+            }
+            /\*stopped/ { 
+                send("gdb-handle-stopped " frame_info($0))
+            }
+            /\^done,frame=/ {
+                send("gdb-clear-location; gdb-handle-stopped " frame_info($0))
+            }
+            /=breakpoint-created/ {
+                send("gdb-handle-breakpoint-created " breakpoint_info($0))
+            }
+            /=breakpoint-modified/ {
+                send("gdb-handle-breakpoint-modified " breakpoint_info($0))
+            }
+            /=breakpoint-deleted/ {
+                id = get($0, "id=\"", "[0-9]+", "\"")
+                send("gdb-handle-breakpoint-deleted " id)
+            }
+            /\^done,BreakpointTable=/ {
+                command = "gdb-clear-breakpoints"
+                breakpoints_number = split($0, breakpoints, "bkpt=")
+                for (i = 2; i <= breakpoints_number; i++) {
+                    command = command "; gdb-handle-breakpoint-created " breakpoint_info(breakpoints[i])
+                }
+                send(command)
+            }
+            /&"print/ {
+                printing = 1
+                print_value = get($0, "print ", ".*", "..\"") " == "
+            }
+            /~".*"/ {
+                if (printing == 1) {
+                    print_value = print_value get($0, "= ", ".*", "\"")
+                    printing = 2
+                } else if (printing) {
+                    print_value = print_value "\n" get($0, "\"", ".*","\"")
+                }
+            }
+            /\^done/ {
+                if (printing) {
+                    # trim trailing \n
+                    print_value = substr(print_value, 0, length(print_value) - 3)
+                    # QUOTE => \\QUOTE
+                    gsub("'\''", "\\\\'\''", print_value)
+                    # eval -client $client QUOTE info  -- \QUOTE $string \QUOTE QUOTE
+                    send("eval -client '"$kak_client"' '\''info -- \\'\''" print_value "\\'\'\''")
+                    printing = 0
+                }
+            }
+            '
+        } 2>/dev/null >/dev/null &
+        printf "$!" > "${tmpdir}/pid"
+        printf "set-option global gdb_dir %s\n" "$tmpdir"
+        printf "info \"%s\"\n" "Please instruct gdb to \\\"new-ui mi3 ${tmpdir}/pty\\\""
+    }
+    hook -group gdb global BufOpenFile .* %{
+        gdb-refresh-location-flag %val{buffile}
+        gdb-refresh-breakpoints-flags %val{buffile}
+    }
+    hook -group gdb global KakEnd .* %{
+        gdb-session-stop
+    }
+}
+
+define-command gdb-session-stop %{
+    try %{
+        %sh{
+            if [ -n "$kak_opt_gdb_dir" ]; then
+                kill $(ps -o pid= --ppid $(cat "${kak_opt_gdb_dir}/pid"))
+                rm "${kak_opt_gdb_dir}/pid" "${kak_opt_gdb_dir}/pipe"
+                rmdir "$kak_opt_gdb_dir"
+            else
+                printf %s\\n raise
+            fi
+        }
+        set-option global gdb_dir ""
+
+        gdb-clear-location
+        gdb-clear-breakpoints
+
+        remove-hooks global gdb
+    }
+}
+
+define-command gdb-jump-to-location %{
+    %sh{
+        if [ -n "$kak_opt_gdb_location_info" ]; then
+            line="${kak_opt_gdb_location_info%%|*}"
+            buffer="${kak_opt_gdb_location_info#*|}"
+            printf "edit -existing \"%s\" %s\n" "$buffer" "$line"
+        fi
+    }
+}
+
+define-command -params 1 gdb-cmd %{
+    %sh{
+        if [ -n "$kak_opt_gdb_dir" ]; then
+            printf %s\\n "$1" > "$kak_opt_gdb_dir"/pipe
+        fi
+    }
+}
+
+define-command gdb-run              %{ gdb-cmd run }
+define-command gdb-start            %{ gdb-cmd start }
+define-command gdb-step             %{ gdb-cmd step }
+define-command gdb-next             %{ gdb-cmd next }
+define-command gdb-finish           %{ gdb-cmd finish }
+define-command gdb-continue         %{ gdb-cmd continue }
+define-command gdb-advance          %{ gdb-cmd "advance %val{buffile}:%val{cursor_line}" }
+define-command gdb-set-breakpoint   %{ gdb-cmd "break %val{buffile}:%val{cursor_line}" }
+define-command gdb-clear-breakpoint %{ gdb-cmd "clear %val{buffile}:%val{cursor_line}" }
+define-command gdb-toggle-breakpoint %{
+    try %{
+        %sh{
+            printf %s\\n "$kak_opt_gdb_breakpoints_info" | tr ':' '\n' |
+            while read -r current; do
+                buffer="${current#*|*|*|}"
+                line=$(printf %s "$current" | cut -d \| -f 3)
+                if [ "$buffer" = "$kak_buffile" ] && [ "$line" = "$kak_cursor_line" ]; then
+                    printf %s\\n raise
+                    exit
+                fi
+            done
+        }
+        gdb-set-breakpoint
+    } catch %{
+        gdb-clear-breakpoint
+    }
+}
+define-command gdb-print %{ gdb-cmd "print %val{selection}" }
+
+# implementation details commands
+
+define-command -hidden -params 2 gdb-handle-stopped %{
+    set-option global gdb_location_info "%arg{1}|%arg{2}"
+    gdb-refresh-location-flag %arg{2}
+}
+
+define-command -hidden -params 1 gdb-refresh-location-flag %{
+    try %{
+        %sh{
+            if [ -n "$kak_opt_gdb_location_info" ]; then
+                line="${kak_opt_gdb_location_info%%|*}"
+                buffer="${kak_opt_gdb_location_info#*|}"
+                if [ "$buffer" = "$1" ]; then
+                    printf "set-option -add \"buffer=%s\" gdb_location_flag \"%s|➡\"\n" "$buffer" "$line"
+                fi
+            fi
+        }
+    }
+}
+
+define-command -hidden gdb-clear-location %{
+    %sh{
+        if [ -n "$kak_opt_gdb_location_info" ]; then
+            buffer="${kak_opt_gdb_location_info#*|}"
+            printf "unset-option \"buffer=%s\" gdb_location_flag" "$buffer"
+        fi
+    }
+    set-option global gdb_location_info ""
+}
+
+define-command -hidden -params 4 gdb-handle-breakpoint-created %{
+    set-option -add global gdb_breakpoints_info "%arg{1}|%arg{2}|%arg{3}|%arg{4}"
+    gdb-refresh-breakpoints-flags %arg{4}
+}
+
+define-command -hidden -params 1 gdb-handle-breakpoint-deleted %{
+    %sh{
+        printf "set-option global gdb_breakpoints_info \"\"\n"
+        while read -r current; do
+            id="${current%%|*}"
+            if [ "$id" != "$1" ]; then
+                printf "set-option -add global gdb_breakpoints_info \"%s\"\n" "$current"
+            else
+                buffer="${current#*|*|*|}"
+            fi
+        done <<-EOF
+			$(printf %s "$kak_opt_gdb_breakpoints_info" | tr ':' '\n')
+		EOF
+        printf "gdb-refresh-breakpoints-flags \"%s\"\n" "$buffer"
+    }
+}
+
+define-command -hidden -params 4 gdb-handle-breakpoint-modified %{
+    %sh{
+        printf "set-option global gdb_breakpoints_info \"\"\n"
+        printf %s\\n "$kak_opt_gdb_breakpoints_info" | tr ':' '\n' |
+        while read -r current; do
+            id="${current%%|*}"
+            if [ "$id" != "$1" ]; then
+                printf "set-option -add global gdb_breakpoints_info \"%s\"\n" "$current"
+            else
+                printf "set-option -add global gdb_breakpoints_info \"%s|%s|%s|%s\"\n" "$1" "$2" "$3" "$4"
+            fi
+        done
+    }
+    gdb-refresh-breakpoints-flags %arg{4}
+}
+
+define-command -hidden -params 1 gdb-refresh-breakpoints-flags %{
+    # buffer may not exist, so only try
+    try %{
+        unset-option "buffer=%arg{1}" gdb_breakpoints_flags
+        %sh{
+            printf %s\\n "$kak_opt_gdb_breakpoints_info" | tr ':' '\n' |
+            while read -r current; do
+                buffer="${current#*|*|*|}"
+                if [ "$buffer" = "$1" ]; then
+                    line=$(printf %s "$current" | cut -d \| -f 3)
+                    enabled=$(printf %s "$current" | cut -d \| -f 2)
+                    if [ "$enabled" = "y" ]; then
+                        flag="●"
+                    else
+                        flag="○"
+                    fi
+                    printf "set-option -add \"buffer=%s\" gdb_breakpoints_flags %s|%s\n" "$buffer" "$line" "$flag"
+                fi
+            done
+       }
+    }
+}
+
+define-command -hidden gdb-clear-breakpoints %{
+    %sh{
+        if [ -n "$kak_opt_gdb_breakpoints_info" ]; then
+            printf %s\\n "$kak_opt_gdb_breakpoints_info" | tr ':' '\n' |
+            while read -r current; do
+                buffer="${current#*|*|*|}"
+                printf "unset-option \"buffer=%s\" gdb_breakpoints_flags \n" "$buffer"
+            done
+        fi
+    }
+    set-option global gdb_breakpoints_info ""
+}
+

--- a/rc/extra/gdb.kak
+++ b/rc/extra/gdb.kak
@@ -220,11 +220,22 @@ define-command gdb-toggle-breakpoint %{
 }
 define-command gdb-print %{ gdb-cmd "print %val{selection}" }
 
+decl -hidden str gdb_jump_client
+
+define-command gdb-enable-autojump %{
+    set global gdb_jump_client %val{client}
+}
+
+define-command gdb-disable-autojump %{
+    set global gdb_jump_client ""
+}
+
 # implementation details commands
 
 define-command -hidden -params 2 gdb-handle-stopped %{
     set-option global gdb_location_info "%arg{1}|%arg{2}"
     gdb-refresh-location-flag %arg{2}
+    try %{ eval -client %opt{gdb_jump_client} gdb-jump-to-location }
 }
 
 define-command -hidden -params 1 gdb-refresh-location-flag %{
@@ -308,7 +319,7 @@ define-command -hidden -params 1 gdb-refresh-breakpoints-flags %{
                     printf "set-option -add \"buffer=%s\" gdb_breakpoints_flags %s|%s\n" "$buffer" "$line" "$flag"
                 fi
             done
-       }
+        }
     }
 }
 

--- a/rc/extra/gdb.kak
+++ b/rc/extra/gdb.kak
@@ -94,7 +94,7 @@ define-command -hidden gdb-session-connect-internal %{
             /\*running/ {
                 send("gdb-clear-location")
             }
-            /\*stopped/ { 
+            /\*stopped/ {
                 send("gdb-handle-stopped " frame_info($0))
             }
             /\^done,frame=/ {
@@ -174,7 +174,7 @@ define-command gdb-session-stop %{
                 rm "${kak_opt_gdb_dir}/pid" "${kak_opt_gdb_dir}/pipe"
                 rmdir "$kak_opt_gdb_dir"
             else
-                printf %s\\n raise
+                echo raise
             fi
         }
         set-option global gdb_dir ""
@@ -249,12 +249,12 @@ define-command gdb-backtrace %{
                 mkfifo "$kak_opt_gdb_dir"/backtrace
                 echo "-stack-list-frames" > "$kak_opt_gdb_dir"/pipe
             else
-                raise
+                echo raise
             fi
         }
         edit! -fifo "%opt{gdb_dir}/backtrace" *gdb-backtrace*
         hook -group fifo buffer BufCloseFifo .* %{
-            %sh{ rm "${kak_opt_gdb_dir}/backtrace" }
+            nop %sh{ rm -f "${kak_opt_gdb_dir}/backtrace" }
             remove-hooks buffer fifo
         }
     }

--- a/rc/extra/gdb.kak
+++ b/rc/extra/gdb.kak
@@ -15,8 +15,8 @@ declare-option -hidden str-list gdb_location_info
 
 # corresponding flags generated from the previous variables
 # these are only set on buffer scope
-declare-option -hidden line-flags gdb_breakpoints_flags
-declare-option -hidden line-flags gdb_location_flag
+declare-option -hidden line-specs gdb_breakpoints_flags
+declare-option -hidden line-specs gdb_location_flag
 
 set-face GdbBreakpoint red,default
 set-face GdbLocation blue,default
@@ -34,7 +34,7 @@ define-command -params .. -file-completion gdb-session-new %{
     %sh{
         # can't connect until socat has created the pty thing
         while [ ! -e "${kak_opt_gdb_dir}/pty" ]; do
-            sleep 1
+            sleep 0.5
         done
         if [ -n "$TMUX" ]; then
             tmux split-window -h " \


### PR DESCRIPTION
The script works similarly to how mawww described it in [this comment](https://github.com/mawww/kakoune/issues/880#issuecomment-254656973)

This [asciinema](https://asciinema.org/a/116839) gives a quick overview of what the script can do currently. In the second run the execution is controlled in gdb directly.

Known issues:

- the `tail | socat | awk` connection thing is kind of weird, and killing it sometimes also kill the gdb session. I did it that way because that's what I could get to work. The gdb `new-ui` command expects communication to be done through a pty (?) which I don't really understand to be honest.
- ~~pre-existing breakpoints are not known to the script, and the `info breakpoints` command lists them in a different format which is a pain~~
- ~~multi-threading? I haven't looked at all into how that works with the `new-ui` communication, especially with regards to the execution pointer~~ (seems to be fine)

Regarding the first two points I'll probably end up asking for help on the gdb side of things

Some nice additions would be to start the gdb process directly from kakoune into a new terminal, and some way to view/manipulate the callstack