### PR TITLE
Support .properties extension, fix color of the equals sign

### DIFF
--- a/rc/base/ini.kak
+++ b/rc/base/ini.kak
@@ -1,4 +1,4 @@
-hook global BufCreate .*\.(repo|service|target|socket|ini|cfg) %{
+hook global BufCreate .*\.(repo|service|target|socket|ini|cfg|properties) %{
     set-option buffer filetype ini
 }
 
@@ -6,7 +6,7 @@ add-highlighter shared/ regions -default code ini \
     comment '(^|\h)\K[#;]' $ ''
 
 add-highlighter shared/ini/code regex "^\h*\[[^\]]*\]" 0:title
-add-highlighter shared/ini/code regex "^\h*([^\[][^=\n]*=)([^\n]*)" 1:variable 2:value
+add-highlighter shared/ini/code regex "^\h*([^\[][^=\n]*)=([^\n]*)" 1:variable 2:value
 
 add-highlighter shared/ini/comment fill comment
 


### PR DESCRIPTION
The equals sign was colored as part of the property name, but it shouldn't.

Before:

![image](https://user-images.githubusercontent.com/1177900/42002606-3a5dc800-7a68-11e8-881f-0202ad5964e9.png)


After:

![image](https://user-images.githubusercontent.com/1177900/42002587-24f4480e-7a68-11e8-8796-3cc3f2b328c4.png)
