### PR TITLE
Protect against buffer overflows and unchecked string truncations

### DIFF
--- a/src/backtrace.cc
+++ b/src/backtrace.cc
@@ -62,7 +62,8 @@ String Backtrace::desc() const
     {
         SymFromAddr(process, (DWORD64)stackframes[i], 0, symbol_info);
         char desc[276];
-        snprintf(desc, 276, "0x%0llx (%s)\n", symbol_info->Address, symbol_info->Name);
+        int result = snprintf(desc, sizeof(desc), "0x%0llx (%s)\n", symbol_info->Address, symbol_info->Name);
+        kak_assert(0 <= result && result < sizeof(desc));
         res += desc;
     }
     return res;

--- a/src/color.cc
+++ b/src/color.cc
@@ -65,7 +65,8 @@ String to_string(Color color)
     if (color.color == Color::RGB)
     {
         char buffer[11];
-        sprintf(buffer, "rgb:%02x%02x%02x", color.r, color.g, color.b);
+        int res = snprintf(buffer, sizeof(buffer), "rgb:%02x%02x%02x", color.r, color.g, color.b);
+        kak_assert(0 <= res && res < sizeof(buffer));
         return buffer;
     }
     else

--- a/src/file.cc
+++ b/src/file.cc
@@ -545,19 +545,21 @@ timespec get_fs_timestamp(StringView filename)
 
 String get_kak_binary_path()
 {
-    char buffer[2048];
 #if defined(__linux__) or defined(__CYGWIN__)
-    ssize_t res = readlink("/proc/self/exe", buffer, 2048);
+    char buffer[2048];
+    ssize_t res = readlink("/proc/self/exe", buffer, sizeof(buffer) - 1);
     kak_assert(res != -1);
     buffer[res] = '\0';
     return buffer;
 #elif defined(__FreeBSD__)
+    char buffer[2048];
     int mib[] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
     size_t res = sizeof(buffer);
     sysctl(mib, 4, buffer, &res, NULL, 0);
     return buffer;
 #elif defined(__APPLE__)
-    uint32_t bufsize = 2048;
+    char buffer[2048];
+    uint32_t bufsize = sizeof(buffer);
     _NSGetExecutablePath(buffer, &bufsize);
     char* canonical_path = realpath(buffer, nullptr);
     String path = canonical_path;
@@ -571,7 +573,8 @@ String get_kak_binary_path()
     BPath path(&info.ref);
     return path.Path();
 #elif defined(__DragonFly__)
-    ssize_t res = readlink("/proc/curproc/file", buffer, 2048);
+    char buffer[2048];
+    ssize_t res = readlink("/proc/curproc/file", buffer, sizeof(buffer) - 1);
     kak_assert(res != -1);
     buffer[res] = '\0';
     return buffer;

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -1085,7 +1085,8 @@ private:
             const int line_to_format = (m_relative and not is_cursor_line) ?
                                        current_line - main_line : current_line;
             char buffer[16];
-            snprintf(buffer, 16, format, std::abs(line_to_format));
+            int res = snprintf(buffer, sizeof(buffer), format, std::abs(line_to_format));
+            kak_assert(0 <= res && res < sizeof(buffer));
             const auto atom_face = last_line == current_line ? face_wrapped :
                 ((m_hl_cursor_line and is_cursor_line) ? face_absolute : face);
             line.insert(line.begin(), {buffer, atom_face});

--- a/src/json_ui.cc
+++ b/src/json_ui.cc
@@ -52,7 +52,10 @@ String to_json(StringView str)
 
         char buf[7] = {'\\', *next, 0};
         if (*next >= 0 and *next <= 0x1F)
-            sprintf(buf, "\\u%04x", *next);
+        {
+            int result = snprintf(buf, sizeof(buf), "\\u%04x", *next);
+            kak_assert(0 <= result && result < sizeof(buf));
+        }
 
         res += buf;
         it = next+1;
@@ -66,7 +69,8 @@ String to_json(Color color)
     if (color.color == Kakoune::Color::RGB)
     {
         char buffer[10];
-        sprintf(buffer, R"("#%02x%02x%02x")", color.r, color.g, color.b);
+        int res = snprintf(buffer, sizeof(buffer), R"("#%02x%02x%02x")", color.r, color.g, color.b);
+        kak_assert(0 <= res && res < sizeof(buffer));
         return buffer;
     }
     return to_json(to_string(color));

--- a/src/regex_impl.cc
+++ b/src/regex_impl.cc
@@ -1038,7 +1038,8 @@ String dump_regex(const CompiledRegex& program)
     for (auto& inst : program.instructions)
     {
         char buf[20];
-        sprintf(buf, " %03d     ", count++);
+        int result = snprintf(buf, sizeof(buf), " %03d     ", count++);
+        kak_assert(0 <= result && result < sizeof(buf));
         res += buf;
         switch (inst.op)
         {

--- a/src/string_utils.cc
+++ b/src/string_utils.cc
@@ -121,49 +121,63 @@ int str_to_int(StringView str)
 InplaceString<15> to_string(int val)
 {
     InplaceString<15> res;
-    res.m_length = sprintf(res.m_data, "%i", val);
+    int result = snprintf(res.m_data, res.m_length + 1, "%i", val);
+    kak_assert(0 <= result && result <= res.m_length);
+    res.m_length = result;
     return res;
 }
 
 InplaceString<15> to_string(unsigned val)
 {
     InplaceString<15> res;
-    res.m_length = sprintf(res.m_data, "%u", val);
+    int result = snprintf(res.m_data, res.m_length + 1, "%u", val);
+    kak_assert(0 <= result && result <= res.m_length);
+    res.m_length = result;
     return res;
 }
 
 InplaceString<23> to_string(long int val)
 {
     InplaceString<23> res;
-    res.m_length = sprintf(res.m_data, "%li", val);
+    int result = snprintf(res.m_data, res.m_length + 1, "%li", val);
+    kak_assert(0 <= result && result <= res.m_length);
+    res.m_length = result;
     return res;
 }
 
 InplaceString<23> to_string(long long int val)
 {
     InplaceString<23> res;
-    res.m_length = sprintf(res.m_data, "%lli", val);
+    int result = snprintf(res.m_data, res.m_length + 1, "%lli", val);
+    kak_assert(0 <= result && result <= res.m_length);
+    res.m_length = result;
     return res;
 }
 
 InplaceString<23> to_string(unsigned long val)
 {
     InplaceString<23> res;
-    res.m_length = sprintf(res.m_data, "%lu", val);
+    int result = snprintf(res.m_data, res.m_length + 1, "%lu", val);
+    kak_assert(0 <= result && result <= res.m_length);
+    res.m_length = result;
     return res;
 }
 
 InplaceString<23> to_string(Hex val)
 {
     InplaceString<23> res;
-    res.m_length = sprintf(res.m_data, "%zx", val.val);
+    int result = snprintf(res.m_data, res.m_length + 1, "%zx", val.val);
+    kak_assert(0 <= result && result <= res.m_length);
+    res.m_length = result;
     return res;
 }
 
 InplaceString<23> to_string(float val)
 {
     InplaceString<23> res;
-    res.m_length = sprintf(res.m_data, "%f", val);
+    int result = snprintf(res.m_data, res.m_length + 1, "%f", val);
+    kak_assert(0 <= result && result <= res.m_length);
+    res.m_length = result;
     return res;
 }
 

--- a/src/string_utils.hh
+++ b/src/string_utils.hh
@@ -78,7 +78,7 @@ struct InplaceString
     constexpr operator StringView() const { return {m_data, ByteCount{m_length}}; }
     operator String() const { return {m_data, ByteCount{m_length}}; }
 
-    unsigned char m_length;
+    unsigned char m_length = N - 1;
     char m_data[N];
 };
 


### PR DESCRIPTION
I went through calls to sprintf and readlink and did my best to rewrite them in ways protected against buffer overflows and unchecked string truncations.

- I replaced calls to sprintf by calls to snprintf and added a check to ensure that the operation succeeded and did not truncate the string. I followed the [secure idiom](https://www.freebsd.org/cgi/man.cgi?snprintf(3)) found on the FreeBSD man pages:

      snprintf(buffer, sizeof(buffer), "%s", string);

- I made sure to avoid that the terminating null character in calls to readlink would overflow the buffer, following [this page](https://wiki.sei.cmu.edu/confluence/display/c/POS30-C.+Use+the+readlink%28%29+function+properly). See also [https://stackoverflow.com/a/5525712/7599943](https://stackoverflow.com/a/5525712/7599943). 
