### PR TITLE
Add BufReload hook which is triggered on buffer reload

### DIFF
--- a/doc/pages/hooks.asciidoc
+++ b/doc/pages/hooks.asciidoc
@@ -106,6 +106,10 @@ of the given *group*.
 *BufWritePost* `filename`::
     executed just after a buffer is written
 
+*BufReload* `filename`::
+    executed after a buffer reload has been triggered by an external
+    modification to its file
+
 *BufClose* `buffer name`::
     executed when a buffer is deleted, while it is still valid
 

--- a/src/client.cc
+++ b/src/client.cc
@@ -283,6 +283,8 @@ void Client::reload_buffer()
         reload_file_buffer(buffer);
         context().print_status({ format("'{}' reloaded", buffer.display_name()),
                                  context().faces()["Information"] });
+
+        m_window->hooks().run_hook("BufReload", buffer.name(), context());
     }
     catch (runtime_error& error)
     {

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -801,7 +801,7 @@ const CommandDesc remove_highlighter_cmd = {
 };
 
 static constexpr auto hooks = {
-    "BufCreate", "BufNewFile", "BufOpenFile", "BufClose", "BufWritePost",
+    "BufCreate", "BufNewFile", "BufOpenFile", "BufClose", "BufWritePost", "BufReload",
     "BufWritePre", "BufOpenFifo", "BufCloseFifo", "BufReadFifo", "BufSetOption",
     "InsertBegin", "InsertChar", "InsertDelete", "InsertEnd", "InsertIdle", "InsertKey",
     "InsertMove", "InsertCompletionHide", "InsertCompletionShow", "InsertCompletionSelect",


### PR DESCRIPTION
This feature is helpful for example when needing to refresh higlighters like `git show-diff` when an external process has changed a file.