### PR TITLE
rc: Replace `setsid` calls with POSIX shell scripts

### DIFF
--- a/rc/base/x11.kak
+++ b/rc/base/x11.kak
@@ -28,7 +28,9 @@ The optional arguments will be passed as arguments to the new client} \
            exit
         fi
         if [ $# -ne 0 ]; then kakoune_params="-e '$@'"; fi
-        setsid ${kak_opt_termcmd} "kak -c ${kak_session} ${kakoune_params}" < /dev/null > /dev/null 2>&1 &
+        {
+            exec ${kak_opt_termcmd} "kak -c ${kak_session} ${kakoune_params}"
+        } </dev/null >/dev/null 2>&1 &
 }}
 
 def -docstring %{x11-focus [<client>]: focus a given client's window

--- a/rc/extra/ranger.kak
+++ b/rc/extra/ranger.kak
@@ -24,13 +24,15 @@ All the optional arguments are forwarded to the ranger utility} \
             tmux select-pane -t $kak_client_env_TMUX_PANE'.format(file=fm.thisfile.path)) \
           if fm.thisfile.is_file else fm.execute_console('move right=1')"
   elif [ -n "$WINDOWID" ]; then
-    setsid $kak_opt_termcmd " \
-      ranger $@ --cmd "'"'" \
-        map <return> eval \
-          fm.execute_console('shell \
-            echo eval -client $kak_client edit {file} | \
-            kak -p $kak_session; \
-            xdotool windowactivate $kak_client_env_WINDOWID'.format(file=fm.thisfile.path)) \
-          if fm.thisfile.is_file else fm.execute_console('move right=1')"'"' < /dev/null > /dev/null 2>&1 &
+    {
+        exec $kak_opt_termcmd " \
+            ranger $@ --cmd "'"'" \
+              map <return> eval \
+                fm.execute_console('shell \
+                  echo eval -client $kak_client edit {file} | \
+                  kak -p $kak_session; \
+                  xdotool windowactivate $kak_client_env_WINDOWID'.format(file=fm.thisfile.path)) \
+                if fm.thisfile.is_file else fm.execute_console('move right=1')"'"'
+    } </dev/null >/dev/null 2>&1 &
   fi
 }}

--- a/rc/extra/x11-repl.kak
+++ b/rc/extra/x11-repl.kak
@@ -9,7 +9,9 @@ All optional parameters are forwarded to the new window} \
            exit
         fi
         if [ $# -eq 0 ]; then cmd="bash"; else cmd="$@"; fi
-        setsid ${kak_opt_termcmd} ${cmd} -t kak_repl_window < /dev/null > /dev/null 2>&1 &
+        {
+            exec ${kak_opt_termcmd} ${cmd} -t kak_repl_window
+        } </dev/null >/dev/null 2>&1 &
 }}
 
 def x11-send-text -docstring "send the selected text to the repl window" %{


### PR DESCRIPTION
Better rely on the shell rather than on an external binary which might not be installed.