### PR TITLE
docs: add options default values

### DIFF
--- a/doc/manpages/options.asciidoc
+++ b/doc/manpages/options.asciidoc
@@ -53,40 +53,50 @@ Builtin options
 ---------------
 
 *tabstop* 'int'::
+	*default* 8 +
 	width of a tab character
 
 *indentwidth* 'int'::
+	*default* 4 +
 	width (in spaces) used for indentation, 0 means a tab character
 
 *scrolloff* 'coord'::
+	*default* 0,0 +
 	number of lines, columns to keep visible around the cursor when
 	scrolling
 
 *eolformat* 'enum(lf|crlf)'::
+	*default* lf +
 	the format of end of lines when writing a buffer, this is autodetected
 	on load; values of this option assigned to the `window` scope are
 	ignored
 
 *BOM* 'enum(none|utf8)'::
+	*default* none +
 	define if the file should be written with a unicode byte order mark;
 	values of this option assigned to the `window` scope are ignored
 
 *readonly* 'bool'::
+	*default* false +
 	prevent modifications from being saved to disk, all buffers if set
 	to `true` in the `global` scope, or current buffer if set in the
 	`buffer` scope; values of this option assigned to the `window`
 	scope are ignored
 
 *incsearch* 'bool'::
+	*default* true +
 	execute search as it is typed
 
 *aligntab* 'bool'::
+	*default* false +
 	use tabs for alignment command
 
 *autoinfo* 'flags(command|onkey|normal)'::
+	*default* command|onkey +
 	display automatic information box in the enabled contexts
 
 *autoshowcompl* 'bool'::
+	*default* true +
 	automatically display possible completions when editing a prompt
 
 *ignored_files* 'regex'::
@@ -103,9 +113,11 @@ Builtin options
 	actions should hook on this option changing for activation/deactivation
 
 *path* 'str-list'::
+	*default* ./:/usr/include +
 	directories to search for gf command
 
 *completers* 'str-list'::
+	*default* filename:word=all +
 	completion engines to use for insert mode completion (they are tried
 	in order until one generates candidates). Existing completers are:
 
@@ -130,16 +142,19 @@ Builtin options
 	as word character for the purpose of insert mode completion.
 
 *autoreload* 'enum(yes|no|ask)'::
+	*default* ask +
 	auto reload the buffers when an external modification is detected
 
 *debug* 'flags(hooks|shell|profile|keys|commands)'::
 	dump various debug information in the '\*debug*' buffer
 
 *idle_timeout* 'int'::
+	*default* 50 +
 	timeout, in milliseconds, with no user input that will trigger the
 	*PromptIdle*, *InsertIdle* and *NormalIdle* hooks. 
 
 *fs_checkout_timeout* 'int'::
+	*default* 500 +
 	timeout, in milliseconds, between checks in normal mode of modifications
 	of the file associated with the current buffer on the filesystem.
 


### PR DESCRIPTION
Hello

Here's a similar work of the one on command aliases in https://github.com/mawww/kakoune/commit/221e19251ca62622803b81735eefc57179a53cbf

Fix: #1557