### PR TITLE
Remember previous NormalParams::count in view-lock mode

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -318,7 +318,7 @@ void view_commands(Context& context, NormalParams params)
             return;
 
         if (lock)
-            view_commands<true>(context, {});
+            view_commands<true>(context, { count, 0 });
 
         auto cp = key.codepoint();
         if (not cp or not context.has_window())


### PR DESCRIPTION
Hi.

### Current behavior:
Starting from normal mode: `5V`. It will set the count to `5` and enter the view lock mode. Pressing, `j` will scroll the window 5 lines the first time, but the following `j` will only scroll the window 1 line because the count is lost.

### New behavior:
Now, the count value specified before entering the view lock mode will be remembered along the recursion, so after entering this mode with `5V`, all subsequent press on `j` will scroll the window 5 lines.


Related discussion: https://github.com/mawww/kakoune/issues/996