### PR TITLE
Remove make_current_error_line in clang.kak and lint.kak

### DIFF
--- a/rc/base/lint.kak
+++ b/rc/base/lint.kak
@@ -15,7 +15,6 @@ define-command lint -docstring 'Parse the current buffer with a linter' %{
         printf '%s\n' "evaluate-commands -draft %{
                   edit! -fifo $dir/fifo -debug *lint-output*
                   set-option buffer filetype make
-                  set-option buffer make_current_error_line 0
                   hook -always -group fifo buffer BufCloseFifo .* %{
                       nop %sh{ rm -r '$dir' }
                       remove-hooks buffer fifo

--- a/rc/extra/clang.kak
+++ b/rc/extra/clang.kak
@@ -23,7 +23,6 @@ The syntaxic errors detected during parsing are shown when auto-diagnostics are 
         printf %s\\n "evaluate-commands -draft %{
                   edit! -fifo ${dir}/fifo -debug *clang-output*
                   set-option buffer filetype make
-                  set-option buffer make_current_error_line 0
                   hook -always -group fifo buffer BufCloseFifo .* %{
                       nop %sh{ rm -r ${dir} }
                       remove-hooks buffer fifo


### PR DESCRIPTION
Hi

This option was probably introduced by a wrong copy-paste from `make.kak`.