### PR TITLE
rc man: Avoid undefined behavior on `expr`

### DIFF
--- a/rc/core/man.kak
+++ b/rc/core/man.kak
@@ -67,10 +67,13 @@ The page can be a word, or a word directly followed by a section number between 
     subject=${@-$kak_selection}
 
     ## The completion suggestions display the page number, strip them if present
-    pagenum=$(expr "$subject" : '.*(\([1-8].*\))')
-    if [ -n "$pagenum" ]; then
-        subject=${subject%%\(*}
-    fi
+    case "${subject}" in
+        *\([1-8]*\))
+            pagenum="${subject##*(}"
+            pagenum="${pagenum%)}"
+            subject="${subject%%(*}"
+            ;;
+    esac
 
     printf %s\\n "eval -collapse-jumps -try-client %opt{docsclient} man-impl $pagenum $subject"
 } }


### PR DESCRIPTION
Looking up the man page for `index` was failing on systems using
GNU/coreutils. The `:man` command matched whatever page it was given with
the `expr` utility. This tool behaves as expected when it follows strictly
the POSIX standard but the GNU implementation introduces additional commands
(including `index`), about which the standard states:

```
The use of string arguments length, substr, index, or match produces unspecified results.
```

As a result, parsing the man page number is now implemented with pure
shell expansions, to avoid triggering an undefined behavior when the topic
searched is one of the keywords above.