### PR TITLE
Add status info when navigating through jumplist (<c-o>, <c-i>)

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -2,6 +2,7 @@
 
 #include "alias_registry.hh"
 #include "client.hh"
+#include "face_registry.hh"
 #include "register_manager.hh"
 #include "window.hh"
 
@@ -85,26 +86,33 @@ void JumpList::push(SelectionList jump)
     m_current = m_jumps.size();
 }
 
-const SelectionList& JumpList::forward()
+const SelectionList& JumpList::forward(Context& context)
 {
     if (m_current != m_jumps.size() and
         m_current + 1 != m_jumps.size())
     {
         SelectionList& res = m_jumps[++m_current];
         res.update();
+        context.print_status({ format("jumped to #{} ({})",
+                               m_current, m_jumps.size() - 1),
+                               get_face("Information") });
         return res;
     }
     throw runtime_error("no next jump");
 }
 
-const SelectionList& JumpList::backward(const SelectionList& current)
+const SelectionList& JumpList::backward(Context& context)
 {
+    const SelectionList& current = context.selections();
     if (m_current != m_jumps.size() and
         m_jumps[m_current] != current)
     {
         push(current);
         SelectionList& res = m_jumps[--m_current];
         res.update();
+        context.print_status({ format("jumped to #{} ({})",
+                               m_current, m_jumps.size() - 1),
+                               get_face("Information") });
         return res;
     }
     if (m_current != 0)
@@ -117,6 +125,9 @@ const SelectionList& JumpList::backward(const SelectionList& current)
         }
         SelectionList& res = m_jumps[--m_current];
         res.update();
+        context.print_status({ format("jumped to #{} ({})",
+                               m_current, m_jumps.size() - 1),
+                               get_face("Information") });
         return res;
     }
     throw runtime_error("no previous jump");

--- a/src/context.hh
+++ b/src/context.hh
@@ -20,8 +20,8 @@ class AliasRegistry;
 struct JumpList
 {
     void push(SelectionList jump);
-    const SelectionList& forward();
-    const SelectionList& backward(const SelectionList& current);
+    const SelectionList& forward(Context& context);
+    const SelectionList& backward(Context& context);
     void forget_buffer(Buffer& buffer);
 
     friend bool operator==(const JumpList& lhs, const JumpList& rhs)

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1399,8 +1399,8 @@ template<Direction direction>
 void jump(Context& context, NormalParams)
 {
     auto jump = (direction == Forward) ?
-                 context.jump_list().forward() :
-                 context.jump_list().backward(context.selections());
+                 context.jump_list().forward(context) :
+                 context.jump_list().backward(context);
 
     Buffer* oldbuf = &context.buffer();
     Buffer& buffer = const_cast<Buffer&>(jump.buffer());


### PR DESCRIPTION
Hi

This is a followup on https://github.com/mawww/kakoune/pull/1579 which displays similar info for `<a-u>` and `<a-U>`

With this status message, users can know how far they are from the beginning or the end of the jumplist.