### PR TITLE
Make racer support scripts more POSIX compliant

### DIFF
--- a/rc/extra/racer.kak
+++ b/rc/extra/racer.kak
@@ -112,10 +112,8 @@ define-command racer-go-definition -docstring "Jump to where the rust identifier
           racer_file=$(printf %s\\n "$racer_data" | cut -f5 )
           printf %s\\n "edit -existing '$racer_file' $racer_line $racer_column"
           case ${racer_file} in
-            "${RUST_SRC_PATH}"*)
-              printf %s\\n "set-option buffer readonly true";; # The definition resides on the standard library, and the new buffer should be readonly
-            "${HOME}/.cargo/registry/src/"*)
-              printf %s\\n "set-option buffer readonly true";; # The definition resides on an external crate, and the new buffer should be readonly
+            "${RUST_SRC_PATH}"* | "${CARGO_HOME:-$HOME/.cargo}"/registry/src/*)
+              printf %s\\n "set-option buffer readonly true";;
           esac
         else
           printf %s\\n "echo -debug 'racer could not find a definition'"
@@ -139,8 +137,15 @@ define-command racer-show-doc -docstring "Show the documentation about the rust 
           remove_surrond_quotes_regex='s/^"\(.*\)"$/\1/g'
           escape_at_sign_regex="s/@/\\\\@/g"
           racer_doc=$(printf %s\\n "$racer_doc" |
-            sed -e "$remove_surrond_quotes_regex" \
-                -e "$escape_at_sign_regex")
+            sed -e '
+
+              # Remove leading and trailing quotes
+              s/^"\(.*\)"$/\1/g
+
+              # Escape all @ so that it can be properly used in the string expansion
+              s/@/\\@/g
+
+            ')
           printf "info %%@$racer_doc@"
         else
           printf %s\\n "echo -debug 'racer could not find a definition'"

--- a/rc/extra/racer.kak
+++ b/rc/extra/racer.kak
@@ -133,10 +133,9 @@ define-command racer-show-doc -docstring "Show the documentation about the rust 
         racer_data=$(racer --interface tab-text  complete-with-snippet  ${cursor} "${kak_buffile}" "${dir}/buf" | sed -n 2p )
         racer_match=$(printf %s\\n "$racer_data" | cut -f1)
         if [ "$racer_match" = "MATCH" ]; then
-          racer_doc=$(printf %s\\n "$racer_data" | cut -f9 )
-          remove_surrond_quotes_regex='s/^"\(.*\)"$/\1/g'
-          escape_at_sign_regex="s/@/\\\\@/g"
-          racer_doc=$(printf %s\\n "$racer_doc" |
+          racer_doc=$(
+            printf %s\\n "$racer_data" |
+            cut -f9  |
             sed -e '
 
               # Remove leading and trailing quotes


### PR DESCRIPTION
Out of #1924 , there were a couple of comments from @lenormf that needed addressing, and I'm trying to address them here.

Of special relevance was the comment regarding the bashism of using the `if [[foo == bar]]` construct. In that particular case, I wasn't trying to just compare two strings, but checking if one string started with another (which with the `if [ foo = bar ]` construct I haven't been able to make it work). To solve it, I've found this answer online [in ask ubuntu](https://askubuntu.com/a/301748), where they use a `case` statement for a similar purpose in an allegedly posix manner. In fact, if this is acceptable, the code is cleaner than before anyway.