### PR TITLE
src: Make sure buffers are saved regardless of the client count

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -439,7 +439,7 @@ void kill(const ParametersParser& parser, Context& context, const ShellContext&)
 {
     auto& client_manager = ClientManager::instance();
 
-    if (not force and client_manager.count() == 1)
+    if (not force)
         ensure_all_buffers_are_saved();
 
     const int status = parser.positional_count() > 0 ? str_to_int(parser[0]) : 0;


### PR DESCRIPTION
Due to a copy-paste mistake, the `:kill` command in a session with
multiple clients was the equivalent of a force-kill (`:kill!`).

This commit makes sure all buffers are saved before killing the
session, unless the force flag is specified.