### PR TITLE
Ease reading of command-line options

### DIFF
--- a/src/parameters_parser.cc
+++ b/src/parameters_parser.cc
@@ -7,11 +7,26 @@ namespace Kakoune
 
 String generate_switches_doc(const SwitchMap& switches)
 {
+    Vector<int> lengths(switches.size());
+    int i = 0;
+    for (auto& sw : switches) {
+        lengths[i++] = (int)sw.key.length() + (sw.value.takes_arg ? 5: 0);
+    }
+    int maxlen = *std::max_element(lengths.begin(), lengths.end());
+
     String res;
-    for (auto& sw : switches)
-        res += format("-{} {}: {}\n", sw.key,
+    i = 0;
+    for (auto& sw : switches) {
+        int len = lengths[i++];
+        String pad = "  ";
+        while (len++ < maxlen)
+            pad += ' ';
+        res += format("  -{} {}{}{}\n",
+                      sw.key,
                       sw.value.takes_arg ? "<arg>" : "",
+                      pad,
                       sw.value.description);
+    }
     return res;
 }
 


### PR DESCRIPTION
This change displays command-line options in grid format. Each parameter is indented with two spaces and then padded to maintain vertical alignment of each description.

I think the visual spacing makes the options much easier to read and gives a friendlier appearance. This is particularly important for people new to Kakoune who use `-help` as a way to become familiar with the program.

Existing:

    Options:
    -c <arg>: connect to given session
    -e <arg>: execute argument on client initialisation
    -E <arg>: execute argument on server initialisation
    -n : do not source kakrc files on startup
    -s <arg>: set session name
    -d : run as a headless session (requires -s)
    -p <arg>: just send stdin as commands to the given session
    -f <arg>: act as a filter, executing given keys on given files
    -i <arg>: backup the files on which a filter is applied using the given suffix
    -q : in filter mode, be quiet about errors applying keys
    -ui <arg>: set the type of user interface to use (ncurses, dummy, or json)
    -l : list existing sessions
    -clear : clear dead sessions
    -ro : readonly mode
    -help : display a help message and quit

Proposed with this change:

    Options:
      -c <arg>   connect to given session
      -e <arg>   execute argument on client initialisation
      -E <arg>   execute argument on server initialisation
      -n         do not source kakrc files on startup
      -s <arg>   set session name
      -d         run as a headless session (requires -s)
      -p <arg>   just send stdin as commands to the given session
      -f <arg>   act as a filter, executing given keys on given files
      -i <arg>   backup the files on which a filter is applied using the given suffix
      -q         in filter mode, be quiet about errors applying keys
      -ui <arg>  set the type of user interface to use (ncurses, dummy, or json)
      -l         list existing sessions
      -clear     clear dead sessions
      -ro        readonly mode
      -help      display a help message and quit
