### PR TITLE
rc git: Don't force a highlighting format on commits

### DIFF
--- a/rc/base/git.kak
+++ b/rc/base/git.kak
@@ -4,8 +4,6 @@ hook global BufCreate .*(COMMIT_EDITMSG|MERGE_MSG) %{
 
 hook -group git-commit-highlight global WinSetOption filetype=git-commit %{
     add-highlighter group git-commit-highlight
-    add-highlighter -group git-commit-highlight regex "\`[^\n]{1,50}" 0:yellow
-    add-highlighter -group git-commit-highlight regex "\`[^\n]*\n\h*(?!#)([^\n]*)\n?" 1:default,red
     add-highlighter -group git-commit-highlight regex "^\h*#[^\n]*\n" 0:cyan,default
     add-highlighter -group git-commit-highlight regex "\b(?:(modified)|(deleted)|(new file)|(renamed|copied)):([^\n]*)\n" 1:yellow 2:red 3:green 4:blue 5:magenta
     add-highlighter -group git-commit-highlight ref diff # highlight potential diffs from the -v option


### PR DESCRIPTION
Hi,

As the format commits should take is largely subjective and no consensus exists, the editor shouldn't implement a default one (users who want that feature can add those two lines to their configuration).

HTH.