### PR TITLE
Add <c-f> in prompt mode to insert default value

### DIFF
--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -703,6 +703,9 @@ The following keys are recognized by this mode to help edition.
 *<c-v>*::
     insert next keystroke without interpreting it
 
+*<c-f>*::
+    insert the default value for this prompt
+
 *<c-o>*::
     disable auto completion for this prompt
 

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -896,6 +896,13 @@ public:
                 return;
             }
         }
+        else if (key == ctrl('f'))
+        {
+            m_line_editor.insert(m_empty_text);
+            display();
+            m_line_changed = true;
+            m_refresh_completion_pending = true;
+        }
         else
         {
             m_line_editor.handle_key(key);


### PR DESCRIPTION
I'd like to bind the right arrow to this if the prompt is empty (as would ironzorg). I think that could probably be implemented in an rc file, except that currently there's no way to access the value of the default value at all. This PR adds <c-f> to insert the default value in a prompt.