### PR TITLE
Add jumpToDefinition and showDoc support for rust (with racer)

### DIFF
--- a/rc/extra/racer.kak
+++ b/rc/extra/racer.kak
@@ -105,11 +105,11 @@ define-command racer-go-definition -docstring "Jump to where the rust identifier
         (
             cursor="${kak_cursor_line} $((${kak_cursor_column} - 1))"
             racer_data=$(racer --interface tab-text  find-definition ${cursor} ${kak_buffile} ${dir}/buf | head -n 1)
-            racer_match=$(echo "$racer_data" | cut -f1 )
+            racer_match=$(printf %s\\n "$racer_data" | cut -f1 )
             if [[ "$racer_match" == "MATCH" ]]; then
-              racer_line=$(echo "$racer_data" | cut -f3 )
-              racer_column=$(echo "$racer_data" | cut -f4 )
-              racer_file=$(echo "$racer_data" | cut -f5 )
+              racer_line=$(printf %s\\n "$racer_data" | cut -f3 )
+              racer_column=$(printf %s\\n "$racer_data" | cut -f4 )
+              racer_file=$(printf %s\\n "$racer_data" | cut -f5 )
               printf %s\\n "edit -existing '$racer_file' $racer_line $racer_column"
               printf %s\\n "set-option buffer readonly true"
             else
@@ -128,15 +128,16 @@ define-command racer-show-doc -docstring "Show the documentation about the rust 
     %sh{
         dir=${kak_opt_racer_tmp_dir}
         (
-            cursor="${kak_cursor_line} $((${kak_cursor_column} - 1))"
+            printf -v NEWLINE '\n'
+            cursor="${kak_cursor_line} ${kak_cursor_column}"
             racer_data=$(racer --interface tab-text  complete-with-snippet  ${cursor} ${kak_buffile} ${dir}/buf | head -n 2 | tail -n 1)
-            racer_match=$(echo "$racer_data" | cut -f1 )
-            printf %s\\n "info '$racer_data'"
+            racer_match=$(printf %s\\n "$racer_data" | cut -f1)
+            printf %s\\n "info %@.$racer_match.@"
             if [[ "$racer_match" == "MATCH" ]]; then
-              racer_doc=$(echo "$racer_data" | cut -f9 | xargs )
-              racer_doc=$(echo "${racer_doc//\\n/
-}") # This is a bit ugly and probably should be replaced with something better than a new line in the code itself, but I couldn't work how
-              printf %s\\n "info '$racer_doc'"
+              racer_doc=$(printf %s\\n "$racer_data" | cut -f9 | xargs )
+              racer_doc=$(printf %s\\n "$racer_doc" | sed -e "s/\\\n/\\$NEWLINE/g")
+              racer_doc=$(printf %s\\n "$racer_doc" | sed -e "s/@/\\@/g")
+              printf %s\\n "info %@$racer_doc@"
             else
               printf %s\\n "echo -debug 'racer could not find a definition'"
             fi

--- a/rc/extra/racer.kak
+++ b/rc/extra/racer.kak
@@ -102,20 +102,18 @@ define-command racer-go-definition -docstring "Jump to where the rust identifier
     }
     %sh{
         dir=${kak_opt_racer_tmp_dir}
-        (
-            cursor="${kak_cursor_line} $((${kak_cursor_column} - 1))"
-            racer_data=$(racer --interface tab-text  find-definition ${cursor} ${kak_buffile} ${dir}/buf | head -n 1)
-            racer_match=$(printf %s\\n "$racer_data" | cut -f1 )
-            if [[ "$racer_match" == "MATCH" ]]; then
-              racer_line=$(printf %s\\n "$racer_data" | cut -f3 )
-              racer_column=$(printf %s\\n "$racer_data" | cut -f4 )
-              racer_file=$(printf %s\\n "$racer_data" | cut -f5 )
-              printf %s\\n "edit -existing '$racer_file' $racer_line $racer_column"
-              printf %s\\n "set-option buffer readonly true"
-            else
-              printf %s\\n "echo -debug 'racer could not find a definition'"
-            fi
-        )
+        cursor="${kak_cursor_line} $((${kak_cursor_column} - 1))"
+        racer_data=$(racer --interface tab-text  find-definition ${cursor} "${kak_buffile}" "${dir}/buf" | head -n 1)
+        racer_match=$(printf %s\\n "$racer_data" | cut -f1 )
+        if [ "$racer_match" = "MATCH" ]; then
+          racer_line=$(printf %s\\n "$racer_data" | cut -f3 )
+          racer_column=$(printf %s\\n "$racer_data" | cut -f4 )
+          racer_file=$(printf %s\\n "$racer_data" | cut -f5 )
+          printf %s\\n "edit -existing '$racer_file' $racer_line $racer_column"
+          #printf %s\\n "set-option buffer readonly true"
+        else
+          printf %s\\n "echo -debug 'racer could not find a definition'"
+        fi
     }
 }
 
@@ -127,20 +125,16 @@ define-command racer-show-doc -docstring "Show the documentation about the rust 
     }
     %sh{
         dir=${kak_opt_racer_tmp_dir}
-        (
-            printf -v NEWLINE '\n'
-            cursor="${kak_cursor_line} ${kak_cursor_column}"
-            racer_data=$(racer --interface tab-text  complete-with-snippet  ${cursor} ${kak_buffile} ${dir}/buf | head -n 2 | tail -n 1)
-            racer_match=$(printf %s\\n "$racer_data" | cut -f1)
-            printf %s\\n "info %@.$racer_match.@"
-            if [[ "$racer_match" == "MATCH" ]]; then
-              racer_doc=$(printf %s\\n "$racer_data" | cut -f9 | xargs )
-              racer_doc=$(printf %s\\n "$racer_doc" | sed -e "s/\\\n/\\$NEWLINE/g")
-              racer_doc=$(printf %s\\n "$racer_doc" | sed -e "s/@/\\@/g")
-              printf %s\\n "info %@$racer_doc@"
-            else
-              printf %s\\n "echo -debug 'racer could not find a definition'"
-            fi
-        )
+        cursor="${kak_cursor_line} ${kak_cursor_column}"
+        racer_data=$(racer --interface tab-text  complete-with-snippet  ${cursor} "${kak_buffile}" "${dir}/buf" | head -n 2 | tail -n 1)
+        racer_match=$(printf %s\\n "$racer_data" | cut -f1)
+        if [ "$racer_match" = "MATCH" ]; then
+          racer_doc=$(printf %s\\n "$racer_data" | cut -f9 )
+          racer_doc=$(printf %s\\n "$racer_doc" | sed -e 's/^"\(.*\)"$/\1/g')
+          racer_doc=$(printf %s\\n "$racer_doc" | sed -e "s/@/\\\\@/g")
+          printf "info %%@$racer_doc@"
+        else
+          printf %s\\n "echo -debug 'racer could not find a definition'"
+        fi
     }
 }

--- a/rc/extra/racer.kak
+++ b/rc/extra/racer.kak
@@ -104,13 +104,20 @@ define-command racer-go-definition -docstring "Jump to where the rust identifier
         dir=${kak_opt_racer_tmp_dir}
         cursor="${kak_cursor_line} $((${kak_cursor_column} - 1))"
         racer_data=$(racer --interface tab-text  find-definition ${cursor} "${kak_buffile}" "${dir}/buf" | head -n 1)
+
         racer_match=$(printf %s\\n "$racer_data" | cut -f1 )
         if [ "$racer_match" = "MATCH" ]; then
           racer_line=$(printf %s\\n "$racer_data" | cut -f3 )
           racer_column=$(printf %s\\n "$racer_data" | cut -f4 )
           racer_file=$(printf %s\\n "$racer_data" | cut -f5 )
           printf %s\\n "edit -existing '$racer_file' $racer_line $racer_column"
-          #printf %s\\n "set-option buffer readonly true"
+          if [[ "$racer_file" == ${RUST_SRC_PATH}* ]]; then
+            printf %s\\n "set-option buffer readonly true" # The definition resides on the standard library, and the new buffer should be readonly
+          else
+            if [[ "$racer_file" == ${HOME}/.cargo/registry/src* ]]; then
+              printf %s\\n "set-option buffer readonly true" # The definition resides on an external crate, and the new buffer should be readonly
+            fi
+          fi
         else
           printf %s\\n "echo -debug 'racer could not find a definition'"
         fi
@@ -126,12 +133,13 @@ define-command racer-show-doc -docstring "Show the documentation about the rust 
     %sh{
         dir=${kak_opt_racer_tmp_dir}
         cursor="${kak_cursor_line} ${kak_cursor_column}"
-        racer_data=$(racer --interface tab-text  complete-with-snippet  ${cursor} "${kak_buffile}" "${dir}/buf" | head -n 2 | tail -n 1)
+        racer_data=$(racer --interface tab-text  complete-with-snippet  ${cursor} "${kak_buffile}" "${dir}/buf" | sed -n 2p )
         racer_match=$(printf %s\\n "$racer_data" | cut -f1)
         if [ "$racer_match" = "MATCH" ]; then
           racer_doc=$(printf %s\\n "$racer_data" | cut -f9 )
-          racer_doc=$(printf %s\\n "$racer_doc" | sed -e 's/^"\(.*\)"$/\1/g')
-          racer_doc=$(printf %s\\n "$racer_doc" | sed -e "s/@/\\\\@/g")
+          racer_doc=$(printf %s\\n "$racer_doc" |
+            sed -e 's/^"\(.*\)"$/\1/g' | # Remove leading and trailing quotes
+            sed -e "s/@/\\\\@/g")        # Escape all @ so that it can be properly used in the string expansion
           printf "info %%@$racer_doc@"
         else
           printf %s\\n "echo -debug 'racer could not find a definition'"


### PR DESCRIPTION
A couple of notes:
- I've only tested this with linux
- There is a bit where the code has to replace the literal '\n' with a new line. And the only way I managed to make it work is by writing an actual new line in the bash code, which is quite ugly. Any suggestion on how to make it nicer would be really welcome. (Writing '\n' as the string to put as the replacement replaces all the '\n' with 'n', and Writing '\\n' as the string to put as the replacement replaces all the '\n' with '\n')