### PR TITLE
Shift modifiers v3

### DIFF
--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -6,8 +6,8 @@ Usual keys are written using their ascii character, including capital
 keys. Non printable keys use an alternate name, written between *<*
 and *>*, such as *<esc>* or *<del>*. Modified keys are written between
 *<* and *>* as well, with the modifier specified as either *c* for
-Control, or *a* for Alt, followed by a *-* and the key (either its
-name or ascii character), for example *<c-x>*, *<a-space>*, *<c-a-w>*.
+Control, *a* for Alt, or *s* for Shift, followed by a *-* and the key (either
+its name or ascii character), for example *<c-x>*, *<a-space>*, *<c-a-w>*.
 
 In order to bind some keys to arbitrary ones, refer to <<mapping#,`:doc mapping`>>
 
@@ -95,18 +95,20 @@ it when pasting text.
 == Movement
 
 'word' is a sequence of alphanumeric characters or underscore, and 'WORD'
-is a sequence of non whitespace characters
+is a sequence of non whitespace characters. Generally, a movement on it own
+will move the selection to cover the text moved over, while holding down
+the Shift modifier and moving will extend the selection instead.
 
-*h*::
+*h*, *<left>*::
     select the character on the left of selection end
 
-*j*::
+*j*, *<down>*::
     select the character below the selection end
 
-*k*::
+*k*, *<up>*::
     select the character above the selection end
 
-*l*::
+*l*, *<right>*::
     select the character on the right of selection end
 
 *w*::
@@ -134,15 +136,9 @@ is a sequence of non whitespace characters
     select to matching character, see the `matching_pairs` option
     in <<options#,`:doc options`>>
 
-*M*::
-    extend selection to matching character
-
 *x*::
     select line on which selection end lies (or next line when end lies
     on an end-of-line)
-
-*X*::
-    similar to *x*, except the current selection is extended
 
 *<a-x>*::
     expand selections to contain full lines (including end-of-lines)
@@ -154,10 +150,10 @@ is a sequence of non whitespace characters
 *%*::
     select whole buffer
 
-*<a-h>*::
+*<a-h>*, *<home>*::
     select to line begin
 
-*<a-l>*::
+*<a-l>*, *<end>*::
     select to line end
 
 */*::
@@ -696,7 +692,7 @@ The following keys are recognized by this mode to help edition.
 *<tab>*::
     select next completion candidate
 
-*<backtab>*::
+*<s-tab>*::
     select previous completion candidate
 
 *<c-r>*::

--- a/doc/pages/mapping.asciidoc
+++ b/doc/pages/mapping.asciidoc
@@ -65,14 +65,19 @@ be used:
     Keys can also be wrapped in angle-brackets for consistency
     with the non-alphabetic keys below.
 
-*X*, *<X>*::
-    Holding down Shift while pressing the *x* key.
-
 *<c-x>*::
     Holding down Control while pressing the *x* key.
 
 *<a-x>*::
     Holding down Alt while pressing the *x* key.
+
+*<s-x>*, *X*, *<X>*, *<s-X>*::
+    Holding down Shift while pressing the *x* key.
+    *<s-x>*, *<s-X>* and *<X>* are treated as the same key. The *s-* modifier
+    only works with ASCII letters and cannot be used with other printable keys
+    (non-ASCII letters, digits, punctuation) because their shift behaviour
+    depends on your keyboard layout. The *s-* modifier _can_ be used with
+    special keys like *<up>* and *<tab>*.
 
 *<c-a-x>*::
     Holding down Control and Alt while pressing the *x* key.
@@ -92,9 +97,6 @@ be used:
 *<tab>*::
     The Tab key.
 
-*<backtab>*::
-    The reverse-tab key. This is Shift-Tab on most keyboards.
-
 *<backspace>*::
     The Backspace (delete to the left) key.
 
@@ -110,3 +112,8 @@ be used:
 
 *<f1>*, *<f2>*, ...*<f12>*::
     Function keys.
+
+NOTE: Although Kakoune allows many key combinations to be mapped, not every
+possible combination can be triggered. For example, due to limitations in
+the way terminals handle control characters, mappings like *<c-s-a>* are
+unlikely to work in Kakoune's terminal UI.

--- a/src/assert.hh
+++ b/src/assert.hh
@@ -22,8 +22,16 @@ void on_assert_failed(const char* message);
             on_assert_failed("assert failed \"" #__VA_ARGS__ \
                              "\" at " __FILE__ ":" TOSTRING(__LINE__)); \
     } while (false)
+
+    #define kak_expect_throw(exception_type, ...) try {\
+        __VA_ARGS__; \
+        on_assert_failed("expression \"" #__VA_ARGS__ \
+                         "\" did not throw \"" #exception_type \
+                         "\" at " __FILE__ ":" TOSTRING(__LINE__)); \
+    } catch (exception_type &err) {}
 #else
     #define kak_assert(...) do { (void)sizeof(__VA_ARGS__); } while(false)
+    #define kak_expect_throw(_, ...) do { (void)sizeof(__VA_ARGS__); } while(false)
 #endif
 
 

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -461,15 +461,15 @@ public:
         }
         else if (key == ctrl('w'))
             to_next_word_begin<Word>(m_cursor_pos, m_line);
-        else if (key == ctrlalt('w'))
+        else if (key == ctrl(alt('w')))
             to_next_word_begin<WORD>(m_cursor_pos, m_line);
         else if (key == ctrl('b'))
             to_prev_word_begin<Word>(m_cursor_pos, m_line);
-        else if (key == ctrlalt('b'))
+        else if (key == ctrl(alt('b')))
             to_prev_word_begin<WORD>(m_cursor_pos, m_line);
         else if (key == ctrl('e'))
             to_next_word_end<Word>(m_cursor_pos, m_line);
-        else if (key == ctrlalt('e'))
+        else if (key == ctrl(alt('e')))
             to_next_word_end<WORD>(m_cursor_pos, m_line);
         else if (key == ctrl('k'))
             m_line = m_line.substr(0_char, m_cursor_pos).str();
@@ -623,7 +623,7 @@ public:
                 it = std::find_if(m_choices.begin(), m_selected, match_filter);
             select(it);
         }
-        else if (key == Key::Up or key == Key::BackTab or
+        else if (key == Key::Up or key == shift(Key::Tab) or
                  key == ctrl('p') or (not m_edit_filter and key == 'k'))
         {
             ChoiceList::const_reverse_iterator selected(m_selected+1);
@@ -837,9 +837,9 @@ public:
                 m_refresh_completion_pending = true;
             }
         }
-        else if (key == Key::Tab or key == Key::BackTab) // tab completion
+        else if (key == Key::Tab or key == shift(Key::Tab)) // tab completion
         {
-            const bool reverse = (key == Key::BackTab);
+            const bool reverse = (key == shift(Key::Tab));
             CandidateList& candidates = m_completions.candidates;
             // first try, we need to ask our completer for completions
             if (candidates.empty())
@@ -1568,8 +1568,10 @@ InputHandler::ScopedForceNormal::~ScopedForceNormal()
 
 static bool is_valid(Key key)
 {
+    constexpr Key::Modifiers valid_mods = (Key::Modifiers::Control | Key::Modifiers::Alt | Key::Modifiers::Shift);
+
     return key != Key::Invalid and
-        ((key.modifiers & ~Key::Modifiers::ControlAlt) or key.key <= 0x10FFFF);
+        ((key.modifiers & ~valid_mods) or key.key <= 0x10FFFF);
 }
 
 void InputHandler::handle_key(Key key)

--- a/src/keys.hh
+++ b/src/keys.hh
@@ -19,17 +19,17 @@ struct Key
         None    = 0,
         Control = 1 << 0,
         Alt     = 1 << 1,
-        ControlAlt = Control | Alt,
+        Shift   = 1 << 2,
 
-        MousePress   = 1 << 2,
-        MouseRelease = 1 << 3,
-        MousePos     = 1 << 4,
-        MouseWheelDown = 1 << 5,
-        MouseWheelUp = 1 << 6,
+        MousePress   = 1 << 3,
+        MouseRelease = 1 << 4,
+        MousePos     = 1 << 5,
+        MouseWheelDown = 1 << 6,
+        MouseWheelUp = 1 << 7,
         MouseEvent = MousePress | MouseRelease | MousePos |
                      MouseWheelDown | MouseWheelUp,
 
-        Resize = 1 << 7,
+        Resize = 1 << 8,
     };
     enum NamedKey : Codepoint
     {
@@ -47,7 +47,6 @@ struct Key
         Home,
         End,
         Tab,
-        BackTab,
         F1,
         F2,
         F3,
@@ -97,6 +96,10 @@ class StringView;
 KeyList parse_keys(StringView str);
 String  key_to_str(Key key);
 
+constexpr Key shift(Key key)
+{
+    return { key.modifiers | Key::Modifiers::Shift, key.key };
+}
 constexpr Key alt(Key key)
 {
     return { key.modifiers | Key::Modifiers::Alt, key.key };
@@ -104,10 +107,6 @@ constexpr Key alt(Key key)
 constexpr Key ctrl(Key key)
 {
     return { key.modifiers | Key::Modifiers::Control, key.key };
-}
-constexpr Key ctrlalt(Key key)
-{
-    return { key.modifiers | Key::Modifiers::ControlAlt, key.key };
 }
 
 constexpr Codepoint encode_coord(DisplayCoord coord) { return (Codepoint)(((int)coord.line << 16) | ((int)coord.column & 0x0000FFFF)); }

--- a/src/main.cc
+++ b/src/main.cc
@@ -53,7 +53,8 @@ static const char* startup_info =
 " * 'x' will only jump to next line if full line is already selected\n"
 " * WORD text object moved to <a-w> instead of W for consistency\n"
 " * rotate main selection moved to ), rotate content to <a-)>, ( for backward\n"
-" * faces are now scoped, set-face command takes an additional scope parameter\n";
+" * faces are now scoped, set-face command takes an additional scope parameter\n"
+" * <backtab> key is gone, use <s-tab> instead\n";
 
 struct startup_error : runtime_error
 {

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -570,15 +570,24 @@ Optional<Key> NCursesUI::get_next_key()
         {
         case KEY_BACKSPACE: case 127: return {Key::Backspace};
         case KEY_DC: return {Key::Delete};
+        case KEY_SDC: return shift(Key::Delete);
         case KEY_UP: return {Key::Up};
+        case KEY_SR: return shift(Key::Up);
         case KEY_DOWN: return {Key::Down};
+        case KEY_SF: return shift(Key::Down);
         case KEY_LEFT: return {Key::Left};
+        case KEY_SLEFT: return shift(Key::Left);
         case KEY_RIGHT: return {Key::Right};
+        case KEY_SRIGHT: return shift(Key::Right);
         case KEY_PPAGE: return {Key::PageUp};
+        case KEY_SPREVIOUS: return shift(Key::PageUp);
         case KEY_NPAGE: return {Key::PageDown};
+        case KEY_SNEXT: return shift(Key::PageDown);
         case KEY_HOME: return {Key::Home};
+        case KEY_SHOME: return shift(Key::Home);
         case KEY_END: return {Key::End};
-        case KEY_BTAB: return {Key::BackTab};
+        case KEY_SEND: return shift(Key::End);
+        case KEY_BTAB: return shift(Key::Tab);
         case KEY_RESIZE: return resize(m_dimensions);
         }
 

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -2062,6 +2062,11 @@ static const HashMap<Key, NormalCmd, MemoryDomain::Undefined, KeymapBackend> key
     { {'K'}, {"extend up", move<LineCount, Backward, SelectMode::Extend>} },
     { {'L'}, {"extend right", move<CharCount, Forward, SelectMode::Extend>} },
 
+    { shift(Key::Left), {"extend left", move<CharCount, Backward, SelectMode::Extend>} },
+    { shift(Key::Down), {"extend down", move<LineCount, Forward, SelectMode::Extend>} },
+    { shift(Key::Up), {"extend up", move<LineCount, Backward, SelectMode::Extend>} },
+    { shift(Key::Right), {"extend right", move<CharCount, Forward, SelectMode::Extend>} },
+
     { {'t'}, {"select to next character", select_to_next_char<SelectFlags::None>} },
     { {'f'}, {"select to next character included", select_to_next_char<SelectFlags::Inclusive>} },
     { {'T'}, {"extend to next character", select_to_next_char<SelectFlags::Extend>} },
@@ -2140,9 +2145,11 @@ static const HashMap<Key, NormalCmd, MemoryDomain::Undefined, KeymapBackend> key
     { {alt('l')}, {"select to line end", repeated<select<SelectMode::Replace, select_to_line_end<false>>>} },
     { {Key::End}, {"select to line end", repeated<select<SelectMode::Replace, select_to_line_end<false>>>} },
     { {alt('L')}, {"extend to line end", repeated<select<SelectMode::Extend, select_to_line_end<false>>>} },
+    { shift(Key::End), {"extend to line end", repeated<select<SelectMode::Extend, select_to_line_end<false>>>} },
     { {alt('h')}, {"select to line begin", repeated<select<SelectMode::Replace, select_to_line_begin<false>>>} },
     { {Key::Home}, {"select to line begin", repeated<select<SelectMode::Replace, select_to_line_begin<false>>>} },
     { {alt('H')}, {"extend to line begin", repeated<select<SelectMode::Extend, select_to_line_begin<false>>>} },
+    { shift(Key::Home), {"extend to line begin", repeated<select<SelectMode::Extend, select_to_line_begin<false>>>} },
 
     { {'x'}, {"select line", repeated<select<SelectMode::Replace, select_line>>} },
     { {'X'}, {"extend line", repeated<select<SelectMode::Extend, select_line>>} },


### PR DESCRIPTION
This branch teaches Kakoune that Shift is a possible modifier, including the `s-` prefix in key names. `<s-x>` in normalized to `<X>` when `x` is a lowercase ASCII character, but other printable characters (including aliases for printable characters like `lt`, `gt`, `plus` and `minus`) are disallowed because the behaviour of the shift modifier depends on the user's keyboard layout, which Kakoune cannot determine from inside a terminal.

Shifted keys that ncurses recognises are mapped to properly-modified keys so they can be mapped by users, and added to the default normal mappings where appropriate.

This still has some potential problems, but I don't think addressing them is practical:

  - It's possible to create a mapping for a key like `<c-s-a>`, but it cannot be triggered because terminals ignore the shift modifier for control keys
  - You can create a mapping for `<s-f11>`, but it cannot be triggered because there's no universal standard for what key-code ncurses will use for modified function keys
  - It is not universally true that applying the shift modifier to a lower-case ASCII letter will produce the corresponding uppercase ASCII letter (see [Dotted and dotless I](https://en.wikipedia.org/wiki/Dotted_and_dotless_I)), but Kakoune's default keymap already assumes this is the case for mnemonic reasons (`i` is insert, `I` is insert at the beginning of the line) so that ship has already sailed

This branch also includes a commit that teaches Kakoune to normalise `<s-tab>` to `<backtab>` in the same way that it normalises `<s-x>` to `<X>`. Backtab is [theoretically distinct](https://deskthority.net/wiki/Tab_key) from the tab key, but I bet it will be `<s-tab>` on every computer Kakoune is ever run on, and somebody wanting to bind it will probably guess `<s-tab>` before they guess `<backtab>`. However, I can imagine reasons not to do this, or not to do it this way, so I left it as a separate commit that can be left out if desired.