### PR TITLE
Add session name filtering for KakBegin hook

### DIFF
--- a/doc/pages/hooks.asciidoc
+++ b/doc/pages/hooks.asciidoc
@@ -123,7 +123,7 @@ of the given *group*.
 *InputModeChange* `<old mode>:<new mode>`::
     Triggered whenever the current input mode changes
 
-*KakBegin*::
+*KakBegin* `session name`::
     kakoune has started, this hook is called just after reading the user
     configuration files
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -618,7 +618,7 @@ int run_server(StringView session, StringView server_init,
 
     {
         Context empty_context{Context::EmptyContextFlag{}};
-        global_scope.hooks().run_hook("KakBegin", "", empty_context);
+        global_scope.hooks().run_hook("KakBegin", session, empty_context);
     }
 
     if (not files.empty()) try


### PR DESCRIPTION
Hi

Sometimes, Kakoune needs to be configured differently according to each project.

Having the `KakBegin` hook giving more info than just an empty string is more useful, especially where the session name matches the project name like described on the wiki: https://github.com/mawww/kakoune/wiki/Kak-daemon-helper-:-1-session-per-project
