### PR TITLE
Uncomment the selected lines only if all of them were commented

### DIFF
--- a/rc/core/comment.kak
+++ b/rc/core/comment.kak
@@ -150,15 +150,18 @@ define-command comment-line -docstring '(un)comment selected lines using line co
         try %{
             # Keep non-empty lines
             execute-keys <a-K>\A\s*\z<ret>
+            set-register / "\A\Q%opt{comment_line}\E\h?"
 
             try %{
-                # Select the comment characters and remove them
-                set-register / "\A\Q%opt{comment_line}\E\h*"
-                execute-keys s<ret>d
-            } catch %{
-                # Comment the line
+                # See if there are any uncommented lines in the selection
+                execute-keys -draft <a-K><ret>
+
+                # There are uncommented lines, so comment everything
                 set-register '"' "%opt{comment_line} "
                 execute-keys P
+            } catch %{
+                # All lines were commented, so uncomment everything
+                execute-keys s<ret>d
             }
         }
     }


### PR DESCRIPTION
Fixes #2161 

-----------

Suppose you have the following snippet:

```yaml
abc:
    # def: ha
    eg: bla
```

You want to comment it all, so you select everything with `%` and execute `comment-line` command.

Expected:

```yaml
# abc:
#     # def: ha
#     eg: bla
```

Actual:

```yaml
abc:
    def: ha
    eg: bla
```

**NOTE:** Because of #2156, the result of this PR doesn't exactly look as "Expected", but it is still better than what we have in `master`:

```yaml
# abc:
  # # def: ha
  # eg: bla
```