### PR TITLE
Explicitly discard unused variables in selectors.cc

### DIFF
--- a/src/selectors.cc
+++ b/src/selectors.cc
@@ -289,7 +289,7 @@ find_opening(Iterator pos, const Container& container,
     {
         if (nestable)
         {
-            for (auto m : RegexIt{match[0].second, pos, container.begin(), container.end(), closing})
+            for (auto m [[gnu::unused]] : RegexIt{match[0].second, pos, container.begin(), container.end(), closing})
                 ++level;
         }
 
@@ -317,7 +317,7 @@ find_closing(Iterator pos, const Container& container,
     {
         if (nestable)
         {
-            for (auto m : RegexIt{pos, match[0].first, container.begin(), container.end(), opening})
+            for (auto m [[gnu::unused]] : RegexIt{pos, match[0].first, container.begin(), container.end(), opening})
                 ++level;
         }
 


### PR DESCRIPTION
Using `clang++` on OpenBSD, the compiler emits warnings related to `selectors.cc` (see [selectors.log](https://github.com/mawww/kakoune/files/2122684/selectors.log)). These warnings disappear if the unused variables are explicitly recast to void.

Casting to void is suggested in [https://stackoverflow.com/a/34289000](https://stackoverflow.com/a/34289000) and [https://stackoverflow.com/a/17711748](https://stackoverflow.com/a/17711748)