### PR TITLE
tmux-send-text can take 1 parameter now.

### DIFF
--- a/rc/extra/tmux-repl.kak
+++ b/rc/extra/tmux-repl.kak
@@ -50,9 +50,15 @@ define-command tmux-repl-window -params 0..1 -command-completion -docstring "Cre
     tmux-repl-impl 'new-window' %arg{@}
 }
 
-define-command -hidden tmux-send-text -docstring "Send the selected text to the repl pane" %{
+define-command -hidden tmux-send-text -params 0..1 -docstring "Send the selected text to the repl pane if no parameter.
+  Otherwise send parameter with new line" %{
     nop %sh{
-        tmux set-buffer -b kak_selection "${kak_selection}"
+        if [ $# -eq 0 ]; then 
+            tmux set-buffer -b kak_selection "${kak_selection}"
+        else
+            tmux set-buffer -b kak_selection "$1
+"
+        fi
         kak_orig_window=$(tmux display-message -p '#I')
         kak_orig_pane=$(tmux display-message -p '#P')
         tmux select-window -t:$(tmux show-buffer -b kak_repl_window)

--- a/rc/extra/tmux-repl.kak
+++ b/rc/extra/tmux-repl.kak
@@ -50,8 +50,8 @@ define-command tmux-repl-window -params 0..1 -command-completion -docstring "Cre
     tmux-repl-impl 'new-window' %arg{@}
 }
 
-define-command -hidden tmux-send-text -params 0..1 -docstring "Send the selected text to the repl pane if no parameter.
-  Otherwise send parameter with new line" %{
+define-command -hidden tmux-send-text -params 0..1 -docstring "tmux-send-text [text]: Send text(append new line) to the REPL pane.
+  If no text is passed, then the selection is used" %{
     nop %sh{
         if [ $# -eq 0 ]; then 
             tmux set-buffer -b kak_selection "${kak_selection}"

--- a/rc/extra/tmux-repl.kak
+++ b/rc/extra/tmux-repl.kak
@@ -56,8 +56,7 @@ define-command -hidden tmux-send-text -params 0..1 -docstring "tmux-send-text [t
         if [ $# -eq 0 ]; then 
             tmux set-buffer -b kak_selection "${kak_selection}"
         else
-            tmux set-buffer -b kak_selection "$1
-"
+            tmux set-buffer -b kak_selection "$1"
         fi
         kak_orig_window=$(tmux display-message -p '#I')
         kak_orig_pane=$(tmux display-message -p '#P')


### PR DESCRIPTION
This is useful when send any text that is not even exists in current buffer. 
For example send string to reload current script: \l<space><c-r>%<ret>,
which can be then used to bind with convenient hotkey.
