### PR TITLE
Rebase/openbsd

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ else ifeq ($(os),Haiku)
     LIBS += -lncursesw -lnetwork -lbe
 else ifeq ($(os),OpenBSD)
     LIBS += -lncursesw
-    CPPFLAGS += -I/usr/local/include
+    CPPFLAGS += -D'KAK_BIN_PATH="$(bindir)/kak"' -I/usr/local/include
     LDFLAGS += -L/usr/local/lib
 else ifneq (,$(findstring CYGWIN,$(os)))
     CPPFLAGS += -D_XOPEN_SOURCE=700

--- a/src/Makefile
+++ b/src/Makefile
@@ -53,6 +53,10 @@ else ifeq ($(os),FreeBSD)
     LDFLAGS += -L/usr/local/lib
 else ifeq ($(os),Haiku)
     LIBS += -lncursesw -lnetwork -lbe
+else ifeq ($(os),OpenBSD)
+    LIBS += -lncursesw
+    CPPFLAGS += -I/usr/local/include
+    LDFLAGS += -L/usr/local/lib
 else ifneq (,$(findstring CYGWIN,$(os)))
     CPPFLAGS += -D_XOPEN_SOURCE=700
     LIBS += -lncursesw -ldbghelp

--- a/src/file.cc
+++ b/src/file.cc
@@ -573,7 +573,7 @@ String get_kak_binary_path()
     buffer[res] = '\0';
     return buffer;
 #elif defined(__OpenBSD__)
-    return "/usr/local/bin/";
+    return KAK_BIN_PATH;
 #else
 # error "finding executable path is not implemented on this platform"
 #endif

--- a/src/file.cc
+++ b/src/file.cc
@@ -23,6 +23,9 @@
 #if defined(__FreeBSD__)
 #include <sys/sysctl.h>
 #endif
+#if defined(__OpenBSD__)
+#include <sys/sysctl.h>
+#endif
 
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
@@ -572,6 +575,8 @@ String get_kak_binary_path()
     kak_assert(res != -1);
     buffer[res] = '\0';
     return buffer;
+#elif defined(__OpenBSD__)
+    return "/usr/local/bin/";
 #else
 # error "finding executable path is not implemented on this platform"
 #endif

--- a/src/file.cc
+++ b/src/file.cc
@@ -23,9 +23,6 @@
 #if defined(__FreeBSD__)
 #include <sys/sysctl.h>
 #endif
-#if defined(__OpenBSD__)
-#include <sys/sysctl.h>
-#endif
 
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>


### PR DESCRIPTION
Rebase of the pull request by Superpat #2005 with an alternative to hard coding the binary path. Instead, the path is passed in as a macro, by using the preprocessor option `-DKAK_BIN_PATH=$(bindir)/kak`.