### PR TITLE
Update Homebrew installation instructions

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -122,25 +122,10 @@ its source directory, type *make install*, you can specify the `PREFIX` and
 `DESTDIR` if needed.
 
 [TIP]
-.Homebrew (OSX)
+.Homebrew (macOS)
 ====
-NOTE: The ncurses library that comes with OSX is not new enough to support some
-mouse based features of Kakoune (only tested on OSX 10.11.3, where the
-packaged ncurses library is version 5.4, whereas the latest version is 6.0).
-Currently, a fresh Kakoune install requires that you install ncurses 6.0. You
-can install ncurses 6.0 via Homebrew,
---------------------
-brew install ncurses
---------------------
-
-Then, to install,
----------------------------------------------------------------------------------------------
-brew install --HEAD https://raw.githubusercontent.com/mawww/kakoune/master/contrib/kakoune.rb
----------------------------------------------------------------------------------------------
-
-To update kakoune,
 ---------------------------------
-brew upgrade --fetch-HEAD kakoune
+brew install kakoune
 ---------------------------------
 ====
 


### PR DESCRIPTION
I didn't remove the formula from contrib because it's still the only way to install on Linux, until Linuxbrew pulls from Homebrew and I can make a PR over there with the Linux stuff.