### PR TITLE
Update Homebrew install tip in README

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -130,7 +130,7 @@ packaged ncurses library is version 5.4, whereas the latest version is 6.0).
 Currently, a fresh Kakoune install requires that you install ncurses 6.0. You
 can install ncurses 6.0 via Homebrew,
 -----------------------------------
-brew install homebrew/dupes/ncurses
+brew install ncurses
 -----------------------------------
 
 Then, to install,


### PR DESCRIPTION
Homebrew advises not using homebrew/dupes anymore:

% brew install homebrew/dupes/ncurses
Warning: homebrew/dupes was deprecated. This tap is now empty as all its formulae were migrated.
...
Warning: Use ncurses instead of deprecated homebrew/dupes/ncurses

John Doe Copyright Waiver

I dedicate any and all copyright interest in this software to the
public domain.  I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors.  I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.