### PR TITLE
ini.kak: add ';' as a valid comment character

### DIFF
--- a/rc/base/ini.kak
+++ b/rc/base/ini.kak
@@ -3,7 +3,7 @@ hook global BufCreate .*\.(repo|service|target|socket|ini|cfg) %{
 }
 
 add-highlighter -group / regions -default code ini \
-    comment (^|\h)\K\# $ ''
+    comment (^|\h)\K[\#\;] $ ''
 
 add-highlighter -group /ini/code regex "^\h*\[[^\]]*\]" 0:title
 add-highlighter -group /ini/code regex "^\h*([^\[][^=\n]*=)([^\n]*)" 1:variable 2:value


### PR DESCRIPTION
This is a very tiny fix.
Most implementations of the INI syntax I've come across understand `#` and `;` as comments, and so does Vim, which uses `;` as its default comment character for this file type.

Given that comment.kak uses `;` but kakoune only highlights `#`, this simple edit should fix it.

Thank you!