### PR TITLE
Use $USER if getpwuid fails

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -956,7 +956,7 @@ int main(int argc, char* argv[])
         const bool clear_sessions = (bool)parser.get_switch("clear");
         if (list_sessions or clear_sessions)
         {
-            const String username = get_user_name(geteuid());
+            const String username = get_user_name();
             const StringView tmp_dir = tmpdir();
             for (auto& session : list_files(format("{}/kakoune/{}/", tmp_dir,
                                                    username)))

--- a/src/remote.hh
+++ b/src/remote.hh
@@ -44,7 +44,7 @@ private:
 };
 
 void send_command(StringView session, StringView command);
-String get_user_name(int uid);
+String get_user_name();
 
 struct Server : public Singleton<Server>
 {


### PR DESCRIPTION
Sometimes, like when using nix and linking against a slightly broken glibc, or when ldap is used and name resolution fails, getpwuid returns null and this causes kakoune to crash.

[Other projects](https://github.com/NixOS/nix/issues/209) defensively use $USER instead when this happens.