### PR TITLE
Docs: add missing <a-R> key and fix info message

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -421,6 +421,7 @@ Changes
  * `<a-P>`: paste all before current selection begin, and
             select each pasted string.
  * `R`: replace current selection with yanked text
+ * `<a-R>`: replace current selection with every yanked text
 
  * `r`: replace each character with the next entered one
 

--- a/doc/manpages/keys.asciidoc
+++ b/doc/manpages/keys.asciidoc
@@ -254,6 +254,9 @@ Changes
 *R*::
 	replace current selection with yanked text
 
+*<a-R>*::
+	replace current selection with every yanked text
+
 *r*::
 	replace each character with the next entered one
 

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1916,7 +1916,7 @@ const HashMap<Key, NormalCmd> keymap{
     { {alt('p')}, {"paste every yanked selection after selected text", paste_all<InsertMode::Append>} },
     { {alt('P')}, {"paste every yanked selection before selected text", paste_all<InsertMode::Insert>} },
     { {'R'}, {"replace selected text with yanked text", paste<InsertMode::Replace>} },
-    { {alt('R')}, {"replace selected text with yanked text", paste_all<InsertMode::Replace>} },
+    { {alt('R')}, {"replace selected text with every yanked text", paste_all<InsertMode::Replace>} },
 
     { {'s'}, {"select regex matches in selected text", select_regex} },
     { {'S'}, {"split selected text on regex matches", split_regex} },


### PR DESCRIPTION
Hi.

For ref, `<a-R>` new meaning was introduced in this commit: https://github.com/mawww/kakoune/commit/75dd74ff43ba269bd62ff9b69d32f3fda2f511f9