### PR TITLE
Give more hints in "option not found" error

### DIFF
--- a/src/option_manager.cc
+++ b/src/option_manager.cc
@@ -43,7 +43,7 @@ void OptionManager::unregister_watcher(OptionManagerWatcher& watcher) const
 struct option_not_found : public runtime_error
 {
     option_not_found(StringView name)
-        : runtime_error("option not found: " + name) {}
+        : runtime_error(format("option not found: '{}'. Use declare-option first", name)) {}
 };
 
 Option& OptionManager::get_local_option(StringView name)


### PR DESCRIPTION
IRC extract:
```
17:31:30 qyliss^work | Can I create a custom option? I get `option not found` when I try to set one that doesn't exist
17:31:35   Franciman | yes
17:31:39 qyliss^work | Oh, declare-option
17:31:41   Franciman | declare-option
17:31:48   Franciman | yep!
```

This may ease onboarding for future users struggling with the same issue.