### PR TITLE
Fix: GNU Screen integration

### DIFF
--- a/rc/base/screen.kak
+++ b/rc/base/screen.kak
@@ -1,9 +1,9 @@
 # http://gnu.org/software/screen/
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
  
-hook global KakBegin .* %{
+hook -group GNUscreen global KakBegin .* %{
     %sh{
-        [ -z "${kak_client_env_STY}" ] && exit
+        [ -z "${STY}" ] && exit
         echo "
             alias global focus screen-focus
             alias global new screen-new-vertical
@@ -15,14 +15,24 @@ hook global KakBegin .* %{
 define-command screen-new-vertical -params .. -command-completion -docstring "Create a new vertical region" %{
      %sh{
         tty="$(ps -o tty ${kak_client_pid} | tail -n 1)"
-        screen -X eval 'split -h' 'focus down' "screen kak -c \"${kak_session}\" -e \"$*\"" < "/dev/$tty"
+        screen -X eval \
+            'split -h' \
+            'focus down' \
+            "screen sh -c 'kak -c \"${kak_session}\" -e \"$*\" ;
+                screen -X remove'" \
+        < "/dev/$tty"
     }
 }
 
 define-command screen-new-horizontal -params .. -command-completion -docstring "Create a new horizontal region" %{
      %sh{
         tty="$(ps -o tty ${kak_client_pid} | tail -n 1)"
-        screen -X eval 'split -v' 'focus right' "screen kak -c \"${kak_session}\" -e \"$*\"" < "/dev/$tty"
+        screen -X eval \
+            'split -v' \
+            'focus right' \
+            "screen sh -c 'kak -c \"${kak_session}\" -e \"$*\" ;
+                screen -X remove'" \
+        < "/dev/$tty"
     }
 }
 
@@ -39,11 +49,10 @@ If no client is passed then the current one is used} \
     screen-focus %{ %sh{
         if [ $# -eq 1 ]; then
             printf %s\\n "
-                evaluate-commands -client '$1' %{ %sh{
-                    screen -X focus
-            }}"
+                evaluate-commands -client '$1' focus
+                "
         elif [ -n "${kak_client_env_STY}" ]; then
             tty="$(ps -o tty ${kak_client_pid} | tail -n 1)"
-            screen -X select "$kak_client_env_WINDOW" < "/dev/$tty"
+            screen -X select "${kak_client_env_WINDOW}" < "/dev/$tty"
         fi
 } }

--- a/rc/extra/ranger.kak
+++ b/rc/extra/ranger.kak
@@ -4,31 +4,31 @@
 define-command ranger-open-on-edit-directory \
     -docstring 'Start the ranger file system explorer when trying to edit a directory' %{
         hook global RuntimeError "\d+:\d+: '\w+' (.*): is a directory" %{ %sh{
-          directory=$kak_hook_param_capture_1
-          echo ranger $directory
+            directory=$kak_hook_param_capture_1
+            echo ranger $directory
     }}
 }
 
 define-command \
-  -params .. -file-completion \
-  -docstring %{ranger [<arguments>]: open the file system explorer to select buffers to open
-All the optional arguments are forwarded to the ranger utility} \
-  ranger %{ %sh{
-  if [ -n "$TMUX" ]; then
-    tmux split-window -h \
-      ranger $@ --cmd " \
-        map <return> eval \
-          fm.execute_console('shell \
-            echo evaluate-commands -client $kak_client edit {file} | \
-            kak -p $kak_session; \
-            tmux select-pane -t $kak_client_env_TMUX_PANE'.format(file=fm.thisfile.path)) \
-          if fm.thisfile.is_file else fm.execute_console('move right=1')"
+    -params .. -file-completion \
+    -docstring %{ranger [<arguments>]: open the file system explorer to select buffers to open
+    All the optional arguments are forwarded to the ranger utility} \
+    ranger %{ %sh{
+    if [ -n "${TMUX}" ]; then
+        tmux split-window -h \
+            ranger $@ --cmd " \
+                map <return> eval \
+                    fm.execute_console('shell \
+                        echo evaluate-commands -client ' + ranger.ext.shell_escape.shell_escape('$kak_client') + ' edit {file} | \
+                        kak -p '.format(file=fm.thisfile.path) + ranger.ext.shell_escape.shell_escape('$kak_session') + '; \
+                        tmux select-pane -t $kak_client_env_TMUX_PANE') \
+                    if fm.thisfile.is_file else fm.execute_console('move right=1')"
 
-  elif [ -n "${STY}" ]; then
+    elif [ -n "${STY}" ]; then
 
-    script="/tmp/kak-ranger-${kak_client}-${kak_session}.sh"
-    selections="/tmp/kak-ranger-${kak_client}-${kak_session}.txt"
-    cat > "$script" << EOF
+        script="/tmp/kak-ranger-${kak_client}-${kak_session}.sh"
+        selections="/tmp/kak-ranger-${kak_client}-${kak_session}.txt"
+        cat > "$script" << EOF
 #! /usr/bin/env sh
 cd "$PWD"
 ranger --choosefiles="$selections" $@
@@ -46,14 +46,14 @@ EOF
             "screen sh '$script'" \
         < "/dev/$tty"
 
-  elif [ -n "$WINDOWID" ]; then
-    setsid $kak_opt_termcmd " \
-      ranger $@ --cmd "'"'" \
-        map <return> eval \
-          fm.execute_console('shell \
-            echo evaluate-commands -client $kak_client edit {file} | \
-            kak -p $kak_session; \
-            xdotool windowactivate $kak_client_env_WINDOWID'.format(file=fm.thisfile.path)) \
-          if fm.thisfile.is_file else fm.execute_console('move right=1')"'"' < /dev/null > /dev/null 2>&1 &
-  fi
+    elif [ -n "$WINDOWID" ]; then
+        setsid $kak_opt_termcmd " \
+            ranger $@ --cmd "'"'" \
+                map <return> eval \
+                    fm.execute_console('shell \
+                        echo evaluate-commands -client ' + ranger.ext.shell_escape.shell_escape('$kak_client') + ' edit {file} | \
+                        kak -p '.format(file=fm.thisfile.path) + ranger.ext.shell_escape.shell_escape('$kak_session') + '; \
+                        xdotool windowactivate $kak_client_env_WINDOWID') \
+                    if fm.thisfile.is_file else fm.execute_console('move right=1')"'"' < /dev/null > /dev/null 2>&1 &
+    fi
 }}


### PR DESCRIPTION
Ref. #1698
- [x] bug: `screen-focus` doesn't work as expected.  My initial testing was stupid and did not account for the fact that `focus` command's default is to focus regions in a cycle.
  - `screen` is very annoying.  There doesn't seem to be a way to focus an arbitrary region except by navigating in a sequence.  What is the correct solution for scripting `focus`?
  - [x] test: `screen -X select` does not actually switch focus to the region in which it is run so we can't use this.
  - possible fixes:
    - remove `screen-focus` and avoid using the `focus` command.
    - send a patch upstream: `focus [n|title]` 
    - [x] use the current region to switch to the client window.
- [x] `ranger.kak`: integrate with screen.
  - [x] fix: passing directory parameters to `ranger` command in screen doesn't work.
  - [x] fix: If directory name has quotes e.g. `"foo bar"`, then screen will be unable to pass it to ranger and the `ranger` command will fail.
  - [x] fix: If a directory name has a backslash in it e.g. `\"foo bar\"`, then it won't be passed to ranger correctly. The backslashes will be stripped.
  - [x] fix: If `$kak_{session,client}` have spaces in them, then the `ranger` command will fail.
  - [x] fix: passing command-line parameters to ranger fails.