### PR TITLE
Check for gocode, goimports and gogetdoc on go-tools loading

### DIFF
--- a/rc/extra/go-tools.kak
+++ b/rc/extra/go-tools.kak
@@ -6,9 +6,11 @@
 # - jq for json deserializaton
 
 %sh{
-    if ! jq --version > /dev/null 2>&1; then
-        echo 'echo -debug %{Dependency unmet: jq, please install it to use go-tools}'
-    fi
+    for dep in gocode goimports gogetdoc jq; do
+        if ! command -v $dep > /dev/null 2>&1; then
+            echo "echo -debug %{Dependency unmet: $dep, please install it to use go-tools}"
+        fi
+    done
 }
 
 # Auto-completion


### PR DESCRIPTION
These tools also need to be installed and don't come with go's default installation.