### PR TITLE
Fix broken rust racer support (plus tweaks)

### DIFF
--- a/rc/extra/racer.kak
+++ b/rc/extra/racer.kak
@@ -45,7 +45,7 @@ define-command racer-complete -docstring "Complete the current selection with ra
                 }'
             )
             printf %s\\n "evaluate-commands -client '${kak_client}' %{
-                set-option buffer=${kak_bufname} racer_completions %@${compl}@
+                set-option buffer=${kak_bufname} racer_completions %@${compl: : -1}@
             }" | kak -p ${kak_session}
             rm -r ${dir}
         ) > /dev/null 2>&1 < /dev/null &

--- a/rc/extra/racer.kak
+++ b/rc/extra/racer.kak
@@ -29,13 +29,40 @@ define-command racer-complete -docstring "Complete the current selection with ra
                     gsub(/\|/, "\\|", menu)
                     if (type == "Function") {
                         sub(word, "{default+e}" word "{default+d}", menu)
+                        gsub(/^fn /, "    fn ", menu)                            # The extra spaces are there to vertically align
+                                                                                 # the type of element on the menu to make it easy
+                                                                                 # to read
                         menu = "{default+d}" menu
-                        word = word "("
                     } else if (type == "Enum") {
                         menu = substr(menu, 0, length(menu) - 2)
                         sub(word, "{default+e}" word "{default+d}", menu)
-                        menu = "{default+d}" menu
-                        word = word "::"
+                        gsub(/^enum /, "  enum ", menu)                          # The extra spaces are there to vertically align
+                                                                                 # the type of element on the menu to make it easy
+                                                                                 # to read
+                    } else if (type == "Module") {
+                        if (length(menu) > 30) {                                 # The "menu" bit (as returned by racer),
+                                                                                 # contains the path to the source file
+                                                                                 # containing the module...
+
+                          menu = substr(menu, length(menu) - 29, 30)             # ... trimming it, so the completion menu
+                                                                                 # doesn''t get distorted if it''s too long
+                        }
+                        menu = "   mod {default+e}" word "{default+d}   .." menu # The extra spaces are there to vertically align
+                                                                                 # the type of element on the menu to make it easy
+                                                                                 # to read
+                    } else if (type == "Trait") {
+                        sub(word, "{default+e}" word "{default+d}", menu)
+                        gsub(/^trait /, " trait ", menu)                         # The extra spaces are there to vertically align
+                                                                                 # the type of element on the menu to make it easy
+                                                                                 # to read
+                    } else if (type == "Type") {
+                        sub(word, "{default+e}" word "{default+d}", menu)
+                        gsub(/^type /, "  type ", menu)                          # The extra spaces are there to vertically align
+                                                                                 # the type of element on the menu to make it easy
+                                                                                 # to read
+                    } else if (type == "Struct") {
+                        sub(word, "{default+e}" word "{default+d}", menu)        # Struct doesn''t have extra spaces because it''s
+                                                                                 # the longest keyword
                     } else {
                         menu = "{default+e}" word "{default+d} " menu
                     }


### PR DESCRIPTION
I wanted to give rust editing with kakoune a try and I found out that racer integration was broken. With a bit of experimentation I found out what was broken: awk is adding an extra ':' at the end of the list of completions.

And working on it I couldn't resist the temptation to try and see if I could improve a bit how the racer suggestions where presented :)

By the way, since this is my first PR, let me congratulate you for what you have done with kakoune, it's amazing!