### PR TITLE
Fix README TOC

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -781,7 +781,7 @@ Advanced topics
 ---------------
 
 Faces
------
+~~~~~
 
 See <<doc/pages/faces#,`:doc faces`>>.
 


### PR DESCRIPTION
The end chapters should be children of *Advanced Topics*, not *Faces*