### PR TITLE
Add preserve-previous-line-indent

### DIFF
--- a/rc/base/css.kak
+++ b/rc/base/css.kak
@@ -45,8 +45,7 @@ define-command -hidden css-filter-around-selections %{
 
 define-command -hidden css-indent-on-new-line %[
     evaluate-commands -draft -itersel %[
-        # preserve previous line indent
-        try %[ execute-keys -draft \; K <a-&> ]
+        preserve-previous-line-indent
         # filter previous line
         try %[ execute-keys -draft k : css-filter-around-selections <ret> ]
         # indent after lines ending with with {

--- a/rc/base/d.kak
+++ b/rc/base/d.kak
@@ -83,8 +83,7 @@ add-highlighter shared/d/code regex "\b(this)\b\s*[^(]" 1:value
 
 define-command -hidden d-indent-on-new-line %~
     evaluate-commands -draft -itersel %=
-        # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        preserve-previous-line-indent
         # indent after lines ending with { or (
         try %[ execute-keys -draft k<a-x> <a-k> [{(]\h*$ <ret> j<a-gt> ]
         # cleanup trailing white spaces on the previous line

--- a/rc/base/fish.kak
+++ b/rc/base/fish.kak
@@ -47,8 +47,7 @@ define-command -hidden fish-indent-on-char %{
 
 define-command -hidden fish-indent-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
-        # preserve previous line indent
-        try %{ execute-keys -draft <space>K<a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k:fish-filter-around-selections<ret> }
         # indent after start structure

--- a/rc/base/gas.kak
+++ b/rc/base/gas.kak
@@ -76,8 +76,7 @@ define-command -hidden gas-filter-around-selections %{
 
 define-command -hidden gas-indent-on-new-line %~
     evaluate-commands -draft -itersel %<
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : gas-filter-around-selections <ret> }
         # indent after label

--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -55,8 +55,7 @@ add-highlighter shared/go/code regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9]+|0[xX][0-9
 
 define-command -hidden go-indent-on-new-line %~
     evaluate-commands -draft -itersel %=
-        # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        preserve-previous-line-indent
         # indent after lines ending with { or (
         try %[ execute-keys -draft k<a-x> <a-k> [{(]\h*$ <ret> j<a-gt> ]
         # cleanup trailing white spaces on the previous line

--- a/rc/base/haskell.kak
+++ b/rc/base/haskell.kak
@@ -81,8 +81,7 @@ define-command -hidden haskell-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy -- comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # align to first clause
         try %{ execute-keys -draft \; k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|do|let|where)\h+\K.* <ret> s \A|.\z <ret> & }
         # filter previous line

--- a/rc/base/html.kak
+++ b/rc/base/html.kak
@@ -53,8 +53,7 @@ define-command -hidden html-indent-on-greater-than %[
 
 define-command -hidden html-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : html-filter-around-selections <ret> }
         # indent after lines ending with opening tag

--- a/rc/base/java.kak
+++ b/rc/base/java.kak
@@ -20,8 +20,7 @@ add-highlighter shared/java/code regex "\b(final|public|protected|private|abstra
 
 define-command -hidden java-indent-on-new-line %~
     evaluate-commands -draft -itersel %=
-        # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        preserve-previous-line-indent
         # indent after lines ending with { or (
         try %[ execute-keys -draft k<a-x> <a-k> [{(]\h*$ <ret> j<a-gt> ]
         # cleanup trailing white spaces on the previous line

--- a/rc/base/javascript.kak
+++ b/rc/base/javascript.kak
@@ -55,8 +55,7 @@ define-command -hidden javascript-indent-on-new-line %<
     evaluate-commands -draft -itersel %<
         # copy // comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : javascript-filter-around-selections <ret> }
         # indent after lines beginning / ending with opener token

--- a/rc/base/json.kak
+++ b/rc/base/json.kak
@@ -35,8 +35,7 @@ define-command -hidden json-indent-on-char %<
 
 define-command -hidden json-indent-on-new-line %<
     evaluate-commands -draft -itersel %<
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : json-filter-around-selections <ret> }
         # indent after lines beginning with opener token

--- a/rc/base/lisp.kak
+++ b/rc/base/lisp.kak
@@ -33,8 +33,7 @@ define-command -hidden lisp-filter-around-selections %{
 
 define-command -hidden lisp-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # indent when matches opening paren
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> <a-\;> \; <a-gt> }
     }

--- a/rc/base/lua.kak
+++ b/rc/base/lua.kak
@@ -68,8 +68,7 @@ define-command -hidden lua-indent-on-char %{
 
 define-command -hidden lua-indent-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
-        # preserve previous line indent
-        try %{ execute-keys -draft <space>K<a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k:lua-filter-around-selections<ret> }
         # indent after start structure

--- a/rc/base/markdown.kak
+++ b/rc/base/markdown.kak
@@ -62,8 +62,7 @@ define-command -hidden markdown-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy block quote(s), list item prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K((>\h*)+([*+-]\h)?|(>\h*)*[*+-]\h)\h* <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # remove trailing white spaces
         try %{ execute-keys -draft -itersel %{ k<a-x> s \h+$ <ret> d } }
     }

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -72,8 +72,7 @@ add-highlighter shared/perl/code regex \$(LAST_REGEXP_CODE_RESULT|LIST_SEPARATOR
 
 define-command -hidden perl-indent-on-new-line %~
     evaluate-commands -draft -itersel %=
-        # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        preserve-previous-line-indent
         # indent after lines ending with { or (
         try %[ execute-keys -draft k<a-x> <a-k> [{(]\h*$ <ret> j<a-gt> ]
         # cleanup trailing white spaces on the previous line

--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -120,8 +120,7 @@ define-command -hidden ruby-indent-on-char %{
 
 define-command -hidden ruby-indent-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
-        # preserve previous line indent
-        try %{ execute-keys -draft K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : ruby-filter-around-selections <ret> }
         # indent after start structure

--- a/rc/base/rust.kak
+++ b/rc/base/rust.kak
@@ -43,8 +43,7 @@ define-command -hidden rust-indent-on-new-line %~
     evaluate-commands -draft -itersel %<
         # copy // comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K//[!/]?\h* <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : rust-filter-around-selections <ret> }
         # indent after lines ending with { or (

--- a/rc/base/scala.kak
+++ b/rc/base/scala.kak
@@ -43,8 +43,7 @@ define-command -hidden scala-indent-on-new-line %[
     evaluate-commands -draft -itersel %[
         # copy // comments prefix and following white spaces
         try %[ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P ]
-        # preserve previous line indent
-        try %[ execute-keys -draft \; K <a-&> ]
+        preserve-previous-line-indent
         # filter previous line
         try %[ execute-keys -draft k : scala-filter-around-selections <ret> ]
         # indent after lines ending with {

--- a/rc/base/yaml.kak
+++ b/rc/base/yaml.kak
@@ -37,8 +37,7 @@ define-command -hidden yaml-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : yaml-filter-around-selections <ret> }
         # indent after :

--- a/rc/core/indent.kak
+++ b/rc/core/indent.kak
@@ -1,0 +1,3 @@
+define-command preserve-previous-line-indent %{
+    try %{ execute-keys -draft \; K <a-&> }
+}

--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -68,8 +68,7 @@ define-command -hidden kak-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # cleanup trailing whitespaces from previous line
         try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
         # indent after line ending with %[\W\S]

--- a/rc/core/makefile.kak
+++ b/rc/core/makefile.kak
@@ -36,8 +36,7 @@ add-highlighter shared/makefile/content regex [+?:]= 0:operator
 
 define-command -hidden makefile-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
-        # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        preserve-previous-line-indent
         ## If the line above is a target indent with a tab
         try %{ execute-keys -draft Z k<a-x> <a-k>^[^:]+:\s<ret> z i<tab> }
         # cleanup trailing white space son previous line

--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -130,8 +130,7 @@ define-command -hidden python-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # cleanup trailing whitespaces from previous line
         try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
         # indent after line ending with :

--- a/rc/extra/cabal.kak
+++ b/rc/extra/cabal.kak
@@ -33,8 +33,7 @@ define-command -hidden cabal-indent-on-new-line %[
     evaluate-commands -draft -itersel %[
         # copy '#' comment prefix and following white spaces
         try %[ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P ]
-        # preserve previous line indent
-        try %[ execute-keys -draft \; K <a-&> ]
+        preserve-previous-line-indent
         # filter previous line
         try %[ execute-keys -draft k : cabal-filter-around-selections <ret> ]
         # indent after lines ending with { or :

--- a/rc/extra/coffee.kak
+++ b/rc/extra/coffee.kak
@@ -57,8 +57,7 @@ define-command -hidden coffee-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s '^\h*\K#\h*' <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : coffee-filter-around-selections <ret> }
         # indent after start structure

--- a/rc/extra/cucumber.kak
+++ b/rc/extra/cucumber.kak
@@ -65,8 +65,7 @@ define-command -hidden cucumber-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : cucumber-filter-around-selections <ret> }
         # indent after lines containing :

--- a/rc/extra/elixir.kak
+++ b/rc/extra/elixir.kak
@@ -49,13 +49,12 @@ define-command -hidden elixir-filter-around-selections %{
 
 define-command -hidden elixir-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
-        # copy -- comments prefix and following white spaces 
+        # copy -- comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
-        # indent after line ending with: 
-	# try %{ execute-keys -draft k x <a-k> (do|else|->)$ <ret> & }
-	# filter previous line
+        preserve-previous-line-indent
+        # indent after line ending with:
+        # try %{ execute-keys -draft k x <a-k> (do|else|->)$ <ret> & }
+        # filter previous line
         try %{ execute-keys -draft k : elixir-filter-around-selections <ret> }
         # indent after lines ending with do or ->
         try %{ execute-keys -draft \\; k x <a-k> ^.+(do|->)$ <ret> j <a-gt> }

--- a/rc/extra/elm.kak
+++ b/rc/extra/elm.kak
@@ -42,8 +42,7 @@ define-command -hidden elm-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy -- comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # align to first clause
         try %{ execute-keys -draft \; k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|let)\h+\K.* <ret> s \A|.\z <ret> & }
         # filter previous line

--- a/rc/extra/haml.kak
+++ b/rc/extra/haml.kak
@@ -42,8 +42,7 @@ define-command -hidden haml-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '/' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K/\h* <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : haml-filter-around-selections <ret> }
         # indent after lines beginning with : or -

--- a/rc/extra/hbs.kak
+++ b/rc/extra/hbs.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](hbs) %{
 add-highlighter shared/ regions -default html hbs  \
     comment          \{\{!-- --\}\} '' \
     comment          \{\{!   \}\}   '' \
-    block-expression \{\{    \}\}   '' 
+    block-expression \{\{    \}\}   ''
 
 add-highlighter shared/hbs/html ref html
 add-highlighter shared/hbs/comment fill comment
@@ -43,8 +43,7 @@ define-command -hidden hbs-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '/' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K/\h* <ret> y j p }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : hbs-filter-around-selections <ret> }
         # indent after lines beginning with : or -

--- a/rc/extra/moon.kak
+++ b/rc/extra/moon.kak
@@ -78,8 +78,7 @@ define-command -hidden moon-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy -- comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^ \h * \K -- \h * <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : moon-filter-around-selections <ret> }
         # indent after start structure

--- a/rc/extra/nim.kak
+++ b/rc/extra/nim.kak
@@ -60,8 +60,7 @@ def -hidden nim-indent-on-new-line %{
     eval -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ exec -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
-        # preserve previous line indent
-        try %{ exec -draft \; K <a-&> }
+        preserve-previous-line-indent
         # cleanup trailing whitespaces from previous line
         try %{ exec -draft k <a-x> s \h+$ <ret> d }
         # indent after line ending with const, let, var, ':' or '='

--- a/rc/extra/php.kak
+++ b/rc/extra/php.kak
@@ -48,8 +48,7 @@ define-command -hidden php-indent-on-new-line %<
     evaluate-commands -draft -itersel %<
         # copy // comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : php-filter-around-selections <ret> }
         # indent after lines beginning / ending with opener token

--- a/rc/extra/pony.kak
+++ b/rc/extra/pony.kak
@@ -66,8 +66,7 @@ add-highlighter shared/pony/comment       fill comment
 
 define-command -hidden pony-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
-        # preserve previous line indent
-        try %{ execute-keys -draft <space> K <a-&> }
+        preserve-previous-line-indent
         # cleanup trailing whitespaces from previous line
         try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
         # copy '//' comment prefix and following white spaces

--- a/rc/extra/pug.kak
+++ b/rc/extra/pug.kak
@@ -51,8 +51,7 @@ define-command -hidden pug-filter-around-selections %{
 
 define-command -hidden pug-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : pug-filter-around-selections <ret> }
         # copy '//', '|', '-' or '(!)=' prefix and following whitespace

--- a/rc/extra/ragel.kak
+++ b/rc/extra/ragel.kak
@@ -46,8 +46,7 @@ define-command -hidden ragel-indent-on-new-line %<
     evaluate-commands -draft -itersel %<
         # copy _#_ comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : ragel-filter-around-selections <ret> }
         # indent after lines ending with opener token

--- a/rc/extra/sass.kak
+++ b/rc/extra/sass.kak
@@ -38,8 +38,7 @@ define-command -hidden sass-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '/' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K/\h* <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        preserve-previous-line-indent
         # filter previous line
         try %{ execute-keys -draft k : sass-filter-around-selections <ret> }
         # avoid indent after properties and comments

--- a/rc/extra/taskpaper.kak
+++ b/rc/extra/taskpaper.kak
@@ -24,8 +24,7 @@ add-highlighter shared/taskpaper regex (([a-z]+://\S+)|((mailto:)[\w+-]+@\S+)) 0
 
 define-command -hidden taskpaper-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
-        # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        preserve-previous-line-indent
         ## If the line above is a project indent with a tab
         try %{ execute-keys -draft Z k<a-x> <a-k>^\h*([^:\n]+):<ret> z i<tab> }
         # cleanup trailing white spaces on previous line

--- a/test/indent/haskell/indented-comment/rc
+++ b/test/indent/haskell/indented-comment/rc
@@ -1,3 +1,4 @@
 source "%val{runtime}/colors/default.kak"
+source "%val{runtime}/rc/core/indent.kak"
 source "%val{runtime}/rc/base/haskell.kak"
 set buffer filetype haskell

--- a/test/indent/haskell/inside-comment/rc
+++ b/test/indent/haskell/inside-comment/rc
@@ -1,3 +1,4 @@
 source "%val{runtime}/colors/default.kak"
+source "%val{runtime}/rc/core/indent.kak"
 source "%val{runtime}/rc/base/haskell.kak"
 set buffer filetype haskell

--- a/test/indent/html/indent-closing-tag/rc
+++ b/test/indent/html/indent-closing-tag/rc
@@ -1,3 +1,4 @@
 source "%val{runtime}/colors/default.kak"
+source "%val{runtime}/rc/core/indent.kak"
 source "%val{runtime}/rc/base/html.kak"
 set buffer filetype html

--- a/test/indent/markdown/inside-nested-list-item/rc
+++ b/test/indent/markdown/inside-nested-list-item/rc
@@ -1,3 +1,4 @@
 source "%val{runtime}/colors/default.kak"
+source "%val{runtime}/rc/core/indent.kak"
 source "%val{runtime}/rc/base/markdown.kak"
 set buffer filetype markdown

--- a/test/regression/860-python-incorrect-commenting/rc
+++ b/test/regression/860-python-incorrect-commenting/rc
@@ -1,3 +1,4 @@
 source "%val{runtime}/colors/default.kak"
+source "%val{runtime}/rc/core/indent.kak"
 source "%val{runtime}/rc/core/python.kak"
 set buffer filetype python


### PR DESCRIPTION
This is initial work on trying to reduce the code copypaste in the rc-files by introducing commands to do common indentation heuristics.

If this approach is approved by other contributors and merged we can introduce additional commands, such as increasing the indent after a set of keywords passed as a regexp argument to the command.

This was made using the new find and replace in https://github.com/occivink/kakoune-find :star2: 