### PR TITLE
rc: Fix calls to `mktemp`

### DIFF
--- a/rc/base/lint.kak
+++ b/rc/base/lint.kak
@@ -8,7 +8,7 @@ decl -hidden range-specs lint_errors
 
 def lint -docstring 'Parse the current buffer with a linter' %{
     %sh{
-        dir=$(mktemp -d -t kak-lint.XXXXXXXX)
+        dir=$(mktemp --tmpdir -d kak-lint.XXXXXXXX)
         mkfifo "$dir"/fifo
         printf '%s\n' "eval -no-hooks write $dir/buf"
 

--- a/rc/base/spell.kak
+++ b/rc/base/spell.kak
@@ -11,7 +11,7 @@ Formats of language supported:
     spell %{
     try %{ add-highlighter ranges 'spell_regions' }
     %sh{
-        file=$(mktemp -d -t kak-spell.XXXXXXXX)/buffer
+        file=$(mktemp --tmpdir -d kak-spell.XXXXXXXX)/buffer
         printf 'eval -no-hooks write %s\n' "${file}"
         printf 'set buffer spell_tmp_file %s\n' "${file}"
     }

--- a/rc/core/doc.kak
+++ b/rc/core/doc.kak
@@ -3,7 +3,7 @@ decl -docstring "name of the client in which documentation is to be displayed" \
 
 def -hidden -params 1..2 doc-open %{
     %sh{
-        manout=$(mktemp /tmp/kak-man-XXXXXX)
+        manout=$(mktemp --tmpdir kak-man-XXXXXX)
 
         # Those options are handled by the `man-db` implementation
         export MANWIDTH=${kak_window_width}

--- a/rc/core/make.kak
+++ b/rc/core/make.kak
@@ -11,7 +11,7 @@ def -params .. \
     -docstring %{make [<arguments>]: make utility wrapper
 All the optional arguments are forwarded to the make utility} \
     make %{ %sh{
-     output=$(mktemp -d -t kak-make.XXXXXXXX)/fifo
+     output=$(mktemp --tmpdir -d kak-make.XXXXXXXX)/fifo
      mkfifo ${output}
      ( eval ${kak_opt_makecmd} "$@" > ${output} 2>&1 ) > /dev/null 2>&1 < /dev/null &
 

--- a/rc/core/man.kak
+++ b/rc/core/man.kak
@@ -28,8 +28,8 @@ hook global WinSetOption filetype=(?!man).* %{
 }
 
 def -hidden -params 1..2 man-impl %{ %sh{
-    manout=$(mktemp /tmp/kak-man-XXXXXX)
-    colout=$(mktemp /tmp/kak-man-XXXXXX)
+    manout=$(mktemp --tmpdir kak-man-XXXXXX)
+    colout=$(mktemp --tmpdir kak-man-XXXXXX)
     MANWIDTH=${kak_window_width} man "$@" > $manout
     retval=$?
     col -b -x > ${colout} < ${manout}

--- a/rc/extra/clang.kak
+++ b/rc/extra/clang.kak
@@ -11,7 +11,7 @@ def -params ..1 \
 The syntaxic errors detected during parsing are shown when auto-diagnostics are enabled} \
     clang-parse %{
     %sh{
-        dir=$(mktemp -d -t kak-clang.XXXXXXXX)
+        dir=$(mktemp --tmpdir -d kak-clang.XXXXXXXX)
         mkfifo ${dir}/fifo
         printf %s\\n "set buffer clang_tmp_dir ${dir}"
         printf %s\\n "eval -no-hooks write ${dir}/buf"

--- a/rc/extra/git-tools.kak
+++ b/rc/extra/git-tools.kak
@@ -39,7 +39,7 @@ Available commands:\n-add\n-rm\n-blame\n-commit\n-checkout\n-diff\n-hide-blame\n
            log)  filetype=git-log ;;
            status)  filetype=git-status ;;
         esac
-        output=$(mktemp -d -t kak-git.XXXXXXXX)/fifo
+        output=$(mktemp --tmpdir -d kak-git.XXXXXXXX)/fifo
         mkfifo ${output}
         ( git "$@" > ${output} 2>&1 ) > /dev/null 2>&1 < /dev/null &
 

--- a/rc/extra/go-tools.kak
+++ b/rc/extra/go-tools.kak
@@ -13,7 +13,7 @@ decl -hidden completions gocode_completions
 
 def go-complete -docstring "Complete the current selection with gocode" %{
     %sh{
-        dir=$(mktemp -d -t kak-go.XXXXXXXX)
+        dir=$(mktemp --tmpdir -d kak-go.XXXXXXXX)
         printf %s\\n "set buffer go_complete_tmp_dir ${dir}"
         printf %s\\n "eval -no-hooks write ${dir}/buf"
     }
@@ -56,7 +56,7 @@ decl -hidden str go_format_tmp_dir
 def -params ..1 go-format \
     -docstring "go-format [-use-goimports]: custom formatter for go files" %{
     %sh{
-        dir=$(mktemp -d -t kak-go.XXXXXXXX)
+        dir=$(mktemp --tmpdir -d kak-go.XXXXXXXX)
         printf %s\\n "set buffer go_format_tmp_dir ${dir}"
         printf %s\\n "eval -no-hooks write ${dir}/buf"
     }
@@ -87,7 +87,7 @@ decl -hidden str go_doc_tmp_dir
 # FIXME text escaping
 def -hidden -params 1..2 gogetdoc-cmd %{
    %sh{
-        dir=$(mktemp -d -t kak-go.XXXXXXXX)
+        dir=$(mktemp --tmpdir -d kak-go.XXXXXXXX)
         printf %s\\n "set buffer go_doc_tmp_dir ${dir}"
         printf %s\\n "eval -no-hooks write ${dir}/buf"
     }

--- a/rc/extra/jedi.kak
+++ b/rc/extra/jedi.kak
@@ -24,7 +24,6 @@ def jedi-complete -docstring "Complete the current selection" %{
 		print(':'.join([(str(c.name).replace("|", "\\|") + "|" + str(c.docstring()).replace("|", "\\|")).replace(":", "\\:") + "|" + str(c.name).replace("|", "\\|") for c in script.completions()]).replace("'", r"\\\\'"))
 		END
             )
-            printf %s\\n "${compl}" > /tmp/kak-jedi-out
             printf %s\\n "eval -client ${kak_client} 'echo completed; set %{buffer=${kak_buffile}} jedi_completions \'${header}:${compl}\''" | kak -p ${kak_session}
             rm -r ${dir}
         ) > /dev/null 2>&1 < /dev/null &

--- a/rc/extra/jedi.kak
+++ b/rc/extra/jedi.kak
@@ -5,7 +5,7 @@ decl -docstring "colon separated list of path added to `python`'s $PYTHONPATH en
 
 def jedi-complete -docstring "Complete the current selection" %{
     %sh{
-        dir=$(mktemp -d -t kak-jedi.XXXXXXXX)
+        dir=$(mktemp --tmpdir -d kak-jedi.XXXXXXXX)
         mkfifo ${dir}/fifo
         printf %s\\n "set buffer jedi_tmp_dir ${dir}"
         printf %s\\n "eval -no-hooks write ${dir}/buf"

--- a/rc/extra/racer.kak
+++ b/rc/extra/racer.kak
@@ -3,7 +3,7 @@ decl -hidden completions racer_completions
 
 def racer-complete -docstring "Complete the current selection with racer" %{
     %sh{
-        dir=$(mktemp -d -t kak-racer.XXXXXXXX)
+        dir=$(mktemp --tmpdir -d kak-racer.XXXXXXXX)
         printf %s\\n "set buffer racer_tmp_dir ${dir}"
         printf %s\\n "eval -no-hooks %{ write ${dir}/buf }"
     }


### PR DESCRIPTION
Allow `mktemp` to make use of the `TMPDIR` environment variable when
calling it with a template.

Don't use the deprecated `-t` flag.