### PR TITLE
src: Add a `server_pid` default environment variable

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -804,6 +804,7 @@ Some of Kakoune state is available through environment variables:
  * `kak_cursor_byte_offset`: offset of the main selection from the beginning of the buffer (in byte).
  * `kak_window_width`: width of the current kakoune window
  * `kak_window_height`: height of the current kakoune window
+ * `kak_server_pid`: process ID of the kakoune server
  * `kak_hook_param`: filtering text passed to the currently executing hook
  * `kak_hook_param_capture_N`: text captured by the hook filter regex capture N
  * `kak_client_env_<name>`: value of the <name> variable in the client environment.

--- a/doc/manpages/expansions.asciidoc
+++ b/doc/manpages/expansions.asciidoc
@@ -99,6 +99,8 @@ informations about Kakoune's state:
 	width of the current kakoune window
 *kak_window_height*::
 	height of the current kakoune window
+*kak_server_pid*::
+	process ID of the kakoune server
 *kak_hook_param*::
 	filtering text passed to the currently executing hook
 *kak_hook_param_capture_N*::

--- a/src/main.cc
+++ b/src/main.cc
@@ -157,6 +157,10 @@ void register_env_vars()
             "window_height", false,
             [](StringView name, const Context& context) -> String
             { return to_string(context.window().dimensions().line); }
+        }, {
+            "server_pid", false,
+            [](StringView name, const Context& context) -> String
+            { return to_string(Server::instance().pid()); }
         }
     };
 
@@ -544,7 +548,8 @@ int run_server(StringView session,
 
     GlobalScope::instance().options().get_local_option("readonly").set<bool>(flags & ServerFlags::ReadOnly);
 
-    Server server{session.empty() ? to_string(getpid()) : session.str()};
+    const pid_t pid_server = getpid();
+    Server server{pid_server, session.empty() ? to_string(pid_server) : session.str()};
 
     bool startup_error = false;
     if (not (flags & ServerFlags::IgnoreKakrc)) try

--- a/src/remote.cc
+++ b/src/remote.cc
@@ -736,8 +736,8 @@ private:
     MsgReader m_reader;
 };
 
-Server::Server(String session_name)
-    : m_session{std::move(session_name)}
+Server::Server(pid_t pid, String session_name)
+    : m_pid(pid), m_session{std::move(session_name)}
 {
     int listen_sock = socket(AF_UNIX, SOCK_STREAM, 0);
     fcntl(listen_sock, F_SETFD, FD_CLOEXEC);

--- a/src/remote.hh
+++ b/src/remote.hh
@@ -46,8 +46,9 @@ void send_command(StringView session, StringView command);
 
 struct Server : public Singleton<Server>
 {
-    Server(String session_name);
+    Server(pid_t pid, String session_name);
     ~Server();
+    const pid_t &pid() const { return m_pid; }
     const String& session() const { return m_session; }
 
     bool rename_session(StringView name);
@@ -57,6 +58,7 @@ private:
     class Accepter;
     void remove_accepter(Accepter* accepter);
 
+    pid_t m_pid;
     String m_session;
     std::unique_ptr<FDWatcher> m_listener;
     Vector<std::unique_ptr<Accepter>, MemoryDomain::Remote> m_accepters;


### PR DESCRIPTION
Hi,

Since I don't use process IDs as session names, I'd like to have a simple way of gettting the process ID of the server.

Also this feature allows making use of a feature of LSP, namely allowing the language server to have the same lifespan as the process that spawns it[1].

[1] https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#initialize-request