### PR TITLE
Add modified buffers count in error message of non-force quit

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -387,7 +387,8 @@ static void ensure_all_buffers_are_saved()
     if (it == end)
         return;
 
-    String message = "modified buffers remaining: [";
+    String message = format("{} modified buffers remaining: [",
+                            std::count_if(it, end, is_modified));
     while (it != end)
     {
         message += (*it)->name();


### PR DESCRIPTION
Hi

This info is useful to make a decision before suffixing a command with `!`.