### PR TITLE
Expand and contract insert completion menu height

### DIFF
--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -764,9 +764,8 @@ void NCursesUI::menu_show(ConstArrayView<DisplayLine> items,
            space_above -= 1;
            space_below += 1;
         }
-        const bool is_below = space_below >= 10_line or space_below >= space_above;
+        const bool is_below = space_below >= space_above;
         const LineCount space = is_below ? space_below : space_above;
-
         height = min(space, height);
         line = is_below ? anchor.line + 1 : anchor.line - height;
     }

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -754,6 +754,8 @@ void NCursesUI::menu_show(ConstArrayView<DisplayLine> items,
     LineCount line;
     if (is_prompt)
         line = m_status_on_top ? 1_line : m_dimensions.line - height;
+    else if (anchor.line + height < m_dimensions.line)
+        line = anchor.line + 1;
     else {
         LineCount space_below = m_dimensions.line - anchor.line - 1;
         LineCount space_above = anchor.line;


### PR DESCRIPTION
Hi, this change fixes an issue where insert mode completions are not visible (extending upwards off the screen) when using a terminal window of small height.

The issue can be reproduced with

    # set terminal height to a small height, say, 6 rows.
    $ kak -n -e 'exec "|seq 10000<ret> ggA"'

On line 1 no completions are visible, but they are still selectable with `<c-n>`. Remaining in insert mode, `<down>` and `<up>` arrows reveal and hide the completions.

To fix the issue in this PR, after computing the height as normal, an extra check is made on the available screen space. If the existing height can't all fit above or below, the completion list recalculates its height by working out the best position, above or below, to show the maximum possible given size of the window (still restricted to the maximum of 10). The option `status_on_top` is also taken into account.

