### PR TITLE
src: Make `C` skip empty lines

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1386,9 +1386,11 @@ void copy_selections_on_next_lines(Context& context, NormalParams params)
             main_index = result.size();
         result.push_back(std::move(sel));
         const LineCount height = std::max(anchor.line, cursor.line) - std::min(anchor.line, cursor.line) + 1;
-        for (int i = 0; i < std::max(params.count, 1); ++i)
+        const size_t max_lines = std::max(params.count, 1);
+
+        for (size_t i = 0, nb_sels = 0; nb_sels < max_lines; ++i)
         {
-            LineCount offset =  direction * (i + 1) * height;
+            LineCount offset = direction * (i + 1) * height;
 
             const LineCount anchor_line = anchor.line + offset;
             const LineCount cursor_line = cursor.line + offset;
@@ -1407,6 +1409,8 @@ void copy_selections_on_next_lines(Context& context, NormalParams params)
                     main_index = result.size();
                 result.emplace_back(BufferCoord{anchor_line, anchor_byte},
                                     BufferCoordAndTarget{cursor_line, cursor_byte, cursor.target});
+
+                nb_sels++;
             }
         }
     }


### PR DESCRIPTION
This commits changes the way `C` behaves when the next line is empty:
instead of stopping the selection, it will now jump to the next line
that can hold a selection as big as the current one.

The primitive's count parameter holds the maximum amount of selections
that should be added to the current one.

Closes #2061