### PR TITLE
Docs: add missing -collapse-jumps and fix -itersel

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1186,16 +1186,18 @@ Some parameters provide a way to change the context of execution:
      modifications to the selections or input state will not affect
      the client. This permits to make some modification to the buffer
      without modifying the user's selection.
- * `-itersel` (requires `-draft`): execute once per selection, in a
-     context with only the considered selection. This permits avoiding
-     cases where the selections may get merged.
+ * `-itersel`: execute once per selection, in a context with only
+     the considered selection. This permits avoiding cases where
+     the selections may get merged.
  * `-buffer <names>`: execute in the context of each buffers in the
      comma separated list <names>, '*' as a name can be used to iterate
      on all buffers.
  * `-no-hooks`: disable hook execution while executing the keys/commands
  * `-with-maps`: use user key mapping in `:exec` instead of built in keys.
  * `-save-regs <regs>`: regs is a string of registers to be restored after
-    execution (overwrites the list of registers saved by default)
+     execution (overwrites the list of registers saved by default)
+ * `-collapse-jumps`:
+     collapse all jumps into a single one from initial selection
 
 The execution stops when the last key/command is reached, or an error
 is raised.

--- a/doc/manpages/execeval.asciidoc
+++ b/doc/manpages/execeval.asciidoc
@@ -38,7 +38,7 @@ Optional flags
 	permits to make some modification to the buffer without modifying
 	the user’s selection
 
-*-itersel* (requires -draft)::
+*-itersel*::
 	execute once per selection, in a context with only the considered
 	selection. This permits avoiding cases where the selections may
 	get merged
@@ -56,3 +56,6 @@ Optional flags
 *-save-regs* <regs>::
 	regs is a string of registers to be restored after execution (overwrites
 	the list of registers saved by default, c.f. description)
+
+*-collapse-jumps*::
+	collapse all jumps into a single one from initial selection


### PR DESCRIPTION
Hi

`-itersel` no longer requires `-draft` since: https://github.com/mawww/kakoune/issues/706
`-collapse-jumps` was introduced in https://github.com/mawww/kakoune/issues/535