### PR TITLE
More markdown highlighting improvements

### DIFF
--- a/rc/base/markdown.kak
+++ b/rc/base/markdown.kak
@@ -52,6 +52,7 @@ add-highlighter shared/markdown/content regex [^_](_([^\s_]|([^\s_][^_]*[^\s_]))
 add-highlighter shared/markdown/content regex [^*](\*\*([^\s*]|([^\s*][^*]*[^\s*]))\*\*)[^*] 1:bold
 add-highlighter shared/markdown/content regex [^_](__([^\s_]|([^\s_][^_]*[^\s_]))__)[^_] 1:bold
 add-highlighter shared/markdown/content regex <(([a-z]+://.*?)|((mailto:)?[\w+-]+@[a-z]+[.][a-z]+))> 0:link
+add-highlighter shared/markdown/content regex ^\[[^\]\n]*\]:\h*([^\n]*) 1:link
 add-highlighter shared/markdown/content regex ^\h*(>\h*)+ 0:comment
 add-highlighter shared/markdown/content regex \H\K\h\h$ 0:PrimarySelection
 

--- a/rc/base/markdown.kak
+++ b/rc/base/markdown.kak
@@ -46,11 +46,11 @@ add-highlighter shared/markdown/content regex ^(#+)(\h+)([^\n]+) 1:header
 
 add-highlighter shared/markdown/content regex ^\h?((?:[\s\t]+)?[-\*])\h+[^\n]*(\n\h+[^-\*]\S+[^\n]*\n)*$ 0:list 1:bullet
 add-highlighter shared/markdown/content regex \B\+[^\n]+?\+\B 0:mono
-add-highlighter shared/markdown/content regex [^`](``([^\s`]|([^\s`][^`]*[^\s`]))``)[^`] 1:mono
-add-highlighter shared/markdown/content regex [^*](\*([^\s*]|([^\s*][^*]*[^\s*]))\*)[^*] 1:italic
-add-highlighter shared/markdown/content regex [^_](_([^\s_]|([^\s_][^_]*[^\s_]))_)[^_] 1:italic
-add-highlighter shared/markdown/content regex [^*](\*\*([^\s*]|([^\s*][^*]*[^\s*]))\*\*)[^*] 1:bold
-add-highlighter shared/markdown/content regex [^_](__([^\s_]|([^\s_][^_]*[^\s_]))__)[^_] 1:bold
+add-highlighter shared/markdown/content regex [^`](``([^\s`]|([^\s`](\n?[^\n`])*[^\s`]))``)[^`] 1:mono
+add-highlighter shared/markdown/content regex [^*](\*([^\s*]|([^\s*](\n?[^\n*])*[^\s*]))\*)[^*] 1:italic
+add-highlighter shared/markdown/content regex [^_](_([^\s_]|([^\s_](\n?[^\n_])*[^\s_]))_)[^_] 1:italic
+add-highlighter shared/markdown/content regex [^*](\*\*([^\s*]|([^\s*](\n?[^\n*])*[^\s*]))\*\*)[^*] 1:bold
+add-highlighter shared/markdown/content regex [^_](__([^\s_]|([^\s_](\n?[^\n_])*[^\s_]))__)[^_] 1:bold
 add-highlighter shared/markdown/content regex <(([a-z]+://.*?)|((mailto:)?[\w+-]+@[a-z]+[.][a-z]+))> 0:link
 add-highlighter shared/markdown/content regex ^\[[^\]\n]*\]:\h*([^\n]*) 1:link
 add-highlighter shared/markdown/content regex ^\h*(>\h*)+ 0:comment


### PR DESCRIPTION
Some minor changes to Markdown highlighting.

First, I added support for highlighting links in footnote-style link definitions:

    Some text with [a link][tag] and [another link].

    [tag]: http://www.example.com/link1
    [another link]: http://www.example.com/link2

The final two lines will now have their URLs highlighted with the "link" face.

Secondly, I modified the inline-formatting highlighters to accept a maximum of one consecutive newline so they don't cross paragraphs.

    This paragraph has _some italic_ text in it.

    This paragraph also has _some
    italic_ text in it.

    This paragraph does _not have any italic text

    and neither does this_ one.

Previously, the italic formatting would cross from the second-last paragraph to the last paragraph, even if there were dozens of paragraphs in between.

The inline-formatting change doesn't help inline code spans (made with the backtick character), because I think it's overridden by the region highlighter elsewhere in the file. That'll take more picking apart, though.