### PR TITLE
Docs: Fix wording in goto commands (h,l,i)

### DIFF
--- a/doc/manpages/keys.asciidoc
+++ b/doc/manpages/keys.asciidoc
@@ -364,13 +364,13 @@ Goto Commands
 	for one of the following additional keys:
 
 	*h*:::
-		select to line begin
+		go to line begin
 
 	*l*:::
-		select to line end
+		go to line end
 
 	*i*:::
-		select to non blank line start
+		go to non blank line start
 
 	*g*, *k*:::
 		go to the first line


### PR DESCRIPTION
Hi,

Currently the docs said `gh`, `gl`, and `gi` "select to" their target; as far as I can tell they in fact "go to" their target just like the other goto commands.

This PR updates the wording for those commands to make them consistent.