### PR TITLE
Remove unused lambda captures

### DIFF
--- a/src/file.cc
+++ b/src/file.cc
@@ -457,7 +457,7 @@ CandidateList complete_command(StringView prefix, ByteCount cursor_pos)
 
     if (not dirname.empty())
     {
-        auto filter = [&dirname](const dirent& entry, const struct stat& st)
+        auto filter = [](const dirent& entry, const struct stat& st)
         {
             bool executable = (st.st_mode & S_IXUSR)
                             | (st.st_mode & S_IXGRP)
@@ -496,7 +496,7 @@ CandidateList complete_command(StringView prefix, ByteCount cursor_pos)
         auto& cache = command_cache[dirname];
         if (memcmp(&cache.mtim, &st.st_mtim, sizeof(TimeSpec)) != 0)
         {
-            auto filter = [&dirname](const dirent& entry, const struct stat& st) {
+            auto filter = [](const dirent& entry, const struct stat& st) {
                 bool executable = (st.st_mode & S_IXUSR)
                                 | (st.st_mode & S_IXGRP)
                                 | (st.st_mode & S_IXOTH);

--- a/src/insert_completer.cc
+++ b/src/insert_completer.cc
@@ -463,7 +463,7 @@ bool InsertCompleter::setup_ifn()
                 try_complete(complete_filename<true>))
                 return true;
             if (completer.mode == InsertCompleterDesc::Option and
-                try_complete([&,this](const SelectionList& sels, const OptionManager& options) {
+                try_complete([&](const SelectionList& sels, const OptionManager& options) {
                    return complete_option(sels, options, *completer.param);
                 }))
                 return true;

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -760,7 +760,7 @@ void search(Context& context, NormalParams params)
     const int main_index = std::min(context.selections().main_index(), saved_reg.size()-1);
 
     regex_prompt<direction>(context, prompt.str(), saved_reg[main_index],
-                 [reg, count, saved_reg, main_index]
+                 [reg, count, saved_reg]
                  (Regex regex, PromptEvent event, Context& context) {
                      if (event == PromptEvent::Abort)
                      {
@@ -871,7 +871,7 @@ void select_regex(Context& context, NormalParams params)
     const int main_index = std::min(context.selections().main_index(), saved_reg.size()-1);
 
     regex_prompt(context, std::move(prompt), saved_reg[main_index],
-                 [reg, capture, saved_reg, main_index](Regex ex, PromptEvent event, Context& context) {
+                 [reg, capture, saved_reg](Regex ex, PromptEvent event, Context& context) {
          if (event == PromptEvent::Abort)
          {
              RegisterManager::instance()[reg].set(context, saved_reg);
@@ -896,7 +896,7 @@ void split_regex(Context& context, NormalParams params)
     const int main_index = std::min(context.selections().main_index(), saved_reg.size()-1);
 
     regex_prompt(context, std::move(prompt), saved_reg[main_index],
-                 [reg, capture, saved_reg, main_index](Regex ex, PromptEvent event, Context& context) {
+                 [reg, capture, saved_reg](Regex ex, PromptEvent event, Context& context) {
          if (event == PromptEvent::Abort)
          {
              RegisterManager::instance()[reg].set(context, saved_reg);


### PR DESCRIPTION
This eliminates some warnings emitted by clang++.