### PR TITLE
Lua block comment fix

### DIFF
--- a/rc/base/lua.kak
+++ b/rc/base/lua.kak
@@ -14,8 +14,8 @@ hook global BufCreate .*[.](lua) %{
 add-highlighter shared/ regions -default code lua \
     string  '"'      (?<!\\)(\\\\)*"  '' \
     string  "'"      (?<!\\)(\\\\)*'  '' \
-    comment '--'     '$'              '' \
     comment '--\[\[' '\]\]'           '' \
+    comment '--'     '$'              '' \
 
 add-highlighter shared/lua/string fill string
 


### PR DESCRIPTION
If you tried to write this simple Lua program in Kakoune as an example:

``` lua
function test()
    --[[
    print("Hello")
    --]]
    print("There")
end
```
The line containing `print("Hello")` would be highlighted as a normal Lua code instead of it greying out.
This pull request addresses this issue.