### PR TITLE
Add a new hook InsertCharPre

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -803,7 +803,7 @@ const CommandDesc remove_highlighter_cmd = {
 static constexpr auto hooks = {
     "BufCreate", "BufNewFile", "BufOpenFile", "BufClose", "BufWritePost",
     "BufWritePre", "BufOpenFifo", "BufCloseFifo", "BufReadFifo", "BufSetOption",
-    "InsertBegin", "InsertChar", "InsertDelete", "InsertEnd", "InsertIdle", "InsertKey",
+    "InsertBegin", "InsertCharPre", "InsertChar", "InsertDelete", "InsertEnd", "InsertIdle", "InsertKey",
     "InsertMove", "InsertCompletionHide", "InsertCompletionShow", "InsertCompletionSelect",
     "KakBegin", "KakEnd", "FocusIn", "FocusOut", "GlobalSetOption", "RuntimeError", "PromptIdle",
     "NormalBegin", "NormalEnd", "NormalIdle", "NormalKey", "ModeChange", "RawKey",

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1354,6 +1354,7 @@ private:
     void insert(Codepoint key)
     {
         String str{key};
+        context().hooks().run_hook("InsertCharPre", str, context());
         context().selections().insert(str, InsertMode::InsertCursor);
         context().hooks().run_hook("InsertChar", str, context());
     }
@@ -1389,6 +1390,7 @@ private:
             Vector<Selection> new_sels;
             count = count > 0 ? count : 1;
             LineCount inserted_count = 0;
+            context().hooks().run_hook("InsertCharPre", "\n", context());
             for (auto sel : selections)
             {
                 buffer.insert(sel.max().line + inserted_count + 1,
@@ -1407,6 +1409,7 @@ private:
             Vector<Selection> new_sels;
             count = count > 0 ? count : 1;
             LineCount inserted_count = 0;
+            context().hooks().run_hook("InsertCharPre", "\n", context());
             for (auto sel : selections)
             {
                 buffer.insert(sel.min().line + inserted_count,


### PR DESCRIPTION
This hook is the same as InsertChar, except it's triggered
right before the character is inserted.

Rational: plugins might want the cursor position right before the character is inserted (In my case, I want to save the cursor position when the buffer is unmodified, so I can restore it after closing kakoune). This is non-trivial to work out in the InsertChar hook.