### PR TITLE
Remove <scope> from user-modes commands

### DIFF
--- a/doc/pages/commands.asciidoc
+++ b/doc/pages/commands.asciidoc
@@ -129,10 +129,10 @@ command *q!* has to be used). Aliases are mentionned below each commands.
 *unmap* <scope> <mode> <key> [<expected>]::
     unbind a key combination (See <<mapping#,`:doc mapping`>>)
 
-*declare-user-mode* <scope> <name>::
-    declare a new user keymap mode within the context of a scope
+*declare-user-mode* <name>::
+    declare a new user keymap mode
 
-*enter-user-mode* <scope> <name>::
+*enter-user-mode* <name>::
     enable <name> keymap mode for next key
 
     *-lock*:::

--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -126,6 +126,8 @@ informations about Kakoune's state:
 *kak_client_env_<name>*::
     value of the *name* variable in the client environment
     (e.g. *$kak_client_env_SHELL* is the SHELL variable)
+*kak_user_modes*::
+    the user modes list, each modes separated by a colon
 
 Note that in order for Kakoune to pass a value in the environment, the
 variable has to be spelled out within the body of the expansion.

--- a/doc/pages/modes.asciidoc
+++ b/doc/pages/modes.asciidoc
@@ -102,7 +102,7 @@ mostly useful for plugin authors who want to bind their new commands in
 extensible menus.
 
 --------------------------------
-declare-user-mode <scope> <name>
+declare-user-mode <name>
 --------------------------------
 
 Declare a new custom mode that can later be referred by the *map* command.
@@ -110,7 +110,7 @@ For example a `grep` custom mode to attach keys like `n` or `p` to skim
 through the output results.
 
 -------------------------------
-enter-user-mode <scope> <name>
+enter-user-mode <name>
 -------------------------------
 
 Enable the designated mode for the next key. Docstrings are shown in the

--- a/src/keymap_manager.cc
+++ b/src/keymap_manager.cc
@@ -54,16 +54,17 @@ KeymapManager::KeyList KeymapManager::get_mapped_keys(KeymapMode mode) const
 void KeymapManager::add_user_mode(String user_mode_name)
 {
     auto modes = {"normal", "insert", "prompt", "menu", "goto", "view", "user", "object"};
+
     if (contains(modes, user_mode_name))
         throw runtime_error(format("'{}' is already a regular mode", user_mode_name));
 
-    if (contains(m_user_modes, user_mode_name))
+    if (contains(user_modes(), user_mode_name))
         throw runtime_error(format("user mode '{}' already defined", user_mode_name));
 
     if (contains_that(user_mode_name, [](char c){ return not isalnum(c); }))
         throw runtime_error(format("invalid mode name: '{}'", user_mode_name));
 
-    m_user_modes.push_back(std::move(user_mode_name));
+    user_modes().push_back(std::move(user_mode_name));
 }
 
 }

--- a/src/keymap_manager.hh
+++ b/src/keymap_manager.hh
@@ -45,7 +45,11 @@ public:
     const KeymapInfo& get_mapping(Key key, KeymapMode mode) const;
 
     using UserModeList = Vector<String>;
-    const UserModeList& user_modes() const { return m_user_modes; }
+    UserModeList& user_modes() {
+        if (m_parent)
+            return m_parent->user_modes();
+        return m_user_modes;
+    }
     void add_user_mode(const String user_mode_name);
 
 private:

--- a/src/main.cc
+++ b/src/main.cc
@@ -193,6 +193,10 @@ static const EnvVarDesc builtin_env_vars[] = { {
         "window_height", false,
         [](StringView name, const Context& context) -> String
         { return to_string(context.window().dimensions().line); }
+    }, {
+        "user_modes", false,
+        [](StringView name, const Context& context) -> String
+        { return join(context.keymaps().user_modes(), ':'); }
     }
 };
 

--- a/test/normal/user-modes/lock/rc
+++ b/test/normal/user-modes/lock/rc
@@ -1,3 +1,3 @@
-declare-user-mode global foo
+declare-user-mode foo
 map global foo f d
-map global normal <a-,> ':enter-user-mode -lock global foo<ret>'
+map global normal <a-,> ':enter-user-mode -lock foo<ret>'

--- a/test/normal/user-modes/once/rc
+++ b/test/normal/user-modes/once/rc
@@ -1,3 +1,3 @@
-declare-user-mode global foo
+declare-user-mode foo
 map global foo f 'wchello from foo<esc>'
-map global normal <a-,> ':enter-user-mode global foo<ret>'
+map global normal <a-,> ':enter-user-mode foo<ret>'


### PR DESCRIPTION
Hi

## Context

The `declare-user-mode` and `enter-user-mode` commands have been out in a wild for a few days and it has been the perfect opportunity to gather some feedback on it. Thanks guys!

They were well received, **but** unanimously their `<scope>` param has been designated as **confusing**. (and I agree, it was not in my initial design at first).
It's confusing because it's hard to have a clear mental representation of what's going on between _mode scopes_ and _map scopes_.

And, as an unrelated problem, the current implementation is a bit leaky / buggy. (sorry :( )

## TL;DR

So this PR aims at **reducing the complexity** by removing the `<scope>` from `declare-user-mode` and `enter-user-mode` commands. It simplify everything: user modes can be manipulated as if they were global builtin modes.

## Current situation

Let me illustrate the problem with a few diagrams.

### 1

Builtin modes are stored globally in an enum. Scopes are nested. Let's add a classic mapping:

`:map global normal D ':echo global normal D<ret>'`

Mappings are stored in hash-maps, where the key is a tuple `modeId-key`. There are one of this hash-map by scope. So far nothing extraordinary:

![01 svg](https://user-images.githubusercontent.com/39315/36888717-12a132b6-1df7-11e8-8bb2-1f6892ea5865.png)

### 2

Let's add another regular mapping on the same `D` letter, but on a the `buffer` scope. When the user will press `D`, the mappings will be searched from the more nested scope: `window -> buffer -> global`. So our new mapping will *shadow* the first one. Again, nothing special.

![02 svg](https://user-images.githubusercontent.com/39315/36888930-f82f8490-1df7-11e8-840e-39ed27989523.png)

### 3

Now, we start introducing the recent concepts. First: `:declare-user-modes global golf`.
User modes are stored in scopes too (in a vector). Their `modeId` is 8 (number of builtins modes) + position in this vector. So `9` in this case.
Then let's add a mapping on `a` for this mode : `:map global golf a ':echo global golf a<ret>'`

![03 svg](https://user-images.githubusercontent.com/39315/36889085-a80a5b4c-1df8-11e8-9570-59bb4e8082ca.png)

### 4

Here comes complexity / troubles. We can't do `:map buffer golf a ':echo buffer golf a<ret>'`. Kakoune will complain that there's no `golf` mode in the `buffer` scope. So let's add another mode: `bravo`.
And a mapping on `a` as well: `:map buffer bravo a ':echo buffer bravo a<ret>'`.

Oops! We have a collision. `bravo` also get affected the modeId `9` (my bad on the implementation). So our new mapping on `bravo` shadows the one on `golf`! :S

![04 svg](https://user-images.githubusercontent.com/39315/36889281-a285c7a0-1df9-11e8-8f96-ef123184d827.png)

### 5

Even in the situation if we decide to map `b` on `golf` and `c` on `bravo`, there's no direct collision but the `autoinfo` gets leaky because it displays all keymaps for modes with the same modeId:

![05 svg](https://user-images.githubusercontent.com/39315/36889401-13937406-1dfa-11e8-8abe-64c27175015d.png)

### New situation (with this PR)

As you see, the nesting gets a bit messy. Even if I had not make mistakes, and `golf` was 9 and `bravo` was 10, I still believe that it's a bit too complicated to keep the `<scope>` concept for both `:map` and `:declare-user-mode/:enter-user-mode`.

So why not store user modes at the end of the enum of builtin ones? Problem solved!
It was what I had in mind at the beginning, but you can't extend enums in C++ at runtime. Then I try to turn this enum into a vector, but mawww was not very happy having this mutable global floating around the code base. (and he was right).

So in this PR I keep storing the user modes in scopes, the simplification is that it can only be stored on the global one. So to conclude there's a unique place where all the user modes are stored, but on the C++ side it's not a global.
```
UserModeList& user_modes() {
       if (m_parent)
           return m_parent->user_modes();
       return m_user_modes;
 }
```
(accessible through `context.keymaps().user_modes()`):

![06 svg](https://user-images.githubusercontent.com/39315/36889650-3df3ee64-1dfb-11e8-931c-751a587482f4.png)

Thanks for your time when testing the user-modes and reading this.

## Bonus

With this simplification we get 2 new nice things:
- `%val{user_modes}` to get `golf:bravo`. Useful to build a help system like in Spacemacs.
- `:debug mappings` now lists mappings from user modes.