### PR TITLE
Fix typescript highlighter

### DIFF
--- a/rc/extra/typescript.kak
+++ b/rc/extra/typescript.kak
@@ -11,13 +11,29 @@ hook global BufCreate .*[.](ts)x? %{
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
-add-highlighter -group / group typescript
-add-highlighter -group /typescript ref javascript
+add-highlighter -group / regions -default code typescript \
+    double_string '"'  (?<!\\)(\\\\)*"         '' \
+    single_string "'"  (?<!\\)(\\\\)*'         '' \
+    literal       "`"  (?<!\\)(\\\\)*`         '' \
+    comment       //   '$'                     '' \
+    comment       /\*  \*/                     '' \
+    regex         /    (?<!\\)(\\\\)*/[gimuy]* '' \
+    division '[\w\)\]](/|(\h+/\h+))' '\w' '' # Help Kakoune to better detect /…/ literals
 
-add-highlighter -group /typescript regex \b(array|boolean|date|number|object|regexp|string|symbol)\b 0:type
+# Regular expression flags are: g → global match, i → ignore case, m → multi-lines, u → unicode, y → sticky
+# https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
+
+add-highlighter -group /typescript/double_string ref javascript/double_string
+add-highlighter -group /typescript/single_string ref javascript/single_string
+add-highlighter -group /typescript/regex         ref javascript/regex
+add-highlighter -group /typescript/comment       ref javascript/comment
+add-highlighter -group /typescript/literal       ref javascript/literal
+add-highlighter -group /typescript/code          ref javascript/code
+
+add-highlighter -group /typescript/code regex \b(array|boolean|date|number|object|regexp|string|symbol)\b 0:type
 
 # Keywords grabbed from https://github.com/Microsoft/TypeScript/issues/2536
-add-highlighter -group /typescript regex \b(enum|as|implements|interface|package|private|protected|public|static|constructor|declare|get|module|set|type|from|of)\b 0:keyword
+add-highlighter -group /typescript/code regex \b(enum|as|implements|interface|package|private|protected|public|static|constructor|declare|get|module|set|type|from|of|readonly)\b 0:keyword
 
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾


### PR DESCRIPTION
Before this patch keywords are highlighted in comments etc

Bonus: new keyword `readonly`