### PR TITLE
Tweaked some of the c-family highlighting of defines

### DIFF
--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -145,7 +145,7 @@ evaluate-commands %sh{
             add-highlighter shared/FT/comment region /\* \*/ fill comment
             add-highlighter shared/FT/line_comment region // (?<!\\)(?=\n) fill comment
             add-highlighter shared/FT/disabled region -recurse "#\h*if(?:def)?" ^\h*?#\h*if\h+(?:0|FALSE)\b "#\h*(?:else|elif|endif)" fill rgb:666666
-            add-highlighter shared/FT/macro region %{^\h*?\K#} %{(?<!\\)(?=\n)} group
+            add-highlighter shared/FT/macro region %{^\h*?\K#} %{(?<!\\)(?=\n)|(?=//)} group
 
             add-highlighter shared/FT/macro/ fill meta
             add-highlighter shared/FT/macro/ regex ^\h*#include\h+(\S*) 1:module

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -143,12 +143,13 @@ evaluate-commands %sh{
             add-highlighter shared/FT/string region %{MAYBEAT(?<!QUOTE)(?<!QUOTE\\)"} %{(?<!\\)(?:\\\\)*"} fill string
             add-highlighter shared/FT/raw_string region %{R"([^(]*)\(} %{\)([^")]*)"} fill string
             add-highlighter shared/FT/comment region /\* \*/ fill comment
-            add-highlighter shared/FT/line_comment region // $ fill comment
+            add-highlighter shared/FT/line_comment region // (?<!\\)(?=\n) fill comment
             add-highlighter shared/FT/disabled region -recurse "#\h*if(?:def)?" ^\h*?#\h*if\h+(?:0|FALSE)\b "#\h*(?:else|elif|endif)" fill rgb:666666
-            add-highlighter shared/FT/macro region %{^\h*?\K#} %{(?<!\\)\n} group
+            add-highlighter shared/FT/macro region %{^\h*?\K#} %{(?<!\\)(?=\n)} group
 
             add-highlighter shared/FT/macro/ fill meta
             add-highlighter shared/FT/macro/ regex ^\h*#include\h+(\S*) 1:module
+            add-highlighter shared/FT/macro/ regex /\*.*?\*/ 0:comment
             ' | sed -e "s/FT/${ft}/g; s/QUOTE/'/g; s/MAYBEAT/${maybe_at}/;"
     done
 }


### PR DESCRIPTION
Trying to address some of the issues with highlighting in #2388. This pull request adds recognition of comments and line comments to the \#(define,include, etc.) syntax, though it doesn't work perfectly as I could not find out how to get it to ignore line breaks within /* ... */ comments.