### PR TITLE
 src: Implement <a-m> and <a-M>

### DIFF
--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -258,7 +258,7 @@ Yanking (copying) and pasting use the *"* register by default (See <<registers#,
 *<a-J>*::
     join selected lines and select spaces inserted in place of line breaks
 
-*<a-m>*::
+*<a-_>*::
     merge contiguous selections together (works across lines as well)
 
 *>*::

--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -139,6 +139,18 @@ the Shift modifier and moving will extend each selection instead.
     select to the next sequence enclosed by matching character, see the
     `matching_pairs` option in <<options#,`:doc options`>>
 
+*M*::
+    extend the current selection to the next sequence enclosed by matching
+    character, see the `matching_pairs` option in <<options#,`:doc options`>>
+
+*<a-m>*::
+    select to the previous sequence enclosed by matching character, see the
+    `matching_pairs` option in <<options#,`:doc options`>>
+
+*<a-M>*::
+    extend the current selection to the previous sequence enclosed by matching
+    character, see the `matching_pairs` option in <<options#,`:doc options`>>
+
 *x*::
     select line on which the end of each selection lies (or next line when end lies
     on an end-of-line)

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -2215,8 +2215,10 @@ static const HashMap<Key, NormalCmd, MemoryDomain::Undefined, KeymapBackend> key
     { {alt('x')}, {"extend selections to whole lines", select<SelectMode::Replace, select_lines>} },
     { {alt('X')}, {"crop selections to whole lines", select<SelectMode::Replace, trim_partial_lines>} },
 
-    { {'m'}, {"select to matching character", select<SelectMode::Replace, select_matching>} },
-    { {'M'}, {"extend to matching character", select<SelectMode::Extend, select_matching>} },
+    { {'m'}, {"select to matching character", select<SelectMode::Replace, select_matching<true>>} },
+    { {alt('m')}, {"backward select to matching character", select<SelectMode::Replace, select_matching<false>>} },
+    { {'M'}, {"extend to matching character", select<SelectMode::Extend, select_matching<true>>} },
+    { {alt('M')}, {"backward extend to matching character", select<SelectMode::Extend, select_matching<false>>} },
 
     { {'/'}, {"select next given regex match", search<SelectMode::Replace, MatchDirection::Forward>} },
     { {'?'}, {"extend with next given regex match", search<SelectMode::Extend, MatchDirection::Forward>} },

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -2185,7 +2185,7 @@ static const HashMap<Key, NormalCmd, MemoryDomain::Undefined, KeymapBackend> key
     { {';'}, {"reduce selections to their cursor", clear_selections} },
     { {alt(';')}, {"swap selections cursor and anchor", flip_selections} },
     { {alt(':')}, {"ensure selection cursor is after anchor", ensure_forward} },
-    { {alt('m')}, {"merge consecutive selections", merge_consecutive} },
+    { {alt('_')}, {"merge consecutive selections", merge_consecutive} },
 
     { {'w'}, {"select to next word start", repeated<&select<SelectMode::Replace, select_to_next_word<Word>>>} },
     { {'e'}, {"select to next word end", repeated<select<SelectMode::Replace, select_to_next_word_end<Word>>>} },

--- a/src/selectors.hh
+++ b/src/selectors.hh
@@ -31,6 +31,7 @@ select_to_previous_word(const Context& context, const Selection& selection);
 Optional<Selection>
 select_line(const Context& context, const Selection& selection);
 
+template<bool forward>
 Optional<Selection>
 select_matching(const Context& context, const Selection& selection);
 


### PR DESCRIPTION
<kbd>a-m</kbd> was moved to <kbd>a-_</kbd>, to allow implementing a backward <kbd>m</kbd>.

<kbd>a-M</kbd> was implemented to keep the mappings consistent.

Closes #2425