### PR TITLE
Improve git gutter

### DIFF
--- a/rc/extra/git-tools.kak
+++ b/rc/extra/git-tools.kak
@@ -97,7 +97,7 @@ Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-
     }
 
     update_diff() {
-        git --no-pager diff -U0 $kak_buffile | perl -e '
+        git --no-pager diff -U0 "$kak_buffile" 2>/dev/null | perl -e '
             $flags = $ENV{"kak_timestamp"};
             foreach $line (<STDIN>) {
                 if ($line =~ /@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))?/) {


### PR DESCRIPTION
The current git gutter is quite primitive and doesn't account for many cases, it produces weird result with relatively complicated diffs, tries to mark the same line with different icons and doesn't account for modified lines (#129).

This code is heavily inspired by https://github.com/airblade/vim-gitgutter, but rewritten from scratch in a way that shouldn't introduce any licensing issues for you.

Besides showing modified lines, it also uses `_` and `‾` instead of `-` to better display the position of deleted lines, and it can show the lines with deletions and modifications in the same place (using `~_`).

![image](https://user-images.githubusercontent.com/1177900/42129980-1bd16184-7cd5-11e8-9148-c0811af7477b.png)

Before:

![image](https://user-images.githubusercontent.com/1177900/42129988-5d8ebefa-7cd5-11e8-8c74-b1b6266c7131.png)

`update-diff` generates:

```
set-option buffer git_diff_flags  :0|{red}-:0|{green}+:0|{red}-:2|{red}-:2|{green}+:4|{red}-:4|{red}-:4|{green}+:7|{green}+:8|{red}-
```

After:

![image](https://user-images.githubusercontent.com/1177900/42129984-3cbababc-7cd5-11e8-8fc3-bcd2517499ae.png)

`update-diff` generates:

```
set-option buffer git_diff_flags :1|{red}‾:2|{blue}~:4|{blue}~_:7|{green}+:8|{red}-
```

Fixes #129 