### PR TITLE
[RFC] src: Compare buffer contents before prompting for a reload

### DIFF
--- a/src/buffer.hh
+++ b/src/buffer.hh
@@ -138,6 +138,8 @@ public:
     size_t         timestamp() const;
     timespec       fs_timestamp() const;
     void           set_fs_timestamp(timespec ts);
+    size_t         get_file_hash() const;
+    ByteCount      get_file_size() const;
 
     void           commit_undo_group();
     bool           undo(size_t count = 1);
@@ -280,7 +282,13 @@ private:
 
     Vector<Change, MemoryDomain::BufferMeta> m_changes;
 
-    timespec m_fs_timestamp;
+    struct FsStatus
+    {
+        timespec timestamp;
+        ByteCount file_size;
+        size_t file_hash;
+    };
+    FsStatus m_fs_status;
 
     // Values are just data holding by the buffer, they are not part of its
     // observable state

--- a/src/buffer_utils.hh
+++ b/src/buffer_utils.hh
@@ -80,6 +80,8 @@ Buffer* open_file_buffer(StringView filename,
                          Buffer::Flags flags = Buffer::Flags::None);
 Buffer* open_or_create_file_buffer(StringView filename,
                                    Buffer::Flags flags = Buffer::Flags::None);
+
+bool buffer_needs_reload(Buffer& buffer, StringView path);
 void reload_file_buffer(Buffer& buffer);
 
 void write_to_debug_buffer(StringView str);

--- a/src/client.cc
+++ b/src/client.cc
@@ -350,7 +350,8 @@ void Client::check_if_buffer_needs_reloading()
 
     const String& filename = buffer.name();
     timespec ts = get_fs_timestamp(filename);
-    if (ts == InvalidTime or ts == buffer.fs_timestamp())
+    if (ts == InvalidTime or ts == buffer.fs_timestamp()
+        or not buffer_needs_reload(buffer, filename))
         return;
     if (reload == Autoreload::Ask)
     {


### PR DESCRIPTION
Hi,

It's sometimes annoying that the editor prompts for a buffer reload when the underlying file has been modified on the file system (e.g. saved or `touch`ed), but its contents haven't changed.

The CRC32 algorithm should be fast enough for hash computations, and collisions hopefully rare with text files.

HTH.