### PR TITLE
Add main selection index in mode_info

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -298,7 +298,14 @@ public:
 
     DisplayLine mode_line() const override
     {
-        AtomList atoms = { { to_string(context().selections().size()) + " sel", get_face("StatusLineInfo") } };
+        AtomList atoms;
+        auto num_sel = context().selections().size();
+        auto main_index = context().selections().main_index();
+        if (num_sel == 1)
+            atoms.emplace_back(format("{} sel", num_sel), get_face("StatusLineInfo"));
+        else
+            atoms.emplace_back(format("{} sels ({})", num_sel, main_index + 1), get_face("StatusLineInfo"));
+
         if (m_params.count != 0)
         {
             atoms.emplace_back(" param=", get_face("StatusLineInfo"));


### PR DESCRIPTION
Hi.

Very often, when I have to deal with a big number of selections spawning over the whole buffer, I struggle to keep track of where is the main selection.
Specifically, as soon as I start using `'` or `<a-'>` (rotate main selection) a few times. I don't remember how far I am from the first or last selection.

So I think that being able to see the main selection index is valuable (well at least to me, I hope it will be to you as well).

This PR improves the `mode_line` slightly:
- when there's only 1 selection nothing change, it keeps the current behavior: `1 sel`.
- when there are more than 1 selection it displays: `3/5 sels`, where 3 means that the current main selection is the third on a total of 5 selections.


