### PR TITLE
Add link to 'Why Kakoune' on home page

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -157,6 +157,14 @@ a:hover {
     margin-bottom: 1em;
 }
 
+.feature-more {
+    background: white;
+    border: #fa5300 1px solid;
+    color: #fa5300;
+    font-size: 1.2em;
+    margin: 1em 0;
+}
+
 .demo-caption {
     font-size: 1.1em;
     font-style: italic;

--- a/index.html
+++ b/index.html
@@ -151,6 +151,14 @@
                             </div>
                         </div>
                     </div>
+
+                    <div class="col-sm-12">
+                      <p class="text-center">
+                          <a class="btn btn-default feature-more" href="why-kakoune/why-kakoune.html">
+                            Learn more about Kakoune philosophy
+                          </a>
+                      </p>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
Hi

There was no link to the inspiring *Why Kakoune?* article on the website and I always had to google it before sharing it.

So I've added one in a prominent place (the orange *Learn about Kakoune philosophy*) on the home page because I think it is the perfect introduction that crystallizes what this editor is all about.

![image](https://user-images.githubusercontent.com/39315/36598159-8557c974-18ab-11e8-8b1d-c144193f187a.png)
