### PR TITLE
Add ncurses_layout option to customize the UI (buffer-list, grep summary…)

### DIFF
--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -248,9 +248,15 @@ are exclusively available to built-in options.
             if *yes* or *true*, the terminal emulator title will
             be changed
 
-        *ncurses_status_on_top*:::
-            if *yes*, or *true* the status line will be placed
-            at the top of the terminal rather than at the bottom
+        *ncurses_layout*:::
+            a comma separated list of "zone names" describing the UI appearance
+            from top to bottom. Default value is `main,status`, meaning that
+            the status bar is displayed below the main editing zone.
+            *main* and *status* are mandatory names reserved by Kakoune.
+            If specified, additional zone names must refer to existing keys=value
+            pairs in `ui_options`. For example:
+            `set global ui_options 'ncurses_layout=foo,main,status:foo=hello'`
+            will add a bar on top of the screen displaying hello.
 
         *ncurses_assistant*:::
             specify the nice assistant displayed in info boxes,

--- a/src/ncurses_ui.hh
+++ b/src/ncurses_ui.hh
@@ -32,6 +32,10 @@ public:
                      const DisplayLine& mode_line,
                      const Face& default_face) override;
 
+    void draw_zone(StringView zone,
+                   const DisplayLine& zone_line,
+                   const Face& default_face);
+
     void menu_show(ConstArrayView<DisplayLine> items,
                    DisplayCoord anchor, Face fg, Face bg,
                    MenuStyle style) override;
@@ -144,6 +148,11 @@ private:
     bool m_change_colors = true;
 
     bool m_dirty = false;
+
+    Vector<String> m_layout;
+    using ZoneMap = HashMap<String, DisplayLine>;
+    ZoneMap m_zones;
+    int get_zone_line(StringView zone_name);
 };
 
 }


### PR DESCRIPTION
Hi

## TL;DR

This PR removes `ncurses_status_on_top` option in favor of a more powerful and flexible `ncurses_layout`.

`ncurses_layout` is `main,status` by default. If you want the status on top behavior: `status,main`.

But it offers more potential. You can add extra `zones` (a better name can be discussed).
Let say you want to add a _buffer list_ on top of the screen.

1 - declare a regular string option, and name it like you desire, like `buffer_list`.
2 - add it to the `ncurses_layout` list. Example `buffer_list,main,status` to display the content of the `buffer_list` option in a new line on top of the screen.
3 - now it's up to a kak script to compute and update `buffer_list` when needed. It's value will be updated on screen. You can use faces.

That's it. No new commands involved, we just reuse and extend a feature pioneered by the `modelinefmt` option.

## UI paradigm

Kakoune already offers two ways to display extra bits of data on screen:
- `info`: only one at a time, no styles, get in the way if too big
- `menu`: only one at a time, interactive features

So having a system to just display `exta lines` of data like described in this PR provides an alternative persistent approach which is non intrusive and useful.

## Prior attempts

- https://github.com/mawww/kakoune/pull/1065:  this PR only focus on a buffer list. With `ncurses_layout` you can add as many _zones_ you need with any content you want.
- https://github.com/mawww/kakoune/wiki/Bar: this solution uses an external `bar` program to display things. It's hard to keep it displayed in the correct workspace, in the right position, always tied to the correct terminal window…
- [kakoune-electron](https://github.com/delapouite/kakoune-electron): using a complete foreign GUI system may have other advantages but it's a lot of work and rewriting for such a nice feature that can be implemented right in the current ncurses_ui and benefit every kakoune users out of the box.

## About the code

It's about 100ish new lines of code (including doc), with mainly plumbing stuffs for the different UIs (Remote, JSON…). Of course there's room to improve / fix things, it's mainly a proof of concept.

## Screenshot and example

![image](https://user-images.githubusercontent.com/39315/37586823-cd0c6e54-2b5d-11e8-8c81-3b278914e6d0.png)

```
declare-option str zone_buflist

define-command -hidden zone-buflist %{ %sh{
  list=''
  while read buf; do
    index=$(($index + 1))
    if [ "$buf" = "$kak_bufname" ]; then
      # markup specific to lemonbar
      list="$list{+r} $index $buf "
    else
      list="$list{Default} $index $buf "
    fi
  done <<< $(printf '%s\n' "$kak_buflist" | tr ':' '\n')
  echo "set-option global zone_buflist '$list'"
} }

hook global WinDisplay .* zone-buflist

set global ui_options ncurses_assistant=none:ncurses_layout=zone_buflist,main,status
```

