### PR TITLE
Insert complete: Remove path info with one buffer

### DIFF
--- a/src/insert_completer.cc
+++ b/src/insert_completer.cc
@@ -181,7 +181,7 @@ InsertCompletion complete_word(const SelectionList& sels, const OptionManager& o
         if (candidates.empty() or candidates.back().completion != first->candidate())
         {
             DisplayLine menu_entry;
-            if (first->buffer)
+            if (other_buffers && first->buffer)
             {
                 const auto pad_len = longest + 1 - first->candidate().char_length();
                 menu_entry.push_back(first->candidate().str());


### PR DESCRIPTION
This change is useful when using `set scope completers word=buffer` instead of the default `word=all`.

If candidates all come from the same buffer, then the path/filename information is the same and therefore unnecessary. This change prevents the same path from being repeated, and the buffer's source code is less obscured.

More generally, there could be an option to disable the path information entirely in all cases, but for now this change seems a reasonable solution until any such option exists.