### PR TITLE
rust.kak: Support Rust's raw-string syntax.

### DIFF
--- a/rc/base/rust.kak
+++ b/rc/base/rust.kak
@@ -14,6 +14,7 @@ hook global BufCreate .*[.](rust|rs) %{
 add-highlighter shared/rust regions
 add-highlighter shared/rust/code default-region group
 add-highlighter shared/rust/string       region %{(?<!')"} (?<!\\)(\\\\)*"  fill string
+add-highlighter shared/rust/raw_string   region -match-capture %{(?<!')r(#*)"} %{"(#*)}  fill string
 add-highlighter shared/rust/comment      region -recurse /\* /\*        \*/ fill comment
 add-highlighter shared/rust/line_comment region //          $               fill comment
 


### PR DESCRIPTION
According to the [Rust language reference][1], a raw string starts with an 'r', zero or more '#' characters, and a '"', and doesn't close until a '"' is immediately followed by the matching number of '#' characters.

[1]: https://doc.rust-lang.org/reference/tokens.html#raw-string-literals