### PR TITLE
Fix python indent for lines ending with colon

### DIFF
--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -128,7 +128,7 @@ define-command -hidden python-indent-on-new-line %{
         # cleanup trailing whitespaces from previous line
         try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
         # indent after line ending with :
-        try %{ execute-keys -draft <space> k x <a-k> :$ <ret> j <a-gt> }
+        try %{ execute-keys -draft <space> k <a-x> <a-k> :$ <ret> j <a-gt> }
     }
 }
 


### PR DESCRIPTION
The fix proposed in https://github.com/mawww/kakoune/issues/2112#issuecomment-395949821 works, I checked, let's merge it.

Fixes #2112.