### PR TITLE
Expose last entered command in register :

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -149,7 +149,8 @@ constexpr StringView register_doc =
     "    * @: default macro register\n"
     "    * /: default search register\n"
     "    * ^: default mark register\n"
-    "    * |: default shell command register\n";
+    "    * |: default shell command register\n"
+    "    * :: last entered command\n";
 
 class Normal : public InputMode
 {

--- a/src/main.cc
+++ b/src/main.cc
@@ -171,7 +171,7 @@ void register_registers()
 {
     RegisterManager& register_manager = RegisterManager::instance();
 
-    for (auto c : "abcdefghijklmnopqrstuvwxyz/\"|^@")
+    for (auto c : "abcdefghijklmnopqrstuvwxyz/\"|^@:")
         register_manager.add_register(c, make_unique<StaticRegister>());
 
     using StringList = Vector<String, MemoryDomain::Registers>;

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -451,6 +451,7 @@ void command(Context& context, NormalParams params)
             }
             if (event == PromptEvent::Validate)
             {
+                RegisterManager::instance()[':'].set(context, cmdline.str());
                 EnvVarMap env_vars = {
                     { "count", to_string(params.count) },
                     { "register", String{&params.reg, 1} }


### PR DESCRIPTION
I've often written some command in the command line only to later wish I had written it in a buffer. This patch puts the last entered command in register `:`, similar to the `|` and `/` registers.

(Related feature request: #1130 would make this information available as shell expansion)