### PR TITLE
Various improvements to Homebrew formula

### DIFF
--- a/contrib/kakoune.rb
+++ b/contrib/kakoune.rb
@@ -1,17 +1,20 @@
-require "formula"
-
 class Kakoune < Formula
   homepage "https://github.com/mawww/kakoune"
   head "https://github.com/mawww/kakoune.git"
 
-  depends_on 'docbook-xsl' => :build
-  depends_on 'ncurses' => [:build, :recommended]
-  depends_on 'asciidoc' => [:build, 'with-docbook-xsl']
+  depends_on "docbook-xsl" => :build
+  depends_on "ncurses" => [:build, :recommended]
+  depends_on "asciidoc" => :build
+
+  unless OS.mac?
+    depends_on "libxslt" => :build
+    depends_on "pkg-config" => :build
+  end
 
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 
-    cd 'src' do
+    cd "src" do
       system "make", "install", "PREFIX=#{prefix}", "debug=no"
     end
   end


### PR DESCRIPTION
* Add missing Homebrew dependencies on Linux
* `require "formula"` is unnecessary
* `brew audit --strict` warns on single quotes
* Remove unnecessary option