### PR TITLE
docs: fix missing `]` in wrap hl -marker switch docstring

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -11,6 +11,8 @@ released versions.
 * The search prompt uses buffer word completion so that fuzzy completion
   can be used to quickly search for a buffer word.
 
+* The `wrap` highlighter can accept a new `-marker <marker_text>` switch.
+
 == Kakoune 2018.04.13
 
 First official Kakoune release.

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -2096,7 +2096,7 @@ void register_highlighters()
     registry.insert({
         "wrap",
         { WrapHighlighter::create,
-          "Parameters: [-word] [-indent] [-width <max_width>] [-marker <marker_text>\n"
+          "Parameters: [-word] [-indent] [-width <max_width>] [-marker <marker_text>]\n"
           "Wrap lines to window width, or max_width if given and window is wider,\n"
           "wrap at word boundaries instead of codepoint boundaries if -word is given\n"
           "insert marker_text at start of wrapped lines if given\n"


### PR DESCRIPTION
Also add the related changelog entry