### PR TITLE
src: Introduce the `KAK_SESSION` environment variable

### DIFF
--- a/doc/kak.1.txt
+++ b/doc/kak.1.txt
@@ -85,6 +85,14 @@ directory is used, once the user wants control on autoloading, they can create a
 symlink individual scripts, or the whole system wide autoload directory. They can as well add any new scripts not
 provided with Kakoune.
 
+ENVIRONMENT VARIABLES
+---------------------
+The following environment variables can be used to set default values for some command line flags, when they are omitted:
+
+KAK_SESSION::
+	the session whose name is stored in this variable will be connected to automatically;
+	the `-c` flag overrides this variable if both are set
+
 EXAMPLES
 --------
 kak /path/to/file::

--- a/doc/kak.1.txt
+++ b/doc/kak.1.txt
@@ -91,7 +91,7 @@ The following environment variables can be used to set default values for some c
 
 KAK_SESSION::
 	the session whose name is stored in this variable will be connected to automatically;
-	the `-c` flag overrides this variable if both are set
+	the '-c' and '-p' flags override this variable if they are set
 
 EXAMPLES
 --------

--- a/src/main.cc
+++ b/src/main.cc
@@ -877,7 +877,8 @@ int main(int argc, char* argv[])
             return 0;
         }
 
-        if (auto session = parser.get_switch("p"))
+        StringView server_session = parser.get_switch("p").value_or(std::getenv("KAK_SESSION"));
+        if (fd_readable(0) and not server_session.empty())
         {
             for (auto opt : { "c", "n", "s", "d", "e", "E", "ro" })
             {
@@ -887,7 +888,7 @@ int main(int argc, char* argv[])
                     return -1;
                 }
             }
-            return run_pipe(*session);
+            return run_pipe(server_session);
         }
 
         auto client_init = parser.get_switch("e").value_or(StringView{});
@@ -938,7 +939,7 @@ int main(int argc, char* argv[])
             files.emplace_back(name);
         }
 
-        StringView server_session = parser.get_switch("c").value_or(std::getenv("KAK_SESSION"));
+        server_session = parser.get_switch("c").value_or(std::getenv("KAK_SESSION"));
         if (not server_session.empty())
         {
             for (auto opt : { "n", "s", "d", "E", "ro" })

--- a/src/main.cc
+++ b/src/main.cc
@@ -938,7 +938,8 @@ int main(int argc, char* argv[])
             files.emplace_back(name);
         }
 
-        if (auto server_session = parser.get_switch("c"))
+        StringView server_session = parser.get_switch("c").value_or(std::getenv("KAK_SESSION"));
+        if (not server_session.empty())
         {
             for (auto opt : { "n", "s", "d", "E", "ro" })
             {
@@ -952,7 +953,7 @@ int main(int argc, char* argv[])
             for (auto name : files)
                 new_files += format("edit '{}';", escape(real_path(name), "'", '\\'));
 
-            return run_client(*server_session, new_files + client_init, init_coord, ui_type);
+            return run_client(server_session, new_files + client_init, init_coord, ui_type);
         }
         else
         {


### PR DESCRIPTION
This commit allows the parent environment to define a default session
name to connect to when the `-c` flag is unspecified (if `-c` is given,
then its parameter overrides the environment variable).

With those small modifications, I can use the following script to spawn a shell (or any command) in a new terminal/pane whose environment will contain the current session name:

```
def -docstring %{hatch-terminal-x11 [command]: open a new X11 terminal
If specified, the command will be ran in the newly created terminal, otherwise a shell is spawned
The environment contains the `KAK_SESSION` variable set to the parent session's name} \
    -params .. hatch-terminal-x11 %{ %sh{
    setsid ${kak_opt_termcmd} "env TMPDIR='${TMPDIR}' KAK_SESSION='${kak_session}' ${*:-${SHELL}}" </dev/null >/dev/null 2>&1 &
} }

def -docstring %{hatch-terminal-tmux [command]: open a new `tmux` horizontal pane
If specified, the command will be ran in the newly created terminal, otherwise a shell is spawned
The environment contains the `KAK_SESSION` variable set to the parent session's name} \
    -params .. hatch-terminal-tmux %{ %sh{
    env TMUX="${kak_client_env_TMUX:-${TMUX}}" tmux split-window -h \
        "env TMPDIR='${TMPDIR}' KAK_SESSION='${kak_session}' ${*:-${SHELL}}" </dev/null >/dev/null 2>&1 &
} }

def -docstring %{hatch-terminal-dvtm [command]: open a new `dvtm` pane
If specified, the command will be ran in the newly created terminal, otherwise a shell is spawned
The environment contains the `KAK_SESSION` variable set to the parent session's name} \
    -params .. hatch-terminal-dvtm %{ %sh{
    if [ -p "${DVTM_CMD_FIFO}" ]; then
        printf %s\\n "create \"env TMPDIR='${TMPDIR}' KAK_SESSION='${kak_session}' ${*:-${SHELL}}\"" > "${DVTM_CMD_FIFO}"
    fi
} }

alias global hatch-terminal hatch-terminal-x11
%sh{
    if [ -n "${TMUX}" ]; then
        echo "alias global hatch-terminal hatch-terminal-tmux"
    elif [ -n "${DVTM}" ]; then
        echo "alias global hatch-terminal hatch-terminal-dvtm"
    fi
}
```

Upon using the `hatch-terminal` alias (which is misnamed), I can use `kak [files]` to seamlessly edit files in the parent session. This becomes even more useful when a file manager is needed in the workflow, where one could simply use `:hatch-terminal ranger`, and not worry about passing a `-c` flag to `kak`.

I also went slightly further by having the following script in my path (it's called `kak-edit`):

```
#!/bin/sh

if [ -n "${KAK_SESSION}" ]; then
    printf 'edit "%s"' "$(readlink -f "${1}")" | kak -p "${KAK_SESSION}"
else
    kak "$@"
fi
```

Once within a shell/command spawned from `:hatch-terminal`, I can use `kak-edit <files>` to send the files to the parent session without spawning a new client in the newly created terminal/pane. Note that this particular usage doesn't require the changes put forward by this pull request to work.

HTH.