### PR TITLE
Cosmetic changes to the version notes

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -40,10 +40,10 @@ namespace Kakoune
 extern const char* version;
 
 struct {
-    int version;
+    unsigned int version;
     const char* notes;
 } constexpr version_notes[] = { {
-        99999999,
+        0,
         "• Big breaking refactoring of various Kakoune features,\n"
         "  configuration might need to be updated see `:doc changelog` for details\n"
         "• define-command -allow-override switch has been renamed -override\n"
@@ -66,7 +66,9 @@ void show_startup_info(Client* local_client, int last_version)
     String info;
     for (auto note : version_notes)
     {
-        if (note.version > last_version)
+        if (not note.version)
+            info += format("● Development version\n{}\n", note.notes);
+        else if (note.version > last_version)
         {
             const auto year = note.version / 10000;
             const auto month = (note.version / 100) % 100;

--- a/src/main.cc
+++ b/src/main.cc
@@ -44,21 +44,21 @@ struct {
     const char* notes;
 } constexpr version_notes[] = { {
         0,
-        "• Big breaking refactoring of various Kakoune features,\n"
+        "» Big breaking refactoring of various Kakoune features,\n"
         "  configuration might need to be updated see `:doc changelog` for details\n"
-        "• define-command -allow-override switch has been renamed -override\n"
+        "» define-command -allow-override switch has been renamed -override\n"
     }, {
         20180413,
-        "• ModeChange hook has been introduced and is expected to replace\n"
+        "» ModeChange hook has been introduced and is expected to replace\n"
         "  the various ${MODE}Begin/${MODE}End hooks, consider those deprecated.\n"
-        "• '*' Does not strip whitespaces anymore, use built-in '_' to strip them\n"
-        "• 'l' on eol will go to next line, 'h' on first char will go to previous\n"
-        "• selections merging behaviour is now a bit more complex again\n"
-        "• 'x' will only jump to next line if full line is already selected\n"
-        "• WORD text object moved to <a-w> instead of W for consistency\n"
-        "• rotate main selection moved to ), rotate content to <a-)>, ( for backward\n"
-        "• faces are now scoped, set-face command takes an additional scope parameter\n"
-        "• <backtab> key is gone, use <s-tab> instead\n"
+        "» '*' Does not strip whitespaces anymore, use built-in '_' to strip them\n"
+        "» 'l' on eol will go to next line, 'h' on first char will go to previous\n"
+        "» selections merging behaviour is now a bit more complex again\n"
+        "» 'x' will only jump to next line if full line is already selected\n"
+        "» WORD text object moved to <a-w> instead of W for consistency\n"
+        "» rotate main selection moved to ), rotate content to <a-)>, ( for backward\n"
+        "» faces are now scoped, set-face command takes an additional scope parameter\n"
+        "» <backtab> key is gone, use <s-tab> instead\n"
 } };
 
 void show_startup_info(Client* local_client, int last_version)
@@ -67,13 +67,13 @@ void show_startup_info(Client* local_client, int last_version)
     for (auto note : version_notes)
     {
         if (not note.version)
-            info += format("● Development version\n{}\n", note.notes);
+            info += format("• Development version\n{}\n", note.notes);
         else if (note.version > last_version)
         {
             const auto year = note.version / 10000;
             const auto month = (note.version / 100) % 100;
             const auto day = note.version % 100;
-            info += format("● Kakoune v{}.{}{}.{}{}\n{}\n",
+            info += format("• Kakoune v{}.{}{}.{}{}\n{}\n",
                            year, month < 10 ? "0" : "", month, day < 10 ? "0" : "", day, note.notes);
         }
     }


### PR DESCRIPTION
Hi,

I didn't like having a dummy number (99999) set for the development version, so I made it so the version changelog says plainly "Development version".

I also changed the round bullet points to double brackets, I think it looks neater (suggestions of other symbols to use welcome!).

![](https://my.mixtape.moe/dkijyk.png)