### PR TITLE
Docs: fix docstrings in rc files `set-option` → `set`

### DIFF
--- a/rc/base/x11.kak
+++ b/rc/base/x11.kak
@@ -1,7 +1,7 @@
-# termcmd should be set-option such as the next argument is the whole
+# termcmd should be set such as the next argument is the whole
 # command line to execute
 declare-option -docstring %{shell command run to spawn a new terminal
-A shell command is appended to the one set-option in this option at runtime} \
+A shell command is appended to the one set in this option at runtime} \
     str termcmd %sh{
     for termcmd in 'alacritty      -e sh -c' \
                    'termite        -e      ' \
@@ -27,7 +27,7 @@ The optional arguments will be passed as arguments to the new client} \
     -command-completion \
     x11-new %{ %sh{
         if [ -z "${kak_opt_termcmd}" ]; then
-           echo "echo -markup '{Error}termcmd option is not set-option'"
+           echo "echo -markup '{Error}termcmd option is not set'"
            exit
         fi
         if [ $# -ne 0 ]; then kakoune_params="-e '$@'"; fi

--- a/rc/extra/editorconfig.kak
+++ b/rc/extra/editorconfig.kak
@@ -3,7 +3,7 @@
 
 declare-option -hidden bool editorconfig_trim_trailing_whitespace false
 
-define-command editorconfig-load -params ..1 -docstring "editorconfig-load [file]: set-option formatting behavior according to editorconfig" %{
+define-command editorconfig-load -params ..1 -docstring "editorconfig-load [file]: set formatting behavior according to editorconfig" %{
     remove-hooks buffer editorconfig-hooks
     %sh{
         command -v editorconfig >/dev/null 2>&1 || { echo 'echo -markup "{Error}editorconfig could not be found"'; exit 1; }

--- a/rc/extra/x11-repl.kak
+++ b/rc/extra/x11-repl.kak
@@ -1,11 +1,11 @@
-# termcmd should already be set-option in x11.kak
+# termcmd should already be set in x11.kak
 define-command -docstring %{x11-repl [<arguments>]: create a new window for repl interaction
 All optional parameters are forwarded to the new window} \
     -params .. \
     -command-completion \
     x11-repl %{ %sh{
         if [ -z "${kak_opt_termcmd}" ]; then
-           echo "echo -markup '{Error}termcmd option is not set-option'"
+           echo "echo -markup '{Error}termcmd option is not set'"
            exit
         fi
         if [ $# -eq 0 ]; then cmd="${SHELL:-sh}"; else cmd="$@"; fi


### PR DESCRIPTION
Hi

This extraneous conversions were introduced in https://github.com/mawww/kakoune/commit/c9b28