### PR TITLE
Add underscore char as a valid punctuation for text-object pairs

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1146,7 +1146,7 @@ void select_object(Context& context, NormalParams params)
                                    pair_it->opening, pair_it->closing,
                                    count, flags));
 
-        if (is_punctuation(cp))
+        if (is_punctuation(cp) or cp == '_')
         {
             auto utf8cp = to_string(cp);
             return select_and_set_last<mode>(


### PR DESCRIPTION
As described in https://github.com/mawww/kakoune/issues/1362#issuecomment-306193864 this PR let the user do a `<a-i>_` instead of a `<a-i>: _,_` which is quite handy for snake_case languages or markdown.