### PR TITLE
Docs: add missing PromptIdle hook mentions and completion

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -966,7 +966,7 @@ Some options are built in Kakoune, and can be used to control its behaviour:
  * `debug` _flags(hooks|shell|profile)_: dump various debug information in
    the `*debug*` buffer.
  * `idle_timeout` _int_: timeout, in milliseconds, with no user input that will
-   trigger the `InsertIdle` and `NormalIdle` hooks. 
+   trigger the `PromptIdle`, `InsertIdle` and `NormalIdle` hooks. 
  * `fs_checkout_timeout` _int_: timeout, in milliseconds, between checks in
    normal mode of modifications of the file associated with the current buffer
    on the filesystem.
@@ -1427,6 +1427,8 @@ Existing hooks are:
        by the main selection is used for filtering
  * `InsertMove`: The cursor moved (without inserting) in insert mode, the key
        that triggered the move is used for filtering
+ * `PromptIdle`: A certain duration has passed since last key was pressed in
+       prompt mode.
  * `WinCreate`: A window was created, the filtering text is the buffer name
  * `WinClose`: A window was destroyed, the filtering text is the buffer name
  * `WinDisplay`: A window was bound a client, the filtering text is the buffer

--- a/doc/manpages/hooks.asciidoc
+++ b/doc/manpages/hooks.asciidoc
@@ -76,6 +76,9 @@ Default hooks
 	the cursor moved (without inserting) in insert mode, the key that
 	triggered the move is used for filtering
 
+*PromptIdle*::
+	a certain duration has passed since last key was pressed in prompt mode
+
 *WinCreate*::
 	a window was created, the filtering text is the buffer name
 

--- a/doc/manpages/options.asciidoc
+++ b/doc/manpages/options.asciidoc
@@ -137,7 +137,7 @@ Builtin options
 
 *idle_timeout* 'int'::
 	timeout, in milliseconds, with no user input that will trigger the
-	*InsertIdle* and *NormalIdle* hooks. 
+	*PromptIdle*, *InsertIdle* and *NormalIdle* hooks. 
 
 *fs_checkout_timeout* 'int'::
 	timeout, in milliseconds, between checks in normal mode of modifications

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -766,7 +766,7 @@ static constexpr auto hooks = {
     "BufWritePre", "BufOpenFifo", "BufCloseFifo", "BufReadFifo", "BufSetOption",
     "InsertBegin", "InsertChar", "InsertDelete", "InsertEnd", "InsertIdle", "InsertKey",
     "InsertMove", "InsertCompletionHide", "InsertCompletionShow",
-    "KakBegin", "KakEnd", "FocusIn", "FocusOut", "RuntimeError",
+    "KakBegin", "KakEnd", "FocusIn", "FocusOut", "RuntimeError", "PromptIdle",
     "NormalBegin", "NormalEnd", "NormalIdle", "NormalKey", "RawKey",
     "WinClose", "WinCreate", "WinDisplay", "WinResize", "WinSetOption",
 };


### PR DESCRIPTION
Here it is in the code : https://github.com/mawww/kakoune/blob/620e718087a57a4a725007cbc25a2888ccc1e95c/src/input_handler.cc#L715