### PR TITLE
Mention the default value of the "count" variable.

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -106,7 +106,7 @@ informations about Kakoune's state:
     version of the current Kakoune server (git hash or release name)
 
 *kak_count*::
-    count parameter passed to the command
+    count parameter passed to the command, defaults to 0 if no count given
 
 *kak_register*::
     register parameter passed to the command


### PR DESCRIPTION
I would have mentioned the default value of the "register" variable too, except that apparently defaults to the NUL register (Not the null register, named `_`, but the register named ASCII NUL) and I'm not sure that's a thing we even want to document.