### PR TITLE
base javascript: Tweak variable highlighting

### DIFF
--- a/rc/base/javascript.kak
+++ b/rc/base/javascript.kak
@@ -64,8 +64,7 @@ define-command -hidden init-javascript-filetype -params 1 %~
     add-highlighter "shared/%arg{1}/literal"       fill string
     add-highlighter "shared/%arg{1}/literal"       regex \$\{.*?\} 0:value
 
-    add-highlighter "shared/%arg{1}/code" regex \$\w* 0:variable
-    add-highlighter "shared/%arg{1}/code" regex \b(document|false|null|parent|self|this|true|undefined|window)\b 0:value
+    add-highlighter "shared/%arg{1}/code" regex [^$_]\b(document|false|null|parent|self|this|true|undefined|window)\b 1:value
     add-highlighter "shared/%arg{1}/code" regex "-?\b[0-9]*\.?[0-9]+" 0:value
     add-highlighter "shared/%arg{1}/code" regex \b(Array|Boolean|Date|Function|Number|Object|RegExp|String|Symbol)\b 0:type
 


### PR DESCRIPTION
This commit avoids false positives when highlighting literals such as
`$window`, which is a regular variable but still highlighted as a
special value.

Special highlighting of variables that start with a dollar sign `$`
was also removed, as not all variables start with a dollar sign,
and we don't have a reliable way yet to detect variables.