### PR TITLE
[WIP] share: Introduce the `sh` directory, `mktemp` implementation

### DIFF
--- a/rc/base/lint.kak
+++ b/rc/base/lint.kak
@@ -8,6 +8,9 @@ decl -hidden range-specs lint_errors
 
 def lint -docstring 'Parse the current buffer with a linter' %{
     %sh{
+        # fallback implementation: mktemp
+        export PATH="${PATH}:${kak_runtime}/sh"
+
         dir=$(mktemp -d "${TMPDIR:-/tmp}"/kak-lint.XXXXXXXX)
         mkfifo "$dir"/fifo
         printf '%s\n' "eval -no-hooks write $dir/buf"

--- a/rc/base/spell.kak
+++ b/rc/base/spell.kak
@@ -11,6 +11,9 @@ Formats of language supported:
     spell %{
     try %{ add-highlighter ranges 'spell_regions' }
     %sh{
+        # fallback implementation: mktemp
+        export PATH="${PATH}:${kak_runtime}/sh"
+
         file=$(mktemp -d "${TMPDIR:-/tmp}"/kak-spell.XXXXXXXX)/buffer
         printf 'eval -no-hooks write %s\n' "${file}"
         printf 'set buffer spell_tmp_file %s\n' "${file}"

--- a/rc/core/doc.kak
+++ b/rc/core/doc.kak
@@ -3,6 +3,9 @@ decl -docstring "name of the client in which documentation is to be displayed" \
 
 def -hidden -params 1..2 doc-open %{
     %sh{
+        # fallback implementation: mktemp
+        export PATH="${PATH}:${kak_runtime}/sh"
+
         manout=$(mktemp "${TMPDIR:-/tmp}"/kak-man-XXXXXX)
 
         # Those options are handled by the `man-db` implementation

--- a/rc/core/make.kak
+++ b/rc/core/make.kak
@@ -11,19 +11,22 @@ def -params .. \
     -docstring %{make [<arguments>]: make utility wrapper
 All the optional arguments are forwarded to the make utility} \
     make %{ %sh{
-     output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-make.XXXXXXXX)/fifo
-     mkfifo ${output}
-     ( eval ${kak_opt_makecmd} "$@" > ${output} 2>&1 ) > /dev/null 2>&1 < /dev/null &
+    # fallback implementation: mktemp
+    export PATH="${PATH}:${kak_runtime}/sh"
 
-     printf %s\\n "eval -try-client '$kak_opt_toolsclient' %{
-               edit! -fifo ${output} -scroll *make*
-               set buffer filetype make
-               set buffer make_current_error_line 0
-               hook -group fifo buffer BufCloseFifo .* %{
-                   nop %sh{ rm -r $(dirname ${output}) }
-                   remove-hooks buffer fifo
-               }
-           }"
+    output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-make.XXXXXXXX)/fifo
+    mkfifo ${output}
+    ( eval ${kak_opt_makecmd} "$@" > ${output} 2>&1 ) > /dev/null 2>&1 < /dev/null &
+
+    printf %s\\n "eval -try-client '$kak_opt_toolsclient' %{
+              edit! -fifo ${output} -scroll *make*
+              set buffer filetype make
+              set buffer make_current_error_line 0
+              hook -group fifo buffer BufCloseFifo .* %{
+                  nop %sh{ rm -r $(dirname ${output}) }
+                  remove-hooks buffer fifo
+              }
+          }"
 }}
 
 add-highlighter -group / group make

--- a/rc/core/man.kak
+++ b/rc/core/man.kak
@@ -28,6 +28,9 @@ hook global WinSetOption filetype=(?!man).* %{
 }
 
 def -hidden -params 1..2 man-impl %{ %sh{
+    # fallback implementation: mktemp
+    export PATH="${PATH}:${kak_runtime}/sh"
+
     manout=$(mktemp "${TMPDIR:-/tmp}"/kak-man-XXXXXX)
     colout=$(mktemp "${TMPDIR:-/tmp}"/kak-man-XXXXXX)
     MANWIDTH=${kak_window_width} man "$@" > $manout

--- a/rc/extra/clang.kak
+++ b/rc/extra/clang.kak
@@ -11,6 +11,9 @@ def -params ..1 \
 The syntaxic errors detected during parsing are shown when auto-diagnostics are enabled} \
     clang-parse %{
     %sh{
+        # fallback implementation: mktemp
+        export PATH="${PATH}:${kak_runtime}/sh"
+
         dir=$(mktemp -d "${TMPDIR:-/tmp}"/kak-clang.XXXXXXXX)
         mkfifo ${dir}/fifo
         printf %s\\n "set buffer clang_tmp_dir ${dir}"

--- a/rc/extra/git-tools.kak
+++ b/rc/extra/git-tools.kak
@@ -33,6 +33,9 @@ Available commands:\n-add\n-rm\n-blame\n-commit\n-checkout\n-diff\n-hide-blame\n
   } \
   git %{ %sh{
     show_git_cmd_output() {
+        # fallback implementation: mktemp
+        export PATH="${PATH}:${kak_runtime}/sh"
+
         local filetype
         case "$1" in
            show|diff) filetype=diff ;;

--- a/rc/extra/go-tools.kak
+++ b/rc/extra/go-tools.kak
@@ -13,6 +13,9 @@ decl -hidden completions gocode_completions
 
 def go-complete -docstring "Complete the current selection with gocode" %{
     %sh{
+        # fallback implementation: mktemp
+        export PATH="${PATH}:${kak_runtime}/sh"
+
         dir=$(mktemp -d "${TMPDIR:-/tmp}"/kak-go.XXXXXXXX)
         printf %s\\n "set buffer go_complete_tmp_dir ${dir}"
         printf %s\\n "eval -no-hooks write ${dir}/buf"
@@ -56,6 +59,9 @@ decl -hidden str go_format_tmp_dir
 def -params ..1 go-format \
     -docstring "go-format [-use-goimports]: custom formatter for go files" %{
     %sh{
+        # fallback implementation: mktemp
+        export PATH="${PATH}:${kak_runtime}/sh"
+
         dir=$(mktemp -d "${TMPDIR:-/tmp}"/kak-go.XXXXXXXX)
         printf %s\\n "set buffer go_format_tmp_dir ${dir}"
         printf %s\\n "eval -no-hooks write ${dir}/buf"
@@ -87,6 +93,9 @@ decl -hidden str go_doc_tmp_dir
 # FIXME text escaping
 def -hidden -params 1..2 gogetdoc-cmd %{
    %sh{
+        # fallback implementation: mktemp
+        export PATH="${PATH}:${kak_runtime}/sh"
+
         dir=$(mktemp -d "${TMPDIR:-/tmp}"/kak-go.XXXXXXXX)
         printf %s\\n "set buffer go_doc_tmp_dir ${dir}"
         printf %s\\n "eval -no-hooks write ${dir}/buf"

--- a/rc/extra/jedi.kak
+++ b/rc/extra/jedi.kak
@@ -5,6 +5,9 @@ decl -docstring "colon separated list of path added to `python`'s $PYTHONPATH en
 
 def jedi-complete -docstring "Complete the current selection" %{
     %sh{
+        # fallback implementation: mktemp
+        export PATH="${PATH}:${kak_runtime}/sh"
+
         dir=$(mktemp -d "${TMPDIR:-/tmp}"/kak-jedi.XXXXXXXX)
         mkfifo ${dir}/fifo
         printf %s\\n "set buffer jedi_tmp_dir ${dir}"

--- a/rc/extra/racer.kak
+++ b/rc/extra/racer.kak
@@ -3,6 +3,9 @@ decl -hidden completions racer_completions
 
 def racer-complete -docstring "Complete the current selection with racer" %{
     %sh{
+        # fallback implementation: mktemp
+        export PATH="${PATH}:${kak_runtime}/sh"
+
         dir=$(mktemp -d "${TMPDIR:-/tmp}"/kak-racer.XXXXXXXX)
         printf %s\\n "set buffer racer_tmp_dir ${dir}"
         printf %s\\n "eval -no-hooks %{ write ${dir}/buf }"

--- a/share/kak/sh/mktemp
+++ b/share/kak/sh/mktemp
@@ -1,0 +1,55 @@
+#!/bin/sh
+## mktemp fallback implementation
+## Usage: mktemp [options] <template>
+## The <template> argument is the path to the target file,
+## it must end with at least 6 'X' characters
+## Options supported:
+##  -d: create a directory
+
+error() {
+    printf 'mktemp: %s\n' "$*" >&2
+    exit 1
+}
+
+main() {
+    flag_directory=0
+
+    for arg in "$@"; do
+        case "${arg}" in
+            -d) flag_directory=1;;
+            -*) error "Unsupported flag ${arg}";;
+            *) break;;
+        esac
+
+        shift
+    done
+
+    if [ $# -eq 0 ]; then
+        error "Template of the target file missing"
+    fi
+
+    template="${1}"
+    if ! printf %s\\n "${template}" | grep -q 'XXXXXX$'; then
+        error "The template must end with at least 6 consecutive 'X's"
+    fi
+
+    template=$(printf %s\\n "${template}" | awk '{
+        idx = match($0, /X+$/) - 1
+        printf "%." idx "s", $0
+        system("cat /dev/urandom | tr -dc a-zA-Z0-9 | fold -w " RLENGTH " | head -n 1")
+    }')
+
+    set -e
+    if [ ${flag_directory} -ne 0 ]; then
+        mkdir -p "${template}"
+        chmod u+rwx "${template}"
+    else
+        mkdir -p "$(dirname "${template}")"
+        touch "${template}"
+        chmod u+rw "${template}"
+    fi
+
+    printf %s\\n "${template}"
+}
+
+main "$@"

--- a/src/Makefile
+++ b/src/Makefile
@@ -108,6 +108,7 @@ distclean: clean
 
 installdirs:
 	install -d $(bindir) \
+		$(sharedir)/sh \
 		$(sharedir)/rc/base \
 		$(sharedir)/rc/core \
 		$(sharedir)/rc/extra \
@@ -117,6 +118,7 @@ installdirs:
 
 install: kak man doc installdirs
 	install -m 0755 kak $(bindir)
+	install -m 0755 ../share/kak/sh/* $(sharedir)/sh
 	install -m 0644 ../share/kak/kakrc $(sharedir)
 	install -m 0644 ../rc/base/* $(sharedir)/rc/base
 	install -m 0644 ../rc/core/* $(sharedir)/rc/core


### PR DESCRIPTION
This commit installs an `sh` directory in the share directory, in which
implementations of popular tools that might not be available on a user's
system sit.

In order for a shell scope to use those implementations if the regular
binaries are unavailable, the `PATH` variable has to be modified as follows,
at the beginning of the scope:

```
%sh{
    export PATH="${PATH}:${kak_runtime}/sh"

    <code>
}
```