### PR TITLE
rc lint formatter: Let users handle shell commands fully

### DIFF
--- a/rc/core/formatter.kak
+++ b/rc/core/formatter.kak
@@ -1,4 +1,10 @@
-declare-option -docstring "shell command to which the contents of the current buffer is piped" \
+declare-option -docstring %{
+    shell command running an external formatting tool to format the current buffer
+
+The following environment variables are available:
+  - format_file_in: path to a copy of the current buffer
+  - format_file_out: path to the file that should be filled with the buffer's formatted data
+    } \
     str formatcmd
 
 define-command format -docstring "Format the contents of the current buffer" %{ evaluate-commands -draft -no-hooks %{
@@ -11,7 +17,10 @@ define-command format -docstring "Format the contents of the current buffer" %{ 
                 evaluate-commands %sh{
                     readonly path_file_out=\$(mktemp \"${TMPDIR:-/tmp}\"/kak-formatter-XXXXXX)
 
-                    if cat \"${path_file_tmp}\" | eval \"${kak_opt_formatcmd}\" > \"\${path_file_out}\"; then
+                    export format_file_in=\"${path_file_tmp}\"
+                    export format_file_out=\"\${path_file_out}\"
+
+                    if eval \"${kak_opt_formatcmd}\"; then
                         printf '%s\\n' \"execute-keys \\%|cat<space>'\${path_file_out}'<ret>\"
                         printf '%s\\n' \"nop %sh{ rm -f '\${path_file_out}' }\"
                     else


### PR DESCRIPTION
Hi.

It looks like users are more comfortable handling the commands that format/lint code directly in their configuration file, rather than drop a wrapper in their `$PATH` to work around limitations set by the lint/formatter scripts.

This PR exports variables in the environment of the command that is run during linting/formatting, which makes the `lintcmd`/`formatcmd` options uglier, but at the same time easier to use.

Comments?