### PR TITLE
Add current history id to env variables

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -792,7 +792,7 @@ Some of Kakoune state is available through environment variables:
  * `kak_buf_line_count`: the current buffer line count
  * `kak_timestamp`: timestamp of the current buffer, the timestamp is an
        integer value which is incremented each time the buffer is modified.
- * `kak_curr_history_id`: history id of the current buffer, the history id is an integer value
+ * `kak_history_id`: history id of the current buffer, the history id is an integer value
        which is used to reference a specific buffer version in the undo tree
  * `kak_runtime`: directory containing the kak binary
  * `kak_count`: count parameter passed to the command

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -792,6 +792,8 @@ Some of Kakoune state is available through environment variables:
  * `kak_buf_line_count`: the current buffer line count
  * `kak_timestamp`: timestamp of the current buffer, the timestamp is an
        integer value which is incremented each time the buffer is modified.
+ * `kak_curr_history_id`: history id of the current buffer, the history id is an integer value
+       which is used to reference a specific buffer version in the undo tree
  * `kak_runtime`: directory containing the kak binary
  * `kak_count`: count parameter passed to the command
  * `kak_opt_<name>`: value of option <name>

--- a/doc/manpages/expansions.asciidoc
+++ b/doc/manpages/expansions.asciidoc
@@ -74,7 +74,7 @@ informations about Kakoune's state:
 *kak_timestamp*::
 	timestamp of the current buffer, the timestamp is an integer value
 	which is incremented each time the buffer is modified
-*kak_curr_history_id*::
+*kak_history_id*::
 	history id of the current buffer, the history id is an integer value
 	which is used to reference a specific buffer version in the undo tree
 *kak_runtime*::

--- a/doc/manpages/expansions.asciidoc
+++ b/doc/manpages/expansions.asciidoc
@@ -74,6 +74,9 @@ informations about Kakoune's state:
 *kak_timestamp*::
 	timestamp of the current buffer, the timestamp is an integer value
 	which is incremented each time the buffer is modified
+*kak_curr_history_id*::
+	history id of the current buffer, the history id is an integer value
+	which is used to reference a specific buffer version in the undo tree
 *kak_runtime*::
 	directory containing the kak binary
 *kak_count*::

--- a/src/main.cc
+++ b/src/main.cc
@@ -94,6 +94,10 @@ void register_env_vars()
             [](StringView name, const Context& context) -> String
             { return to_string(context.buffer().timestamp()); }
         }, {
+            "curr_history_id", false,
+            [](StringView name, const Context& context) -> String
+            { return to_string(context.buffer().current_history_id()); }
+        }, {
             "selection", false,
             [](StringView name, const Context& context)
             { const Selection& sel = context.selections().main();

--- a/src/main.cc
+++ b/src/main.cc
@@ -94,7 +94,7 @@ void register_env_vars()
             [](StringView name, const Context& context) -> String
             { return to_string(context.buffer().timestamp()); }
         }, {
-            "curr_history_id", false,
+            "history_id", false,
             [](StringView name, const Context& context) -> String
             { return to_string(context.buffer().current_history_id()); }
         }, {


### PR DESCRIPTION
The curr_history_id env variable could help implementing LSP's textDocument/didChange more efficiently
because we could track all the changes since last sync point and only send those changes instead of sending the whole text document every time.

Maybe also #745 could benefit from this?
Also related to #1520