### PR TITLE
Handle hyphens in user-mode names

### DIFF
--- a/src/keymap_manager.cc
+++ b/src/keymap_manager.cc
@@ -61,7 +61,7 @@ void KeymapManager::add_user_mode(String user_mode_name)
     if (contains(user_modes(), user_mode_name))
         throw runtime_error(format("user mode '{}' already defined", user_mode_name));
 
-    if (contains_that(user_mode_name, [](char c){ return not isalnum(c); }))
+    if (contains_that(user_mode_name, is_blank))
         throw runtime_error(format("invalid mode name: '{}'", user_mode_name));
 
     user_modes().push_back(std::move(user_mode_name));


### PR DESCRIPTION
Hi.

Using the same check than for command names:
https://github.com/mawww/kakoune/blob/master/src/commands.cc#L846

Fix #1921