### PR TITLE
iterm: fix setting TMPDIR with fish shell, close pane on exit

### DIFF
--- a/rc/extra/iterm.kak
+++ b/rc/extra/iterm.kak
@@ -25,7 +25,8 @@ def -hidden -params 1.. iterm-new-split-impl %{
         -e "    tell current session of current window"               \
         -e "        tell (split ${direction} with same profile)"      \
         -e "            select"                                       \
-        -e "            write text \"TMPDIR='${TMPDIR}' ${sh_cmd}\"" \
+        -e "            write text \"export TMPDIR='${TMPDIR}'\""     \
+        -e "            write text \"exec ${sh_cmd}\""                \
         -e "        end tell"                                         \
         -e "    end tell"                                             \
         -e "end tell"
@@ -51,7 +52,8 @@ All optional arguments are forwarded to the new kak client} \
         -e "tell application \"iTerm\""                                        \
         -e "    tell current window"                                           \
         -e "        tell current session of (create tab with default profile)" \
-        -e "            write text \"TMPDIR='${TMPDIR}' ${sh_cmd}\""          \
+        -e "            write text \"export TMPDIR='${TMPDIR}'\""              \
+        -e "            write text \"exec ${sh_cmd}\""                         \
         -e "        end tell"                                                  \
         -e "    end tell"                                                      \
         -e "end tell"
@@ -69,7 +71,8 @@ All optional arguments are forwarded to the new kak client} \
         -e "tell application \"iTerm\""                           \
         -e "    set w to (create window with default profile)"    \
         -e "    tell current session of w"                        \
-        -e "        write text \"TMPDIR='${TMPDIR}' ${sh_cmd}\"" \
+        -e "        write text \"export TMPDIR='${TMPDIR}'\""     \
+        -e "        write text \"exec ${sh_cmd}\""                \
         -e "    end tell"                                         \
         -e "end tell"
     }


### PR DESCRIPTION
This PR changes the iterm window handling to run the following:

```sh
export TMPDIR='${TMPDIR}'
exec kak ...
```

This does two things:

1. Fixes support for `fish`; `FOO=1 bar` doesn't work, but it does include bash-compatibility for `export`.
1. Makes it so that when you close the editor, the pane closes, consistent with the `tmux` rc.

Tested this manually by overriding the `def`s in my own [`kakrc`](https://github.com/vito/dotfiles/blob/master/kakoune/.config/kak/kakrc#L65-L120).