### PR TITLE
Fix introduced mistake in kakrc highlighting

### DIFF
--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -13,16 +13,16 @@ hook global BufCreate (.*/)?(kakrc|.*.kak) %{
 
 add-highlighter -group / regions -default code kakrc \
     comment (^|\h)\K\# $ '' \
-    double_string %{(^|\h)"} %{(?<!\\)(\\\\)*"} '' \
-    single_string %{(^|\h)'} %{(?<!\\)(\\\\)*'} '' \
-    shell '%sh\{' '\}' '\{' \
-    shell '%sh\(' '\)' '\(' \
-    shell '%sh\[' '\]' '\[' \
-    shell '%sh\<' '\>' '\<' \
-    shell '-shell-(completion|candidates)\h+%\{' '\}' '\{' \
-    shell '-shell-(completion|candidates)\h+%\(' '\)' '\(' \
-    shell '-shell-(completion|candidates)\h+%\[' '\]' '\[' \
-    shell '-shell-(completion|candidates)\h+%\<' '\>' '\<'
+    double_string %{(^|\h)\K"} %{(?<!\\)(\\\\)*"} '' \
+    single_string %{(^|\h)\K'} %{(?<!\\)(\\\\)*'} '' \
+    shell '(^|\h)\K%sh\{' '\}' '\{' \
+    shell '(^|\h)\K%sh\(' '\)' '\(' \
+    shell '(^|\h)\K%sh\[' '\]' '\[' \
+    shell '(^|\h)\K%sh\<' '\>' '\<' \
+    shell '(^|\h)\K-shell-(completion|candidates)\h+%\{' '\}' '\{' \
+    shell '(^|\h)\K-shell-(completion|candidates)\h+%\(' '\)' '\(' \
+    shell '(^|\h)\K-shell-(completion|candidates)\h+%\[' '\]' '\[' \
+    shell '(^|\h)\K-shell-(completion|candidates)\h+%\<' '\>' '\<'
 
 %sh{
     # Grammar


### PR DESCRIPTION
Without this commit: keywords followed by quoted string makes the keyword not highlighted. Example:

    exec '<space>'

Here `exec` got no highlighting unless it was followed by two or more spaces.

This commit fixes this, so `exec` etc gets highlighted properly again in these situations.