### PR TITLE
Add '[debug]' context_info for debug buffers

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -136,6 +136,8 @@ String generate_context_info(const Context& context)
         s += "[no-hooks]";
     if (context.buffer().flags() & Buffer::Flags::Fifo)
         s += "[fifo]";
+    if (context.buffer().flags() & Buffer::Flags::Debug)
+        s += "[debug]";
     return s;
 }
 


### PR DESCRIPTION
Hi

While developing JavaScript, I'm starting to have a few concurrent debug buffers alongside my regular ones: `*lint-output*`, `*flow-coverage*`, `*flow-types*`…

The double star naming convention is a first hint when listing / browsing the buffer list, but I found that having a stronger indicator in the status bar help me me a lot to figure out more quickly what type of buffers I look at.