### PR TITLE
Fix/improve html-indent-on-new-line hook in html.kak highlighter

### DIFF
--- a/rc/base/html.kak
+++ b/rc/base/html.kak
@@ -51,8 +51,7 @@ define-command -hidden html-indent-on-new-line %{
         # filter previous line
         try %{ execute-keys -draft k : html-filter-around-selections <ret> }
         # indent after lines ending with opening tag
-        try %{ execute-keys -draft k <a-x> <a-k> <[^/][^>]+>$ <ret> j <a-gt> }
-    }
+        try %{ execute-keys -draft k <a-x> <a-k> <lt>(?!area)(?!base)(?!br)(?!col)(?!command)(?!embed)(?!hr)(?!img)(?!input)(?!keygen)(?!link)(?!menuitem)(?!meta)(?!param)(?!source)(?!track)(?!wbr)(?!/)(?!>)[a-zA-Z0-9_-]+[^>]*?>$ <ret> j <a-gt> } }
 }
 
 # Initialization


### PR DESCRIPTION
* Fixes erroring execute-keys statement by using `<lt>` rather then `<`
* Reworks hook to not indent after self closing tags