### PR TITLE
Remove whitespace stripping from all rc files

### DIFF
--- a/rc/base/clojure.kak
+++ b/rc/base/clojure.kak
@@ -22,7 +22,6 @@ add-highlighter shared/clojure/ regex \b(clojure.core/['/\w]+)\b 0:keyword
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden clojure-filter-around-selections lisp-filter-around-selections
 define-command -hidden clojure-indent-on-new-line       lisp-indent-on-new-line
 
 # Initialization
@@ -30,7 +29,6 @@ define-command -hidden clojure-indent-on-new-line       lisp-indent-on-new-line
 hook -group clojure-highlight global WinSetOption filetype=clojure %{ add-highlighter window/clojure ref clojure }
 
 hook global WinSetOption filetype=clojure %[
-    hook window ModeChange insert:.* -group clojure-hooks  clojure-filter-around-selections
     hook window InsertChar \n -group clojure-indent clojure-indent-on-new-line
 ]
 

--- a/rc/base/css.kak
+++ b/rc/base/css.kak
@@ -35,17 +35,10 @@ add-highlighter shared/css/selector/ regex [*]|[#.][A-Za-z][A-Za-z0-9_-]* 0:vari
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden css-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden css-indent-on-new-line %[
     evaluate-commands -draft -itersel %[
         # preserve previous line indent
         try %[ execute-keys -draft \; K <a-&> ]
-        # filter previous line
-        try %[ execute-keys -draft k : css-filter-around-selections <ret> ]
         # indent after lines ending with with {
         try %[ execute-keys -draft k <a-x> <a-k> \{$ <ret> j <a-gt> ]
     ]
@@ -64,7 +57,6 @@ define-command -hidden css-indent-on-closing-curly-brace %[
 hook -group css-highlight global WinSetOption filetype=css %{ add-highlighter window/css ref css }
 
 hook global WinSetOption filetype=css %[
-    hook window ModeChange insert:.* -group css-hooks  css-filter-around-selections
     hook window InsertChar \n -group css-indent css-indent-on-new-line
     hook window InsertChar \} -group css-indent css-indent-on-closing-curly-brace
     set-option buffer extra_word_chars '-'

--- a/rc/base/d.kak
+++ b/rc/base/d.kak
@@ -90,8 +90,6 @@ define-command -hidden d-indent-on-new-line %~
         try %{ execute-keys -draft \;K<a-&> }
         # indent after lines ending with { or (
         try %[ execute-keys -draft k<a-x> <a-k> [{(]\h*$ <ret> j<a-gt> ]
-        # cleanup trailing white spaces on the previous line
-        try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
         # copy // comments prefix
@@ -119,8 +117,6 @@ define-command -hidden d-indent-on-closing-curly-brace %[
 hook -group d-highlight global WinSetOption filetype=d %{ add-highlighter window/d ref d }
 
 hook global WinSetOption filetype=d %{
-    # cleanup trailing whitespaces when exiting insert mode
-    hook window ModeChange insert:.* -group d-hooks %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group d-indent d-indent-on-new-line
     hook window InsertChar \{ -group d-indent d-indent-on-opening-curly-brace
     hook window InsertChar \} -group d-indent d-indent-on-closing-curly-brace

--- a/rc/base/fish.kak
+++ b/rc/base/fish.kak
@@ -28,13 +28,6 @@ add-highlighter shared/fish/code/ regex \b(and|begin|bg|bind|block|break|breakpo
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden fish-filter-around-selections %{
-    evaluate-commands -no-hooks -draft -itersel %{
-        # remove trailing white spaces
-        try %{ execute-keys -draft <a-x>s\h+$<ret>d }
-    }
-}
-
 define-command -hidden fish-indent-on-char %{
     evaluate-commands -no-hooks -draft -itersel %{
         # align middle and end structures to start and indent when necessary
@@ -48,8 +41,6 @@ define-command -hidden fish-indent-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <space>K<a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k:fish-filter-around-selections<ret> }
         # indent after start structure
         try %{ execute-keys -draft k<a-x><a-k>^\h*(begin|case|else|for|function|if|switch|while)\b<ret>j<a-gt> }
     }

--- a/rc/base/gas.kak
+++ b/rc/base/gas.kak
@@ -62,20 +62,10 @@ add-highlighter shared/gas/code/ regex \
 ^\h*(cvttp[ds]2dq|cvttp[ds]2pi|cvtts[ds]2si)\b|\
 ^\h*(vxorp[sd]|vandp[sd]|ucomis[sd])\b 0:keyword
 
-define-command -hidden gas-filter-around-selections %{
-    evaluate-commands -draft -itersel %{
-        execute-keys <a-x>
-        # remove trailing white spaces
-        try %{ execute-keys -draft s \h+$ <ret> d }
-    }
-}
-
 define-command -hidden gas-indent-on-new-line %~
     evaluate-commands -draft -itersel %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : gas-filter-around-selections <ret> }
         # indent after label
         try %[ execute-keys -draft k <a-x> <a-k> :$ <ret> j <a-gt> ]
     >

--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -55,8 +55,6 @@ define-command -hidden go-indent-on-new-line %~
         try %{ execute-keys -draft \;K<a-&> }
         # indent after lines ending with { or (
         try %[ execute-keys -draft k<a-x> <a-k> [{(]\h*$ <ret> j<a-gt> ]
-        # cleanup trailing white spaces on the previous line
-        try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
         # copy // comments prefix
@@ -84,8 +82,6 @@ define-command -hidden go-indent-on-closing-curly-brace %[
 hook -group go-highlight global WinSetOption filetype=go %{ add-highlighter window/go ref go }
 
 hook global WinSetOption filetype=go %{
-    # cleanup trailing whitespaces when exiting insert mode
-    hook window ModeChange insert:.* -group go-hooks %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group go-indent go-indent-on-new-line
     hook window InsertChar \{ -group go-indent go-indent-on-opening-curly-brace
     hook window InsertChar \} -group go-indent go-indent-on-closing-curly-brace

--- a/rc/base/haskell.kak
+++ b/rc/base/haskell.kak
@@ -68,11 +68,6 @@ add-highlighter shared/haskell/code/ regex \B'([^\\]|[\\]['"\w\d\\])' 0:string
 
 # http://en.wikibooks.org/wiki/Haskell/Indentation
 
-define-command -hidden haskell-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden haskell-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy -- comments prefix and following white spaces
@@ -81,8 +76,6 @@ define-command -hidden haskell-indent-on-new-line %{
         try %{ execute-keys -draft \; K <a-&> }
         # align to first clause
         try %{ execute-keys -draft \; k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|do|let|where)\h+\K.* <ret> s \A|.\z <ret> & }
-        # filter previous line
-        try %{ execute-keys -draft k : haskell-filter-around-selections <ret> }
         # indent after lines beginning with condition or ending with expression or =(
         try %{ execute-keys -draft \; k x <a-k> ^\h*(if)|(case\h+[\w']+\h+of|do|let|where|[=(])$ <ret> j <a-gt> }
     }
@@ -95,7 +88,6 @@ hook -group haskell-highlight global WinSetOption filetype=haskell %{ add-highli
 
 hook global WinSetOption filetype=haskell %{
     set-option window extra_word_chars "'"
-    hook window ModeChange insert:.* -group haskell-hooks  haskell-filter-around-selections
     hook window InsertChar \n -group haskell-indent haskell-indent-on-new-line
 }
 

--- a/rc/base/html.kak
+++ b/rc/base/html.kak
@@ -32,11 +32,6 @@ add-highlighter shared/html/tag/base/ regex <(!DOCTYPE(\h+\w+)+) 1:meta
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden html-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden html-indent-on-greater-than %[
     evaluate-commands -draft -itersel %[
         # align closing tag to opening when alone on a line
@@ -48,8 +43,6 @@ define-command -hidden html-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : html-filter-around-selections <ret> }
         # indent after lines ending with opening tag
         try %{ execute-keys -draft k <a-x> <a-k> <[^/][^>]+>$ <ret> j <a-gt> }
     }
@@ -61,7 +54,6 @@ define-command -hidden html-indent-on-new-line %{
 hook -group html-highlight global WinSetOption filetype=(?:html|xml) %{ add-highlighter window/html ref html }
 
 hook global WinSetOption filetype=(?:html|xml) %{
-    hook window ModeChange insert:.* -group html-hooks  html-filter-around-selections
     hook window InsertChar '>' -group html-indent html-indent-on-greater-than
     hook window InsertChar \n -group html-indent html-indent-on-new-line
 }

--- a/rc/base/java.kak
+++ b/rc/base/java.kak
@@ -23,8 +23,6 @@ define-command -hidden java-indent-on-new-line %~
         try %{ execute-keys -draft \;K<a-&> }
         # indent after lines ending with { or (
         try %[ execute-keys -draft k<a-x> <a-k> [{(]\h*$ <ret> j<a-gt> ]
-        # cleanup trailing white spaces on the previous line
-        try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
         # copy // comments prefix
@@ -49,8 +47,6 @@ define-command -hidden java-indent-on-closing-curly-brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 hook global WinSetOption filetype=java %{
-    # cleanup trailing whitespaces when exiting insert mode
-    hook window ModeChange insert:.* -group java-hooks %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group java-indent java-indent-on-new-line
     hook window InsertChar \{ -group java-indent java-indent-on-opening-curly-brace
     hook window InsertChar \} -group java-indent java-indent-on-closing-curly-brace

--- a/rc/base/javascript.kak
+++ b/rc/base/javascript.kak
@@ -12,11 +12,6 @@ hook global BufCreate .*[.](ts)x? %{
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden javascript-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden javascript-indent-on-char %<
     evaluate-commands -draft -itersel %<
         # align closer token to its opener when alone on a line
@@ -30,8 +25,6 @@ define-command -hidden javascript-indent-on-new-line %<
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : javascript-filter-around-selections <ret> }
         # indent after lines beginning / ending with opener token
         try %_ execute-keys -draft k <a-x> <a-k> ^\h*[[{]|[[{]$ <ret> j <a-gt> _
     >
@@ -72,7 +65,6 @@ define-command -hidden init-javascript-filetype -params 1 %~
 
     add-highlighter "shared/%arg{1}/jsx/tag"  region -recurse <  <(?=[/a-zA-Z]) (?<!=)> regions
     add-highlighter "shared/%arg{1}/jsx/expr" region -recurse \{ \{             \}      ref %arg{1}
-        
 
     add-highlighter "shared/%arg{1}/jsx/tag/base" default-region group
     add-highlighter "shared/%arg{1}/jsx/tag/double_string" region =\K" (?<!\\)(\\\\)*" fill string
@@ -96,7 +88,6 @@ define-command -hidden init-javascript-filetype -params 1 %~
     hook -group "%arg{1}-highlight" global WinSetOption "filetype=%arg{1}" "add-highlighter window/%arg{1} ref %arg{1}"
 
     hook global WinSetOption "filetype=%arg{1}" "
-        hook window ModeChange insert:.* -group %arg{1}-hooks  javascript-filter-around-selections
         hook window InsertChar .* -group %arg{1}-indent javascript-indent-on-char
         hook window InsertChar \n -group %arg{1}-indent javascript-indent-on-new-line
     "

--- a/rc/base/json.kak
+++ b/rc/base/json.kak
@@ -20,11 +20,6 @@ add-highlighter shared/json/code/ regex \b(true|false|null|\d+(?:\.\d+)?(?:[eE][
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden json-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden json-indent-on-char %<
     evaluate-commands -draft -itersel %<
         # align closer token to its opener when alone on a line
@@ -36,8 +31,6 @@ define-command -hidden json-indent-on-new-line %<
     evaluate-commands -draft -itersel %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : json-filter-around-selections <ret> }
         # indent after lines beginning with opener token
         try %< execute-keys -draft k <a-x> <a-k> ^\h*[[{] <ret> j <a-gt> >
     >
@@ -49,7 +42,6 @@ define-command -hidden json-indent-on-new-line %<
 hook -group json-highlight global WinSetOption filetype=json %{ add-highlighter window/json ref json }
 
 hook global WinSetOption filetype=json %{
-    hook window ModeChange insert:.* -group json-hooks  json-filter-around-selections
     hook window InsertChar .* -group json-indent json-indent-on-char
     hook window InsertChar \n -group json-indent json-indent-on-new-line
 }

--- a/rc/base/lisp.kak
+++ b/rc/base/lisp.kak
@@ -24,11 +24,6 @@ add-highlighter shared/lisp/code/ regex \b(def[a-z]+|if|do|let|lambda|catch|and|
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden lisp-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden lisp-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # preserve previous line indent
@@ -44,7 +39,6 @@ define-command -hidden lisp-indent-on-new-line %{
 hook -group lisp-highlight global WinSetOption filetype=lisp %{ add-highlighter window/lisp ref lisp }
 
 hook global WinSetOption filetype=lisp %{
-    hook window ModeChange insert:.* -group lisp-hooks  lisp-filter-around-selections
     hook window InsertChar \n -group lisp-indent lisp-indent-on-new-line
 }
 

--- a/rc/base/lua.kak
+++ b/rc/base/lua.kak
@@ -61,8 +61,6 @@ define-command -hidden lua-indent-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <space>K<a-&> }
-        # remove trailing white spaces from previous line
-        try %{ execute-keys -draft k<a-x>s\h+$<ret>d }
         # indent after start structure
         try %{ execute-keys -draft k<a-x><a-k>^\h*(else|elseif|for|function|if|while)\b<ret>j<a-gt> }
     }

--- a/rc/base/markdown.kak
+++ b/rc/base/markdown.kak
@@ -59,8 +59,6 @@ define-command -hidden markdown-indent-on-new-line %{
         try %{ execute-keys -draft k <a-x> s ^\h*\K((>\h*)+([*+-]\h)?|(>\h*)*[*+-]\h)\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # remove trailing white spaces
-        try %{ execute-keys -draft -itersel %{ k<a-x> s \h+$ <ret> d } }
     }
 }
 

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -72,8 +72,6 @@ define-command -hidden perl-indent-on-new-line %~
         try %{ execute-keys -draft \;K<a-&> }
         # indent after lines ending with { or (
         try %[ execute-keys -draft k<a-x> <a-k> [{(]\h*$ <ret> j<a-gt> ]
-        # cleanup trailing white spaces on the previous line
-        try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
         # copy // comments prefix
@@ -101,8 +99,6 @@ define-command -hidden perl-indent-on-closing-curly-brace %[
 hook -group perl-highlight global WinSetOption filetype=perl %{ add-highlighter window/perl ref perl }
 
 hook global WinSetOption filetype=perl %{
-    # cleanup trailing whitespaces when exiting insert mode
-    hook window ModeChange insert:.* -group perl-hooks %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group perl-indent perl-indent-on-new-line
     hook window InsertChar \{ -group perl-indent perl-indent-on-opening-curly-brace
     hook window InsertChar \} -group perl-indent perl-indent-on-closing-curly-brace

--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -93,14 +93,6 @@ define-command ruby-alternative-file -docstring 'Jump to the alternate file (imp
     echo "edit $altfile"
 }}
 
-define-command -hidden ruby-filter-around-selections %{
-    evaluate-commands -no-hooks -draft -itersel %{
-        execute-keys <a-x>
-        # remove trailing white spaces
-        try %{ execute-keys -draft s \h + $ <ret> d }
-    }
-}
-
 define-command -hidden ruby-indent-on-char %{
     evaluate-commands -no-hooks -draft -itersel %{
         # align middle and end structures to start
@@ -115,8 +107,6 @@ define-command -hidden ruby-indent-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : ruby-filter-around-selections <ret> }
         # indent after start structure
         try %{ execute-keys -draft k <a-x> <a-k> ^ \h * (begin|case|class|def|do|else|elsif|ensure|for|if|module|rescue|unless|until|when|while) \b <ret> j <a-gt> }
     }

--- a/rc/base/rust.kak
+++ b/rc/base/rust.kak
@@ -36,19 +36,12 @@ add-highlighter shared/rust/code/ regex "('\w+)[^']" 1:meta
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden rust-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden rust-indent-on-new-line %~
     evaluate-commands -draft -itersel %<
         # copy // comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K//[!/]?\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : rust-filter-around-selections <ret> }
         # indent after lines ending with { or (
         try %[ execute-keys -draft k <a-x> <a-k> [{(]\h*$ <ret> j <a-gt> ]
         # align to opening paren of previous line
@@ -76,7 +69,6 @@ define-command -hidden rust-indent-on-closing-curly-brace %[
 hook -group rust-highlight global WinSetOption filetype=rust %{ add-highlighter window/rust ref rust }
 
 hook global WinSetOption filetype=rust %[
-    hook window ModeChange insert:.* -group rust-hooks  rust-filter-around-selections
     hook window InsertChar \n -group rust-indent rust-indent-on-new-line
     hook window InsertChar \{ -group rust-indent rust-indent-on-opening-curly-brace
     hook window InsertChar \} -group rust-indent rust-indent-on-closing-curly-brace

--- a/rc/base/scala.kak
+++ b/rc/base/scala.kak
@@ -33,19 +33,12 @@ add-highlighter shared/scala/code/ regex (\[|\]|=>|<:|:>|=:=|::|&&|\|\|) 0:opera
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden scala-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden scala-indent-on-new-line %[
     evaluate-commands -draft -itersel %[
         # copy // comments prefix and following white spaces
         try %[ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P ]
         # preserve previous line indent
         try %[ execute-keys -draft \; K <a-&> ]
-        # filter previous line
-        try %[ execute-keys -draft k : scala-filter-around-selections <ret> ]
         # indent after lines ending with {
         try %[ execute-keys -draft k <a-x> <a-k> \{$ <ret> j <a-gt> ]
     ]
@@ -64,7 +57,6 @@ define-command -hidden scala-indent-on-closing-curly-brace %[
 hook -group scala-highlight global WinSetOption filetype=scala %{ add-highlighter window/scala ref scala }
 
 hook global WinSetOption filetype=scala %[
-    hook window ModeChange insert:.* -group scala-hooks  scala-filter-around-selections
     hook window InsertChar \n -group scala-indent scala-indent-on-new-line
     hook window InsertChar \} -group scala-indent scala-indent-on-closing-curly-brace
 ]

--- a/rc/base/screen.kak
+++ b/rc/base/screen.kak
@@ -1,6 +1,6 @@
 # http://gnu.org/software/screen/
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
- 
+
 hook -group GNUscreen global KakBegin .* %sh{
     [ -z "${STY}" ] && exit
     echo "

--- a/rc/base/yaml.kak
+++ b/rc/base/yaml.kak
@@ -25,19 +25,12 @@ add-highlighter shared/yaml/code/ regex ^\h*-?\h*(\S+): 1:attribute
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden yaml-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden yaml-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : yaml-filter-around-selections <ret> }
         # indent after :
         try %{ execute-keys -draft <space> k x <a-k> :$ <ret> j <a-gt> }
     }
@@ -49,7 +42,6 @@ define-command -hidden yaml-indent-on-new-line %{
 hook -group yaml-highlight global WinSetOption filetype=yaml %{ add-highlighter window/yaml ref yaml }
 
 hook global WinSetOption filetype=yaml %{
-    hook window ModeChange insert:.* -group yaml-hooks  yaml-filter-around-selections
     hook window InsertChar \n -group yaml-indent yaml-indent-on-new-line
 }
 

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -23,11 +23,6 @@ hook global BufCreate .*\.m %{
     set-option buffer filetype objc
 }
 
-define-command -hidden c-family-trim-autoindent %{
-    # remove the line if it's empty when leaving the insert mode
-    try %{ execute-keys -draft <a-x> 1s^(\h+)$<ret> d }
-}
-
 define-command -hidden c-family-indent-on-newline %< evaluate-commands -draft -itersel %<
     execute-keys \;
     try %<
@@ -40,8 +35,6 @@ define-command -hidden c-family-indent-on-newline %< evaluate-commands -draft -i
         # else indent new lines with the same level as the previous one
         execute-keys -draft K <a-&>
     >
-    # remove previous empty lines resulting from the automatic indent
-    try %< execute-keys -draft k <a-x> <a-k>^\h+$<ret> Hd >
     # indent after an opening brace or parenthesis at end of line
     try %< execute-keys -draft k <a-x> s[{(]\h*$<ret> j <a-gt> >
     # indent after a label
@@ -119,8 +112,6 @@ define-command -hidden c-family-insert-on-newline %[ evaluate-commands -itersel 
             ]
         ]
 
-        # trim trailing whitespace on the previous line
-        try %[ execute-keys -draft s\h+$<ret> d ]
         # align the new star with the previous one
         execute-keys K<a-x>1s^[^*]*(\*)<ret>&
     ]
@@ -278,7 +269,6 @@ hook global WinSetOption filetype=(c|cpp|objc) %[
         remove-hooks window c-family-insert
     }
 
-    hook -group c-family-indent window ModeChange insert:.* c-family-trim-autoindent
     hook -group c-family-insert window InsertChar \n c-family-insert-on-newline
     hook -group c-family-indent window InsertChar \n c-family-indent-on-newline
     hook -group c-family-indent window InsertChar \{ c-family-indent-on-opening-curly-brace

--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -72,8 +72,6 @@ define-command -hidden kak-indent-on-new-line %{
         try %{ execute-keys -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # cleanup trailing whitespaces from previous line
-        try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
         # indent after line ending with %[\W\S]
         try %{ execute-keys -draft k <a-x> <a-k> \%[\W\S]$ <ret> j <a-gt> }
     }
@@ -86,8 +84,6 @@ hook -group kak-highlight global WinSetOption filetype=kak %{ add-highlighter wi
 
 hook global WinSetOption filetype=kak %{
     hook window InsertChar \n -group kak-indent kak-indent-on-new-line
-    # cleanup trailing whitespaces on current line insert end
-    hook window ModeChange insert:.* -group kak-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
     set-option buffer extra_word_chars '-'
 }
 

--- a/rc/core/makefile.kak
+++ b/rc/core/makefile.kak
@@ -39,8 +39,6 @@ define-command -hidden makefile-indent-on-new-line %{
         try %{ execute-keys -draft \;K<a-&> }
         ## If the line above is a target indent with a tab
         try %{ execute-keys -draft Z k<a-x> <a-k>^[^:]+:\s<ret> z i<tab> }
-        # cleanup trailing white space son previous line
-        try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # indent after some keywords
         try %{ execute-keys -draft Z k<a-x> <a-k> ^\h*(ifeq|ifneq|ifdef|ifndef|else|define)\b<ret> z <a-gt> }
     }

--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -125,8 +125,6 @@ define-command -hidden python-indent-on-new-line %{
         try %{ execute-keys -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # cleanup trailing whitespaces from previous line
-        try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
         # indent after line ending with :
         try %{ execute-keys -draft <space> k <a-x> <a-k> :$ <ret> j <a-gt> }
     }
@@ -139,8 +137,6 @@ hook -group python-highlight global WinSetOption filetype=python %{ add-highligh
 
 hook global WinSetOption filetype=python %{
     hook window InsertChar \n -group python-indent python-indent-on-new-line
-    # cleanup trailing whitespaces on current line insert end
-    hook window ModeChange insert:.* -group python-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
 }
 
 hook -group python-highlight global WinSetOption filetype=(?!python).* %{ remove-highlighter window/python }

--- a/rc/extra/cabal.kak
+++ b/rc/extra/cabal.kak
@@ -23,19 +23,12 @@ add-highlighter shared/cabal/code/ regex ^\h*([A-Za-z][A-Za-z0-9_-]*)\h*: 1:vari
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden cabal-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden cabal-indent-on-new-line %[
     evaluate-commands -draft -itersel %[
         # copy '#' comment prefix and following white spaces
         try %[ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P ]
         # preserve previous line indent
         try %[ execute-keys -draft \; K <a-&> ]
-        # filter previous line
-        try %[ execute-keys -draft k : cabal-filter-around-selections <ret> ]
         # indent after lines ending with { or :
         try %[ execute-keys -draft <space> k <a-x> <a-k> [:{]$ <ret> j <a-gt> ]
     ]
@@ -61,7 +54,6 @@ define-command -hidden cabal-indent-on-closing-curly-brace %[
 hook -group cabal-highlight global WinSetOption filetype=cabal %{ add-highlighter window/cabal ref cabal }
 
 hook global WinSetOption filetype=cabal %[
-    hook window ModeChange insert:.* -group cabal-hooks  cabal-filter-around-selections
     hook window InsertChar \n -group cabal-indent cabal-indent-on-new-line
     hook window InsertChar \{ -group cabal-indent cabal-indent-on-opening-curly-brace
     hook window InsertChar \} -group cabal-indent cabal-indent-on-closing-curly-brace

--- a/rc/extra/coffee.kak
+++ b/rc/extra/coffee.kak
@@ -42,22 +42,12 @@ add-highlighter shared/coffee/code/ regex \b(break|case|catch|class|const|contin
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden coffee-filter-around-selections %{
-    evaluate-commands -draft -itersel %{
-        execute-keys <a-x>
-        # remove trailing white spaces
-        try %{ execute-keys -draft s \h + $ <ret> d }
-    }
-}
-
 define-command -hidden coffee-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s '^\h*\K#\h*' <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : coffee-filter-around-selections <ret> }
         # indent after start structure
         try %{ execute-keys -draft k <a-x> <a-k> ^ \h * (case|catch|class|else|finally|for|function|if|switch|try|while|with) \b | (=|->) $ <ret> j <a-gt> }
     }
@@ -69,7 +59,6 @@ define-command -hidden coffee-indent-on-new-line %{
 hook -group coffee-highlight global WinSetOption filetype=coffee %{ add-highlighter window/coffee ref coffee }
 
 hook global WinSetOption filetype=coffee %{
-    hook window ModeChange insert:.* -group coffee-hooks  coffee-filter-around-selections
     hook window InsertChar \n -group coffee-indent coffee-indent-on-new-line
 }
 

--- a/rc/extra/cucumber.kak
+++ b/rc/extra/cucumber.kak
@@ -55,19 +55,12 @@ add-highlighter shared/cucumber/code/ regex \b(Feature|Business\h+Need|Ability|B
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden cucumber-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden cucumber-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : cucumber-filter-around-selections <ret> }
         # indent after lines containing :
         try %{ execute-keys -draft <space> k x <a-k> : <ret> j <a-gt> }
     }
@@ -79,7 +72,6 @@ define-command -hidden cucumber-indent-on-new-line %{
 hook -group cucumber-highlight global WinSetOption filetype=cucumber %{ add-highlighter window/cucumber ref cucumber }
 
 hook global WinSetOption filetype=cucumber %{
-    hook window ModeChange insert:.* -group cucumber-hooks  cucumber-filter-around-selections
     hook window InsertChar \n -group cucumber-indent cucumber-indent-on-new-line
 }
 

--- a/rc/extra/elixir.kak
+++ b/rc/extra/elixir.kak
@@ -41,21 +41,14 @@ add-highlighter shared/elixir/code/ regex '\b\d+[\d_]*\b' 0:value
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden elixir-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden elixir-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
-        # copy -- comments prefix and following white spaces 
+        # copy -- comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # indent after line ending with: 
-	# try %{ execute-keys -draft k x <a-k> (do|else|->)$ <ret> & }
-	# filter previous line
-        try %{ execute-keys -draft k : elixir-filter-around-selections <ret> }
+        # indent after line ending with:
+        # try %{ execute-keys -draft k x <a-k> (do|else|->)$ <ret> & }
         # indent after lines ending with do or ->
         try %{ execute-keys -draft \\; k x <a-k> ^.+(do|->)$ <ret> j <a-gt> }
     }
@@ -67,7 +60,6 @@ define-command -hidden elixir-indent-on-new-line %{
 hook -group elixir-highlight global WinSetOption filetype=elixir %{ add-highlighter window/elixir ref elixir }
 
 hook global WinSetOption filetype=elixir %{
-    hook window ModeChange insert:.* -group elixir-hooks  elixir-filter-around-selections
     hook window InsertChar \n -group elixir-indent elixir-indent-on-new-line
 }
 

--- a/rc/extra/elm.kak
+++ b/rc/extra/elm.kak
@@ -27,11 +27,6 @@ add-highlighter shared/elm/code/ regex \b(Array|Bool|Char|Float|Int|String)\b 0:
 
 # http://elm-lang.org/docs/style-guide
 
-define-command -hidden elm-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden elm-indent-after "
  execute-keys -draft \\; k x <a-k> ^\\h*(if)|(case\\h+[\\w']+\\h+of|let|in|\\{\\h+\\w+|\\w+\\h+->|[=(])$ <ret> j <a-gt>
 "
@@ -44,8 +39,6 @@ define-command -hidden elm-indent-on-new-line %{
         try %{ execute-keys -draft \; K <a-&> }
         # align to first clause
         try %{ execute-keys -draft \; k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|let)\h+\K.* <ret> s \A|.\z <ret> & }
-        # filter previous line
-        try %{ execute-keys -draft k : elm-filter-around-selections <ret> }
         # indent after lines beginning with condition or ending with expression or =(
         try %{ elm-indent-after }
     }
@@ -57,7 +50,6 @@ define-command -hidden elm-indent-on-new-line %{
 hook -group elm-highlight global WinSetOption filetype=elm %{ add-highlighter window/elm ref elm }
 
 hook global WinSetOption filetype=elm %{
-    hook window ModeChange insert:.* -group elm-hooks  elm-filter-around-selections
     hook window InsertChar \n -group elm-indent elm-indent-on-new-line
 }
 

--- a/rc/extra/haml.kak
+++ b/rc/extra/haml.kak
@@ -28,19 +28,12 @@ add-highlighter shared/haml/code/ regex ^\h*%([A-Za-z][A-Za-z0-9_-]*)([#.][A-Za-
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden haml-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden haml-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '/' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K/\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : haml-filter-around-selections <ret> }
         # indent after lines beginning with : or -
         try %{ execute-keys -draft k <a-x> <a-k> ^\h*[:-] <ret> j <a-gt> }
     }
@@ -52,7 +45,6 @@ define-command -hidden haml-indent-on-new-line %{
 hook -group haml-highlight global WinSetOption filetype=haml %{ add-highlighter window/haml ref haml }
 
 hook global WinSetOption filetype=haml %{
-    hook window ModeChange insert:.* -group haml-hooks  haml-filter-around-selections
     hook window InsertChar \n -group haml-indent haml-indent-on-new-line
 }
 

--- a/rc/extra/hbs.kak
+++ b/rc/extra/hbs.kak
@@ -33,19 +33,12 @@ add-highlighter shared/hbs/block-expression/ regex ((\w|-)+)=(('|").*?('|")) 1:a
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden hbs-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden hbs-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '/' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K/\h* <ret> y j p }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : hbs-filter-around-selections <ret> }
         # indent after lines beginning with : or -
         try %{ execute-keys -draft k <a-x> <a-k> ^\h*[:-] <ret> j <a-gt> }
     }
@@ -59,7 +52,6 @@ hook -group hbs-highlight global WinSetOption filetype=hbs %{
 }
 
 hook global WinSetOption filetype=hbs %{
-    hook window ModeChange insert:.* -group hbs-hooks  hbs-filter-around-selections
     hook window InsertChar \n -group hbs-indent hbs-indent-on-new-line
 }
 

--- a/rc/extra/just.kak
+++ b/rc/extra/just.kak
@@ -12,8 +12,6 @@ define-command -hidden just-indent-on-new-line %{
      evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft \;K<a-&> }
-        # cleanup trailing white spaces on previous line
-        try %{ execute-keys -draft k<a-x> s \h+$ <ret>"_d }
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*//\h* <ret> y jgh P }
     }

--- a/rc/extra/moon.kak
+++ b/rc/extra/moon.kak
@@ -51,14 +51,6 @@ define-command moon-alternative-file -docstring 'Jump to the alternate file (imp
     printf %s\\n "edit $altfile"
 }}
 
-define-command -hidden moon-filter-around-selections %{
-    evaluate-commands -draft -itersel %{
-        execute-keys <a-x>
-        # remove trailing white spaces
-        try %{ execute-keys -draft s \h + $ <ret> d }
-    }
-}
-
 define-command -hidden moon-indent-on-char %{
     evaluate-commands -draft -itersel %{
         # align _else_ statements to start
@@ -76,8 +68,6 @@ define-command -hidden moon-indent-on-new-line %{
         try %{ execute-keys -draft k <a-x> s ^ \h * \K -- \h * <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : moon-filter-around-selections <ret> }
         # indent after start structure
         try %{ execute-keys -draft k <a-x> <a-k> ^ \h * (class|else(if)?|for|if|switch|unless|when|while|with) \b | ([:=]|[-=]>) $ <ret> j <a-gt> }
         # deindent after return statements
@@ -91,7 +81,6 @@ define-command -hidden moon-indent-on-new-line %{
 hook -group moon-highlight global WinSetOption filetype=moon %{ add-highlighter window/moon ref moon }
 
 hook global WinSetOption filetype=moon %{
-    hook window ModeChange insert:.* -group moon-hooks  moon-filter-around-selections
     hook window InsertChar .* -group moon-indent moon-indent-on-char
     hook window InsertChar \n -group moon-indent moon-indent-on-new-line
 

--- a/rc/extra/nim.kak
+++ b/rc/extra/nim.kak
@@ -60,8 +60,6 @@ def -hidden nim-indent-on-new-line %{
         try %{ exec -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
         # preserve previous line indent
         try %{ exec -draft \; K <a-&> }
-        # cleanup trailing whitespaces from previous line
-        try %{ exec -draft k <a-x> s \h+$ <ret> d }
         # indent after line ending with const, let, var, ':' or '='
         try %{ exec -draft <space> k x <a-k> (:|=|const|let|var)$ <ret> j <a-gt> }
     }
@@ -74,8 +72,6 @@ hook -group nim-highlight global WinSetOption filetype=nim %{ add-highlighter wi
 
 hook global WinSetOption filetype=nim %{
     hook window InsertChar \n -group nim-indent nim-indent-on-new-line
-    # cleanup trailing whitespaces on current line insert end
-    hook window ModeChange insert:.* -group nim-indent %{ try %{ exec -draft \; <a-x> s ^\h+$ <ret> d } }
 }
 
 hook -group nim-highlight global WinSetOption filetype=(?!nim).* %{ remove-highlighter window/nim }

--- a/rc/extra/php.kak
+++ b/rc/extra/php.kak
@@ -48,11 +48,6 @@ add-highlighter shared/php-file/php  region '<\?(php)?'     '\?>'      ref php
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden php-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden php-indent-on-char %<
     evaluate-commands -draft -itersel %<
         # align closer token to its opener when alone on a line
@@ -66,8 +61,6 @@ define-command -hidden php-indent-on-new-line %<
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : php-filter-around-selections <ret> }
         # indent after lines beginning / ending with opener token
         try %_ execute-keys -draft k <a-x> <a-k> ^\h*[[{]|[[{]$ <ret> j <a-gt> _
     >
@@ -79,7 +72,6 @@ define-command -hidden php-indent-on-new-line %<
 hook -group php-highlight global WinSetOption filetype=php %{ add-highlighter window/php-file ref php-file }
 
 hook global WinSetOption filetype=php %{
-    hook window ModeChange insert:.* -group php-hooks  php-filter-around-selections
     hook window InsertChar .* -group php-indent php-indent-on-char
     hook window InsertChar \n -group php-indent php-indent-on-new-line
 }

--- a/rc/extra/pony.kak
+++ b/rc/extra/pony.kak
@@ -64,8 +64,6 @@ define-command -hidden pony-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <space> K <a-&> }
-        # cleanup trailing whitespaces from previous line
-        try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
         # copy '//' comment prefix and following white spaces
         # try %{ execute-keys -draft k x s ^\h*//\h* <ret> y jgh P }
         # indent after line ending with :
@@ -82,8 +80,6 @@ hook -group pony-highlight global WinSetOption filetype=pony %{ add-highlighter 
 
 hook global WinSetOption filetype=pony %{
     hook window InsertChar \n -group pony-indent pony-indent-on-new-line
-    # cleanup trailing whitespaces on current line insert end
-    hook window ModeChange insert:.* -group pony-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
 }
 
 hook -group pony-highlight global WinSetOption filetype=(?!pony).* %{ remove-highlighter pony }

--- a/rc/extra/protobuf.kak
+++ b/rc/extra/protobuf.kak
@@ -1,0 +1,89 @@
+# https://developers.google.com/protocol-buffers/
+
+# Detection
+# ‾‾‾‾‾‾‾‾‾
+
+hook global BufCreate .*\.proto$ %{
+    set-option buffer filetype protobuf
+}
+
+# Highlighters
+# ‾‾‾‾‾‾‾‾‾‾‾‾
+
+add-highlighter shared/protobuf regions
+add-highlighter shared/protobuf/code default-region group
+add-highlighter shared/protobuf/double_string region '"' (?<!\\)(\\\\)*" fill string
+add-highlighter shared/protobuf/comment region /\* \*/ fill comment
+add-highlighter shared/protobuf/comment_line region '//' $ fill comment
+
+add-highlighter shared/protobuf/code/ regex %{(0x)?[0-9]+\b} 0:value
+
+evaluate-commands %sh{
+    # Grammer
+    keywords="default|deprecated|enum|extend|import|message|oneof|option"
+    keywords="${keywords}|package|service|syntax"
+    attributes="optional|repeated|required"
+    types="double|float|int32|int64|uint32|uint64|sint32|sint64|fixed32|fixed64"
+    types="${types}|sfixed32|sfixed64|bool|string|bytes|rpc"
+    values="false|true"
+
+    # Add the language's grammer to the static completion list
+    printf '%s\n' "hook global WinSetOption filetype=protobuf %{
+        set-option window static_words ${keywords} ${attributes} ${types} ${values}
+    }" | tr '|' ' '
+
+    # Highlight keywords
+    printf %s "
+        add-highlighter shared/protobuf/code/keywords regex \b(${keywords})\b 0:keyword
+        add-highlighter shared/protobuf/code/attributes regex \b(${attributes})\b 0:attribute
+        add-highlighter shared/protobuf/code/types regex \b(${types})\b 0:type
+        add-highlighter shared/protobuf/code/values regex \b(${values})\b 0:value
+    "
+}
+
+# Commands
+# ‾‾‾‾‾‾‾‾
+
+
+define-command -hidden protobuf-indent-on-newline %~
+    evaluate-commands -draft -itersel %[
+        # preserve previous line indent
+        try %{ execute-keys -draft \;K<a-&> }
+        # indent after lines ending with {
+        try %[ execute-keys -draft k<a-x> <a-k> \{\h*$ <ret> j<a-gt> ]
+        # cleanup trailing white spaces on the previous line
+        try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
+        # copy // comments prefix
+        try %{ execute-keys -draft \;<c-s>k<a-x> s ^\h*\K/{2,}(\h*(?=\S))? <ret> y<c-o>P<esc> }
+    ]
+~
+
+define-command -hidden protobuf-indent-on-opening-curly-brace %[
+    # align indent with opening paren when { is entered on a new line after the closing paren
+    try %[ execute-keys -draft -itersel h<a-F>)M <a-k> \A\(.*\)\h*\n\h*\{\z <ret> s \A|.\z <ret> 1<a-&> ]
+]
+
+define-command -hidden protobuf-indent-on-closing-curly-brace %[
+    # align to opening curly brace when alone on a line
+    try %[ execute-keys -itersel -draft <a-h><a-k>^\h+\}$<ret>hms\A|.\z<ret>1<a-&> ]
+]
+
+# Initialization
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+hook -group protobuf-highlight global WinSetOption filetype=protobuf %{ add-highlighter window/protobuf ref protobuf }
+
+hook global WinSetOption filetype=protobuf %[
+    # cleanup trailing whitespaces when exiting insert mode
+    hook -group protobuf-hooks  window ModeChange insert:.* %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
+    hook -group protobuf-indent window InsertChar \n protobuf-indent-on-newline
+    hook -group protobuf-indent window InsertChar \{ protobuf-indent-on-opening-curly-brace
+    hook -group protobuf-indent window InsertChar \} protobuf-indent-on-closing-curly-brace
+]
+
+hook -group protobuf-highlight global WinSetOption filetype=(?!protobuf).* %{ remove-highlighter window/protobuf }
+
+hook global WinSetOption filetype=(?!protobuf).* %{
+    remove-hooks window protobuf-hooks
+    remove-hooks window protobuf-indent
+}

--- a/rc/extra/protobuf.kak
+++ b/rc/extra/protobuf.kak
@@ -51,8 +51,6 @@ define-command -hidden protobuf-indent-on-newline %~
         try %{ execute-keys -draft \;K<a-&> }
         # indent after lines ending with {
         try %[ execute-keys -draft k<a-x> <a-k> \{\h*$ <ret> j<a-gt> ]
-        # cleanup trailing white spaces on the previous line
-        try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # copy // comments prefix
         try %{ execute-keys -draft \;<c-s>k<a-x> s ^\h*\K/{2,}(\h*(?=\S))? <ret> y<c-o>P<esc> }
     ]
@@ -74,8 +72,6 @@ define-command -hidden protobuf-indent-on-closing-curly-brace %[
 hook -group protobuf-highlight global WinSetOption filetype=protobuf %{ add-highlighter window/protobuf ref protobuf }
 
 hook global WinSetOption filetype=protobuf %[
-    # cleanup trailing whitespaces when exiting insert mode
-    hook -group protobuf-hooks  window ModeChange insert:.* %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
     hook -group protobuf-indent window InsertChar \n protobuf-indent-on-newline
     hook -group protobuf-indent window InsertChar \{ protobuf-indent-on-opening-curly-brace
     hook -group protobuf-indent window InsertChar \} protobuf-indent-on-closing-curly-brace

--- a/rc/extra/pug.kak
+++ b/rc/extra/pug.kak
@@ -40,17 +40,10 @@ add-highlighter shared/pug/code/            regex   ((?:\.[A-Za-z][A-Za-z0-9_-]*
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden pug-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden pug-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : pug-filter-around-selections <ret> }
         # copy '//', '|', '-' or '(!)=' prefix and following whitespace
         try %{ execute-keys -draft k <a-x> s ^\h*\K[/|!=-]{1,2}\h* <ret> y gh j P }
         # indent unless we copied something above
@@ -64,7 +57,6 @@ define-command -hidden pug-indent-on-new-line %{
 hook -group pug-highlight global WinSetOption filetype=pug %{ add-highlighter window/pug ref pug }
 
 hook global WinSetOption filetype=pug %{
-    hook window ModeChange insert:.* -group pug-hooks  pug-filter-around-selections
     hook window InsertChar \n -group pug-indent pug-indent-on-new-line
 }
 

--- a/rc/extra/ragel.kak
+++ b/rc/extra/ragel.kak
@@ -27,11 +27,6 @@ add-highlighter shared/ragel/code/ regex \b(action|alnum|alpha|any|ascii|case|cn
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden ragel-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden ragel-indent-on-char %<
     evaluate-commands -draft -itersel %<
         # align closer token to its opener when alone on a line
@@ -46,8 +41,6 @@ define-command -hidden ragel-indent-on-new-line %<
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : ragel-filter-around-selections <ret> }
         # indent after lines ending with opener token
         try %< execute-keys -draft k <a-x> <a-k> [[{(*]$ <ret> j <a-gt> >
     >
@@ -59,7 +52,6 @@ define-command -hidden ragel-indent-on-new-line %<
 hook -group ragel-highlight global WinSetOption filetype=ragel %{ add-highlighter window/ragel ref ragel }
 
 hook global WinSetOption filetype=ragel %{
-    hook window ModeChange insert:.* -group ragel-hooks  ragel-filter-around-selections
     hook window InsertChar .* -group ragel-indent ragel-indent-on-char
     hook window InsertChar \n -group ragel-indent ragel-indent-on-new-line
 }

--- a/rc/extra/sass.kak
+++ b/rc/extra/sass.kak
@@ -27,19 +27,12 @@ add-highlighter shared/sass/code/ regex !important 0:keyword
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden sass-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden sass-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '/' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K/\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : sass-filter-around-selections <ret> }
         # avoid indent after properties and comments
         try %{ execute-keys -draft k <a-x> <a-K> [:/] <ret> j <a-gt> }
     }
@@ -51,7 +44,6 @@ define-command -hidden sass-indent-on-new-line %{
 hook -group sass-highlight global WinSetOption filetype=sass %{ add-highlighter window/sass ref sass }
 
 hook global WinSetOption filetype=sass %{
-    hook window ModeChange insert:.* -group sass-hooks  sass-filter-around-selections
     hook window InsertChar \n -group sass-indent sass-indent-on-new-line
     set-option buffer extra_word_chars '-'
 }

--- a/rc/extra/scheme.kak
+++ b/rc/extra/scheme.kak
@@ -122,7 +122,6 @@ hook -group scheme-highlight global WinSetOption filetype=(?!scheme).* %{
 
 hook global WinSetOption filetype=scheme %{
 	set-option -add buffer extra_word_chars %{-:!:%:?:<:>:=}
-    hook window InsertEnd  .* -group scheme-hooks  lisp-filter-around-selections
     hook window InsertChar \n -group scheme-indent lisp-indent-on-new-line
 }
 

--- a/rc/extra/scss.kak
+++ b/rc/extra/scss.kak
@@ -23,7 +23,6 @@ add-highlighter shared/scss/core/ regex @[A-Za-z][A-Za-z0-9_-]* 0:meta
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden scss-filter-around-selections      css-filter-around-selections
 define-command -hidden scss-indent-on-new-line            css-indent-on-new-line
 define-command -hidden scss-indent-on-closing-curly-brace css-indent-on-closing-curly-brace
 
@@ -33,7 +32,6 @@ define-command -hidden scss-indent-on-closing-curly-brace css-indent-on-closing-
 hook -group scss-highlight global WinSetOption filetype=scss %{ add-highlighter window/scss ref scss }
 
 hook global WinSetOption filetype=scss %[
-    hook window ModeChange insert:.* -group scss-hooks  scss-filter-around-selections
     hook window InsertChar \n -group scss-indent scss-indent-on-new-line
     hook window InsertChar \} -group scss-indent scss-indent-on-closing-curly-brace
     set-option buffer extra_word_chars '-'

--- a/rc/extra/taskpaper.kak
+++ b/rc/extra/taskpaper.kak
@@ -6,7 +6,7 @@
 
 hook global BufCreate .*\.taskpaper %{
     set-option buffer filetype taskpaper
-} 
+}
 
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
@@ -28,8 +28,6 @@ define-command -hidden taskpaper-indent-on-new-line %{
         try %{ execute-keys -draft \;K<a-&> }
         ## If the line above is a project indent with a tab
         try %{ execute-keys -draft Z k<a-x> <a-k>^\h*([^:\n]+):<ret> z i<tab> }
-        # cleanup trailing white spaces on previous line
-        try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
     }
 }
 

--- a/rc/extra/toml.kak
+++ b/rc/extra/toml.kak
@@ -31,19 +31,12 @@ add-highlighter shared/toml/code/ regex \
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden toml-filter-around-selections %{
-    # remove trailing white spaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
-
 define-command -hidden toml-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
-        # filter previous line
-        try %{ execute-keys -draft k : toml-filter-around-selections <ret> }
     }
 }
 
@@ -55,7 +48,6 @@ hook -group toml-highlight global WinSetOption filetype=toml %{
 }
 
 hook global WinSetOption filetype=toml %{
-    hook window ModeChange insert:.* -group toml-hooks toml-filter-around-selections
     hook window InsertChar \n -group toml-indent toml-indent-on-new-line
 }
 


### PR DESCRIPTION
This pull request implements the changes proposed by @lenormf and @maximbaz to remove the stripping of whitespace from the syntax scripts. I'm not sure if this should get merged as is, this is mostly to see the proposed new default behavior of kakoune.