### PR TITLE
Add toggling capabilities for <c-o> in Insert and Prompt mode

### DIFF
--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -49,7 +49,7 @@ The `completers` option controls automatic completion, which kicks in when
 the value specified in the `idle_timeout` option is reached.
 
 *<c-o>*::
-    disable automatic completion for this insert session
+    toggle automatic completion
 
 *<c-n>*::
     select next completion candidate
@@ -734,7 +734,7 @@ The following keys are recognized by this mode to help with editing (See <<comma
     insert next keystroke without interpreting it
 
 *<c-o>*::
-    disable auto completion for this prompt
+    toggle automatic completion
 
 *<a-!>*::
     expand the typed expansions in currently entered text

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -887,10 +887,14 @@ public:
         }
         else if (key == ctrl('o'))
         {
-            m_auto_complete = false;
-            clear_completions();
-            if (context().has_client())
+            m_auto_complete = not m_auto_complete;
+            if (m_auto_complete)
+                refresh_completions(CompletionFlags::Fast);
+            else if (context().has_client())
+            {
+                clear_completions();
                 context().client().menu_hide();
+            }
         }
         else if (key == alt('!'))
         {
@@ -1280,7 +1284,7 @@ public:
         }
         else if (key == ctrl('o'))
         {
-            m_auto_complete = false;
+            m_auto_complete = not m_auto_complete;
             m_completer.reset();
         }
         else if (key == ctrl('u'))


### PR DESCRIPTION
Hi

As described in https://github.com/mawww/kakoune/issues/2121 there's no easy way to re-enable auto-completion if it was (accidentally) disabled by `<c-o>` during an Insert session or a Prompt editing.

In this PR `<c-o>` now acts as a toggle to go from one state to another. `<c-i>` was suggested to be used as "enable auto-complete" but I didn't go that road because of the `<c-i>` vs `<tab>` mess.