### PR TITLE
Adds openbsd support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -57,6 +57,10 @@ else ifeq ($(os),DragonFly)
     LIBS += -lncursesw
     CPPFLAGS += -I/usr/local/include
     LDFLAGS += -L/usr/local/lib
+else ifeq ($(os),OpenBSD)
+    LIBS += -lncursesw
+    CPPFLAGS += -I/usr/local/include
+    LDFLAGS += -L/usr/local/lib
 else ifneq (,$(findstring CYGWIN,$(os)))
     CPPFLAGS += -D_XOPEN_SOURCE=700
     LIBS += -lncursesw -ldbghelp

--- a/src/file.cc
+++ b/src/file.cc
@@ -22,9 +22,6 @@
 #if defined(__FreeBSD__)
 #include <sys/sysctl.h>
 #endif
-#if defined(__OpenBSD__)
-#include <sys/sysctl.h>
-#endif
 
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>

--- a/src/file.cc
+++ b/src/file.cc
@@ -22,6 +22,9 @@
 #if defined(__FreeBSD__)
 #include <sys/sysctl.h>
 #endif
+#if defined(__OpenBSD__)
+#include <sys/sysctl.h>
+#endif
 
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
@@ -571,6 +574,8 @@ String get_kak_binary_path()
     kak_assert(res != -1);
     buffer[res] = '\0';
     return buffer;
+#elif defined(__OpenBSD__)
+    return "/usr/local/bin/";
 #else
 # error "finding executable path is not implemented on this platform"
 #endif


### PR DESCRIPTION
Seems to work on openbsd 6.3-current but needs more testing. Had to
hardcode the binary path as openbsd considers getting the executable
path at runtime a security flaw. 

Closes #2004 