### PR TITLE
github: Add a template for bug reports

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,10 @@
+<!--
+If you're not reporting a bug (e.g. requesting a feature or asking a general question), feel free to remove this template.
+Otherwise, please edit the following sections with the relevant information ().
+-->
+
+### Steps <!-- how to reproduce the issue? -->
+
+### Outcome <!-- what is the result of the above steps? -->
+
+### Expected <!-- what should have been the result of the above steps? -->


### PR DESCRIPTION
Demo issue at #1707.

I constantly follow the same format when I report an issue, making use of github's templates could save us some time as the same questions often come back when investigating a bug.

HTH.