### PR TITLE
src: Fix cycle hogging when using `C` at EOF

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1395,7 +1395,7 @@ void copy_selections_on_next_lines(Context& context, NormalParams params)
 
             if (anchor_line < 0 or cursor_line < 0 or
                 anchor_line >= buffer.line_count() or cursor_line >= buffer.line_count())
-                continue;
+                break;
 
             const ByteCount anchor_byte = get_byte_to_column(buffer, tabstop, {anchor_line, anchor_col});
             const ByteCount cursor_byte = get_byte_to_column(buffer, tabstop, {cursor_line, cursor_col});


### PR DESCRIPTION
To reproduce the issue: open an empty buffer, then use `C` with a high count; the UI will freeze until the editor has iterated from 1 to the given count, doing nothing on each iteration.