### PR TITLE
rc c-family: Show a menu to list alternative files

### DIFF
--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -327,16 +327,15 @@ define-command -hidden c-family-insert-include-guards %{
 
 hook -group c-family-insert global BufNewFile .*\.(h|hh|hpp|hxx|H) c-family-insert-include-guards
 
-declare-option -docstring "colon separated list of path in which header files will be looked for" \
-    str-list alt_dirs '.' '..'
+declare-option -docstring "list of paths in which header files will be looked for" \
+    str-list altdirs '.' '..'
 
 define-command c-family-alternative-file -docstring "Jump to the alternate file (header/implementation)" %{ evaluate-commands %sh{
     file="${kak_buffile##*/}"
     file_noext="${file%.*}"
     dir=$(dirname "${kak_buffile}")
 
-    # Set $@ to alt_dirs
-    eval "set -- ${kak_opt_alt_dirs}"
+    eval "set -- ${kak_opt_altdirs}"
 
     case ${file} in
         *.c|*.cc|*.cpp|*.cxx|*.C|*.inl|*.m)

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -333,7 +333,7 @@ declare-option -docstring "list of paths in which header files will be looked fo
 define-command c-family-alternative-file -docstring "Jump to the alternate file (header/implementation)" %{ evaluate-commands %sh{
     file="${kak_buffile##*/}"
     file_noext="${file%.*}"
-    dir=$(dirname "${kak_buffile}")
+    dir="${kak_buffile%/*}"
 
     eval "set -- ${kak_opt_altdirs}"
 

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -331,39 +331,40 @@ declare-option -docstring "list of paths in which header files will be looked fo
     str-list altdirs '.' '..'
 
 define-command c-family-alternative-file -docstring "Jump to the alternate file (header/implementation)" %{ evaluate-commands %sh{
-    file="${kak_buffile##*/}"
-    file_noext="${file%.*}"
-    dir="${kak_buffile%/*}"
+    populate_menu() {
+        file="${kak_buffile##*/}"
+        file_noext="${file%.*}"
+        dir="${kak_buffile%/*}"
 
-    eval "set -- ${kak_opt_altdirs}"
+        base_extensions="${1}"
+        alt_extensions="${2}"
 
-    case ${file} in
-        *.c|*.cc|*.cpp|*.cxx|*.C|*.inl|*.m)
-            for alt_dir in "$@"; do
-                for ext in h hh hpp hxx H; do
-                    altname="${dir}/${alt_dir}/${file_noext}.${ext}"
-                    if [ -f ${altname} ]; then
-                        printf 'edit %%{%s}\n' "${altname}"
-                        exit
-                    fi
-                done
-            done
-        ;;
-        *.h|*.hh|*.hpp|*.hxx|*.H)
-            for alt_dir in "$@"; do
-                for ext in c cc cpp cxx C m; do
-                    altname="${dir}/${alt_dir}/${file_noext}.${ext}"
-                    if [ -f ${altname} ]; then
-                        printf 'edit %%{%s}\n' "${altname}"
-                        exit
-                    fi
-                done
-            done
-        ;;
-        *)
-            echo "echo -markup '{Error}extension not recognized'"
-            exit
-        ;;
-    esac
-    echo "echo -markup '{Error}alternative file not found'"
+        eval "set -- ${kak_opt_altdirs}"
+
+        for ext in ${base_extensions}; do
+            case "${file}" in
+                *\.${ext})
+                    for alt_dir in "$@"; do
+                        for alt_ext in ${alt_extensions}; do
+                            alt_name="${file_noext}.${alt_ext}"
+                            alt_path="${dir}/${alt_dir}/${alt_name}"
+                            if [ -f "${alt_path}" ]; then
+                                menu_entries="${menu_entries} '${alt_name}' 'edit! %{${alt_path}}'"
+                            fi
+                        done
+                    done;;
+            esac
+        done
+    }
+
+    menu_entries=""
+
+    populate_menu "c cc cpp cxx C inl m" "h hh hpp hxx H"
+    populate_menu "h hh hpp hxx H"       "c cc cpp cxx C m"
+
+    if [ -z "${menu_entries}" ]; then
+        echo "echo -markup '{Error}alternative file not found'"
+    else
+        printf 'menu -auto-single %s' "${menu_entries}"
+    fi
 }}


### PR DESCRIPTION
Hi,

This is a partial re-work of #1483, the `:alt` command will now show a menu if several alternative files are available when the current buffer is a C-family one.

It's still unclear how this functionality should be migrated to other modules (e.g. the LUA one), if it was accepted.