### PR TITLE
Add more details in wrong_argument_count error message

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -208,7 +208,7 @@ template<bool force_reload>
 void edit(const ParametersParser& parser, Context& context, const ShellContext&)
 {
     if (parser.positional_count() == 0 and not force_reload)
-        throw wrong_argument_count();
+        throw wrong_argument_count(0, 1, 3);
 
     auto& name = parser.positional_count() > 0 ? parser[0]
                                                : context.buffer().name();
@@ -1815,7 +1815,7 @@ const CommandDesc menu_cmd = {
 
         const size_t count = parser.positional_count();
         if (count == 0 or (count % modulo) != 0)
-            throw wrong_argument_count();
+            throw wrong_argument_count(count, 0, -1);
 
         if (count == modulo and parser.get_switch("auto-single"))
         {
@@ -1936,7 +1936,7 @@ const CommandDesc try_catch_cmd = {
     [](const ParametersParser& parser, Context& context, const ShellContext& shell_context)
     {
         if (parser.positional_count() == 2)
-            throw wrong_argument_count();
+            throw wrong_argument_count(2, 1, 3);
 
         const bool do_catch = parser.positional_count() == 3;
         if (do_catch and parser[1] != "catch")

--- a/src/parameters_parser.cc
+++ b/src/parameters_parser.cc
@@ -49,7 +49,7 @@ ParametersParser::ParametersParser(ParameterList params,
     }
     size_t count = m_positional_indices.size();
     if (count > desc.max_positionals or count < desc.min_positionals)
-        throw wrong_argument_count();
+        throw wrong_argument_count(count, desc.min_positionals, desc.max_positionals);
 }
 
 Optional<StringView> ParametersParser::get_switch(StringView name) const

--- a/src/parameters_parser.hh
+++ b/src/parameters_parser.hh
@@ -32,7 +32,9 @@ struct missing_option_value: public parameter_error
 
 struct wrong_argument_count : public parameter_error
 {
-    wrong_argument_count() : parameter_error("wrong argument count") {}
+    wrong_argument_count(size_t count,size_t min, size_t max)
+        : parameter_error(format("wrong argument count - given: {}, expected: min {} max {}",
+                                  count, min, max)) {}
 };
 
 struct SwitchDesc


### PR DESCRIPTION
Hi

I often trigger by mistake `wrong_argument_count` errors, especially when typing custom commands where I don't remember (or know) the number of params and the docstring is not clear (or absent).

With this PR, the user can more distinctly see what's going on, the new message provides additional data:

`"wrong argument count - given: {}, expected: min {} max {}`