### PR TITLE
Improve kakoune startup time by 33%

### DIFF
--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -28,7 +28,7 @@ def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
 evaluate-commands %sh{
     autoload_directory() {
         find -L "$1" -type f -name '*\.kak' \
-            -exec printf 'try %%{ source "%s" } catch %%{ echo -debug Autoload: could not load "%s" }\n' '{}' '{}' \;
+            | sed 's/.*/try %{ source "&" } catch %{ echo -debug Autoload: could not load "&" }/'
     }
 
     echo "colorscheme default"


### PR DESCRIPTION
Before:

```
❯ time (repeat 300 kak -e 'quit')
115.89s user 48.61s system 108% cpu **2:31.93 total**
```

After:

```
❯ time (repeat 300 kak -e 'quit')
82.50s user 31.23s system 111% cpu **1:42.31 total**
```

Related to #2152, but not good enough to close it just yet.

**Can anyone test this on Mac?**