### PR TITLE
Expose kak_buf_line_count

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -780,6 +780,7 @@ Some of Kakoune state is available through environment variables:
  * `kak_buffile`: full path of the file or same as `kak_bufname` when
        there's no associated file
  * `kak_buflist`: the current buffer list, each buffer separated by a colon
+ * `kak_buf_line_count`: the current buffer line count
  * `kak_timestamp`: timestamp of the current buffer, the timestamp is an
        integer value which is incremented each time the buffer is modified.
  * `kak_runtime`: directory containing the kak binary

--- a/doc/manpages/expansions.asciidoc
+++ b/doc/manpages/expansions.asciidoc
@@ -69,6 +69,8 @@ informations about Kakoune's state:
 	associated file
 *kak_buflist*::
 	the current buffer list, each buffer separated by a colon
+*kak_buf_line_count*::
+	the current buffer line count
 *kak_timestamp*::
 	timestamp of the current buffer, the timestamp is an integer value
 	which is incremented each time the buffer is modified
@@ -95,7 +97,7 @@ informations about Kakoune's state:
 	column of the end of the main selection (in byte)
 *kak_cursor_char_column*::
 	column of the end of the main selection (in character)
-*kak_cursor_byte_offset*:: 
+*kak_cursor_byte_offset*::
 	Offset of the main selection from the beginning of the buffer (in bytes).
 *kak_window_width*::
 	width of the current kakoune window

--- a/src/main.cc
+++ b/src/main.cc
@@ -94,6 +94,10 @@ void register_env_vars()
             { return join(BufferManager::instance() |
                           transform(std::mem_fn(&Buffer::display_name)), ':'); }
         }, {
+            "buf_line_count", false,
+            [](StringView name, const Context& context) -> String
+            { return to_string(context.buffer().line_count()); }
+        }, {
             "timestamp", false,
             [](StringView name, const Context& context) -> String
             { return to_string(context.buffer().timestamp()); }


### PR DESCRIPTION
Hi

This PR introduces a new `kak_buf_line_count`, which is I think a info quite generic in text editors.

### Use cases:
Easily display the line count of the current buffer in the modeline. For example, it will save an extra call to `wc -l` as in [lenormf percent.kak](https://github.com/lenormf/kakoune-extra/blob/master/widgets/percent.kak) on the shell side by providing a value already available on the C++ side.

from
```
$(($kak_cursor_line * 100 / $(wc -l < $kak_buffile)))
```
to
```
$(($kak_cursor_line * 100 / $kak_buf_line_count))
```

This value may also turn handy in *lint* (or *grep* like) scenarios. Those scripts list errors/warning in a separate buffer. Here `kak_buf_line_count` has a deeper meaning because it reflects the number of errors/warning found.

### About the naming

Currently we're in a weird situation where we have some variables in snake_case, others without.

`bufname`, `buffile` vs `cursor_char_column`, `cursor_byte_offset`…

I decided to favor `buf_line_count` over `buf_linecount` or `buflinecount` or `bufline_count`, because it's easier to read and it respects the concept of var namespacing better. (Maybe  a later PR should rename `bufname` to `buf_name` etc. for consistency)