### PR TITLE
Use <esc> to exit on-key modes

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -260,15 +260,15 @@ public:
         {
             on_next_key_with_autoinfo(context(), KeymapMode::None,
                 [this](Key key, Context& context) {
-                    if (auto cp = key.codepoint())
-                    {
-                        if (*cp <= 127)
-                            m_params.reg = *cp;
-                        else
-                            context.print_status(
-                                { format("invalid register '{}'", *cp),
-                                  get_face("Error") });
-                    }
+                    auto cp = key.codepoint();
+                    if (not cp or key == Key::Escape)
+                        return;
+                    if (*cp <= 127)
+                        m_params.reg = *cp;
+                    else
+                        context.print_status(
+                            { format("invalid register '{}'", *cp),
+                              get_face("Error") });
                 }, "enter target register", register_doc);
         }
         else
@@ -755,14 +755,14 @@ public:
         {
             on_next_key_with_autoinfo(context(), KeymapMode::None,
                 [this](Key key, Context&) {
-                    if (auto cp = key.codepoint())
-                    {
-                        StringView reg = context().main_sel_register_value(String{*cp});
-                        m_line_editor.insert(reg);
+                    auto cp = key.codepoint();
+                    if (not cp or key == Key::Escape)
+                        return;
+                    StringView reg = context().main_sel_register_value(String{*cp});
+                    m_line_editor.insert(reg);
 
-                        display();
-                        m_line_changed = true;
-                    }
+                    display();
+                    m_line_changed = true;
                 }, "enter register name", register_doc);
             display();
             return;
@@ -1183,8 +1183,10 @@ public:
         {
             on_next_key_with_autoinfo(context(), KeymapMode::None,
                 [this](Key key, Context&) {
-                    if (auto cp = key.codepoint())
-                        insert(RegisterManager::instance()[*cp].get(context()));
+                    auto cp = key.codepoint();
+                    if (not cp or key == Key::Escape)
+                        return;
+                    insert(RegisterManager::instance()[*cp].get(context()));
                 }, "enter register name", register_doc);
             update_completions = false;
         }

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -185,7 +185,7 @@ void goto_commands(Context& context, NormalParams params)
         on_next_key_with_autoinfo(context, KeymapMode::Goto,
                                  [](Key key, Context& context) {
             auto cp = key.codepoint();
-            if (not cp)
+            if (not cp or key == Key::Escape)
                 return;
             auto& buffer = context.buffer();
             switch (to_lower(*cp))
@@ -1119,7 +1119,7 @@ void select_object(Context& context, NormalParams params)
     on_next_key_with_autoinfo(context, KeymapMode::Object,
                              [count](Key key, Context& context) {
         auto cp = key.codepoint().value_or((Codepoint)-1);
-        if (cp == -1)
+        if (cp == -1 or key == Key::Escape)
             return;
 
         static constexpr struct ObjectType
@@ -1332,15 +1332,17 @@ void select_to_next_char(Context& context, NormalParams params)
 
     on_next_key_with_autoinfo(context, KeymapMode::None,
                              [params](Key key, Context& context) {
+        auto cp = key.codepoint();
+        if (not cp or key == Key::Escape)
+            return;
         constexpr auto new_flags = flags & SelectFlags::Extend ? SelectMode::Extend
                                                                : SelectMode::Replace;
-        if (auto cp = key.codepoint())
-            select_and_set_last<new_flags>(
-                context,
-                std::bind(flags & SelectFlags::Reverse ? select_to_reverse
-                                                       : select_to,
-                          _1, _2, *cp, params.count,
-                          flags & SelectFlags::Inclusive));
+        select_and_set_last<new_flags>(
+            context,
+            std::bind(flags & SelectFlags::Reverse ? select_to_reverse
+                                                   : select_to,
+                      _1, _2, *cp, params.count,
+                      flags & SelectFlags::Inclusive));
     }, get_title(),"enter char to select to");
 }
 


### PR DESCRIPTION
In particular, object and next char selection used to complain if you pressed esc.