### PR TITLE
Fix typos in C++ string literals

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1122,7 +1122,7 @@ KeymapMode parse_keymap_mode(StringView str, const KeymapManager::UserModeList& 
 const CommandDesc debug_cmd = {
     "debug",
     nullptr,
-    "debug <command>: write some debug informations in the debug buffer\n"
+    "debug <command>: write some debug information to the debug buffer\n"
     "existing commands: info, buffers, options, memory, shared-strings, profile-hash-maps, faces",
     ParameterDesc{{}, ParameterDesc::Flags::SwitchesOnlyAtStart, 1},
     CommandFlags::None,

--- a/src/highlighter_group.cc
+++ b/src/highlighter_group.cc
@@ -27,7 +27,7 @@ void HighlighterGroup::fill_unique_ids(Vector<StringView>& unique_ids) const
 void HighlighterGroup::add_child(HighlighterAndId&& hl)
 {
     if ((hl.second->passes() & passes()) != hl.second->passes())
-        throw runtime_error{"Cannot add that highlighter to this group, passes dont match"};
+        throw runtime_error{"Cannot add that highlighter to this group, passes don't match"};
 
     hl.first = replace(hl.first, "/", "<slash>");
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -299,7 +299,7 @@ void register_options()
     reg.declare_option("BOM", "byte order mark to use when writing buffer",
                        ByteOrderMark::None);
     reg.declare_option("incsearch",
-                       "incrementaly apply search/select/split regex",
+                       "incrementally apply search/select/split regex",
                        true);
     reg.declare_option("autoinfo",
                        "automatically display contextual help",
@@ -308,7 +308,7 @@ void register_options()
                        "automatically display possible completions for prompts",
                        true);
     reg.declare_option("aligntab",
-                       "use tab characters when possible for alignement",
+                       "use tab characters when possible for alignment",
                        false);
     reg.declare_option("ignored_files",
                        "patterns to ignore when completing filenames",

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1740,7 +1740,7 @@ void combine_selections(Context& context, SelectionList list, Func func)
                                  else
                                  {
                                      if (list.size() != sels.size())
-                                         throw runtime_error{"The two selection lists dont have the same number of elements"};
+                                         throw runtime_error{"The two selection lists don't have the same number of elements"};
                                      for (int i = 0; i < list.size(); ++i)
                                          combine_selection(sels.buffer(), list[i], sels[i], op);
                                      list.set_main_index(sels.main_index());


### PR DESCRIPTION
informations, dont, incrementaly, alignement