### PR TITLE
src: Make `!` re-evaluate the command for each selection

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -617,10 +617,26 @@ void insert_output(Context& context, NormalParams)
             if (cmdline.empty())
                 return;
 
-            auto str = ShellManager::instance().eval(
-                cmdline, context, {}, ShellManager::Flags::WaitForStdout).first;
             ScopedEdition edition(context);
-            context.selections().insert(str, mode);
+            Buffer& buffer = context.buffer();
+            auto& shell_manager = ShellManager::instance();
+            auto& selections = context.selections();
+            Vector<String> ins;
+            const size_t old_main = selections.main_index();
+
+            for (size_t i = 0; i < selections.size(); i++)
+            {
+                selections.set_main_index(i);
+
+                auto& sel = selections.main();
+                auto str = shell_manager.eval(cmdline, context, content(buffer, sel),
+                                       ShellManager::Flags::WaitForStdout).first;
+
+                ins.emplace_back(str);
+            }
+
+            selections.set_main_index(old_main);
+            selections.insert(ins, mode);
         });
 }
 


### PR DESCRIPTION
Fixes #2138 

Can't figure out why the `0-comment-after-command` test fails, it doesn't involve `!` and passes when I pass it directly to `run`.

Trace:

```
uncaught exception (N7Kakoune13assert_failedE):
assert failed "anchor.column < buffer[anchor.line].length()" at selection.cc:283
[Debug Infos]
pid: 25438
callstack:
kak(Kakoune::Backtrace::Backtrace()+0x2b) [0x56383afb3dbf]
kak(Kakoune::on_assert_failed(char const*)+0x33) [0x56383afb32f2]
kak(Kakoune::SelectionList::check_invariant() const+0x3e5) [0x56383b246f01]
kak(Kakoune::SelectionList::SelectionList(Kakoune::Buffer&, Kakoune::Selection, unsigned long)+0xe2) [0x56383b245032]
kak(Kakoune::SelectionList::SelectionList(Kakoune::Buffer&, Kakoune::Selection)+0x68) [0x56383b24511c]
kak(Kakoune::insert_output<(Kakoune::InsertMode)0>(Kakoune::Context&, Kakoune::NormalParams)::{lambda(Kakoune::StringView, Kakoune::PromptEvent, Kakoune::Context&)#1}::operator()(Kakoune::StringView, Kakoune::PromptEvent, Kakoune::Context&) const+0x46a) [0x56383b1bc050]
kak(std::_Function_handler<void (Kakoune::StringView, Kakoune::PromptEvent, Kakoune::Context&), Kakoune::insert_output<(Kakoune::InsertMode)0>(Kakoune::Context&, Kakoune::NormalParams)::{lambda(Kakoune::StringView, Kakoune::PromptEvent, Kakoune::Context&)#1}>::_M_invoke(std::_Any_data const&, Kakoune::StringView&&, Kakoune::PromptEvent&&, Kakoune::Context&)+0x6f) [0x56383b1efc5b]
kak(std::function<void (Kakoune::StringView, Kakoune::PromptEvent, Kakoune::Context&)>::operator()(Kakoune::StringView, Kakoune::PromptEvent, Kakoune::Context&) const+0x82) [0x56383b117cce]
kak(Kakoune::InputModes::Prompt::on_key(Kakoune::Key)+0x23c) [0x56383b10ef52]
kak(Kakoune::InputMode::handle_key(Kakoune::Key)+0x51) [0x56383b108c97]
kak(+0x52adeb) [0x56383b106deb]
kak(Kakoune::InputHandler::handle_key(Kakoune::Key)+0x203) [0x56383b106ff1]
kak(+0x441c40) [0x56383b01dc40]
kak(+0x44e52c) [0x56383b02a52c]
kak(+0x441ce2) [0x56383b01dce2]
kak(+0x441d26) [0x56383b01dd26]
```