### PR TITLE
rc formatter: Don't force selection restoration

### DIFF
--- a/rc/core/formatter.kak
+++ b/rc/core/formatter.kak
@@ -4,10 +4,6 @@ decl -docstring "shell command to which the contents of the current buffer is pi
 def format -docstring "Format the contents of the current buffer" %{ eval -draft %{
     %sh{
         if [ -n "${kak_opt_formatcmd}" ]; then
-            ## Save the current position of the cursor
-            readonly x=$((kak_cursor_column - 1))
-            readonly y="${kak_cursor_line}"
-
             path_file_tmp=$(mktemp "${TMPDIR:-/tmp}"/kak-formatter-XXXXXX)
             printf %s\\n "
                 write \"${path_file_tmp}\"
@@ -18,8 +14,6 @@ def format -docstring "Format the contents of the current buffer" %{ eval -draft
                     if cat \"${path_file_tmp}\" | eval \"${kak_opt_formatcmd}\" > \"\${path_file_out}\"; then
                         printf '%s\\n' \"exec \\%|cat<space>'\${path_file_out}'<ret>\"
                         printf '%s\\n' \"%sh{ rm -f '\${path_file_out}' }\"
-                        ## Try to restore the position of the cursor as it was prior to formatting
-                        printf '%s\\n' 'exec gg ${y}g ${x}l'
                     else
                         printf '%s\\n' \"
                             eval -client '${kak_client}' echo -color Error formatter returned an error (\$?)


### PR DESCRIPTION
The `|` primitive now correctly restores selections, we don't need to
forcibly restore the main one after formatting anymore.