### PR TITLE
fix regression in highlighting of qualified Haskell variables

### DIFF
--- a/rc/base/haskell.kak
+++ b/rc/base/haskell.kak
@@ -39,7 +39,7 @@ add-highlighter shared/haskell/code regex (?<!')\b(case|do|else|if|in|let|mdo|of
 
 # matches uppercase identifiers:  Monad Control.Monad
 # not non-space separated dot:    Just.const
-add-highlighter shared/haskell/code regex \b([A-Z]['\w]*\.)*[A-Z]['\w]*(?!\.) 0:variable
+add-highlighter shared/haskell/code regex \b([A-Z]['\w]*\.)*[A-Z]['\w]*(?!['\w])(?![.\l]) 0:variable
 
 # matches infix identifier: `mod` `Apa._T'M`
 add-highlighter shared/haskell/code regex `\b([A-Z]['\w]*\.)*[\w]['\w]*` 0:operator


### PR DESCRIPTION
Commit 870d2d22d7aa5f2edbf9efb2e73157e08566d789 introduced a regression
in the highlighting of qualified Haskell variables, such as `Foo.bar`.
After that commit `Fo` was highlighted as a constructor (note, not
`Foo`, just `Fo` without the trailing `o`). This restores the original
behavior.