### PR TITLE
Mention autoinfo for normal mode in TRAMPOLINE

### DIFF
--- a/contrib/TRAMPOLINE
+++ b/contrib/TRAMPOLINE
@@ -13,6 +13,9 @@ This walk-through is an introduction to Kakoune's basic editing capabilities
 to help new users transition over easily from another editor, or simply
 learn how to write and edit documents with style.
 
+During the learning period it is useful to activate an automatically displayed
+contextual help for commands in normal mode: `:set -add global autoinfo normal`
+
 In the first section, you will learn about the primitives of the editing
 language to be able to get to a level of knowledge of the editor that
 guarantees that you can work with it efficiently.


### PR DESCRIPTION
I learned about this option when reading [Why kakoune](http://kakoune.org/why-kakoune/why-kakoune.html) and asking for details on IRC, but I think this is so useful during the learning period that it must be mentioned in TRAMPOLINE.