### PR TITLE
Use user-supplied autoshowcompl option's value.

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1036,7 +1036,7 @@ public:
           m_restore_cursor(mode == InsertMode::Append),
           m_edition(context()),
           m_completer(context()),
-          m_autoshowcompl(true),
+          m_autoshowcompl{context().options()["autoshowcompl"].get<bool>()},
           m_idle_timer{TimePoint::max(), context().flags() & Context::Flags::Transient ?
                        Timer::Callback{} : [this](Timer&) {
                            if (m_autoshowcompl)


### PR DESCRIPTION
I couldn't switch autoshowcomplete off with 

`:set buffer autoshowcompl no`

The replacement of `m_autocompl(true)` here seems to fix this.
