### PR TITLE
Added an option for vertical menu layout

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -389,6 +389,7 @@ void register_options()
                        "The ncurses ui supports the following options:\n"
                        "    <key>:                        <value>:\n"
                        "    ncurses_assistant             clippy|cat|dilbert|none|off\n"
+                       "    ncurses_menu_layout           horizontal|vertical\n"
                        "    ncurses_status_on_top         bool\n"
                        "    ncurses_set_title             bool\n"
                        "    ncurses_enable_mouse          bool\n"

--- a/src/ncurses_ui.hh
+++ b/src/ncurses_ui.hh
@@ -147,6 +147,8 @@ private:
     bool m_set_title = true;
     bool m_change_colors = true;
 
+    bool m_menu_vertical = false;
+
     bool m_dirty = false;
 
     bool m_resize_pending = false;


### PR DESCRIPTION
Added the ability to have menus in the ncurses ui laid out alphabetically in vertical columns. Also added an option to manage the layout with `ncurses_menu_layout` in `ui_options`.
Based on the request by #2199