### PR TITLE
Integration with GNU screen.

### DIFF
--- a/rc/base/screen.kak
+++ b/rc/base/screen.kak
@@ -1,0 +1,50 @@
+# http://gnu.org/software/screen/
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+ 
+hook global KakBegin .* %{
+    %sh{
+        [ -z "kak_client_env_$STY" ] && exit
+        echo "
+            alias global focus screen-focus
+            alias global new screen-new-vertical
+        "
+    }
+}
+
+
+def screen-new-vertical -params .. -command-completion -docstring "Create a new vertical region" %{
+     %sh{
+
+        tty="$(ps -o tty ${kak_client_pid} | tail -n 1)"
+        screen -X eval 'split -h' 'focus down' "screen kak -c \"${kak_session}\" -e \"$*\"" < "/dev/$tty"
+    }
+}
+
+def screen-new-horizontal -params .. -command-completion -docstring "Create a new horizontal region" %{
+     %sh{
+        tty="$(ps -o tty ${kak_client_pid} | tail -n 1)"
+        screen -X eval 'split -v' 'focus right' "screen kak -c \"${kak_session}\" -e \"$*\"" < "/dev/$tty"
+    }
+}
+
+def screen-new-window -params .. -command-completion -docstring "Create a new window" %{
+    %sh{
+        tty="$(ps -o tty ${kak_client_pid} | tail -n 1)"
+        screen -X screen kak -c "${kak_session}" -e "$*" < "/dev/$tty"
+    }
+}
+
+def -docstring %{screen-focus [<client>]: focus the given client
+If no client is passed then the current one is used} \
+    -params ..1 -client-completion \
+    screen-focus %{ %sh{
+        if [ $# -eq 1 ]; then
+            printf %s\\n "
+                evaluate-commands -client '$1' %{ %sh{
+                    screen -X focus
+            }}"
+        elif [ -n "kak_client_env_$STY" ]; then
+            tty="$(ps -o tty ${kak_client_pid} | tail -n 1)"
+            screen -X select "$kak_client_env_WINDOW" < "$/dev/$tty"
+        fi
+} }

--- a/rc/base/screen.kak
+++ b/rc/base/screen.kak
@@ -3,7 +3,7 @@
  
 hook global KakBegin .* %{
     %sh{
-        [ -z "kak_client_env_$STY" ] && exit
+        [ -z "${kak_client_env_STY}" ] && exit
         echo "
             alias global focus screen-focus
             alias global new screen-new-vertical
@@ -14,7 +14,6 @@ hook global KakBegin .* %{
 
 def screen-new-vertical -params .. -command-completion -docstring "Create a new vertical region" %{
      %sh{
-
         tty="$(ps -o tty ${kak_client_pid} | tail -n 1)"
         screen -X eval 'split -h' 'focus down' "screen kak -c \"${kak_session}\" -e \"$*\"" < "/dev/$tty"
     }
@@ -43,8 +42,8 @@ If no client is passed then the current one is used} \
                 evaluate-commands -client '$1' %{ %sh{
                     screen -X focus
             }}"
-        elif [ -n "kak_client_env_$STY" ]; then
+        elif [ -n "${kak_client_env_STY}" ]; then
             tty="$(ps -o tty ${kak_client_pid} | tail -n 1)"
-            screen -X select "$kak_client_env_WINDOW" < "$/dev/$tty"
+            screen -X select "$kak_client_env_WINDOW" < "/dev/$tty"
         fi
 } }


### PR DESCRIPTION
- [x] **FIXME: BUG:** If screen session is open in >1 terminals, `screen-new` commands will create a region in the most recently connected terminal.  Expected: region should be created in the terminal that has focus. wtf!
  - @mawww, @lenormf, @Delapouite: Might this be because [screen checks `ttyname(3)`](http://git.savannah.gnu.org/cgit/screen.git/tree/src/screen.c#n868)?
    - `eval %{%sh{ echo echo -debug $(tty) }}` -> "not a tty" 
    - Both emacs and vim return a valid tty and screen behaves as expected.