### PR TITLE
Rust and Haskell highlighters: don't treat character literal '"' as the start of a string

### DIFF
--- a/rc/base/haskell.kak
+++ b/rc/base/haskell.kak
@@ -12,10 +12,10 @@ hook global BufCreate .*[.](hs) %{
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
 add-highlighter -group / regions -default code haskell \
-    string   '"'      (?<!\\)(\\\\)*"      ''  \
-    comment  (--[^>]) $                    ''  \
-    comment \{-       -\}                  \{- \
-    macro   ^\h*?\K#  (?<!\\)\n            ''
+    string   %{(?<!')"} (?<!\\)(\\\\)*"      ''  \
+    comment  (--[^>])   $                    ''  \
+    comment \{-         -\}                  \{- \
+    macro   ^\h*?\K#    (?<!\\)\n            ''
 
 add-highlighter -group /haskell/string  fill string
 add-highlighter -group /haskell/comment fill comment

--- a/rc/base/rust.kak
+++ b/rc/base/rust.kak
@@ -12,9 +12,9 @@ hook global BufCreate .*[.](rust|rs) %{
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
 add-highlighter -group / regions -default code rust \
-    string  '"' (?<!\\)(\\\\)*"        '' \
-    comment //   $                     '' \
-    comment /\* \*/                   /\*
+    string  %{(?<!')"} (?<!\\)(\\\\)*"        '' \
+    comment //          $                     '' \
+    comment /\*        \*/                   /\*
 
 add-highlighter -group /rust/string  fill string
 add-highlighter -group /rust/comment fill comment


### PR DESCRIPTION
Previously, the character literal `'"'` would cause the rest of the file to be highlighted as a string. The C-family highlighter used a regex for string openings that prevents this, so I've added it to the Rust and Haskell highlighters as well.