### PR TITLE
Docs: add missing colon register (last entered command)

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1098,6 +1098,7 @@ contain some special data:
  * `.` (`dot`): current selection contents
  * `#` (`hash`): selection indices (first selection has 1, second has 2, ...)
  * `_` (`underscore`): null register, always empty
+ * `:` (`colon`): last entered command
 
 Default registers
 ^^^^^^^^^^^^^^^^^

--- a/doc/manpages/registers.asciidoc
+++ b/doc/manpages/registers.asciidoc
@@ -65,6 +65,9 @@ contain some special data
 *_* (underscore)::
 	null register, always empty
 
+*:* (colon)::
+	last entered command
+
 Integer registers
 -----------------
 Registers *1* to *9* hold the grouped sub-matches of the regular

--- a/src/register_manager.cc
+++ b/src/register_manager.cc
@@ -20,7 +20,8 @@ Register& RegisterManager::operator[](StringView reg) const
         { "percent", '%' },
         { "dot", '.' },
         { "hash", '#' },
-        { "underscore", '_' }
+        { "underscore", '_' },
+        { "colon", ':' }
     };
     auto it = reg_names.find(reg);
     if (it == reg_names.end())


### PR DESCRIPTION
Hi.

This register was introduced in https://github.com/mawww/kakoune/commit/b1735ae76ed730698c9b25b9534a96c625f52b03