### PR TITLE
tmux version check fails on FreeBSD

### DIFF
--- a/rc/extra/tmux-repl.kak
+++ b/rc/extra/tmux-repl.kak
@@ -4,8 +4,8 @@
 hook global KakBegin .* %{
     %sh{
         if [ -n "$TMUX" ]; then
-            VERSION_TMUX=$(tmux -V)
-            VERSION_TMUX=$(expr "${VERSION_TMUX}" : 'tmux \([0-9]*\|master\)')
+            VERSION_TMUX=$(tmux -V | cut -d' ' -f2)
+            VERSION_TMUX=${VERSION_TMUX%%.*}
 
             if [ "${VERSION_TMUX}" = "master" ] \
                 || [ "${VERSION_TMUX}" -ge 2 ]; then


### PR DESCRIPTION
tmux-repl fails on FreeBSD and claims that tmux' version is too old
even though tmux 2.7 is installed.

The problem is that
```
expr "$(tmux -V)" : 'tmux \([0-9]*\|master\)'
```
fails on FreeBSD.  It works fine with GNU expr.

Attempt to fix it by expanding the expression a bit.
