### PR TITLE
Fix spell.kak

### DIFF
--- a/rc/base/mercurial.kak
+++ b/rc/base/mercurial.kak
@@ -21,6 +21,6 @@ hook -group hg-commit-highlight global WinSetOption filetype=(?!hg-commit).* %{
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
 hook -group hg-commit-highlight global WinSetOption filetype=hg-commit %{
-    add-highlighter window group hg-commit-highlight
+    add-highlighter window/ group hg-commit-highlight
     add-highlighter window/hg-commit-highlight regex '^HG:[^\n]*' 0:MercurialCommitComment
 }

--- a/rc/base/spell.kak
+++ b/rc/base/spell.kak
@@ -9,7 +9,7 @@ Formats of language supported:
  - ISO language code, e.g. 'en'
  - language code above followed by a dash or underscore with an ISO country code, e.g. 'en-US'} \
     spell %{
-    try %{ add-highlighter window ranges 'spell_regions' }
+    try %{ add-highlighter window/ ranges 'spell_regions' }
     evaluate-commands %sh{
         file=$(mktemp -d "${TMPDIR:-/tmp}"/kak-spell.XXXXXXXX)/buffer
         printf 'eval -no-hooks write -sync %s\n' "${file}"

--- a/rc/base/spell.kak
+++ b/rc/base/spell.kak
@@ -64,7 +64,7 @@ define-command spell-next %{ evaluate-commands %sh{
 
     start_first="${kak_opt_spell_regions#* }"
     start_first="${start_first%%|*}"
-    start_first="${start_first#'}"
+    start_first="${start_first#\'}"
 
     find_next_word_desc() {
         ## XXX: the `spell` command adds sorted selection descriptions to the range


### PR DESCRIPTION
Errors:

1. Missing / behind add-highlighter path
2. Unescaped '

I fixed error 1 also in another file
