### PR TITLE
Improve Haskell highlighter

### DIFF
--- a/rc/base/haskell.kak
+++ b/rc/base/haskell.kak
@@ -12,19 +12,61 @@ hook global BufCreate .*[.](hs) %{
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
 add-highlighter -group / regions -default code haskell \
-    string   %{(?<!')"} (?<!\\)(\\\\)*"      ''  \
-    comment  (--[^>])   $                    ''  \
-    comment \{-         -\}                  \{- \
-    macro   ^\h*?\K#    (?<!\\)\n            ''
+    string   '(?<!\'\\)(?<!\')"'         (?<!\\)(\\\\)*" ''   \
+    macro   ^\h*?\K#                     (?<!\\)\n       ''   \
+    pragma  \{-#                         \#-\}           \{-  \
+    comment \{-                            -\}           \{-  \
+    comment --(?![!#$%&*+./<>?@\\\^|~=]) $               ''
 
 add-highlighter -group /haskell/string  fill string
 add-highlighter -group /haskell/comment fill comment
+add-highlighter -group /haskell/pragma  fill meta
 add-highlighter -group /haskell/macro   fill meta
 
-add-highlighter -group /haskell/code regex \b(import)\b 0:meta
-add-highlighter -group /haskell/code regex \b(True|False)\b 0:value
-add-highlighter -group /haskell/code regex \b(as|case|class|data|default|deriving|do|else|hiding|if|in|infix|infixl|infixr|instance|let|module|newtype|of|qualified|then|type|where)\b 0:keyword
-add-highlighter -group /haskell/code regex \b(Int|Integer|Char|Bool|Float|Double|IO|Void|Addr|Array|String)\b 0:type
+# Use (?<!['\w]) and (?!['\w]) instead of \b because ' is valid in identifiers
+add-highlighter -group /haskell/code regex (?<!['\w])0x+[A-Fa-f0-9]+ 0:value
+add-highlighter -group /haskell/code regex (?<!['\w])\d+([.]\d+)? 0:value
+add-highlighter -group /haskell/code regex (?<!['\w])(import|hiding|qualified|module)(?!['\w]) 0:keyword
+add-highlighter -group /haskell/code regex (?<!['\w])(import)(?!['\w])[^\n]+(?<!['\w])(as)(?!['\w]) 2:keyword
+add-highlighter -group /haskell/code regex (?<!['\w])(class|data|default|deriving|infix|infixl|infixr|instance|module|newtype|pattern|type|where)(?!['\w]) 0:keyword
+add-highlighter -group /haskell/code regex (?<!['\w])(case|do|else|if|in|let|mdo|of|proc|rec|then)(?!['\w]) 0:attribute
+
+# The complications below is because period has many uses:
+# As function composition operator (possibly without spaces) like "." and "f.g"
+# Hierarchical modules like "Data.Maybe"
+# Qualified imports like "Data.Maybe.Just", "Data.Maybe.maybe", "Control.Applicative.<$>"
+# Quantifier separator in "forall a . [a] -> [a]"
+# Enum comprehensions like "[1..]" and "[a..b]" (making ".." and "Module..." illegal)
+
+# matches uppercase identifiers:  Monad Control.Monad
+# not non-space separated dot:    Just.const
+add-highlighter -group /haskell/code regex \b(\u['\w]*\.)*\u['\w]*(?!['\w])(?![.\l]) 0:variable
+
+# matches infix identifier: `mod` `Apa._T'M`
+add-highlighter -group /haskell/code regex `\b(\u['\w]*\.)*[\w]['\w]*` 0:operator
+# matches imported operators: M.! M.. Control.Monad.>>
+# not operator keywords:      M... M.->
+add-highlighter -group /haskell/code regex \b\u['\w]*\.(?!([~=|:@\\]|<-|->|=>|\.\.|::)[^~<=>|:!?/.@$*&#%+\^\-\\])[~<=>|:!?/.@$*&#%+\^\-\\]+ 0:operator
+# matches dot: .
+# not possibly incomplete import:  a.
+# not other operators:             !. .!
+add-highlighter -group /haskell/code regex (?<![\w~<=>|:!?/.@$*&#%+\^\-\\])\.(?![~<=>|:!?/.@$*&#%+\^\-\\]) 0:operator
+# matches other operators: ... > < <= ^ <*> <$> etc
+# not dot: .
+# not operator keywords:  @ .. -> :: ~
+add-highlighter -group /haskell/code regex (?<![~<=>|:!?/.@$*&#%+\^\-\\])(?!([~=|:.@\\]|<-|->|=>|\.\.|::)[^~<=>|:!?/.@$*&#%+\^\-\\])[~<=>|:!?/.@$*&#%+\^\-\\]+ 0:operator
+
+# matches operator keywords: @ ->
+add-highlighter -group /haskell/code regex (?<![~<=>|:!?/.@$*&#%+\^\-\\])(@|~|<-|->|=>|::|=|:|[|])(?![~<=>|:!?/.@$*&#%+\^\-\\]) 1:keyword
+# matches: forall [..variables..] .
+# not the variables
+add-highlighter -group /haskell/code regex \b(forall)\b[^.\n]*?(\.) 1:keyword 2:keyword
+
+# matches 'x' '\\' '\'' '\n' '\0'
+# not incomplete literals: '\'
+# not valid identifiers:   w' _'
+add-highlighter -group /haskell/code regex (?<!\w)'([^\\]|[\\]['"\w\d\\])' 0:string
+# this has to come after operators so '-' etc is correct
 
 # Commands
 # ‾‾‾‾‾‾‾‾


### PR DESCRIPTION
Import keywords are put in keyword face instead of meta face.
This leaves room for pragmas and macros to be in the meta face.

Operator keywords are put in keyword face too.

Finally, expression keywords are put in face attribute.

NB: Now with comments at start of line