### PR TITLE
Improve the documentation for the 'm' key

### DIFF
--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -136,8 +136,8 @@ the Shift modifier and moving will extend each selection instead.
     repeat last object or *f*/*t* selection command
 
 *m*::
-    select to matching character, see the `matching_pairs` option
-    in <<options#,`:doc options`>>
+    select to the next sequence enclosed by matching character, see the
+    `matching_pairs` option in <<options#,`:doc options`>>
 
 *x*::
     select line on which the end of each selection lies (or next line when end lies


### PR DESCRIPTION
The GitHub issue referenced below describes the default behavior of
the 'm' key in a way that was unknown to me.  As the issue says,
"'m' is a pretty misunderstood key", and goes on to describe how
the documentation makes it sound as if the cursor must be on the
matching character before 'm' will work.  However, this is not true;
pressing 'm' will jump forward to "select the next sequence enclosed
in balanced chars".  This patch updates the documentation so that it
describes that behavior.

GitHub-Issue: #2425
Special-thanks: Delapouite