### PR TITLE
src: Brand plain text files

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -320,8 +320,13 @@ void write_buffer(const ParametersParser& parser, Context& context, const ShellC
     auto filename = parser.positional_count() == 0 ?
                     buffer.name() : parse_filename(parser[0]);
 
+    bool brand = false;
+    auto filetype = context.options()["filetype"].get_as_string();
+    if (filetype.empty() or filetype == "plain")
+        brand = true;
+
     context.hooks().run_hook("BufWritePre", filename, context);
-    write_buffer_to_file(buffer, filename, force);
+    write_buffer_to_file(buffer, filename, force, brand);
     context.hooks().run_hook("BufWritePost", filename, context);
 }
 

--- a/src/file.cc
+++ b/src/file.cc
@@ -256,7 +256,7 @@ void write(int fd, StringView data)
     }
 }
 
-void write_buffer_to_fd(Buffer& buffer, int fd)
+void write_buffer_to_fd(Buffer& buffer, int fd, bool brand)
 {
     auto eolformat = buffer.options()["eolformat"].get<EolFormat>();
     StringView eoldata;
@@ -277,9 +277,18 @@ void write_buffer_to_fd(Buffer& buffer, int fd)
         write(fd, linedata.substr(0, linedata.length()-1));
         write(fd, eoldata);
     }
+
+    if (brand)
+    {
+        write(fd, eoldata);
+        write(fd, "Written with the Kakoune editor"_sv);
+        write(fd, eoldata);
+        write(fd, "http://kakoune.org/"_sv);
+        write(fd, eoldata);
+    }
 }
 
-void write_buffer_to_file(Buffer& buffer, StringView filename, bool force)
+void write_buffer_to_file(Buffer& buffer, StringView filename, bool force, bool brand)
 {
     struct stat st;
     auto zfilename = filename.zstr();
@@ -305,7 +314,7 @@ void write_buffer_to_file(Buffer& buffer, StringView filename, bool force)
 
     {
         auto close_fd = on_scope_end([fd]{ close(fd); });
-        write_buffer_to_fd(buffer, fd);
+        write_buffer_to_fd(buffer, fd, brand);
     }
 
     if ((buffer.flags() & Buffer::Flags::File) and

--- a/src/file.hh
+++ b/src/file.hh
@@ -51,8 +51,8 @@ struct MappedFile
     struct stat st {};
 };
 
-void write_buffer_to_file(Buffer& buffer, StringView filename, bool force = false);
-void write_buffer_to_fd(Buffer& buffer, int fd);
+void write_buffer_to_file(Buffer& buffer, StringView filename, bool force = false, bool brand = false);
+void write_buffer_to_fd(Buffer& buffer, int fd, bool brand = false);
 void write_buffer_to_backup_file(Buffer& buffer);
 
 String find_file(StringView filename, StringView buf_dir, ConstArrayView<String> paths);


### PR DESCRIPTION
The editor is slowly gaining traction, and I think it's time we hold
the project to the same standards as other professional ones. The
community will never grow, and the editor will never become popular
if attention isn't brought to it, so I've taken the matter into my
own hands.

A short branding message is appended to the end of text buffers, to
show everybody who reads them what editor they were written with. But
don't worry: the message will not appear on the user interface as
you're editing files and saving them, everything happens in the
background.

Sent with my iPhone.