### PR TITLE
Remove Fedora versions from Readme

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -145,7 +145,7 @@ brew upgrade --fetch-HEAD kakoune
 ====
 
 [TIP]
-.Fedora 22/23/24/Rawhide
+.Fedora supported versions and Rawhide
 ====
 Use the https://copr.fedoraproject.org/coprs/jkonecny/kakoune/[copr]
 repository.


### PR DESCRIPTION
They are releasing Fedora too fast and I'm still forgetting to update them. So it will be better to write it in as general supported Fedora.