### PR TITLE
Add support for regex flag to toggle dot-matches-newline

### DIFF
--- a/doc/pages/regex.asciidoc
+++ b/doc/pages/regex.asciidoc
@@ -156,7 +156,9 @@ Some modifiers can control the matching behavior of the atoms following
 them:
 
 * `(?i)` enables case-insensitive matching
-* `(?I)` disables case-insensitive matching
+* `(?I)` disables case-insensitive matching (default)
+* `(?s)` enables dot-matches-newline (default)
+* `(?S)` disables dot-matches-newline
 
 == Quoting
 


### PR DESCRIPTION
This used to be supported by boost regex with the `s` modifier as well. 

Using a character class for this seems like it could be expensive, maybe it's worth introducing an `Op` for this, or simply reusing the same `CharacterClass`?