### PR TITLE
rust.kak: lifetimes do not include the following non-word character.

### DIFF
--- a/rc/base/rust.kak
+++ b/rc/base/rust.kak
@@ -33,7 +33,7 @@ add-highlighter shared/rust/code regex \b(?:u8|u16|u32|u64|u128|usize|i8|i16|i32
 add-highlighter shared/rust/code regex \b(?:mod|crate|use|extern)\b 0:module
 add-highlighter shared/rust/code regex \$\w+\b 0:variable
 add-highlighter shared/rust/code regex "'\\\\?.'" 0:value
-add-highlighter shared/rust/code regex "'\w+[^']" 0:meta
+add-highlighter shared/rust/code regex "('\w+)[^']" 1:meta
 
 # Commands
 # ‾‾‾‾‾‾‾‾


### PR DESCRIPTION
A Rust data structure that is generic over a type conventionally uses a single capital letter for the type variable, like `Vec<T>` or `HashMap<K, V>`. A Rust data structure that is generic over a reference-lifetime conventionally uses an apostrophe followed by a single lower-case letter for the lifetime variable, like `Something<'a>`.

Previously, Kakoune would highlight "'a>" as the lifetime parameter; with this change Kakoune highlights "'a" and leaves the closing ">" alone.