### PR TITLE
Update README.asciidoc to mention FreeBSD

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -215,6 +215,18 @@ PREFIX=$HOME/.local make install
 ----------------------------------------------------------------
 ====
 
+[TIP]
+.FreeBSD
+====
+Kakoune is available in the official ports tree as
+https://www.freshports.org/editors/kakoune[editors/kakoune].
+
+A binary package is also available and can be installed with
+--------------------------------------------------
+pkg install kakoune
+--------------------------------------------------
+====
+
 Running
 ~~~~~~~
 


### PR DESCRIPTION
I've just committed a FreeBSD port of kakoune to the ports tree [1]. A binary package should also be available in the next couple of days.
It would be nice if it could be mentioned in the README.

Thank you :)

[1] https://www.freshports.org/editors/kakoune