### PR TITLE
Minor fix to modeline regex.

### DIFF
--- a/rc/extra/modeline.kak
+++ b/rc/extra/modeline.kak
@@ -96,7 +96,7 @@ def -hidden modeline-parse-impl %{
 def modeline-parse -docstring "Read and interpret vi-format modelines at the beginning/end of the buffer" %{
     try %{ eval -draft %{
         exec \%s\`|.\'<ret> %opt{modelines}k <a-x> %opt{modelines}X \
-             s^[^\s]*?\s(vim?|kak(oune)?):\s?[^\n]+<ret> <a-x>
+             s^\S*?\s+?(vim?|kak(oune)?):\s?[^\n]+<ret> <a-x>
         eval -draft -itersel modeline-parse-impl
     } }
 }


### PR DESCRIPTION
vim modeline regex should accept not only one but "at least one" whitespace.