### PR TITLE
Add debug mappings

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -685,7 +685,7 @@ Some commands take an exclamation mark (`!`), which can be used to force
 the execution of the command (i.e. to quit a modified buffer, the
 command `q!` has to be used).
 
- * `cd [<directory>]`: change the current directory to `<directory>`, or the home directory is unspecified
+ * `cd [<directory>]`: change the current directory to `<directory>`, or the home directory if unspecified
  * `doc <topic>`: display documentation about a topic. The completion list
      displays the available topics.
  * `e[dit][!] <filename> [<line> [<column>]]`: open buffer on file, go to given
@@ -1597,7 +1597,7 @@ Some helper commands can be used to define composite commands:
  * `reg <name> <content>`: set register <name> to <content>
  * `select <anchor_line>.<anchor_column>,<cursor_line>.<cursor_column>:...`:
      replace the current selections with the one described in the argument
- * `debug {info,buffers,options,memory,shared-strings,profile-hash-maps,faces}`:
+ * `debug {info,buffers,options,memory,shared-strings,profile-hash-maps,faces,mappings}`:
      print some debug information in the `*debug*` buffer
 
 Note that these commands are available in interactive command mode, but are

--- a/doc/manpages/commands.asciidoc
+++ b/doc/manpages/commands.asciidoc
@@ -221,7 +221,7 @@ commands:
 *select* <anchor_line>.<anchor_column>,<cursor_line>.<cursor_column>:...::
 	replace the current selections with the one described in the argument
 
-*debug* {info,buffers,options,memory,shared-strings,profile-hash-maps,faces}::
+*debug* {info,buffers,options,memory,shared-strings,profile-hash-maps,faces,mappings}::
 	print some debug information in the *\*debug** buffer
 
 Note that those commands are also available in the interactive mode, but


### PR DESCRIPTION
Hi

The output `debug mappings` offers a consolidated view of mappings defined across all sourced `rc` files and let the user see quickly which keys are still available for each modes.