### PR TITLE
Fix use of default face attributes in ncurses set_face

### DIFF
--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -202,6 +202,8 @@ void NCursesUI::set_face(NCursesWin* window, Face face, const Face& default_face
         face.fg = default_face.fg;
     if (face.bg == Color::Default)
         face.bg = default_face.bg;
+    if (face.attributes == Attribute::Normal)
+        face.attributes = default_face.attributes;
 
     if (face.fg != Color::Default or face.bg != Color::Default)
     {


### PR DESCRIPTION
Hi

Currently it is not possible to give face attributes like `bold` or `italic` to gui parts like the `Menu` or the `StatusLine`:

`face MenuForeground +b` does not work

Since the atoms composing menus don't have their own face attributes, we rely on the ones provided by the default face.