### PR TITLE
Add a way to unmap all keys of a given mode at once

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1544,16 +1544,7 @@ static Completions map_key_completer(const Context& context, CompletionFlags fla
 const CommandDesc map_key_cmd = {
     "map",
     nullptr,
-    "map [<switches>] <scope> <mode> <key> <keys>: map <key> to <keys> in given mode in <scope>.\n"
-    "<mode> can be:\n"
-    "    normal\n"
-    "    insert\n"
-    "    menu\n"
-    "    prompt\n"
-    "    goto\n"
-    "    view\n"
-    "    user\n"
-    "    object\n",
+    "map [<switches>] <scope> <mode> <key> <keys>: map <key> to <keys> in given <mode> in <scope>",
     ParameterDesc{
         { { "docstring", { true,  "specify mapping description" } } },
         ParameterDesc::Flags::None, 4, 4
@@ -1579,18 +1570,10 @@ const CommandDesc map_key_cmd = {
 const CommandDesc unmap_key_cmd = {
     "unmap",
     nullptr,
-    "unmap <scope> <mode> <key> [<expected-keys>]: unmap <key> from given mode in <scope>.\n"
-    "If <expected> is specified, remove the mapping only if its value is <expected>\n"
-    "<mode> can be:\n"
-    "    normal\n"
-    "    insert\n"
-    "    menu\n"
-    "    prompt\n"
-    "    goto\n"
-    "    view\n"
-    "    user\n"
-    "    object\n",
-    ParameterDesc{{}, ParameterDesc::Flags::None, 3, 4},
+    "unmap <scope> <mode> [<key> [<expected-keys>]]: unmap <key> from given <mode> in <scope>.\n"
+    "If <expected-keys> is specified, remove the mapping only if its value is <expected-keys>.\n"
+    "If only <scope> and <mode> are specified remove all mappings",
+    ParameterDesc{{}, ParameterDesc::Flags::None, 2, 4},
     CommandFlags::None,
     CommandHelper{},
     map_key_completer<true>,
@@ -1599,9 +1582,15 @@ const CommandDesc unmap_key_cmd = {
         KeymapManager& keymaps = get_scope(parser[0], context).keymaps();
         KeymapMode keymap_mode = parse_keymap_mode(parser[1], keymaps.user_modes());
 
+        if (parser.positional_count() == 2)
+        {
+            keymaps.unmap_keys(keymap_mode);
+            return;
+        }
+
         KeyList key = parse_keys(parser[2]);
         if (key.size() != 1)
-            throw runtime_error("only a single key can be mapped");
+            throw runtime_error("only a single key can be unmapped");
 
         if (keymaps.is_mapped(key[0], keymap_mode) and
             (parser.positional_count() < 4 or

--- a/src/keymap_manager.cc
+++ b/src/keymap_manager.cc
@@ -21,6 +21,18 @@ void KeymapManager::unmap_key(Key key, KeymapMode mode)
     m_mapping.remove(KeyAndMode{key, mode});
 }
 
+void KeymapManager::unmap_keys(KeymapMode mode)
+{
+    auto it = m_mapping.begin();
+    while (it != m_mapping.end())
+    {
+        auto& map = *it;
+        if (map.key.second == mode)
+            unmap_key(map.key.first, map.key.second);
+        else
+            ++it;
+    }
+}
 
 bool KeymapManager::is_mapped(Key key, KeymapMode mode) const
 {

--- a/src/keymap_manager.hh
+++ b/src/keymap_manager.hh
@@ -33,6 +33,7 @@ public:
     using KeyList = Vector<Key, MemoryDomain::Mapping>;
     void map_key(Key key, KeymapMode mode, KeyList mapping, String docstring);
     void unmap_key(Key key, KeymapMode mode);
+    void unmap_keys(KeymapMode mode);
 
     bool is_mapped(Key key, KeymapMode mode) const;
     KeyList get_mapped_keys(KeymapMode mode) const;


### PR DESCRIPTION
Hi

Sometimes the list of mappings previously added to a mode can get pretty big when multiple plugins are involved.

In order to start from a clean state without killing the session, it's a bit tiresome to have to `unmap global goto a`, `unmap global goto b`… manually for each of the mappings.

With this PR you can just do `unmap global goto` to reset the `goto` mode.

Also I've removed the hardcoded list of modes in the autoinfo since this list is provided by the auto-complete and is out of date when user modes are declared.