### PR TITLE
Added shell command completion support to define-command

### DIFF
--- a/doc/pages/commands.asciidoc
+++ b/doc/pages/commands.asciidoc
@@ -291,6 +291,9 @@ New commands can be defined using the *define-command* command:
     try command completion on any parameter passed to this command
 
 *-shell-completion*:::
+    try shell command completion on any parameter passed to this command
+
+*-shell-script-completion*:::
     following string is a shell command which takes parameters as
     positional params and output one completion candidate per line.
     The provided shell command will run after each keypress
@@ -305,7 +308,7 @@ New commands can be defined using the *define-command* command:
         Position of the cursor inside the token being completed, in bytes
         from token start.
 
-*-shell-candidates*:::
+*-shell-script-candidates*:::
     following string is a shell command which takes parameters as
     positional params and output one completion candidate per line.
     The provided shell command will run once at the beginning of each

--- a/rc/base/ctags.kak
+++ b/rc/base/ctags.kak
@@ -7,7 +7,7 @@ declare-option -docstring "list of paths to tag files to parse when looking up a
     str-list ctagsfiles 'tags'
 
 define-command -params ..1 \
-    -shell-candidates %{
+    -shell-script-candidates %{
         realpath() { ( path=$(readlink "$1"); cd "$(dirname "$1")"; printf "%s/%s\n" "$(pwd -P)" "$(basename "$1")" ) }
         eval "set -- $kak_opt_ctagsfiles"
         for candidate in "$@"; do

--- a/rc/core/doc.kak
+++ b/rc/core/doc.kak
@@ -131,7 +131,7 @@ define-command -params 1 -hidden doc-render %{
 }
 
 define-command -params 1..2 \
-    -shell-candidates %{
+    -shell-script-candidates %{
         if [ "$kak_token_to_complete" -eq 0 ]; then
             find "${kak_runtime}/doc/" -type f -name "*.asciidoc" | sed 's,.*/,,; s/\.[^/]*$//'
         elif [ "$kak_token_to_complete" -eq 1 ]; then

--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -20,10 +20,10 @@ add-highlighter shared/kakrc/shell1 region -recurse '\{' '(^|\h)\K%?%sh\{' '\}' 
 add-highlighter shared/kakrc/shell2 region -recurse '\(' '(^|\h)\K%?%sh\(' '\)' ref sh
 add-highlighter shared/kakrc/shell3 region -recurse '\[' '(^|\h)\K%?%sh\[' '\]' ref sh
 add-highlighter shared/kakrc/shell4 region -recurse '<'  '(^|\h)\K%?%sh<'  '>'  ref sh
-add-highlighter shared/kakrc/shell5 region -recurse '\{' '(^|\h)\K-shell-(completion|candidates)\h+%\{' '\}' ref sh
-add-highlighter shared/kakrc/shell6 region -recurse '\(' '(^|\h)\K-shell-(completion|candidates)\h+%\(' '\)' ref sh
-add-highlighter shared/kakrc/shell7 region -recurse '\[' '(^|\h)\K-shell-(completion|candidates)\h+%\[' '\]' ref sh
-add-highlighter shared/kakrc/shell8 region -recurse '<'  '(^|\h)\K-shell-(completion|candidates)\h+%<'  '>'  ref sh
+add-highlighter shared/kakrc/shell5 region -recurse '\{' '(^|\h)\K-script-(completion|candidates)\h+%\{' '\}' ref sh
+add-highlighter shared/kakrc/shell6 region -recurse '\(' '(^|\h)\K-script-(completion|candidates)\h+%\(' '\)' ref sh
+add-highlighter shared/kakrc/shell7 region -recurse '\[' '(^|\h)\K-script-(completion|candidates)\h+%\[' '\]' ref sh
+add-highlighter shared/kakrc/shell8 region -recurse '<'  '(^|\h)\K-script-(completion|candidates)\h+%<'  '>'  ref sh
 
 evaluate-commands %sh{
     # Grammar

--- a/rc/core/man.kak
+++ b/rc/core/man.kak
@@ -51,8 +51,8 @@ define-command -hidden -params 2..3 man-impl %{ evaluate-commands %sh{
 } }
 
 define-command -params ..1 \
-  -shell-candidates %{
-      find /usr/share/man/ -name '*.[1-8]*' | sed 's,^.*/\(.*\)\.\([1-8][a-zA-Z]*\).*$,\1(\2),' 
+  -shell-script-candidates %{
+      find /usr/share/man/ -name '*.[1-8]*' | sed 's,^.*/\(.*\)\.\([1-8][a-zA-Z]*\).*$,\1(\2),'
   } \
   -docstring %{man [<page>]: manpage viewer wrapper
 If no argument is passed to the command, the selection will be used as page

--- a/rc/extra/git-tools.kak
+++ b/rc/extra/git-tools.kak
@@ -27,7 +27,7 @@ define-command -params 1.. \
   -docstring %sh{printf 'git [<arguments>]: git wrapping helper
 All the optional arguments are forwarded to the git utility
 Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-blame\n  hide-diff\n  log\n  show\n  show-diff\n  status\n  update-diff'} \
-  -shell-candidates %{
+  -shell-script-candidates %{
     if [ $kak_token_to_complete -eq 0 ]; then
         printf "add\nrm\nblame\ncommit\ncheckout\ndiff\nhide-blame\nhide-diff\nlog\nshow\nshow-diff\nstatus\nupdate-diff\n"
     else

--- a/rc/extra/kitty.kak
+++ b/rc/extra/kitty.kak
@@ -43,9 +43,7 @@ If no client is passed then the current one is used} \
 define-command -docstring %{kitty-repl [<arguments>]: create a new window for repl interaction
 All optional parameters are forwarded to the new window} \
     -params .. \
-    -shell-candidates %{
-        find $(echo $PATH | tr ':' ' ') -mindepth 1 -maxdepth 1 -executable -printf "%f\n"
-    } \
+    -shell-completion \
     kitty-repl %{ evaluate-commands %sh{
         if [ $# -eq 0 ]; then cmd="${SHELL:-/bin/sh}"; else cmd="$*"; fi
         kitty @ new-window --no-response --window-type $kak_opt_kitty_window_type --title kak_repl_window $cmd < /dev/null > /dev/null 2>&1 &

--- a/rc/extra/x11-repl.kak
+++ b/rc/extra/x11-repl.kak
@@ -2,7 +2,7 @@
 define-command -docstring %{x11-repl [<arguments>]: create a new window for repl interaction
 All optional parameters are forwarded to the new window} \
     -params .. \
-    -command-completion \
+    -shell-completion \
     x11-repl %{ evaluate-commands %sh{
         if [ -z "${kak_opt_termcmd}" ]; then
            echo "echo -markup '{Error}termcmd option is not set'"

--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -1,5 +1,5 @@
 def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
-    -shell-candidates %{
+    -shell-script-candidates %{
     find -L "${kak_runtime}/colors" "${kak_config}/colors" -type f -name '*\.kak' \
         | while read -r filename; do
             basename="${filename##*/}"

--- a/test/regression/0-nothing-selected-on-prompt-initial-shift-tab/rc
+++ b/test/regression/0-nothing-selected-on-prompt-initial-shift-tab/rc
@@ -1,1 +1,1 @@
-def my-command -params 0..1 -shell-candidates %{ printf "aaa\nbbb\nccc" } %{ exec i %arg{1} <esc> }
+def my-command -params 0..1 -shell-script-candidates %{ printf "aaa\nbbb\nccc" } %{ exec i %arg{1} <esc> }


### PR DESCRIPTION
This option was introduced so `repl` commands could have proper completion suggestions.

This commit also introduces a regression in that I decided that the best way to avoid overly long and confusing switch names was to rename the current `shell-*` switches to `script-*`, and have the shell command completion switch be `shell-completion`. I am open to name suggestions if this regression is a bad idea.