### PR TITLE
Fix overlapping inline markup

### DIFF
--- a/rc/base/markdown.kak
+++ b/rc/base/markdown.kak
@@ -112,10 +112,11 @@ add-highlighter shared/markdown/content regex ^(#+)(\h+)([^\n]+) 1:header
 
 add-highlighter shared/markdown/content regex ^\h?((?:[\s\t]+)?[-\*])\h+[^\n]*(\n\h+[^-\*]\S+[^\n]*\n)*$ 0:list 1:bullet
 add-highlighter shared/markdown/content regex \B\+[^\n]+?\+\B 0:mono
-add-highlighter shared/markdown/content regex \B\*[^\n]+?\*\B 0:italic
-add-highlighter shared/markdown/content regex \b_[^\n]+?_\b 0:italic
-add-highlighter shared/markdown/content regex \B\*\*[^\n]+?\*\*\B 0:bold
-add-highlighter shared/markdown/content regex \B__[^\n]+?__\B 0:bold
+add-highlighter shared/markdown/content regex [^`](``([^\s`]|([^\s`][^`]*[^\s`]))``)[^`] 1:mono
+add-highlighter shared/markdown/content regex [^*](\*([^\s*]|([^\s*][^*]*[^\s*]))\*)[^*] 1:italic
+add-highlighter shared/markdown/content regex [^_](_([^\s_]|([^\s_][^_]*[^\s_]))_)[^_] 1:italic
+add-highlighter shared/markdown/content regex [^*](\*\*([^\s*]|([^\s*][^*]*[^\s*]))\*\*)[^*] 1:bold
+add-highlighter shared/markdown/content regex [^_](__([^\s_]|([^\s_][^_]*[^\s_]))__)[^_] 1:bold
 add-highlighter shared/markdown/content regex <(([a-z]+://.*?)|((mailto:)?[\w+-]+@[a-z]+[.][a-z]+))> 0:link
 add-highlighter shared/markdown/content regex ^\h*(>\h*)+ 0:comment
 add-highlighter shared/markdown/content regex \H\K\h\h$ 0:PrimarySelection


### PR DESCRIPTION
Make it so text like "**bold**" wil not be marked as italic and bold.