### PR TITLE
Make ncurses title configurable

### DIFF
--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -260,8 +260,10 @@ are exclusively available to built-in options.
     interface implementation. The NCurses UI support the following options:
 
         *ncurses_set_title*:::
-            if *yes* or *true*, the terminal emulator title will
-            be changed
+            if not set to *no* or *false*, the terminal emulator
+            title will be changed. if set to *yes* or *true*, the
+            default title line will be used, otherwise the value
+            of this option will be used as the title line
 
         *ncurses_status_on_top*:::
             if *yes*, or *true* the status line will be placed

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -458,7 +458,7 @@ void NCursesUI::draw_status(const DisplayLine& status_line,
     {
         char buf[4 + 511 + 2] = "\033]2;";
         auto buf_it = &buf[4];
-        if (m_title_line != "")
+        if (not m_title_line.empty())
         {
             auto buf_end = &buf[511 + 1];
             for (auto ch: m_title_line)

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -463,7 +463,7 @@ void NCursesUI::draw_status(const DisplayLine& status_line,
             auto buf_end = &buf[511 + 1];
             for (auto ch: m_title_line)
             {
-                if (buf_it == buf_end)
+                if (buf_it + 1 == buf_end)
                     break;
                 *buf_it++ = ch;
             }

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -456,19 +456,34 @@ void NCursesUI::draw_status(const DisplayLine& status_line,
 
     if (m_set_title)
     {
-        constexpr char suffix[] = " - Kakoune\007";
         char buf[4 + 511 + 2] = "\033]2;";
-        // Fill title escape sequence buffer, removing non ascii characters
-        auto buf_it = &buf[4], buf_end = &buf[4 + 511 - (sizeof(suffix) - 2)];
-        for (auto& atom : mode_line)
+        auto buf_it = &buf[4];
+        if (m_title_line != "")
         {
-            const auto str = atom.content();
-            for (auto it = str.begin(), end = str.end();
-                 it != end and buf_it != buf_end; utf8::to_next(it, end))
-                *buf_it++ = (*it >= 0x20 and *it <= 0x7e) ? *it : '?';
+            auto buf_end = &buf[511 + 1];
+            for (auto ch: m_title_line)
+            {
+                if (buf_it == buf_end)
+                    break;
+                *buf_it++ = ch;
+            }
+            *buf_it = '\007';
         }
-        for (auto c : suffix)
-            *buf_it++ = c;
+        else
+        {
+            constexpr char suffix[] = " - Kakoune\007";
+            // Fill title escape sequence buffer, removing non ascii characters
+            auto buf_it = &buf[4], buf_end = &buf[4 + 511 - (sizeof(suffix) - 2)];
+            for (auto& atom : mode_line)
+            {
+                const auto str = atom.content();
+                for (auto it = str.begin(), end = str.end();
+                     it != end and buf_it != buf_end; utf8::to_next(it, end))
+                    *buf_it++ = (*it >= 0x20 and *it <= 0x7e) ? *it : '?';
+            }
+            for (auto c : suffix)
+                *buf_it++ = c;
+        }
 
         fputs(buf, stdout);
         fflush(stdout);
@@ -1186,7 +1201,12 @@ void NCursesUI::set_ui_options(const Options& options)
     {
         auto it = options.find("ncurses_set_title"_sv);
         m_set_title = it == options.end() or
-            (it->value == "yes" or it->value == "true");
+            (it->value != "no" and it->value != "false");
+        if (m_set_title and it != options.end() and
+            it->value != "yes" and it->value != "true")
+            m_title_line = it->value;
+        else
+            m_title_line = "";
     }
 
     {

--- a/src/ncurses_ui.hh
+++ b/src/ncurses_ui.hh
@@ -145,6 +145,7 @@ private:
     int m_shift_function_key = default_shift_function_key;
 
     bool m_set_title = true;
+    String m_title_line;
     bool m_change_colors = true;
 
     bool m_dirty = false;


### PR DESCRIPTION
When ncurses_set_title is set to a string other than "yes" and "true", it will be used to set the title line. This give the user the ability to configure the title line.