### PR TITLE
go-tools.kak: fix set-options for go completions

### DIFF
--- a/rc/extra/go-tools.kak
+++ b/rc/extra/go-tools.kak
@@ -33,9 +33,9 @@ define-command go-complete -docstring "Complete the current selection with gocod
             column_offset=$(echo "${gocode_data}" | head -n1 | cut -d, -f1)
 
             header="${kak_cursor_line}.$((${kak_cursor_column} - $column_offset))@${kak_timestamp}"
-            compl=$(echo "${gocode_data}" | sed 1d | awk -F ",," '{print $2 "||" $1}' | paste -s -d: -)
+            compl=$(echo "${gocode_data}" | sed 1d | awk -F ",," '{print "%~" $2 "||" $1 "~"}' | paste -s -)
             printf %s\\n "evaluate-commands -client '${kak_client}' %{
-                set-option buffer=${kak_bufname} gocode_completions '${header}' '${compl}'
+                set-option 'buffer=${kak_bufname}' gocode_completions ${header} ${compl}
             }" | kak -p ${kak_session}
         ) > /dev/null 2>&1 < /dev/null &
     }

--- a/rc/extra/go-tools.kak
+++ b/rc/extra/go-tools.kak
@@ -35,14 +35,14 @@ define-command go-complete -docstring "Complete the current selection with gocod
             header="${kak_cursor_line}.$((${kak_cursor_column} - $column_offset))@${kak_timestamp}"
             compl=$(echo "${gocode_data}" | sed 1d | awk -F ",," '{print $2 "||" $1}' | paste -s -d: -)
             printf %s\\n "evaluate-commands -client '${kak_client}' %{
-                set-option buffer=${kak_bufname} gocode_completions '${header}:${compl}'
+                set-option buffer=${kak_bufname} gocode_completions '${header}' '${compl}'
             }" | kak -p ${kak_session}
         ) > /dev/null 2>&1 < /dev/null &
     }
 }
 
 define-command go-enable-autocomplete -docstring "Add gocode completion candidates to the completer" %{
-    set-option window completers "option=gocode_completions:%opt{completers}"
+    set-option window completers "option=gocode_completions" %opt{completers}
     hook window -group go-autocomplete InsertIdle .* %{ try %{
         execute-keys -draft <a-h><a-k>[\w\.].\z<ret>
         go-complete


### PR DESCRIPTION
This PR addresses #2215 by correcting the `set-option` to support the new syntax in the `2018.09.04` release and meddling with how the results from `gocode` are formatted.