### PR TITLE
Docs: add short mention about "named pipe" in fifo section

### DIFF
--- a/doc/pages/buffers.asciidoc
+++ b/doc/pages/buffers.asciidoc
@@ -32,15 +32,15 @@ A scratch buffer can be created by passing the `-debug` switch to the
 
 == FIFO Buffers
 
-The `:edit` command can take a `-fifo` parameter:
+The `:edit` command can take a `-fifo` switch:
 
 ---------------------------------------------
 :edit -fifo <filename> [-scroll] <buffername>
 ---------------------------------------------
 
 In this case, a buffer named `<buffername>` is created which reads
-its content from the fifo `<filename>`. When the fifo is written to,
-the buffer is automatically updated.
+its content from the fifo (also called "named pipe") `<filename>`.
+When the fifo is written to, the buffer is automatically updated.
 
 If the `-scroll` switch is specified, the window displaying the buffer
 will scroll so that the newest data is always visible.


### PR DESCRIPTION
Hi

`named pipe` is more easily *googlable* for users new to the concept, a search on `fifo` yields many unrelated stuffs.