### PR TITLE
src: Check that `Once` hooks to remove exist

### DIFF
--- a/src/hook_manager.cc
+++ b/src/hook_manager.cc
@@ -127,8 +127,11 @@ void HookManager::run_hook(StringView hook_name, StringView param, Context& cont
             if (to_run.hook->flags & HookFlags::Once)
             {
                 auto it = find(hook_list->value, to_run.hook);
-                m_hooks_trash.push_back(std::move(*it));
-                hook_list->value.erase(it);
+                if (it != hook_list->value.end())
+                {
+                    m_hooks_trash.push_back(std::move(*it));
+                    hook_list->value.erase(it);
+                }
             }
         }
         catch (runtime_error& err)


### PR DESCRIPTION
I assumed that the current hook would always be in the `to_run` list, in what cases would it not be?

Fixes #2370.