### PR TITLE
kakrc: Load files sorted by name

### DIFF
--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -24,8 +24,8 @@ def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
 
 %sh{
     autoload_directory() {
-        find -L "$1" -type f -name '*\.kak' \
-            -exec printf 'try %%{ source "%s" } catch %%{ echo -debug Autoload: could not load "%s" }\n' '{}' '{}' \;
+        find -L "$1" -type f -name '*\.kak' | sort | xargs -I {} \
+            printf 'try %%{ source "%s" } catch %%{ echo -debug Autoload: could not load "%s" }\n' '{}' '{}'
     }
 
     localconfdir=${XDG_CONFIG_HOME:-${HOME}/.config}/kak


### PR DESCRIPTION
In certain cases configuration files must be sourced in a particular order.
File systems usually do not enable users to reorder entries. However,
users usually have control over the naming.