### PR TITLE
rc git: Re-add support for the `d` short-hand

### DIFF
--- a/rc/base/git.kak
+++ b/rc/base/git.kak
@@ -22,7 +22,7 @@ hook global BufCreate .*git-rebase-todo %{
 hook -group git-rebase-highlight global WinSetOption filetype=git-rebase %{
     add-highlighter window/git-rebase-highlight group
     add-highlighter window/git-rebase-highlight/ regex "#[^\n]*\n" 0:cyan,default
-    add-highlighter window/git-rebase-highlight/ regex "^(pick|edit|reword|squash|fixup|exec|delete|[persfx]) (\w+)" 1:green 2:magenta
+    add-highlighter window/git-rebase-highlight/ regex "^(pick|edit|reword|squash|fixup|exec|delete|[persfxd]) (\w+)" 1:green 2:magenta
 }
 
 hook -group git-rebase-highlight global WinSetOption filetype=(?!git-rebase).* %{ remove-highlighter window/git-rebase-highlight }


### PR DESCRIPTION
The change was lost in f61bcef.