### PR TITLE
Preserve whitespaces when uncommenting lines

### DIFF
--- a/rc/core/comment.kak
+++ b/rc/core/comment.kak
@@ -153,7 +153,7 @@ define-command comment-line -docstring '(un)comment selected lines using line co
 
             try %{
                 # Select the comment characters and remove them
-                set-register / "\A\Q%opt{comment_line}\E\h*"
+                set-register / "\A\Q%opt{comment_line}\E\h?"
                 execute-keys s<ret>d
             } catch %{
                 # Comment the line


### PR DESCRIPTION
Just like with #2069 we add a single whitespace after the comment character, when uncommenting we should also remove only a single whitespace at most, not all of them. You probably don't feel this pain because #2156 is not fixed yet, but I can't stand #2156 so I comment with block selection, and I want kakoune to support that way of commenting as well.

Example, try to uncomment this block:

```yaml
# abc:
#     def: ha
#     eg: bla
```

Expected:

```yaml
abc:
    def: ha
    eg: bla
```

Actual:

```yaml
abc:
def: ha
eg: bla
```