### PR TITLE
Add 'line' in completers option as a way to force explicit <c-x>f

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -982,6 +982,7 @@ Some options are built in Kakoune, and can be used to control its behaviour:
      (`word=all`) or only the current one (`word=buffer`)
    - `filename` which tries to detect when a filename is being entered and
      provides completion based on local filesystem.
+   - `line` which complete using lines in current buffer
    - `option=<opt-name>` where <opt-name> is a _completions_ option.
  * `static_words` _str-list_: list of words that are always added to completion
      candidates when completing words in insert mode.

--- a/doc/manpages/options.asciidoc
+++ b/doc/manpages/options.asciidoc
@@ -129,6 +129,9 @@ Builtin options
 		which tries to detect when a filename is being entered and
 		provides completion based on local filesystem
 
+	*line*:::
+		which complete using lines in current buffer
+
 	*option=<opt-name>*:::
 		where *opt-name* is an option of type 'completions' whose
 		contents will be used

--- a/src/insert_completer.cc
+++ b/src/insert_completer.cc
@@ -32,6 +32,8 @@ String option_to_string(const InsertCompleterDesc& opt)
             return "filename";
         case InsertCompleterDesc::Option:
             return "option=" + (opt.param ? *opt.param : "");
+        case InsertCompleterDesc::Line:
+            return "line";
     }
     kak_assert(false);
     return "";
@@ -58,6 +60,12 @@ void option_from_string(StringView str, InsertCompleterDesc& opt)
     else if (str == "filename")
     {
         opt.mode = InsertCompleterDesc::Filename;
+        opt.param = Optional<String>{};
+        return;
+    }
+    else if (str == "line")
+    {
+        opt.mode = InsertCompleterDesc::Line;
         opt.param = Optional<String>{};
         return;
     }
@@ -466,6 +474,9 @@ bool InsertCompleter::setup_ifn()
             if (completer.mode == InsertCompleterDesc::Word and
                 *completer.param == "all" and
                 try_complete(complete_word<true>))
+                return true;
+            if (completer.mode == InsertCompleterDesc::Line and
+                try_complete(complete_line))
                 return true;
         }
         return false;

--- a/src/insert_completer.hh
+++ b/src/insert_completer.hh
@@ -20,7 +20,8 @@ struct InsertCompleterDesc
     {
         Word,
         Option,
-        Filename
+        Filename,
+        Line
     };
 
     bool operator==(const InsertCompleterDesc& other) const


### PR DESCRIPTION
Hi

In some editing scenario which relies heavily on full line completion, it can get cumbersome to always trigger explicite line completion with `<c-x>f`.
With this PR one can do `set buffer completers line`.