### PR TITLE
Add error message when using format command with no formatcmd specified

### DIFF
--- a/rc/core/formatter.kak
+++ b/rc/core/formatter.kak
@@ -30,6 +30,8 @@ def format -docstring "Format the contents of the current buffer" %{ eval -draft
                     rm -f \"${path_file_tmp}\"
                 }
             "
+        else
+            printf '%s\n' "eval -client '${kak_client}' echo -color Error formatcmd option not specified"
         fi
     }
 } }


### PR DESCRIPTION
Hi.

To follow the [principle of least surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment), I think this error message will help users find why the `format` command does nothing by default (when `formatcmd` option is empty).