### PR TITLE
Improve coloring of wrapped line numbers in gruvbox

### DIFF
--- a/colors/gruvbox.kak
+++ b/colors/gruvbox.kak
@@ -57,6 +57,7 @@
         face global SecondaryCursorEol ${bg},${fg4}
         face global LineNumbers        ${bg4}
         face global LineNumberCursor   ${yellow},${bg1}
+        face global LineNumbersWrapped ${bg}
         face global MenuForeground     ${bg2},${blue}
         face global MenuBackground     default,${bg2}
         face global MenuInfo           ${bg}

--- a/colors/gruvbox.kak
+++ b/colors/gruvbox.kak
@@ -57,7 +57,7 @@
         face global SecondaryCursorEol ${bg},${fg4}
         face global LineNumbers        ${bg4}
         face global LineNumberCursor   ${yellow},${bg1}
-        face global LineNumbersWrapped ${bg}
+        face global LineNumbersWrapped ${bg1}
         face global MenuForeground     ${bg2},${blue}
         face global MenuBackground     default,${bg2}
         face global MenuInfo           ${bg}


### PR DESCRIPTION
The default coloring of wrapped line numbers in gruvbox is simply too bright:

![image](https://user-images.githubusercontent.com/1177900/41812813-8eb248ae-772a-11e8-8f36-c23b7e2fe0e5.png)

I used the same pattern as in solarized-dark and made these numbers blend in the background:

![image](https://user-images.githubusercontent.com/1177900/41812816-9e1083f6-772a-11e8-8d1a-8ee68dc8cc9b.png)

In my mind, this is a much better default value to have.