### PR TITLE
Add selections_desc format to select autoinfo

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -798,7 +798,7 @@ Some of Kakoune state is available through environment variables:
         the selection contents are escaped with a backslash.
  * `kak_selection_desc`: range of the main selection, represented as `anchor,cursor`;
         anchor and cursor are in this format: `line.column`
- * `kak_selections_desc`: range of the selecations separated by colons
+ * `kak_selections_desc`: range of the selections separated by colons
  * `kak_bufname`: name of the current buffer
  * `kak_buffile`: full path of the file or same as `kak_bufname` when
        there's no associated file

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1989,7 +1989,7 @@ const CommandDesc set_face_cmd = {
     "attributes is a combination of:\n"
     "    u: underline, i: italic, b: bold, r: reverse,\n"
     "    B: blink, d: dim, e: exclusive\n"
-    "facespec can as well just be the name of another face" ,
+    "facespec can as well just be the name of another face",
     ParameterDesc{{}, ParameterDesc::Flags::None, 2, 2},
     CommandFlags::None,
     CommandHelper{},
@@ -2037,7 +2037,9 @@ const CommandDesc set_register_cmd = {
 const CommandDesc select_cmd = {
     "select",
     nullptr,
-    "select <selections_desc>: select given selections",
+    "select <selections_desc>: select given selections\n"
+    "\n"
+    "selections_desc format is <anchor_line>.<anchor_column>,<cursor_line>.<cursor_column>:...",
     single_param,
     CommandFlags::None,
     CommandHelper{},


### PR DESCRIPTION
Hi

For no apparent reasons, I struggle every time I have to use the `select` command.
My mind never remembers which version is correct `x.y,x2.y2` or `x,y.x2,y2`

The correct format is available in `:doc commands` but I think it's useful to also have it in the autoinfo, which is displayed right when we need it.
The same strategy is already used for the `set-face` command where the format is also mentioned in the autoinfo.