### PR TITLE
Add TOML v4.0.0 config

### DIFF
--- a/rc/extra/toml.kak
+++ b/rc/extra/toml.kak
@@ -1,0 +1,72 @@
+# https://github.com/toml-lang/toml/tree/v0.4.0
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+# Detection
+# ‾‾‾‾‾‾‾‾‾
+
+hook global BufCreate .*\.(toml) %{
+    set-option buffer filetype toml
+}
+
+# Highlighters
+# ‾‾‾‾‾‾‾‾‾‾‾‾
+
+add-highlighter shared regions -default code toml \
+    comment '#'   $                 '' \
+    string  '"""' (?<!\\)(\\\\)*""" '' \
+    string  "'''" "'''"             '' \
+    string  '"'   (?<!\\)(\\\\)*"   '' \
+    string  "'"   "'"               ''
+
+add-highlighter shared/toml/comment fill comment
+add-highlighter shared/toml/string fill string
+
+add-highlighter shared/toml/code regex \
+    "^\h*\[\[?([A-Za-z0-9._-]*)\]\]?" 1:title
+add-highlighter shared/toml/code regex \
+    (?<!\w)[+-]?[0-9](_?\d)*(\.[0-9](_?\d)*)?([eE][+-]?[0-9](_?\d)*)?\b 0:value
+add-highlighter shared/toml/code regex \
+    true|false 0:value
+add-highlighter shared/toml/code regex \
+    '\d{4}-\d{2}-\d{2}[Tt ]\d{2}:\d{2}:\d{2}(.\d+)?([Zz]|[+-]\d{2}:\d{2})' 0:value
+
+# Commands
+# ‾‾‾‾‾‾‾‾
+
+define-command -hidden toml-filter-around-selections %{
+    # remove trailing white spaces
+    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
+}
+
+define-command -hidden toml-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
+        # copy comment prefix and following white spaces
+        try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
+        # preserve previous line indent
+        try %{ execute-keys -draft \; K <a-&> }
+        # filter previous line
+        try %{ execute-keys -draft k : toml-filter-around-selections <ret> }
+    }
+}
+
+# Initialization
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+hook -group toml-highlight global WinSetOption filetype=toml %{
+    add-highlighter window ref toml
+}
+
+hook global WinSetOption filetype=toml %{
+    hook window ModeChange insert:.* -group toml-hooks toml-filter-around-selections
+    hook window InsertChar \n -group toml-indent toml-indent-on-new-line
+}
+
+hook -group toml-highlight global WinSetOption filetype=(?!toml).* %{
+    remove-highlighter window/toml
+}
+
+hook global WinSetOption filetype=(?!toml).* %{
+    remove-hooks window toml-indent
+    remove-hooks window toml-hooks
+}
+


### PR DESCRIPTION
Fixes #2022.

The syntax highlighting is (necessarily, I think) approximate, but it should work for the most common cases:

![toml](https://user-images.githubusercontent.com/29521119/40145866-5dfbb872-595b-11e8-8e81-b413e3af96ee.png)