### PR TITLE
rust.kak: Support Rust's documentation comments.

### DIFF
--- a/rc/base/rust.kak
+++ b/rc/base/rust.kak
@@ -42,7 +42,7 @@ define-command -hidden rust-filter-around-selections %{
 define-command -hidden rust-indent-on-new-line %~
     evaluate-commands -draft -itersel %<
         # copy // comments prefix and following white spaces
-        try %{ execute-keys -draft k <a-x> s ^\h*\K//\h* <ret> y gh j P }
+        try %{ execute-keys -draft k <a-x> s ^\h*\K//[!/]?\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line


### PR DESCRIPTION
As well as ordinary `//` line-comments, Rust regards `///` comments
as documentation applying to the following item, and `//!` comments as
documentation applying to the enclosing item, so we should copy those
to new lines, too.