### PR TITLE
markdown.kak: backtick spans should be non-greedy.

### DIFF
--- a/rc/base/markdown.kak
+++ b/rc/base/markdown.kak
@@ -44,7 +44,7 @@ add-highlighter shared/markdown/content regex ^(#+)(\h+)([^\n]+) 1:header
 
 add-highlighter shared/markdown/content regex ^\h?((?:[\s\t]+)?[-\*])\h+[^\n]*(\n\h+[^-\*]\S+[^\n]*\n)*$ 0:list 1:bullet
 add-highlighter shared/markdown/content regex \B\+[^\n]+?\+\B 0:mono
-add-highlighter shared/markdown/content regex [^`](`([^\s*]|([^\s*](\n?[^\n*])*[^\s*]))`)[^`] 1:mono
+add-highlighter shared/markdown/content regex [^`](`([^\s`]|([^\s`](\n?[^\n`])*[^\s`]))`)[^`] 1:mono
 add-highlighter shared/markdown/content regex [^`](``([^\s`]|([^\s`](\n?[^\n`])*[^\s`]))``)[^`] 1:mono
 add-highlighter shared/markdown/content regex [^*](\*([^\s*]|([^\s*](\n?[^\n*])*[^\s*]))\*)[^*] 1:italic
 add-highlighter shared/markdown/content regex [^_](_([^\s_]|([^\s_](\n?[^\n_])*[^\s_]))_)[^_] 1:italic


### PR DESCRIPTION
Previously, due to a typo, Kakoune would highlight backtick spans from the first backtick to the last backtick in a paragraph, no matter how many backticks were in between. Now spans correctly stop at the first backtick after the opening backtick.