### PR TITLE
update line-flag related documentation

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -867,6 +867,9 @@ Options are typed, their type can be
    (`<begin line>.<begin column>,<end line>.<end column>` or
    `<begin line>.<end line>+<length>`) and  a face (separated by `|`),
    except for the first element which is just the timestamp of the buffer.
+ * `line-flags`: a `:` separated list of a line number and a corresponding
+    flag (`<line>|<flag text>`), except for the first element which is just
+    the timestamp of the buffer.
  * `completions`: a `:` separated list of `<text>|<docstring>|<menu text>`
    candidates, except for the first element which follows the
    `<line>.<column>[+<length>]@<timestamp>` format to define where the
@@ -1230,9 +1233,8 @@ General highlighters are:
        yellow on red background.
  * `dynregex`: Similar to regex, but expand (like a command parameter would) the
        given expression before building a regex from the result.
- * `flag_lines <flag> <option_name>`: add a column in front of text, and display the
-       given flag in it for everly line contained in the int-list option named
-       <option_name>.
+ * `flag_lines <face> <option_name>`: add a column in front of the buffer,
+       and display the flags specified in <option_name>, using <face>
  * `show_matching`: highlight matching char of the character under the selections'
        cursor using `MatchingChar` face.
  * `show_whitespaces \<-tab <separator> \<-tabpad <separator> \<-lf <separator> \<-spc <separator> \<-nbsp <separator>`: display symbols on top of whitespaces to make them more explicit using the Whitespace face.

--- a/doc/manpages/expansions.asciidoc
+++ b/doc/manpages/expansions.asciidoc
@@ -113,7 +113,7 @@ variable has to be spelled out within the body of the expansion
 Markup strings
 --------------
 In certain contexts, Kakoune can take a markup string, which is a string
-containing formatting informations.  In these strings, the {facename}
+containing formatting informations. In these strings, the {facename}
 syntax will enable the face facename until another face gets activated,
 or the end of the string is reached.
 

--- a/doc/manpages/highlighters.asciidoc
+++ b/doc/manpages/highlighters.asciidoc
@@ -43,9 +43,9 @@ General highlighters
 	Similar to regex, but expand (like a command parameter would) the
 	given expression before building a regex from the result
 
-*flag_lines* <flag> <option_name>::
-	add a column in front of text, and display the given flag in it for
-	every line contained in the int-list option named <option_name>
+*flag_lines* <face> <option_name>::
+	add a column in front of the buffer, and display the flags specified
+	in <option_name>, using <face>
 
 *show_matching*::
 	highlight matching char of the character under the selections' cursor

--- a/doc/manpages/options.asciidoc
+++ b/doc/manpages/options.asciidoc
@@ -20,12 +20,11 @@ Types
 	is not a valid regex
 *int-list*, *str-list*::
 	a list, elements are separated by a colon (:) if an element needs
-	to contain a colon, it can be escaped
-	with a backslash
+	to contain a colon, it can be escaped with a backslash
 *range-faces*::
 	a `:` separated list of a pair of a buffer range
 	(`<begin line>.<begin column>,<end line>.<end column>` or
-	`<begin line>.<begin column>+<length>`) and  a face (separated by `|`),
+	`<begin line>.<begin column>+<length>`) and a face (separated by `|`),
 	except for the first element which is just the timestamp of the buffer.
 *line-flags*::
 	a `:` separated list of a line number and a corresponding flag
@@ -145,7 +144,7 @@ Builtin options
 	Two special atoms are available as markup:
 
 		*`{{mode_info}}`*:::
-			Information about the current mode, such as  `insert 3 sel` or
+			Information about the current mode, such as `insert 3 sel` or
 			`prompt`. The faces used are StatusLineMode, StatusLineInfo,
 			and StatusLineValue.
 

--- a/doc/manpages/options.asciidoc
+++ b/doc/manpages/options.asciidoc
@@ -27,6 +27,10 @@ Types
 	(`<begin line>.<begin column>,<end line>.<end column>` or
 	`<begin line>.<begin column>+<length>`) and  a face (separated by `|`),
 	except for the first element which is just the timestamp of the buffer.
+*line-flags*::
+	a `:` separated list of a line number and a corresponding flag
+	(`<line>|<flag text>`), except for the first element which is just the
+	timestamp of the buffer.
 *completions*::
 	a `:` separated list of `<text>|<docstring>|<menu text>`
 	candidates, except for the first element which follows the

--- a/doc/manpages/registers.asciidoc
+++ b/doc/manpages/registers.asciidoc
@@ -8,7 +8,7 @@ registers - a
 Description
 -----------
 Registers are named lists of text -instead of simply text- in order to interact
-well with multiselection.  They are used for various purposes, like storing
+well with multiselection. They are used for various purposes, like storing
 the last yanked text, or the captured groups associated with the selections.
 
 Interacting

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -1879,9 +1879,8 @@ void register_highlighters()
     registry.insert({
         "flag_lines",
         { FlagLinesHighlighter::create,
-          "Parameters: <option name> <bg color>\n"
-          "Display flags specified in the line-flag-list option <option name>\n"
-          "A line-flag is written: <line>|<fg color>|<text>, the list is : separated" } });
+          "Parameters: <face> <option name>\n"
+          "Display flags specified in the line-flags option <option name> with <face>"} });
     registry.insert({
         "ranges",
         { RangesHighlighter::create,


### PR DESCRIPTION
I guess it reflected an older design of the flag lines option and highlighter.

The second commit is not related, but I don't really want to make a separate PR for this.