### PR TITLE
src: Add a `commands` debug flag

### DIFF
--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -9,6 +9,7 @@
 #include "utils.hh"
 #include "optional.hh"
 #include "containers.hh"
+#include "buffer_utils.hh"
 
 #include <algorithm>
 
@@ -442,6 +443,16 @@ void CommandManager::execute_single_command(CommandParameters params,
     auto command_it = find_command(context, params[0]);
     if (command_it == m_commands.end())
         throw command_not_found(params[0]);
+
+    const DebugFlags debug_flags = context.options()["debug"].get<DebugFlags>();
+    if (debug_flags & DebugFlags::Commands)
+    {
+        String repr_parameters;
+
+        for (auto repr_param : param_view)
+            repr_parameters += " " + repr_param;
+        write_to_debug_buffer(format("command {}{}", params[0], repr_parameters));
+    }
 
     try
     {

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1115,7 +1115,7 @@ const CommandDesc debug_cmd = {
     "debug",
     nullptr,
     "debug <command>: write some debug informations in the debug buffer\n"
-    "existing commands: info, buffers, options, memory, shared-strings",
+    "existing commands: info, buffers, options, memory, shared-strings, profile-hash-maps",
     ParameterDesc{{}, ParameterDesc::Flags::SwitchesOnlyAtStart, 1},
     CommandFlags::None,
     CommandHelper{},

--- a/src/option.hh
+++ b/src/option.hh
@@ -36,22 +36,24 @@ using TimestampedList = PrefixedList<size_t, T>;
 
 enum class DebugFlags
 {
-    None  = 0,
-    Hooks = 1 << 0,
-    Shell = 1 << 1,
-    Profile = 1 << 2,
-    Keys = 1 << 3,
+    None     = 0,
+    Hooks    = 1 << 0,
+    Shell    = 1 << 1,
+    Profile  = 1 << 2,
+    Keys     = 1 << 3,
+    Commands = 1 << 4,
 };
 
 constexpr bool with_bit_ops(Meta::Type<DebugFlags>) { return true; }
 
-constexpr Array<EnumDesc<DebugFlags>, 4> enum_desc(Meta::Type<DebugFlags>)
+constexpr Array<EnumDesc<DebugFlags>, 5> enum_desc(Meta::Type<DebugFlags>)
 {
     return { {
         { DebugFlags::Hooks, "hooks" },
         { DebugFlags::Shell, "shell" },
         { DebugFlags::Profile, "profile" },
-        { DebugFlags::Keys, "keys" }
+        { DebugFlags::Keys, "keys" },
+        { DebugFlags::Commands, "commands" },
     } };
 }
 


### PR DESCRIPTION
Hi,

When writing modules, it can be tricky to have some sort of backtrace that can help us narrow down a bug. I added a `commands` flag to the `debug` option that prints all the commands that are being executed (as well as their arguments), to know precisely the path taken by our code.

Thrown in is also a commit that fixes the `debug` command's docstring.

HTH.