### PR TITLE
Adding support for `kitty` terminal

### DIFF
--- a/rc/base/x11.kak
+++ b/rc/base/x11.kak
@@ -4,6 +4,7 @@ declare-option -docstring %{shell command run to spawn a new terminal
 A shell command is appended to the one set in this option at runtime} \
     str termcmd %sh{
     for termcmd in 'alacritty      -e sh -c' \
+                   'kitty             sh -c' \
                    'termite        -e      ' \
                    'urxvt          -e sh -c' \
                    'rxvt           -e sh -c' \


### PR DESCRIPTION
`kitty` is a modern terminal similar to `alacritty`, except with a cuter name and proper ligature support :grin: