### PR TITLE
Do not enable poking at ncurses internals.

### DIFF
--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -8,9 +8,6 @@
 
 #include <algorithm>
 
-#define NCURSES_OPAQUE 0
-#define NCURSES_INTERNALS
-
 #include <ncurses.h>
 
 #include <fcntl.h>


### PR DESCRIPTION
While browsing Kakoune's code, I noticed that before including ncurses' header, it defines macros to prevent ncurses from hiding internal implementation details. I removed those lines and Kakoune still builds and runs cleanly, so they don't appear to expose anything Kakoune truly needs.

The lines were introduced by a642026e7; previously Kakoune set ncurses' `ESCDELAY` by assigning directly to the global variable, that commit switched to using `set_escdelay()` instead. The `set_escdelay()` docs point out that this is an ncurses extension and so implementations should check whether `NCURSES_VERSION` is defined before using it, but since the file is literally called `ncurses_ui.cc` rather than `curses_ui.cc`, I'm guessing portability to other Curses implementations is not a high priority.