### PR TITLE
Give more hints in "command already defined" error about -allow-override switch.

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -861,7 +861,7 @@ void define_command(const ParametersParser& parser, Context& context, const Shel
         throw runtime_error(format("invalid command name: '{}'", cmd_name));
 
     if (cm.command_defined(cmd_name) and not parser.get_switch("allow-override"))
-        throw runtime_error(format("command '{}' already defined", cmd_name));
+        throw runtime_error(format("command '{}' already defined. Use the -allow-override switch to redefine it.", cmd_name));
 
     CommandFlags flags = CommandFlags::None;
     if (parser.get_switch("hidden"))


### PR DESCRIPTION
Hi.

I've been victim of a misinterpretation of the doc for a long time and judging from various messages on IRC, it appears to be recurrent among new users.

The confusion in my mind was that `-allow-override` had to be set on the original function, to let future redefinitions possible. But it's the other way around! Old definitions can be overriden if the new ones explicitely says they want to.

```
# wrong interpretation:
def -allow-override foo-command 'echo original'
def foo-command 'echo new def'

# right behavior:
def foo-command 'echo original'
def -allow-override foo-command 'echo new def'
```

PS: I remember a few people on IRC suggesting that renaming the switch to simply `-override` could potentially avoid the confusion. So it may be a better fix than this PR.

