### PR TITLE
Add g++ as new build dependency

### DIFF
--- a/contrib/kakoune.spec
+++ b/contrib/kakoune.spec
@@ -9,6 +9,7 @@ Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  ncurses-devel >= 5.3
 BuildRequires:  asciidoc
+BuildRequires:  gcc-c++
 Requires:       ncurses-libs >= 5.3
 
 %description


### PR DESCRIPTION
From Fedora 29 the gcc package is not part of the buildroot environment.