### PR TITLE
Add max_history_id in status printed with <a-u> and <a-U>

### DIFF
--- a/src/buffer.hh
+++ b/src/buffer.hh
@@ -142,6 +142,7 @@ public:
     bool           redo(size_t count = 1) noexcept;
     bool           move_to(size_t history_id) noexcept;
     size_t         current_history_id() const noexcept;
+    size_t         next_history_id() const noexcept { return m_next_history_id; }
 
     String         string(BufferCoord begin, BufferCoord end) const;
     StringView     substr(BufferCoord begin, BufferCoord end) const;

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1770,6 +1770,7 @@ void move_in_history(Context& context, NormalParams params)
     const int count = std::max(1, params.count);
     const int history_id = (int)buffer.current_history_id() +
         (direction == Direction::Forward ? count : -count);
+    const int max_history_id = (int)buffer.next_history_id() - 1;
     if (buffer.move_to((size_t)history_id))
     {
         auto ranges = compute_modified_ranges(buffer, timestamp);
@@ -1777,11 +1778,13 @@ void move_in_history(Context& context, NormalParams params)
             context.selections_write_only() = std::move(ranges);
         context.selections().avoid_eol();
 
-        context.print_status({ format("moved to change #{}", history_id),
+        context.print_status({ format("moved to change #{} ({})",
+                               history_id, max_history_id),
                                get_face("Information") });
     }
     else
-        context.print_status({ format("no such change: #{}", history_id),
+        context.print_status({ format("no such change: #{} ({})",
+                               history_id, max_history_id),
                                get_face("Information") });
 }
 


### PR DESCRIPTION
Hi

Follow up to the work done on https://github.com/mawww/kakoune/pull/1553

This PR adds valuable info about how *far* we are from the original / final version of a buffer while using successive `<a-u>` and `<a-U>`, which is handy to better combine with a `count`.

The format `#id (total)` follows the one recommended in this PR about selection index: https://github.com/mawww/kakoune/pull/1500