### PR TITLE
Fix highlighting of unsigned long long in C filetype

### DIFF
--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -154,7 +154,7 @@ evaluate-commands %sh{
 }
 
 # c specific
-add-highlighter shared/c/code/numbers regex %{\b-?(0x[0-9a-fA-F]+|\d+)[fdiu]?|'((\\.)?|[^'\\])'} 0:value
+add-highlighter shared/c/code/numbers regex %{\b-?(0x[0-9a-fA-F]+|\d+)([fdiuUlL]+)?|'((\\.)?|[^'\\])'} 0:value
 evaluate-commands %sh{
     # Grammar
     keywords="asm break case continue default do else for goto if return

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -154,7 +154,7 @@ evaluate-commands %sh{
 }
 
 # c specific
-add-highlighter shared/c/code/numbers regex %{\b-?(0x[0-9a-fA-F]+|\d+)([fdiuUlL]+)?|'((\\.)?|[^'\\])'} 0:value
+add-highlighter shared/c/code/numbers regex %{\b-?(0x[0-9a-fA-F]+|\d+)([fFdDiIuUlL]+)?|'((\\.)?|[^'\\])'} 0:value
 evaluate-commands %sh{
     # Grammar
     keywords="asm break case continue default do else for goto if return

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -154,7 +154,7 @@ evaluate-commands %sh{
 }
 
 # c specific
-add-highlighter shared/c/code/numbers regex %{\b-?(0x[0-9a-fA-F]+|\d+)([uU][lL]{1,2}|[uU]|[lL]{1,2}|[lL]{1,2}[uU]|[fFdDiI])?|'((\\.)?|[^'\\])'} 0:value
+add-highlighter shared/c/code/numbers regex %{\b-?(0x[0-9a-fA-F]+|\d+)([uU][lL]{0,2}|[lL]{1,2}[uU]?|[fFdDiI])?|'((\\.)?|[^'\\])'} 0:value
 evaluate-commands %sh{
     # Grammar
     keywords="asm break case continue default do else for goto if return

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -154,7 +154,7 @@ evaluate-commands %sh{
 }
 
 # c specific
-add-highlighter shared/c/code/numbers regex %{\b-?(0x[0-9a-fA-F]+|\d+)([fFdDiIuUlL]+)?|'((\\.)?|[^'\\])'} 0:value
+add-highlighter shared/c/code/numbers regex %{\b-?(0x[0-9a-fA-F]+|\d+)([uU][lL]{1,2}|[uU]|[lL]{1,2}|[lL]{1,2}[uU]|[fFdDiI])?|'((\\.)?|[^'\\])'} 0:value
 evaluate-commands %sh{
     # Grammar
     keywords="asm break case continue default do else for goto if return


### PR DESCRIPTION
Values like `0xffffffffffffffffull` were highlighted only till first `u` leaving `ll` without highlighting. This change addresses this issue. It also adds uppercase `ULL` highlighting in values.
Old:
![image](https://user-images.githubusercontent.com/19470159/45757644-8e7deb80-bc2c-11e8-9539-76192ae5ffd7.png)
New:
![image](https://user-images.githubusercontent.com/19470159/45757591-6c846900-bc2c-11e8-96de-a6d5fa70e1c2.png)
