### PR TITLE
Add debug faces

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1573,8 +1573,8 @@ Some helper commands can be used to define composite commands:
  * `reg <name> <content>`: set register <name> to <content>
  * `select <anchor_line>.<anchor_column>,<cursor_line>.<cursor_column>:...`:
      replace the current selections with the one described in the argument
- * `debug {info,buffers,options,memory,shared-strings}`: print some debug
-     information in the `*debug*` buffer
+ * `debug {info,buffers,options,memory,shared-strings,profile-hash-maps,faces}`:
+     print some debug information in the `*debug*` buffer
 
 Note that these commands are available in interactive command mode, but are
 not that useful in this context.

--- a/doc/manpages/commands.asciidoc
+++ b/doc/manpages/commands.asciidoc
@@ -200,7 +200,7 @@ commands:
 *select* <anchor_line>.<anchor_column>,<cursor_line>.<cursor_column>:...::
 	replace the current selections with the one described in the argument
 
-*debug* {info,buffers,options,memory,shared-strings}::
+*debug* {info,buffers,options,memory,shared-strings,profile-hash-maps,faces}::
 	print some debug information in the *\*debug** buffer
 
 Note that those commands are also available in the interactive mode, but

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1116,14 +1116,15 @@ const CommandDesc debug_cmd = {
     "debug",
     nullptr,
     "debug <command>: write some debug informations in the debug buffer\n"
-    "existing commands: info, buffers, options, memory, shared-strings, profile-hash-maps",
+    "existing commands: info, buffers, options, memory, shared-strings, profile-hash-maps, faces",
     ParameterDesc{{}, ParameterDesc::Flags::SwitchesOnlyAtStart, 1},
     CommandFlags::None,
     CommandHelper{},
     make_completer(
         [](const Context& context, CompletionFlags flags,
            const String& prefix, ByteCount cursor_pos) -> Completions {
-               auto c = {"info", "buffers", "options", "memory", "shared-strings", "profile-hash-maps"};
+               auto c = {"info", "buffers", "options", "memory", "shared-strings",
+                         "profile-hash-maps", "faces"};
                return { 0_byte, cursor_pos, complete(prefix, cursor_pos, c) };
     }),
     [](const ParametersParser& parser, Context& context, const ShellContext&)
@@ -1172,6 +1173,12 @@ const CommandDesc debug_cmd = {
         else if (parser[0] == "profile-hash-maps")
         {
             profile_hash_maps();
+        }
+        else if (parser[0] == "faces")
+        {
+            write_to_debug_buffer("Faces:");
+            for (auto& face : FaceRegistry::instance().aliases())
+                write_to_debug_buffer(format(" * {}: {}", face.key, face.value.face));
         }
         else
             throw runtime_error(format("unknown debug command '{}'", parser[0]));

--- a/src/face_registry.cc
+++ b/src/face_registry.cc
@@ -42,6 +42,37 @@ static Face parse_face(StringView facedesc)
     return res;
 }
 
+String attributes_to_str(Attribute attributes)
+{
+    if (attributes == Attribute::Normal)
+        return "";
+
+    struct Attr { Attribute attr; StringView name; }
+    attrs[] {
+        { Attribute::Exclusive, "e" },
+        { Attribute::Underline, "u" },
+        { Attribute::Reverse, "r" },
+        { Attribute::Blink, "B" },
+        { Attribute::Bold, "b" },
+        { Attribute::Dim, "d" },
+        { Attribute::Italic, "i" },
+    };
+
+    auto filteredAttrs = attrs |
+                         filter([=](const Attr& a) { return attributes & a.attr; }) |
+                         transform([](const Attr& a) { return a.name; });
+
+    return accumulate(filteredAttrs, String{"+"}, std::plus<>{});
+}
+
+String to_string(Face face)
+{
+    return format("{},{}{}",
+                  color_to_str(face.fg),
+                  color_to_str(face.bg),
+                  attributes_to_str(face.attributes));
+}
+
 Face FaceRegistry::operator[](const String& facedesc)
 {
     auto it = m_aliases.find(facedesc);

--- a/src/face_registry.hh
+++ b/src/face_registry.hh
@@ -20,13 +20,17 @@ public:
 
     CandidateList complete_alias_name(StringView prefix,
                                       ByteCount cursor_pos) const;
-private:
+
     struct FaceOrAlias
     {
         Face face = {};
         String alias = {};
     };
+
     using AliasMap = HashMap<String, FaceOrAlias, MemoryDomain::Faces>;
+    const AliasMap &aliases() const { return m_aliases; }
+
+private:
     AliasMap m_aliases;
 };
 
@@ -36,6 +40,8 @@ inline Face get_face(const String& facedesc)
         return FaceRegistry::instance()[facedesc];
     return Face{};
 }
+
+String to_string(Face face);
 
 }
 


### PR DESCRIPTION
Hello

## What this PR does

It adds a new `debug faces` command, similar to the already existing `debug options`. It writes a list of all current `Face: FaceDesc` to the `*debug*` buffer.
Example of the output with my config:

```
Faces:
 * Default: rgb:f8f8f2,rgb:282a36
 * PrimarySelection: rgb:282a36,rgb:ff79c6
 * SecondarySelection: rgb:282a36,rgb:bd93f9
 * PrimaryCursor: rgb:282a36,rgb:8be9fd
 * SecondaryCursor: rgb:282a36,rgb:ffb86c
 * LineNumbers: rgb:44475a,rgb:282a36
 * LineNumberCursor: rgb:f8f8f2,rgb:44475a+b
 * LineNumbersWrapped: default,default+i
 * MenuForeground: rgb:6272a4,rgb:f8f8f2
 * MenuBackground: rgb:f8f8f2,rgb:6272a4
 * MenuInfo: rgb:8be9fd,rgb:6272a4
 * Information: rgb:f1fa8c,rgb:282a36
 * Error: rgb:282a36,rgb:ff5555
 * StatusLine: rgb:f8f8f2,rgb:282a36
 * StatusLineMode: rgb:282a36,rgb:50fa7b
 * StatusLineInfo: rgb:bd93f9,rgb:282a36
 * StatusLineValue: rgb:ffb86c,rgb:282a36
 * StatusCursor: rgb:f8f8f2,rgb:6272a4
 * Prompt: rgb:282a36,rgb:50fa7b
 * MatchingChar: rgb:282a36,rgb:6272a4
 * BufferPadding: rgb:44475a,rgb:282a36
 * Whitespace: rgb:44475a,rgb:282a36
 * value: rgb:50fa7b,default
 * type: rgb:bd93f9,default
 * variable: rgb:ff5555,default
 * module: rgb:ff5555,default
 * function: rgb:ff5555,default
 * string: rgb:f1fa8c,default
 * keyword: rgb:8be9fd,default
 * operator: rgb:ffb86c,default
 * attribute: rgb:ff79c6,default
 * comment: rgb:6272a4,default+i
 * meta: rgb:ff5555,default
 * builtin: rgb:f8f8f2,default+b
 * title: rgb:ff5555,default
 * header: rgb:ffb86c,default
 * bold: rgb:ff79c6,default
 * italic: rgb:bd93f9,default
 * mono: rgb:50fa7b,default
 * block: rgb:8be9fd,default
 * link: rgb:50fa7b,default
 * bullet: rgb:50fa7b,default
 * list: rgb:f8f8f2,default
 * GitBlame: default,magenta
 * GitDiffFlags: default,black
 * error: rgb:ff5555,default
 * Search: rgb:6272a4,rgb:50fa7b
 * CurrentWord: rgb:f8f8f2,rgb:6272a4
…
```

## Why?

During the last months, I've built a few tools related to faces and colorschemes with kakoune : 
- https://github.com/Delapouite/kakoune-ink
- https://github.com/Delapouite/kakoune-palette
- https://github.com/Delapouite/kakoune-colors

Sometimes you get to a point where too many rc kak files are loaded, each adding their own faces and it's getting harder to know/remember which ones are active, what are their foreground, background etc…
So the previous output offers a valuable summary of what's going on with face at a given point in time.
Also I strongly believe that the more we can retrieve from kakoune internal state, the better to build parallel tools.
@lenormf had a similar request in this PR https://github.com/mawww/kakoune/issues/736 (a `get-face` command could possibly be created in a script by parsing the output of the present `debug faces`)

## About the code implementation

The code I added in this PR is not that long and not very complicated. It works, but I'm not much proud of it.
I'm not a C++ guy so I have certainly made rookie mistake or used non idiomatic way to get/iterate the info.
I will gladly correct it based on your observations.

Thanks!