### PR TITLE
Prevent the :format command from triggering hooks.

### DIFF
--- a/rc/core/formatter.kak
+++ b/rc/core/formatter.kak
@@ -1,7 +1,7 @@
 declare-option -docstring "shell command to which the contents of the current buffer is piped" \
     str formatcmd
 
-define-command format -docstring "Format the contents of the current buffer" %{ evaluate-commands -draft %{
+define-command format -docstring "Format the contents of the current buffer" %{ evaluate-commands -draft -no-hooks %{
     %sh{
         if [ -n "${kak_opt_formatcmd}" ]; then
             path_file_tmp=$(mktemp "${TMPDIR:-/tmp}"/kak-formatter-XXXXXX)


### PR DESCRIPTION
The :format command is often called from a BufWritePre hook to format the current buffer, however the :format command itself calls `:write` to store the buffer in a temporary location, potentially causing an infinite recursion.

If we disable hooks while running :format, there's no danger of that occurring.

I encountered this issue while trying to use `kak-lsp` with `:format`, but couldn't find a simplified test-case. However, in my experience this change removes the error *and* makes `:format` noticably faster to execute, so there's definitely something weird going on.