### PR TITLE
src: Handle files bigger than 2G

### DIFF
--- a/src/buffer.hh
+++ b/src/buffer.hh
@@ -233,11 +233,11 @@ private:
     {
         [[gnu::always_inline]]
         StringDataPtr& get_storage(LineCount line)
-        { return BufferLines::operator[]((int)line); }
+        { return BufferLines::operator[]((int64_t)line); }
 
         [[gnu::always_inline]]
         const StringDataPtr& get_storage(LineCount line) const
-        { return BufferLines::operator[]((int)line); }
+        { return BufferLines::operator[]((int64_t)line); }
 
         [[gnu::always_inline]]
         StringView operator[](LineCount line) const

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1791,7 +1791,7 @@ const CommandDesc prompt_cmd = {
                 auto& text = sc.env_vars["text"_sv] = str.str();
                 auto clear_password = on_scope_end([&] {
                     if (flags & PromptFlags::Password)
-                        memset(text.data(), 0, (int)text.length());
+                        memset(text.data(), 0, (int64_t)text.length());
                 });
 
                 ScopedSetBool disable_history{context.history_disabled()};

--- a/src/file.cc
+++ b/src/file.cc
@@ -108,7 +108,7 @@ String compact_path(StringView filename)
     const char* home = getenv("HOME");
     if (home)
     {
-        ByteCount home_len = (int)strlen(home);
+        ByteCount home_len = strlen(home);
         if (real_filename.substr(0, home_len) == home)
             return "~" + real_filename.substr(home_len);
     }
@@ -202,7 +202,7 @@ MappedFile::MappedFile(StringView filename)
     if (data == MAP_FAILED)
         throw file_access_error{filename, strerror(errno)};
 
-    if (st.st_size > std::numeric_limits<int>::max())
+    if (st.st_size > std::numeric_limits<int64_t>::max())
         throw runtime_error("file is too big");
 }
 
@@ -218,7 +218,7 @@ MappedFile::~MappedFile()
 
 MappedFile::operator StringView() const
 {
-    return { data, (int)st.st_size };
+    return { data, (int64_t)st.st_size };
 }
 
 bool file_exists(StringView filename)
@@ -230,7 +230,7 @@ bool file_exists(StringView filename)
 void write(int fd, StringView data)
 {
     const char* ptr = data.data();
-    ssize_t count   = (int)data.length();
+    ssize_t count   = (int64_t)data.length();
 
     while (count)
     {

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -1050,13 +1050,13 @@ private:
 
         char format[16];
         format_to(format, "%{}d", digit_count);
-        const int main_line = (int)context.context.selections().main().cursor().line + 1;
-        int last_line = -1;
+        const int64_t main_line = (int64_t)context.context.selections().main().cursor().line + 1;
+        int64_t last_line = -1;
         for (auto& line : display_buffer.lines())
         {
-            const int current_line = (int)line.range().begin.line + 1;
+            const int64_t current_line = (int64_t)line.range().begin.line + 1;
             const bool is_cursor_line = main_line == current_line;
-            const int line_to_format = (m_relative and not is_cursor_line) ?
+            const int64_t line_to_format = (m_relative and not is_cursor_line) ?
                                        current_line - main_line : current_line;
             char buffer[16];
             snprintf(buffer, 16, format, std::abs(line_to_format));
@@ -1317,7 +1317,7 @@ private:
         const DisplayAtom empty{String{' ', width}, def_face};
         for (auto& line : display_buffer.lines())
         {
-            int line_num = (int)line.range().begin.line + 1;
+            int64_t line_num = (int64_t)line.range().begin.line + 1;
             auto it = find_if(lines,
                               [&](const LineAndSpec& l)
                               { return std::get<0>(l) == line_num; });

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -517,7 +517,7 @@ public:
 
     DisplayLine build_display_line(ColumnCount in_width)
     {
-        CharCount width = (int)in_width; // Todo: proper handling of char/column
+        CharCount width = (int64_t)in_width; // Todo: proper handling of char/column
         kak_assert(m_cursor_pos <= m_line.char_length());
         if (m_cursor_pos < m_display_pos)
             m_display_pos = m_cursor_pos;

--- a/src/keys.hh
+++ b/src/keys.hh
@@ -110,7 +110,7 @@ constexpr Key ctrlalt(Key key)
     return { key.modifiers | Key::Modifiers::ControlAlt, key.key };
 }
 
-constexpr Codepoint encode_coord(DisplayCoord coord) { return (Codepoint)(((int)coord.line << 16) | ((int)coord.column & 0x0000FFFF)); }
+constexpr Codepoint encode_coord(DisplayCoord coord) { return (Codepoint)(((int64_t)coord.line << 16) | ((int64_t)coord.column & 0x0000FFFF)); }
 
 constexpr Key resize(DisplayCoord dim) { return { Key::Modifiers::Resize, encode_coord(dim) }; }
 

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -470,7 +470,7 @@ void command(Context& context, NormalParams params)
 
 void apply_diff(Buffer& buffer, BufferCoord pos, StringView before, StringView after)
 {
-    auto diffs = find_diff(before.begin(), (int)before.length(), after.begin(), (int)after.length());
+    auto diffs = find_diff(before.begin(), (int64_t)before.length(), after.begin(), (int64_t)after.length());
 
     for (auto& diff : diffs)
     {
@@ -1491,8 +1491,8 @@ void align(Context& context, NormalParams)
                 ColumnCount inscol = get_column(buffer, tabstop, insert_coord);
                 ColumnCount targetcol = inscol + inscount;
                 ColumnCount tabcol = inscol - (inscol % tabstop);
-                CharCount tabs = (int)((targetcol - tabcol) / tabstop);
-                CharCount spaces = (int)(targetcol - (tabs ? (tabcol + (int)tabs * tabstop) : inscol));
+                CharCount tabs = (int64_t)((targetcol - tabcol) / tabstop);
+                CharCount spaces = (int64_t)(targetcol - (tabs ? (tabcol + (int64_t)tabs * tabstop) : inscol));
                 padstr = String{ '\t', tabs } + String{ ' ', spaces };
             }
             buffer.insert(insert_coord, padstr);
@@ -1503,7 +1503,7 @@ void align(Context& context, NormalParams)
 
 void copy_indent(Context& context, NormalParams params)
 {
-    int selection = params.count;
+    int64_t selection = params.count;
     auto& buffer = context.buffer();
     auto& selections = context.selections();
     Vector<LineCount> lines;
@@ -1522,7 +1522,7 @@ void copy_indent(Context& context, NormalParams params)
     auto it = line.begin();
     while (it != line.end() and is_horizontal_blank(*it))
         ++it;
-    const StringView indent = line.substr(0_byte, (int)(it-line.begin()));
+    const StringView indent = line.substr(0_byte, (int64_t)(it-line.begin()));
 
     ScopedEdition edition{context};
     for (auto& l : lines)

--- a/src/remote.cc
+++ b/src/remote.cc
@@ -73,7 +73,7 @@ public:
     void write(StringView str)
     {
         write(str.length());
-        write(str.data(), (int)str.length());
+        write(str.data(), (int64_t)str.length());
     };
 
     void write(const String& str)
@@ -271,8 +271,8 @@ String MsgReader::read<String>()
     String res;
     if (length > 0)
     {
-        res.force_size((int)length);
-        read(&res[0_byte], (int)length);
+        res.force_size((int64_t)length);
+        read(&res[0_byte], (int64_t)length);
     }
     return res;
 }

--- a/src/shared_string.cc
+++ b/src/shared_string.cc
@@ -9,7 +9,7 @@ namespace Kakoune
 StringDataPtr StringData::create(ArrayView<const StringView> strs)
 {
     const int len = accumulate(strs, 0, [](int l, StringView s) {
-                        return l + (int)s.length();
+                        return l + (int64_t)s.length();
                     });
     void* ptr = StringData::operator new(sizeof(StringData) + len + 1);
     auto* res = new (ptr) StringData(len);
@@ -17,7 +17,7 @@ StringDataPtr StringData::create(ArrayView<const StringView> strs)
     for (auto& str : strs)
     {
         memcpy(data, str.begin(), (size_t)str.length());
-        data += (int)str.length();
+        data += (int64_t)str.length();
     }
     *data = 0;
     return RefPtr<StringData, PtrPolicy>{res};
@@ -50,7 +50,7 @@ void StringData::Registry::debug_stats() const
     for (auto& st : m_strings)
     {
         total_refcount += st.value->refcount - 1;
-        total_size += (int)st.value->length;
+        total_size += (int64_t)st.value->length;
     }
     write_to_debug_buffer(format("  data size: {}, mean: {}", total_size, (float)total_size/count));
     write_to_debug_buffer(format("  refcounts: {}, mean: {}", total_refcount, (float)total_refcount/count));

--- a/src/string.hh
+++ b/src/string.hh
@@ -21,7 +21,7 @@ public:
 
     friend constexpr size_t hash_value(const Type& str)
     {
-        return hash_data(str.data(), (int)str.length());
+        return hash_data(str.data(), (size_t)str.length());
     }
 
     using iterator = CharType*;
@@ -36,10 +36,10 @@ public:
     const_iterator begin() const { return type().data(); }
 
     [[gnu::always_inline]]
-    iterator end() { return type().data() + (int)type().length(); }
+    iterator end() { return type().data() + (int64_t)type().length(); }
 
     [[gnu::always_inline]]
-    const_iterator end() const { return type().data() + (int)type().length(); }
+    const_iterator end() const { return type().data() + (int64_t)type().length(); }
 
     reverse_iterator rbegin() { return reverse_iterator{end()}; }
     const_reverse_iterator rbegin() const { return const_reverse_iterator{end()}; }
@@ -49,14 +49,14 @@ public:
 
     CharType& front() { return *type().data(); }
     const CharType& front() const { return *type().data(); }
-    CharType& back() { return type().data()[(int)type().length() - 1]; }
-    const CharType& back() const { return type().data()[(int)type().length() - 1]; }
+    CharType& back() { return type().data()[(int64_t)type().length() - 1]; }
+    const CharType& back() const { return type().data()[(int64_t)type().length() - 1]; }
 
     [[gnu::always_inline]]
-    CharType& operator[](ByteCount pos) { return type().data()[(int)pos]; }
+    CharType& operator[](ByteCount pos) { return type().data()[(int64_t)pos]; }
 
     [[gnu::always_inline]]
-    const CharType& operator[](ByteCount pos) const { return type().data()[(int)pos]; }
+    const CharType& operator[](ByteCount pos) const { return type().data()[(int64_t)pos]; }
 
     Codepoint operator[](CharCount pos) const
     { return utf8::codepoint(utf8::advance(begin(), end(), pos), end()); }
@@ -74,10 +74,10 @@ public:
     { return utf8::advance(begin(), end(), count) - begin(); }
 
     CharCount char_count_to(ByteCount count) const
-    { return utf8::distance(begin(), begin() + (int)count); }
+    { return utf8::distance(begin(), begin() + (int64_t)count); }
 
     ColumnCount column_count_to(ByteCount count) const
-    { return utf8::column_distance(begin(), begin() + (int)count); }
+    { return utf8::column_distance(begin(), begin() + (int64_t)count); }
 
     StringView substr(ByteCount from, ByteCount length = INT_MAX) const;
     StringView substr(CharCount from, CharCount length = INT_MAX) const;
@@ -106,13 +106,13 @@ public:
     String(const char* content, ByteCount len) : m_data(content, (size_t)len) {}
     explicit String(Codepoint cp, CharCount count = 1)
     {
-        reserve(utf8::codepoint_size(cp) * (int)count);
+        reserve(utf8::codepoint_size(cp) * (int64_t)count);
         while (count-- > 0)
             utf8::dump(std::back_inserter(*this), cp);
     }
     explicit String(Codepoint cp, ColumnCount count)
     {
-        int cp_count = (int)(count / std::max(codepoint_width(cp), 1_col));
+        int64_t cp_count = (int64_t)(count / std::max(codepoint_width(cp), 1_col));
         reserve(utf8::codepoint_size(cp) * cp_count);
         while (cp_count-- > 0)
             utf8::dump(std::back_inserter(*this), cp);
@@ -216,7 +216,7 @@ public:
         : m_data{data}, m_length{length} {}
     constexpr StringView(const char* data) : m_data{data}, m_length{data ? strlen(data) : 0} {}
     constexpr StringView(const char* begin, const char* end) : m_data{begin}, m_length{(int)(end - begin)} {}
-    StringView(const String& str) : m_data{str.data()}, m_length{(int)str.length()} {}
+    StringView(const String& str) : m_data{str.data()}, m_length{str.length()} {}
     StringView(const char& c) : m_data(&c), m_length(1) {}
     StringView(int c) = delete;
     StringView(Codepoint c) = delete;
@@ -265,7 +265,7 @@ inline StringView StringOps<Type, CharType>::substr(ByteCount from, ByteCount le
         length = INT_MAX;
     const auto str_len = type().length();
     kak_assert(from >= 0 and from <= str_len);
-    return StringView{ type().data() + (int)from, std::min(str_len - from, length) };
+    return StringView{ type().data() + (int64_t)from, std::min(str_len - from, length) };
 }
 
 template<typename Type, typename CharType>

--- a/src/string_utils.cc
+++ b/src/string_utils.cc
@@ -90,7 +90,7 @@ String replace(StringView str, StringView substr, StringView replacement)
             break;
 
         res += replacement;
-        it = match + (int)substr.length();
+        it = match + (int64_t)substr.length();
     }
     return res;
 }

--- a/src/unit_tests.cc
+++ b/src/unit_tests.cc
@@ -49,7 +49,7 @@ UnitTest test_diff{[]()
         StringView s1 = "mais que fais la police";
         StringView s2 = "mais ou va la police";
 
-        auto diff = find_diff(s1.begin(), (int)s1.length(), s2.begin(), (int)s2.length());
+        auto diff = find_diff(s1.begin(), (int64_t)s1.length(), s2.begin(), (int64_t)s2.length());
         kak_assert(diff.size() == 11);
     }
 }};

--- a/src/units.hh
+++ b/src/units.hh
@@ -4,12 +4,13 @@
 #include "assert.hh"
 #include "hash.hh"
 
+#include <stdint.h>
 #include <type_traits>
 
 namespace Kakoune
 {
 
-template<typename RealType, typename ValueType = int>
+template<typename RealType, typename ValueType = int64_t>
 class StronglyTypedNumber
 {
 public:
@@ -124,12 +125,12 @@ protected:
     ValueType m_value;
 };
 
-struct LineCount : public StronglyTypedNumber<LineCount, int>
+struct LineCount : public StronglyTypedNumber<LineCount, int64_t>
 {
     LineCount() = default;
 
     [[gnu::always_inline]]
-    constexpr LineCount(int value) : StronglyTypedNumber<LineCount>(value) {}
+    constexpr LineCount(int64_t value) : StronglyTypedNumber<LineCount>(value) {}
 };
 
 [[gnu::always_inline]]
@@ -138,12 +139,12 @@ inline constexpr LineCount operator"" _line(unsigned long long int value)
     return LineCount(value);
 }
 
-struct ByteCount : public StronglyTypedNumber<ByteCount, int>
+struct ByteCount : public StronglyTypedNumber<ByteCount, int64_t>
 {
     ByteCount() = default;
 
     [[gnu::always_inline]]
-    constexpr ByteCount(int value) : StronglyTypedNumber<ByteCount>(value) {}
+    constexpr ByteCount(int64_t value) : StronglyTypedNumber<ByteCount>(value) {}
 };
 
 [[gnu::always_inline]]
@@ -152,12 +153,12 @@ inline constexpr ByteCount operator"" _byte(unsigned long long int value)
     return ByteCount(value);
 }
 
-struct CharCount : public StronglyTypedNumber<CharCount, int>
+struct CharCount : public StronglyTypedNumber<CharCount, int64_t>
 {
     CharCount() = default;
 
     [[gnu::always_inline]]
-    constexpr CharCount(int value) : StronglyTypedNumber<CharCount>(value) {}
+    constexpr CharCount(int64_t value) : StronglyTypedNumber<CharCount>(value) {}
 };
 
 [[gnu::always_inline]]
@@ -166,12 +167,12 @@ inline constexpr CharCount operator"" _char(unsigned long long int value)
     return CharCount(value);
 }
 
-struct ColumnCount : public StronglyTypedNumber<ColumnCount, int>
+struct ColumnCount : public StronglyTypedNumber<ColumnCount, int64_t>
 {
     ColumnCount() = default;
 
     [[gnu::always_inline]]
-    constexpr ColumnCount(int value) : StronglyTypedNumber<ColumnCount>(value) {}
+    constexpr ColumnCount(int64_t value) : StronglyTypedNumber<ColumnCount>(value) {}
 };
 
 [[gnu::always_inline]]

--- a/src/window.cc
+++ b/src/window.cc
@@ -286,9 +286,9 @@ BufferCoord Window::buffer_coord(DisplayCoord coord) const
     if (coord <= 0_line)
         coord = {0,0};
     if ((size_t)coord.line >= m_display_buffer.lines().size())
-        coord = DisplayCoord{(int)m_display_buffer.lines().size()-1, INT_MAX};
+        coord = DisplayCoord{(int64_t)m_display_buffer.lines().size()-1, INT_MAX};
 
-    return find_buffer_coord(m_display_buffer.lines()[(int)coord.line],
+    return find_buffer_coord(m_display_buffer.lines()[(int64_t)coord.line],
                              buffer(), coord.column);
 }
 

--- a/src/word_db.cc
+++ b/src/word_db.cc
@@ -94,7 +94,7 @@ void WordDB::rebuild_db()
 
     m_words.clear();
     m_lines.clear();
-    m_lines.reserve((int)buffer.line_count());
+    m_lines.reserve((int64_t)buffer.line_count());
     for (auto line = 0_line, end = buffer.line_count(); line < end; ++line)
     {
         m_lines.push_back(buffer.line_storage(line));
@@ -114,7 +114,7 @@ void WordDB::update_db()
         return;
 
     Lines new_lines;
-    new_lines.reserve((int)buffer.line_count());
+    new_lines.reserve((int64_t)buffer.line_count());
 
     auto old_line = 0_line;
     for (auto& modif : modifs)
@@ -123,14 +123,14 @@ void WordDB::update_db()
         kak_assert(modif.new_line < buffer.line_count() or modif.num_added == 0);
         kak_assert(old_line <= modif.old_line);
         while (old_line < modif.old_line)
-            new_lines.push_back(std::move(m_lines[(int)old_line++]));
+            new_lines.push_back(std::move(m_lines[(int64_t)old_line++]));
 
-        kak_assert((int)new_lines.size() == (int)modif.new_line);
+        kak_assert((int64_t)new_lines.size() == (int64_t)modif.new_line);
 
         while (old_line < modif.old_line + modif.num_removed)
         {
             kak_assert(old_line < m_lines.size());
-            remove_words(m_lines[(int)old_line++]->strview());
+            remove_words(m_lines[(int64_t)old_line++]->strview());
         }
 
         for (auto l = 0_line; l < modif.num_added; ++l)
@@ -139,8 +139,8 @@ void WordDB::update_db()
             add_words(new_lines.back()->strview());
         }
     }
-    while (old_line != (int)m_lines.size())
-        new_lines.push_back(std::move(m_lines[(int)old_line++]));
+    while (old_line != (int64_t)m_lines.size())
+        new_lines.push_back(std::move(m_lines[(int64_t)old_line++]));
 
     m_lines = std::move(new_lines);
 }


### PR DESCRIPTION
I managed to open a 4G file with this patch, and scroll through it.

However adding a line at the end of file took 100% of the CPU and was very slow. Not sure if it's my modifications causing this, or if it hints at a loop somewhere that could be optimized.

The process also took 10G of RAM.