### PR TITLE
Fixed mistakenly indenting matching characters

### DIFF
--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -97,7 +97,7 @@ hook -group kak-highlight global WinSetOption filetype=kak %{ add-highlighter wi
 hook global WinSetOption filetype=kak %~
     hook window InsertChar \n -group kak-indent kak-indent-on-new-line
     hook window InsertChar [>)}\]] -group kak-indent kak-indent-on-closing-matching
-    hook window InsertChar (?![>)}\]])[^\s\w] -group kak-indent kak-indent-on-closing-char
+    hook window InsertChar (?![[{(<>)}\]])[^\s\w] -group kak-indent kak-indent-on-closing-char
     # cleanup trailing whitespaces on current line insert end
     hook window ModeChange insert:.* -group kak-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
     set-option buffer extra_word_chars '-'

--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -81,12 +81,12 @@ define-command -hidden kak-indent-on-new-line %{
 
 define-command -hidden kak-indent-on-closing-matching %~
     # align to opening matching brace when alone on a line
-    try %= execute-keys -draft -itersel <a-h><a-k>\h*\Q %val{hook_param} \E$<ret> mGi s \A|.\z<ret> 1<a-&> =
+    try %= execute-keys -draft -itersel <a-h><a-k>^\h*\Q %val{hook_param} \E$<ret> mGi s \A|.\z<ret> 1<a-&> =
 ~
 
 define-command -hidden kak-indent-on-closing-char %{
     # align to opening matching character when alone on a line
-    try %{ execute-keys -draft -itersel <a-h><a-k>\h*\Q %val{hook_param} \E$<ret>gi<a-f> %val{hook_param} <a-T>%<a-k>\w*\Q %val{hook_param} \E$<ret> s \A|.\z<ret> gi 1<a-&> }
+    try %{ execute-keys -draft -itersel <a-h><a-k>^\h*\Q %val{hook_param} \E$<ret>gi<a-f> %val{hook_param} <a-T>%<a-k>\w*\Q %val{hook_param} \E$<ret> s \A|.\z<ret> gi 1<a-&> }
 }
 
 # Initialization


### PR DESCRIPTION
Fixed the kakrc deindent hook mistakenly deindenting when inserting opening matching characters inside scopes using the same matching characters, i.e.
```
hook global WinCreate .* %{
    try %{
```
runs the hook to produce
```
hook global WinCreate .* %{
try %{
```