### PR TITLE
src: Allow hooks to be run only once

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -842,7 +842,8 @@ const CommandDesc add_hook_cmd = {
     "  * window: hook is executed only for the current window\n",
     ParameterDesc{
         { { "group", { true, "set hook group, see remove-hooks" } },
-          { "always", { false, "run hook even if hooks are disabled" } }},
+          { "always", { false, "run hook even if hooks are disabled" } },
+          { "once", { false, "run the hook only once" } } },
         ParameterDesc::Flags::None, 4, 4
     },
     CommandFlags::None,
@@ -860,9 +861,9 @@ const CommandDesc add_hook_cmd = {
         Regex regex{parser[2], RegexCompileFlags::Optimize};
         const String& command = parser[3];
         auto group = parser.get_switch("group").value_or(StringView{});
-        get_scope(parser[0], context).hooks().add_hook(parser[1], group.str(),
-                                                       parser.get_switch("always") ?
-                                                       HookFlags::Always : HookFlags::None,
+        const auto flags = (parser.get_switch("always") ? HookFlags::Always : HookFlags::None) \
+                            | (parser.get_switch("once") ? HookFlags::Once : HookFlags::None);
+        get_scope(parser[0], context).hooks().add_hook(parser[1], group.str(), flags,
                                                        std::move(regex), command);
     }
 };

--- a/src/hook_manager.hh
+++ b/src/hook_manager.hh
@@ -14,7 +14,8 @@ class Regex;
 enum class HookFlags
 {
     None = 0,
-    Always = 1 << 0
+    Always = 1 << 0,
+    Once = 1 << 1
 };
 constexpr bool with_bit_ops(Meta::Type<HookFlags>) { return true; }
 
@@ -29,7 +30,7 @@ public:
     void remove_hooks(StringView group);
     CandidateList complete_hook_group(StringView prefix, ByteCount pos_in_token);
     void run_hook(StringView hook_name, StringView param,
-                  Context& context) const;
+                  Context& context);
 
 private:
     HookManager();


### PR DESCRIPTION
This commit implements the -once flag on the `:hook` command, which
automatically removes a hook after it was run, to avoid having to
declare a group and remove it in the hook implementation.

Closes #2277