### PR TITLE
Add 'Source' hook

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1467,6 +1467,8 @@ Existing hooks are:
        hidden.
  * `RawKey`: Triggered whenever a key is pressed by the user, the key is
        used for filtering.
+ * `Source`: Triggered when a file is sourced. The filtering text is
+       the file path
 
 When not specified, the filtering text is an empty string.
 

--- a/doc/manpages/hooks.asciidoc
+++ b/doc/manpages/hooks.asciidoc
@@ -158,6 +158,9 @@ Default hooks
 	Triggered whenever a key is pressed by the user, the key is
 	used for filtering.
 
+*Source*::
+	Triggered when a file is sourced. The filtering text is the file path
+
 When not specified, the filtering text is an empty string. Note that
 some hooks will not consider underlying scopes depending on what context
 they are bound to be run into, e.g. the `BufWritePost` hook is a buffer

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -766,7 +766,7 @@ static constexpr auto hooks = {
     "BufWritePre", "BufOpenFifo", "BufCloseFifo", "BufReadFifo", "BufSetOption",
     "InsertBegin", "InsertChar", "InsertDelete", "InsertEnd", "InsertIdle", "InsertKey",
     "InsertMove", "InsertCompletionHide", "InsertCompletionShow",
-    "KakBegin", "KakEnd", "FocusIn", "FocusOut", "RuntimeError",
+    "KakBegin", "KakEnd", "FocusIn", "FocusOut", "RuntimeError", "Source",
     "NormalBegin", "NormalEnd", "NormalIdle", "NormalKey", "RawKey",
     "WinClose", "WinCreate", "WinDisplay", "WinResize", "WinSetOption",
 };
@@ -1188,6 +1188,8 @@ const CommandDesc source_cmd = {
         {
             CommandManager::instance().execute(file_content, context,
                                                {{}, {{"source", path}}});
+
+            context.hooks().run_hook("Source", path, context);
         }
         catch (Kakoune::runtime_error& err)
         {


### PR DESCRIPTION
There's currently no easy way to know which `kak` files are sourced.
This hook provides info about this, it's triggered every-time the `source` command is used and give the path.

This way we can ease coordination about conditional or/and dependent sourcing of kak scripts.
Examples in @danr 's [kakrc](https://github.com/danr/dotfiles/blob/4f0b117d7d15ea6f164610298c1d02c1786d5383/config/kak/kakrc) import / plug logic