### PR TITLE
Docs: add missing insert mode <c-x>L in docs

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -709,18 +709,9 @@ See <<doc/pages/execeval#,`:doc execeval`>>.
 Insert mode completion
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Kakoune can propose completions while inserting text, the `completers` option
-controls automatic completion, which kicks in when a certain idle timeout is
-reached (see `idle_timeout` option). Insert mode completion can be explicitly triggered
-using `<c-x>`, followed, by:
+Kakoune can propose completions while inserting text: filenames, words, lines…
 
- * *f* : filename completion
- * *w* : word completion (current buffer)
- * *W* : word completion (all buffers)
- * *l* : line completion (current buffer)
- * *L* : line completion (all buffers)
-
-Completion candidates can be selected using `<c-n>` and `<c-p>`.
+See <<doc/pages/keys#insert-mode-completion,`:doc keys insert-mode-completion`>>.
 
 Escape to normal mode
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -31,6 +31,26 @@ In order to bind some keys to arbitrary ones, refer to <<mapping#,`:doc mapping`
 *<end>*::
     move cursors to end of line
 
+*<c-r>*::
+    insert contents of the register given by next key
+
+*<c-v>*::
+    insert next keystroke directly into the buffer, without interpreting it
+
+*<c-u>*::
+    commit changes up to now as a single undo group
+
+*<a-;>*::
+    escape to normal mode for a single command
+
+== Insert mode completion
+
+The `completers` option controls automatic completion, which kicks in when
+the value specified in the `idle_timeout` option is reached.
+
+*<c-o>*::
+    disable automatic completion for this insert session
+
 *<c-n>*::
     select next completion candidate
 
@@ -50,22 +70,10 @@ In order to bind some keys to arbitrary ones, refer to <<mapping#,`:doc mapping`
         explicit word completion (all buffers)
 
     *l*:::
-        explicit line completion
+        explicit line completion (current buffer)
 
-*<c-o>*::
-    disable automatic completion for this insert session
-
-*<c-r>*::
-    insert contents of the register given by next key
-
-*<c-v>*::
-    insert next keystroke directly into the buffer, without interpreting it
-
-*<c-u>*::
-    commit changes up to now as a single undo group
-
-*<a-;>*::
-    escape to normal mode for a single command
+    *L*:::
+        explicit line completion (all buffers)
 
 == Using Counts
 


### PR DESCRIPTION
Hi.

In https://github.com/mawww/kakoune/pull/1655 I added the new `L` choice in `README` but forgot to do it in `/docs`. So, as we already did with other parts mentioned in `Advanced Topics`, I have added a direct link to the `Insert mode completion` section. 