### PR TITLE
Solarized with termcolors

### DIFF
--- a/colors/solarized-dark-termcolors.kak
+++ b/colors/solarized-dark-termcolors.kak
@@ -1,0 +1,52 @@
+# Solarized Dark (with termcolors)
+# Useful if you've set up your terminal with the exact Solarized colors
+
+# code
+face global value              cyan
+face global type               yellow
+face global variable           blue
+face global module             cyan
+face global function           blue
+face global string             cyan
+face global keyword            green
+face global operator           green
+face global attribute          bright-magenta
+face global comment            bright-green
+face global meta               bright-red
+face global builtin            default+b
+
+# markup
+face global title              blue+b
+face global header             blue
+face global bold               bright-blue+b
+face global italic             bright-blue+i
+face global mono               bright-cyan
+face global block              cyan
+face global link               bright-cyan
+face global bullet             yellow
+face global list               green
+
+# builtin
+face global Default            bright-blue,bright-black
+face global PrimarySelection   bright-black,blue
+face global SecondarySelection bright-green,bright-cyan
+face global PrimaryCursor      bright-black,bright-blue
+face global SecondaryCursor    bright-black,bright-green
+face global PrimaryCursorEol   bright-black,white
+face global SecondaryCursorEol bright-black,bright-white
+face global LineNumbers        bright-green,black
+face global LineNumberCursor   bright-cyan,black
+face global LineNumbersWrapped black,black
+face global MenuForeground     bright-black,yellow
+face global MenuBackground     bright-cyan,black
+face global MenuInfo           bright-green
+face global Information        black,bright-cyan
+face global Error              red,default+b
+face global StatusLine         bright-cyan,black+b
+face global StatusLineMode     bright-red
+face global StatusLineInfo     cyan
+face global StatusLineValue    green
+face global StatusCursor       bright-yellow,bright-white
+face global Prompt             yellow+b
+face global MatchingChar       red,bright-green+b
+face global BufferPadding      bright-green,bright-black

--- a/colors/solarized-light-termcolors.kak
+++ b/colors/solarized-light-termcolors.kak
@@ -1,0 +1,52 @@
+# Solarized Light (with termcolors)
+# Useful if you've set up your terminal with the exact Solarized colors
+
+# code
+face global value              cyan
+face global type               yellow
+face global variable           blue
+face global module             cyan
+face global function           blue
+face global string             cyan
+face global keyword            green
+face global operator           green
+face global attribute          bright-magenta
+face global comment            bright-cyan
+face global meta               bright-red
+face global builtin            default+b
+
+# markup
+face global title              blue+b
+face global header             blue
+face global bold               bright-green+b
+face global italic             bright-green+i
+face global mono               bright-cyan
+face global block              cyan
+face global link               bright-green
+face global bullet             yellow
+face global list               green
+
+# builtin
+face global Default            bright-yellow,bright-white
+face global PrimarySelection   bright-white,blue
+face global SecondarySelection bright-cyan,bright-green
+face global PrimaryCursor      bright-white,bright-yellow
+face global SecondaryCursor    bright-white,bright-cyan
+face global PrimaryCursorEol   bright-white,yellow
+face global SecondaryCursorEol bright-white,bright-red
+face global LineNumbers        bright-cyan,white
+face global LineNumberCursor   bright-green,white
+face global LineNumbersWrapped white,white
+face global MenuForeground     bright-white,yellow
+face global MenuBackground     bright-green,white
+face global MenuInfo           bright-cyan
+face global Information        white,bright-cyan
+face global Error              red,default+b
+face global StatusLine         bright-green,white+b
+face global StatusLineMode     bright-red
+face global StatusLineInfo     cyan
+face global StatusLineValue    green
+face global StatusCursor       bright-blue,bright-black
+face global Prompt             yellow+b
+face global MatchingChar       red,white+b
+face global BufferPadding      bright-cyan,bright-white


### PR DESCRIPTION
If you use Terminal.app on a Mac and have it set up such that the termcolors match the Solarized color palette, issues #1259 and #1057 will prevent the existing Solarized colorschemes from playing nice. The best I could get is the weird off-colors shown in #1259.

However, this problem can be solved by using the termcolors for the Solarized colorschemes instead of RGB colors (see the bottom of the [Solarized Vim README](http://ethanschoonover.com/solarized/vim-colors-solarized)).

This pull request adds separate `solarized-dark-termcolors` and `solarized-light-termcolors` colorschemes for those that need them. If this would be better as a plugin instead of being in the default set of colorschemes, let me know!