### PR TITLE
Rename KeyMapInfo → KeymapInfo

### DIFF
--- a/src/keymap_manager.cc
+++ b/src/keymap_manager.cc
@@ -26,7 +26,7 @@ bool KeymapManager::is_mapped(Key key, KeymapMode mode) const
            (m_parent and m_parent->is_mapped(key, mode));
 }
 
-const KeymapManager::KeyMapInfo&
+const KeymapManager::KeymapInfo&
 KeymapManager::get_mapping(Key key, KeymapMode mode) const
 {
     auto it = m_mapping.find(KeyAndMode{key, mode});

--- a/src/keymap_manager.hh
+++ b/src/keymap_manager.hh
@@ -36,12 +36,12 @@ public:
     bool is_mapped(Key key, KeymapMode mode) const;
     KeyList get_mapped_keys(KeymapMode mode) const;
 
-    struct KeyMapInfo
+    struct KeymapInfo
     {
         KeyList keys;
         String docstring;
     };
-    const KeyMapInfo& get_mapping(Key key, KeymapMode mode) const;
+    const KeymapInfo& get_mapping(Key key, KeymapMode mode) const;
 
 private:
     KeymapManager()
@@ -51,7 +51,7 @@ private:
 
     KeymapManager* m_parent;
     using KeyAndMode = std::pair<Key, KeymapMode>;
-    HashMap<KeyAndMode, KeyMapInfo, MemoryDomain::Mapping> m_mapping;
+    HashMap<KeyAndMode, KeymapInfo, MemoryDomain::Mapping> m_mapping;
 };
 
 }


### PR DESCRIPTION
`KeyMapInfo` was the only id with a capital `M` (`KeymapMode`, `KeymapManager`…)

I know, nothing fancy, but it was messing with me while using autocomplete.