### PR TITLE
 rc: Clearify the behavior of multiplexers that create new clients

### DIFF
--- a/rc/base/screen.kak
+++ b/rc/base/screen.kak
@@ -12,7 +12,7 @@ hook -group GNUscreen global KakBegin .* %{
 }
 
 
-define-command screen-new-vertical -params .. -command-completion -docstring "Create a new vertical region" %{
+define-command screen-new-vertical -params .. -command-completion -docstring "Split the current pane into two, left and right" %{
      %sh{
         tty="$(ps -o tty ${kak_client_pid} | tail -n 1)"
         screen -X eval \
@@ -24,7 +24,7 @@ define-command screen-new-vertical -params .. -command-completion -docstring "Cr
     }
 }
 
-define-command screen-new-horizontal -params .. -command-completion -docstring "Create a new horizontal region" %{
+define-command screen-new-horizontal -params .. -command-completion -docstring "Split the current pane into two, top and bottom" %{
      %sh{
         tty="$(ps -o tty ${kak_client_pid} | tail -n 1)"
         screen -X eval \

--- a/rc/base/tmux.kak
+++ b/rc/base/tmux.kak
@@ -28,11 +28,11 @@ define-command -hidden -params 1.. tmux-new-impl %{
     }
 }
 
-define-command tmux-new-vertical -params .. -command-completion -docstring "Create a new vertical pane" %{
+define-command tmux-new-vertical -params .. -command-completion -docstring "Split the current pane into two, top and bottom" %{
     tmux-new-impl 'split-window -v' %arg{@}
 }
 
-define-command tmux-new-horizontal -params .. -command-completion -docstring "Create a new horizontal pane" %{
+define-command tmux-new-horizontal -params .. -command-completion -docstring "Split the current pane into two, left and right" %{
     tmux-new-impl 'split-window -h' %arg{@}
 }
 

--- a/rc/extra/iterm.kak
+++ b/rc/extra/iterm.kak
@@ -5,7 +5,7 @@
 ## an iTerm session if not in a tmux session.
 hook global KakBegin .* %{
     %sh{
-        if [ "$TERM_PROGRAM" = "iTerm.app" -a -z "$TMUX" ]; then
+        if [ "$TERM_PROGRAM" = "iTerm.app" ] && [ -z "$TMUX" ]; then
             echo "
                 alias global new iterm-new-vertical
                 alias global focus iterm-focus
@@ -18,8 +18,8 @@ define-command -hidden -params 1.. iterm-new-split-impl %{
     %sh{
         direction="$1"
         shift
-        if [ $# -gt 0 ]; then kakoune_params="-e \\\"$@\\\""; fi
-        cmd="env -P ${PATH} TMPDIR=${TMPDIR} kak -c ${kak_session} ${kakoune_params}"
+        if [ $# -gt 0 ]; then kakoune_params="-e \\\"$*\\\""; fi
+        cmd="env PATH='${PATH}' TMPDIR='${TMPDIR}' kak -c '${kak_session}' ${kakoune_params}"
         osascript                                                                             \
         -e "tell application \"iTerm\""                                                       \
         -e "    tell current session of current window"                                       \
@@ -42,8 +42,8 @@ define-command -params .. -command-completion \
 All optional arguments are forwarded to the new kak client} \
     iterm-new-tab %{
     %sh{
-        if [ $# -gt 0 ]; then kakoune_params="-e \\\"$@\\\""; fi
-        cmd="env -P ${PATH} TMPDIR=${TMPDIR} kak -c ${kak_session} ${kakoune_params}"
+        if [ $# -gt 0 ]; then kakoune_params="-e \\\"$*\\\""; fi
+        cmd="env PATH='${PATH}' TMPDIR='${TMPDIR}' kak -c '${kak_session}' ${kakoune_params}"
         osascript                                                       \
         -e "tell application \"iTerm\""                                 \
         -e "    tell current window"                                    \
@@ -58,8 +58,8 @@ define-command -params .. -command-completion \
 All optional arguments are forwarded to the new kak client} \
     iterm-new-window %{
     %sh{
-        if [ $# -gt 0 ]; then kakoune_params="-e \\\"$@\\\""; fi
-        cmd="env -P ${PATH} TMPDIR=${TMPDIR} kak -c ${kak_session} ${kakoune_params}"
+        if [ $# -gt 0 ]; then kakoune_params="-e \\\"$*\\\""; fi
+        cmd="env PATH='${PATH}' TMPDIR='${TMPDIR}' kak -c '${kak_session}' ${kakoune_params}"
         osascript                                                      \
         -e "tell application \"iTerm\""                                \
         -e "    create window with default profile command \"${cmd}\"" \

--- a/rc/extra/iterm.kak
+++ b/rc/extra/iterm.kak
@@ -29,11 +29,11 @@ define-command -hidden -params 1.. iterm-new-split-impl %{
     }
 }
 
-define-command iterm-new-vertical -params .. -command-completion -docstring "Create a new vertical pane" %{
+define-command iterm-new-vertical -params .. -command-completion -docstring "Split the current pane into two, top and bottom" %{
     iterm-new-split-impl 'vertically' %arg{@}
 }
 
-define-command iterm-new-horizontal -params .. -command-completion -docstring "Create a new horizontal pane" %{
+define-command iterm-new-horizontal -params .. -command-completion -docstring "Split the current pane into two, left and right" %{
     iterm-new-split-impl 'horizontally' %arg{@}
 }
 


### PR DESCRIPTION
Note: `GNU/screen` has a different interpretation of what constitutes
a "vertical split", hence the inverted command descriptions, compared
to the tmux/iterm etc.

Closes #1626 

Also threw in a commit that fixes minor things in `iterm.kak`.