### PR TITLE
src: Rename `auto_complete` to `autocomplete`

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -78,7 +78,7 @@ change to make Kakoune command model cleaner and more robust.
   inserting on the next character, which will be the first character
   of the next line.
 
-- `autoshowcompl` options has been renames `auto_complete` and is
+- `autoshowcompl` options has been renamed `auto_complete` and is
   now a `flags(insert|prompt)` option, allowing more granular
   configuration of when the completions should be displayed
   automatically.

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -716,7 +716,7 @@ public:
         : InputMode(input_handler), m_prompt(prompt.str()), m_prompt_face(face),
           m_empty_text{std::move(emptystr)},
           m_flags(flags), m_completer(std::move(completer)), m_callback(std::move(callback)),
-          m_auto_complete{context().options()["auto_complete"].get<AutoComplete>() & AutoComplete::Prompt},
+          m_auto_complete{context().options()["autocomplete"].get<AutoComplete>() & AutoComplete::Prompt},
           m_idle_timer{TimePoint::max(), context().flags() & Context::Flags::Draft ?
                            Timer::Callback{} : [this](Timer&) {
                            if (m_auto_complete and m_refresh_completion_pending)
@@ -1092,7 +1092,7 @@ public:
           m_restore_cursor(mode == InsertMode::Append),
           m_edition(context()),
           m_completer(context()),
-          m_auto_complete{context().options()["auto_complete"].get<AutoComplete>() & AutoComplete::Insert},
+          m_auto_complete{context().options()["autocomplete"].get<AutoComplete>() & AutoComplete::Insert},
           m_disable_hooks{context().hooks_disabled(), context().hooks_disabled()},
           m_idle_timer{TimePoint::max(), context().flags() & Context::Flags::Draft ?
                        Timer::Callback{} : [this](Timer&) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -350,7 +350,7 @@ void register_options()
     reg.declare_option("autoinfo",
                        "automatically display contextual help",
                        AutoInfo::Command | AutoInfo::OnKey);
-    reg.declare_option("auto_complete",
+    reg.declare_option("autocomplete",
                        "automatically display possible completions",
                        AutoComplete::Insert | AutoComplete::Prompt);
     reg.declare_option("aligntab",

--- a/test/run
+++ b/test/run
@@ -9,7 +9,7 @@ main() {
   kak_commands='
         set global autoreload yes
         set global autoinfo ""
-        set global auto_complete ""
+        set global autocomplete ""
         try %{
             exec -save-regs / %{%s%\(\K[^)]+\)<ret>a<backspace><esc>i<backspace><backspace><c-u><esc><a-;>}
         } catch %{ exec gg }


### PR DESCRIPTION
Removing the underscore seems to make the option name more
in line with the others (even though some do use a separator,
e.g. `disabled_hooks`).