### PR TITLE
Improve coloring of error messages in gruvbox

### DIFF
--- a/colors/gruvbox.kak
+++ b/colors/gruvbox.kak
@@ -61,7 +61,7 @@
         face global MenuBackground     default,${bg2}
         face global MenuInfo           ${bg}
         face global Information        ${bg},${fg}
-        face global Error              default,${red}
+        face global Error              ${bg},${red}
         face global StatusLine         default
         face global StatusLineMode     ${yellow}+b
         face global StatusLineInfo     ${purple}


### PR DESCRIPTION
White text on red background is not really readable:

![image](https://user-images.githubusercontent.com/1177900/41813622-ccfdc728-7739-11e8-88d5-c185c60a90f8.png)

With this change things are much better:

![image](https://user-images.githubusercontent.com/1177900/41813629-e62ad010-7739-11e8-9c7f-7f9ef5182e4d.png)
