### PR TITLE
Add instructions to install from Solus repository

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -208,6 +208,17 @@ pkg install kakoune
 --------------------------------------------------
 ====
 
+[TIP]
+.Solus
+====
+Kakoune is available in the Solus stable repository.
+
+It can be installed with
+---------------------
+eopkg install kakoune
+---------------------
+====
+
 Running
 ~~~~~~~
 


### PR DESCRIPTION
kakoune landed in the [Solus](https://solus-project.com) stable repository, adding instructions to the readme here to indicate that.