### PR TITLE
rc: Document non-hidden options with `-docstring`

### DIFF
--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -299,7 +299,7 @@ def -hidden c-family-insert-include-guards %{
 
 hook global BufNewFile .*\.(h|hh|hpp|hxx|H) c-family-insert-include-guards
 
-decl -docstring "colon separated list of path in which header files will be looked for" \
+decl -docstring "semi-colon separated list of path in which header files will be looked for" \
     str-list alt_dirs ".:.."
 
 def c-family-alternative-file -docstring "Jump to the alternate file (header/implementation)" %{ %sh{


### PR DESCRIPTION
Hi,

This is a preliminary PR that adds a `-docstring` flag to all non-hidden options declared in the `rc` directory. 

There's no way that I know of to interactively read those documentation strings as of today, but I've been working on another PR to include documentation generated directly from the scripts, and it needs as many documented completable options/commands as possible, so there you go.