### PR TITLE
Add support for Void Linux package templates

### DIFF
--- a/rc/extra/void-linux.kak
+++ b/rc/extra/void-linux.kak
@@ -1,0 +1,4 @@
+# Void Linux package template
+hook global BufCreate .*/?srcpkgs/.+/template %{
+    set-option buffer filetype sh
+}


### PR DESCRIPTION
This PR adds support for Void Linux package templates.  They are simple shell scripts, similar to PKGBUILDs.