### PR TITLE
Use egrep instead of grep for ERE

### DIFF
--- a/test/normal/keep-cmd/cmd
+++ b/test/normal/keep-cmd/cmd
@@ -1,1 +1,1 @@
-%<a-s>H$grep "foo\|bar"<ret>
+%<a-s>H$egrep "foo|bar"<ret>


### PR DESCRIPTION
Some implementations of grep (the OpenBSD one for instance) do not support extended regular expressions (ERE). Using egrep instead seems to be more portable.

closes #2136