### PR TITLE
Docs: regroup faces dealing with specific highlighters

### DIFF
--- a/doc/pages/faces.asciidoc
+++ b/doc/pages/faces.asciidoc
@@ -63,15 +63,6 @@ areas of the user interface:
 *SecondaryCursorEol*::
     cursor of the secondary selection when it lies on and end of line character
 
-*LineNumbers*::
-    face used by the number_lines highlighter
-
-*LineNumberCursor*::
-    face used to highlight the line number of the main selection
-
-*LineNumbersWrapped*::
-    face used to highlight the line number of wrapped lines
-
 *MenuForeground*::
     face for the selected element in menus
 
@@ -105,11 +96,25 @@ areas of the user interface:
 *Prompt*::
     face used prompt displayed on the status line
 
-*MatchingChar*::
-    face used by the show_matching highlighter
-
 *BufferPadding*::
     face applied on the characters that follow the last line of a buffer
 
+=== Builtin highlighters faces
+
+The following faces are used by builtin highlighters if enabled.
+(See <<highlighters#,`:doc highlighters`>>.
+
+*LineNumbers*::
+    face used by the `number_lines` highlighter
+
+*LineNumberCursor*::
+    face used to highlight the line number of the main selection
+
+*LineNumbersWrapped*::
+    face used to highlight the line number of wrapped lines
+
+*MatchingChar*::
+    face used by the `show_matching` highlighter
+
 *Whitespace*::
-    face used by the show_whitespaces highlighter
+    face used by the `show_whitespaces` highlighter

--- a/doc/pages/highlighters.asciidoc
+++ b/doc/pages/highlighters.asciidoc
@@ -50,7 +50,8 @@ existing highlighters ids.
         a one character long separator that will be appended to tabulations to honor the *tabstop* option
 
 *number_lines* [options]::
-    show line numbers, with the following *options*:
+    show line numbers using the `LineNumbers`, `LineNumberCursor` and `LineNumbersWrapped` faces,
+    with the following *options*: 
 
     *-relative*:::
         show line numbers relative to the main cursor line


### PR DESCRIPTION
Hi

This PR adds a more obvious link between `faces` <-> builtin `highlighters` to ease navigation between these two related topics.