### PR TITLE
Add history-move command

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -705,6 +705,7 @@ command `q!` has to be used).
      `:%sh{ echo echo tchou }` will echo tchou in Kakoune, whereas
      `:nop %sh{ echo echo tchou }` will not, but both will execute the
      shell command.
+ * `history-move <change_id>`: move to change <change_id> in undo history
 
 Multiple commands
 ~~~~~~~~~~~~~~~~~

--- a/doc/manpages/commands.asciidoc
+++ b/doc/manpages/commands.asciidoc
@@ -144,6 +144,9 @@ command *q!* has to be used).
 	remove the highlighter whose id is *highlighter_id* (c.f. the
 	'highlighters' documentation page)
 
+*history-move* <change_id>::
+	move to change <change_id> in undo history
+
 Helpers
 -------
 Kakoune provides some helper commands that can be used to define composite

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -2071,6 +2071,21 @@ const CommandDesc rename_session_cmd = {
     }
 };
 
+const CommandDesc history_move_cmd = {
+    "history-move",
+    nullptr,
+    "history-move <id>: move to change <id> in undo history",
+    ParameterDesc{{}, ParameterDesc::Flags::None, 1, 1},
+    CommandFlags::None,
+    CommandHelper{},
+    CommandCompleter{},
+    [](const ParametersParser& parser, Context& context, const ShellContext&)
+    {
+        if (not context.buffer().move_to(str_to_int(parser[0])))
+            throw runtime_error(format("unknown change id '{}'", parser[0]));
+    }
+};
+
 }
 
 void register_commands()
@@ -2132,6 +2147,7 @@ void register_commands()
     register_command(select_cmd);
     register_command(change_directory_cmd);
     register_command(rename_session_cmd);
+    register_command(history_move_cmd);
 }
 
 }


### PR DESCRIPTION
Hi

In this PR, I'd like to start thinking about the problematic exposed by @lenormf in this issue https://github.com/mawww/kakoune/issues/745 about having an interface for the history tree.

I think to build a tool such as gundo we must have way to:

1.  move through the history tree
2. query/dump info about the history tree

For point 1) we have almost all the primitives:

`u` and `U` let us move through the tree in child -> parent and parent -> child manner
`<a-u>` and `<a-U>`  let us move the through the tree by decrementing / incrementing the unique `change id`

But these commands only work in relative fashion (even with a `count`) and linearly.

The `history-move` command proposed in this PR let us move to an arbitrary `change id` in an absolute fashion.
I don't think it really deserves a dedicated key, so a command is fine in this case.
Currently, it does not follow kakoune classic naming scheme `verb-noun` because I didn't find a good name (don't hesitate to offer you suggestions) and it's a way to group all the future `history-*` commands under a namespace like `history-dump`, `history-list` etc… for point 2) in future PRs.


