### PR TITLE
src: Don't save whitespace-led commands in the `:` register

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -455,7 +455,7 @@ void command(Context& context, NormalParams params)
             {
                 if (cmdline.empty())
                     cmdline = context.main_sel_register_value(':');
-                else
+                else if (not is_blank(cmdline[0]))
                     RegisterManager::instance()[':'].set(context, cmdline.str());
 
                 EnvVarMap env_vars = {


### PR DESCRIPTION
Commands that are supposed not to be saved in history are saved into the `:` register anyway, and show up upon hitting `:`.