### PR TITLE
src: Restore the main selection's index from the `^` register

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1626,7 +1626,11 @@ SelectionList read_selections_from_register(char reg, Context& context)
     if (sels.empty())
         throw runtime_error(format("Register {} contains an empty selection list", reg));
 
-    return {buffer, std::move(sels), timestamp};
+    SelectionList sels_list{buffer, Selection{}, timestamp};
+
+    sels_list.set(std::move(sels), 0);
+
+    return std::move(sels_list);
 }
 
 enum class CombineOp

--- a/src/selection.cc
+++ b/src/selection.cc
@@ -480,7 +480,18 @@ String selection_to_string(const Selection& selection)
 
 String selection_list_to_string(const SelectionList& selections)
 {
-    return join(selections | transform(selection_to_string), ':', false);
+    String selections_str = selection_to_string(selections.main());
+
+    for (size_t i = 0; i < selections.size(); i++)
+    {
+        if (i == selections.main_index())
+            continue;
+
+        selections_str += ':';
+        selections_str += selection_to_string(selections[i]);
+    }
+
+    return selections_str;
 }
 
 Selection selection_from_string(StringView desc)


### PR DESCRIPTION
This commit sets the first selection in the list of selections stored in
the default mark register to be the main one (`Z` and `z` based keys).

The modifications also impact the `:select` command, to the same effect.

Closes #1750