### PR TITLE
src: Replace include guards with #pragma once

### DIFF
--- a/src/alias_registry.hh
+++ b/src/alias_registry.hh
@@ -1,5 +1,4 @@
-#ifndef alias_registry_hh_INCLUDED
-#define alias_registry_hh_INCLUDED
+#pragma once
 
 #include "safe_ptr.hh"
 #include "string.hh"
@@ -41,5 +40,3 @@ private:
 };
 
 }
-
-#endif // alias_registry_hh_INCLUDED

--- a/src/array_view.hh
+++ b/src/array_view.hh
@@ -1,5 +1,4 @@
-#ifndef array_view_hh_INCLUDED
-#define array_view_hh_INCLUDED
+#pragma once
 
 #include <vector>
 #include <initializer_list>
@@ -91,5 +90,3 @@ bool operator!=(ArrayView<T> lhs, ArrayView<T> rhs)
 }
 
 }
-
-#endif // array_view_hh_INCLUDED

--- a/src/assert.hh
+++ b/src/assert.hh
@@ -1,5 +1,4 @@
-#ifndef assert_hh_INCLUDED
-#define assert_hh_INCLUDED
+#pragma once
 
 namespace Kakoune
 {
@@ -33,6 +32,3 @@ void on_assert_failed(const char* message);
     #define kak_assert(...) do { (void)sizeof(__VA_ARGS__); } while(false)
     #define kak_expect_throw(_, ...) do { (void)sizeof(__VA_ARGS__); } while(false)
 #endif
-
-
-#endif // assert_hh_INCLUDED

--- a/src/backtrace.hh
+++ b/src/backtrace.hh
@@ -1,5 +1,4 @@
-#ifndef backtrace_hh_INCLUDED
-#define backtrace_hh_INCLUDED
+#pragma once
 
 namespace Kakoune
 {
@@ -17,6 +16,3 @@ struct Backtrace
 };
 
 }
-
-#endif // backtrace_hh_INCLUDED
-

--- a/src/buffer.hh
+++ b/src/buffer.hh
@@ -1,5 +1,4 @@
-#ifndef buffer_hh_INCLUDED
-#define buffer_hh_INCLUDED
+#pragma once
 
 #include "clock.hh"
 #include "coord.hh"
@@ -290,5 +289,3 @@ private:
 }
 
 #include "buffer.inl.hh"
-
-#endif // buffer_hh_INCLUDED

--- a/src/buffer.inl.hh
+++ b/src/buffer.inl.hh
@@ -1,5 +1,4 @@
-#ifndef buffer_inl_h_INCLUDED
-#define buffer_inl_h_INCLUDED
+#pragma once
 
 #include "assert.hh"
 
@@ -217,4 +216,3 @@ inline BufferIterator BufferIterator::operator--(int)
 }
 
 }
-#endif // buffer_inl_h_INCLUDED

--- a/src/buffer_manager.hh
+++ b/src/buffer_manager.hh
@@ -1,5 +1,4 @@
-#ifndef buffer_manager_hh_INCLUDED
-#define buffer_manager_hh_INCLUDED
+#pragma once
 
 #include "buffer.hh"
 #include "vector.hh"
@@ -41,5 +40,3 @@ private:
 };
 
 }
-
-#endif // buffer_manager_hh_INCLUDED

--- a/src/buffer_utils.hh
+++ b/src/buffer_utils.hh
@@ -1,5 +1,4 @@
-#ifndef buffer_utils_hh_INCLUDED
-#define buffer_utils_hh_INCLUDED
+#pragma once
 
 #include "buffer.hh"
 #include "selection.hh"
@@ -85,5 +84,3 @@ void reload_file_buffer(Buffer& buffer);
 void write_to_debug_buffer(StringView str);
 
 }
-
-#endif // buffer_utils_hh_INCLUDED

--- a/src/changes.hh
+++ b/src/changes.hh
@@ -1,5 +1,4 @@
-#ifndef changes_hh_INCLUDED
-#define changes_hh_INCLUDED
+#pragma once
 
 #include "buffer.hh"
 #include "coord.hh"
@@ -107,5 +106,3 @@ void update_ranges(Buffer& buffer, size_t& timestamp, RangeContainer& ranges)
 }
 
 }
-
-#endif // changes_hh_INCLUDED

--- a/src/client.hh
+++ b/src/client.hh
@@ -1,5 +1,4 @@
-#ifndef client_hh_INCLUDED
-#define client_hh_INCLUDED
+#pragma once
 
 #include "constexpr_utils.hh"
 #include "display_buffer.hh"
@@ -155,5 +154,3 @@ constexpr auto enum_desc(Meta::Type<Autoreload>)
 }
 
 }
-
-#endif // client_hh_INCLUDED

--- a/src/client_manager.hh
+++ b/src/client_manager.hh
@@ -1,5 +1,4 @@
-#ifndef client_manager_hh_INCLUDED
-#define client_manager_hh_INCLUDED
+#pragma once
 
 #include "client.hh"
 #include "completion.hh"
@@ -64,5 +63,3 @@ private:
 };
 
 }
-
-#endif // client_manager_hh_INCLUDED

--- a/src/clock.hh
+++ b/src/clock.hh
@@ -1,5 +1,4 @@
-#ifndef clock_hh_INCLUDED
-#define clock_hh_INCLUDED
+#pragma once
 
 #include <chrono>
 
@@ -10,5 +9,3 @@ using Clock = std::chrono::steady_clock;
 using TimePoint = Clock::time_point;
 
 }
-
-#endif // clock_hh_INCLUDED

--- a/src/color.hh
+++ b/src/color.hh
@@ -1,5 +1,4 @@
-#ifndef color_hh_INCLUDED
-#define color_hh_INCLUDED
+#pragma once
 
 #include "hash.hh"
 #include "meta.hh"
@@ -72,5 +71,3 @@ constexpr size_t hash_value(const Color& val)
 }
 
 }
-
-#endif // color_hh_INCLUDED

--- a/src/command_manager.hh
+++ b/src/command_manager.hh
@@ -1,5 +1,4 @@
-#ifndef command_manager_hh_INCLUDED
-#define command_manager_hh_INCLUDED
+#pragma once
 
 #include "coord.hh"
 #include "completion.hh"
@@ -154,5 +153,3 @@ String expand(StringView str, const Context& context,
               const std::function<String (String)>& postprocess);
 
 }
-
-#endif // command_manager_hh_INCLUDED

--- a/src/commands.hh
+++ b/src/commands.hh
@@ -1,5 +1,4 @@
-#ifndef commands_hh_INCLUDED
-#define commands_hh_INCLUDED
+#pragma once
 
 namespace Kakoune
 {
@@ -12,5 +11,3 @@ struct kill_session
 };
 
 }
-
-#endif // commands_hh_INCLUDED

--- a/src/completion.hh
+++ b/src/completion.hh
@@ -1,5 +1,4 @@
-#ifndef completion_hh_INCLUDED
-#define completion_hh_INCLUDED
+#pragma once
 
 #include <functional>
 #include <algorithm>
@@ -83,4 +82,3 @@ CandidateList complete(StringView query, ByteCount cursor_pos,
 }
 
 }
-#endif // completion_hh_INCLUDED

--- a/src/constexpr_utils.hh
+++ b/src/constexpr_utils.hh
@@ -1,5 +1,4 @@
-#ifndef constexpr_utils_hh_INCLUDED
-#define constexpr_utils_hh_INCLUDED
+#pragma once
 
 #include <utility>
 #include <initializer_list>
@@ -79,5 +78,3 @@ struct ConstexprVector
 };
 
 }
-
-#endif // constexpr_utils_hh_INCLUDED

--- a/src/context.hh
+++ b/src/context.hh
@@ -1,5 +1,4 @@
-#ifndef context_hh_INCLUDED
-#define context_hh_INCLUDED
+#pragma once
 
 #include "selection.hh"
 #include "optional.hh"
@@ -173,4 +172,3 @@ private:
 };
 
 }
-#endif // context_hh_INCLUDED

--- a/src/coord.hh
+++ b/src/coord.hh
@@ -1,5 +1,4 @@
-#ifndef coord_hh_INCLUDED
-#define coord_hh_INCLUDED
+#pragma once
 
 #include "units.hh"
 #include "hash.hh"
@@ -122,5 +121,3 @@ constexpr size_t hash_value(const BufferCoordAndTarget& val)
 }
 
 }
-
-#endif // coord_hh_INCLUDED

--- a/src/diff.hh
+++ b/src/diff.hh
@@ -1,5 +1,4 @@
-#ifndef diff_hh_INCLUDED
-#define diff_hh_INCLUDED
+#pragma once
 
 // Implementation of the linear space variant of the algorithm described in
 // "An O(ND) Difference Algorithm and Its Variations"
@@ -185,5 +184,3 @@ Vector<Diff> find_diff(Iterator a, int N, Iterator b, int M, Equal eq = Equal{})
 }
 
 }
-
-#endif // diff_hh_INCLUDED

--- a/src/display_buffer.hh
+++ b/src/display_buffer.hh
@@ -1,5 +1,4 @@
-#ifndef display_buffer_hh_INCLUDED
-#define display_buffer_hh_INCLUDED
+#pragma once
 
 #include "face.hh"
 #include "hash.hh"
@@ -173,5 +172,3 @@ private:
 };
 
 }
-
-#endif // display_buffer_hh_INCLUDED

--- a/src/enum.hh
+++ b/src/enum.hh
@@ -1,5 +1,4 @@
-#ifndef enum_hh_INCLUDED
-#define enum_hh_INCLUDED
+#pragma once
 
 #include "string.hh"
 
@@ -9,5 +8,3 @@ namespace Kakoune
 template<typename T> struct EnumDesc { T value; StringView name; };
 
 }
-
-#endif // enum_hh_INCLUDED

--- a/src/env_vars.hh
+++ b/src/env_vars.hh
@@ -1,5 +1,4 @@
-#ifndef env_vars_hh_INCLUDED
-#define env_vars_hh_INCLUDED
+#pragma once
 
 #include "hash_map.hh"
 
@@ -12,5 +11,3 @@ using EnvVarMap = HashMap<String, String, MemoryDomain::EnvVars>;
 EnvVarMap get_env_vars();
 
 }
-
-#endif // env_vars_hh_INCLUDED

--- a/src/event_manager.hh
+++ b/src/event_manager.hh
@@ -1,5 +1,4 @@
-#ifndef event_manager_hh_INCLUDED
-#define event_manager_hh_INCLUDED
+#pragma once
 
 #include "clock.hh"
 #include "meta.hh"
@@ -108,5 +107,3 @@ using SignalHandler = void(*)(int);
 SignalHandler set_signal_handler(int signum, SignalHandler handler);
 
 }
-
-#endif // event_manager_hh_INCLUDED

--- a/src/exception.hh
+++ b/src/exception.hh
@@ -1,5 +1,4 @@
-#ifndef exception_hh_INCLUDED
-#define exception_hh_INCLUDED
+#pragma once
 
 #include "string.hh"
 
@@ -34,5 +33,3 @@ struct logic_error : exception
 };
 
 }
-
-#endif // exception_hh_INCLUDED

--- a/src/face.hh
+++ b/src/face.hh
@@ -1,5 +1,4 @@
-#ifndef face_hh_INCLUDED
-#define face_hh_INCLUDED
+#pragma once
 
 #include "color.hh"
 #include "flags.hh"
@@ -72,5 +71,3 @@ inline Face merge_faces(const Face& base, const Face& face)
 }
 
 }
-
-#endif // face_hh_INCLUDED

--- a/src/face_registry.hh
+++ b/src/face_registry.hh
@@ -1,5 +1,4 @@
-#ifndef face_registry_hh_INCLUDED
-#define face_registry_hh_INCLUDED
+#pragma once
 
 #include "face.hh"
 #include "utils.hh"
@@ -51,5 +50,3 @@ private:
 String to_string(Face face);
 
 }
-
-#endif // face_registry_hh_INCLUDED

--- a/src/file.hh
+++ b/src/file.hh
@@ -1,5 +1,4 @@
-#ifndef file_hh_INCLUDED
-#define file_hh_INCLUDED
+#pragma once
 
 #include "array_view.hh"
 #include "meta.hh"
@@ -89,5 +88,3 @@ CandidateList complete_filename(StringView prefix, const Regex& ignore_regex,
 CandidateList complete_command(StringView prefix, ByteCount cursor_pos = -1);
 
 }
-
-#endif // file_hh_INCLUDED

--- a/src/flags.hh
+++ b/src/flags.hh
@@ -1,5 +1,4 @@
-#ifndef flags_hh_INCLUDED
-#define flags_hh_INCLUDED
+#pragma once
 
 #include <type_traits>
 
@@ -78,5 +77,3 @@ constexpr Flags& operator^=(Flags& lhs, Flags rhs)
 }
 
 }
-
-#endif // flags_hh_INCLUDED

--- a/src/hash.hh
+++ b/src/hash.hh
@@ -1,5 +1,4 @@
-#ifndef hash_hh_INCLUDED
-#define hash_hh_INCLUDED
+#pragma once
 
 #include <type_traits>
 #include <functional>
@@ -76,5 +75,3 @@ template<typename Lhs, typename Rhs>
 constexpr bool IsHashCompatible = HashCompatible<Lhs, Rhs>::value;
 
 }
-
-#endif // hash_hh_INCLUDED

--- a/src/hash_map.hh
+++ b/src/hash_map.hh
@@ -1,5 +1,4 @@
-#ifndef hash_map_hh_INCLUDED
-#define hash_map_hh_INCLUDED
+#pragma once
 
 #include "hash.hh"
 #include "memory.hh"
@@ -322,5 +321,3 @@ private:
 void profile_hash_maps();
 
 }
-
-#endif // hash_map_hh_INCLUDED

--- a/src/highlighter.hh
+++ b/src/highlighter.hh
@@ -1,5 +1,4 @@
-#ifndef highlighter_hh_INCLUDED
-#define highlighter_hh_INCLUDED
+#pragma once
 
 #include "coord.hh"
 #include "completion.hh"
@@ -97,5 +96,3 @@ struct HighlighterRegistry : HashMap<String, HighlighterFactoryAndDocstring, Mem
 {};
 
 }
-
-#endif // highlighter_hh_INCLUDED

--- a/src/highlighter_group.hh
+++ b/src/highlighter_group.hh
@@ -1,5 +1,4 @@
-#ifndef highlighter_group_hh_INCLUDED
-#define highlighter_group_hh_INCLUDED
+#pragma once
 
 #include "exception.hh"
 #include "hash_map.hh"
@@ -64,5 +63,3 @@ struct DefinedHighlighters : public HighlighterGroup,
 };
 
 }
-
-#endif // highlighter_group_hh_INCLUDED

--- a/src/highlighters.hh
+++ b/src/highlighters.hh
@@ -1,5 +1,4 @@
-#ifndef highlighters_hh_INCLUDED
-#define highlighters_hh_INCLUDED
+#pragma once
 
 #include "color.hh"
 #include "highlighter.hh"
@@ -40,5 +39,3 @@ void option_update(RangeAndStringList& opt, const Context& context);
 void option_list_postprocess(Vector<RangeAndString, MemoryDomain::Options>& opt);
 
 }
-
-#endif // highlighters_hh_INCLUDED

--- a/src/hook_manager.hh
+++ b/src/hook_manager.hh
@@ -1,5 +1,4 @@
-#ifndef hook_manager_hh_INCLUDED
-#define hook_manager_hh_INCLUDED
+#pragma once
 
 #include "hash_map.hh"
 #include "completion.hh"
@@ -47,5 +46,3 @@ private:
 };
 
 }
-
-#endif // hook_manager_hh_INCLUDED

--- a/src/input_handler.hh
+++ b/src/input_handler.hh
@@ -1,5 +1,4 @@
-#ifndef input_handler_hh_INCLUDED
-#define input_handler_hh_INCLUDED
+#pragma once
 
 #include "completion.hh"
 #include "constexpr_utils.hh"
@@ -186,5 +185,3 @@ void on_next_key_with_autoinfo(const Context& context, KeymapMode keymap_mode, C
 void scroll_window(Context& context, LineCount offset);
 
 }
-
-#endif // input_handler_hh_INCLUDED

--- a/src/insert_completer.hh
+++ b/src/insert_completer.hh
@@ -1,5 +1,4 @@
-#ifndef insert_completer_hh_INCLUDED
-#define insert_completer_hh_INCLUDED
+#pragma once
 
 #include "option_manager.hh"
 #include "option.hh"
@@ -114,5 +113,3 @@ private:
 };
 
 }
-
-#endif // insert_completer_hh_INCLUDED

--- a/src/json_ui.hh
+++ b/src/json_ui.hh
@@ -1,5 +1,4 @@
-#ifndef json_ui_hh_INCLUDED
-#define json_ui_hh_INCLUDED
+#pragma once
 
 #include "user_interface.hh"
 #include "event_manager.hh"
@@ -60,5 +59,3 @@ private:
 };
 
 }
-
-#endif // json_ui_hh_INCLUDED

--- a/src/keymap_manager.hh
+++ b/src/keymap_manager.hh
@@ -1,5 +1,4 @@
-#ifndef keymap_manager_hh_INCLUDED
-#define keymap_manager_hh_INCLUDED
+#pragma once
 
 #include "array_view.hh"
 #include "keys.hh"
@@ -67,5 +66,3 @@ private:
 };
 
 }
-
-#endif // keymap_manager_hh_INCLUDED

--- a/src/keys.hh
+++ b/src/keys.hh
@@ -1,5 +1,4 @@
-#ifndef keys_hh_INCLUDED
-#define keys_hh_INCLUDED
+#pragma once
 
 #include "coord.hh"
 #include "flags.hh"
@@ -117,5 +116,3 @@ constexpr Key resize(DisplayCoord dim) { return { Key::Modifiers::Resize, encode
 constexpr size_t hash_value(const Key& key) { return hash_values(key.modifiers, key.key); }
 
 }
-
-#endif // keys_hh_INCLUDED

--- a/src/line_modification.hh
+++ b/src/line_modification.hh
@@ -1,5 +1,4 @@
-#ifndef line_change_watcher_hh_INCLUDED
-#define line_change_watcher_hh_INCLUDED
+#pragma once
 
 #include "units.hh"
 #include "utils.hh"
@@ -23,5 +22,3 @@ struct LineModification
 Vector<LineModification> compute_line_modifications(const Buffer& buffer, size_t timestamp);
 
 }
-
-#endif // line_change_watcher_hh_INCLUDED

--- a/src/memory.hh
+++ b/src/memory.hh
@@ -1,5 +1,4 @@
-#ifndef memory_hh_INCLUDED
-#define memory_hh_INCLUDED
+#pragma once
 
 #include <cstddef>
 #include <new>
@@ -155,5 +154,3 @@ struct UseMemoryDomain
 };
 
 }
-
-#endif // memory_hh_INCLUDED

--- a/src/meta.hh
+++ b/src/meta.hh
@@ -1,5 +1,4 @@
-#ifndef meta_hh_INCLUDED
-#define meta_hh_INCLUDED
+#pragma once
 
 namespace Kakoune
 {
@@ -11,5 +10,3 @@ template<typename T> struct Type : AnyType {};
 
 }
 }
-
-#endif // meta_hh_INCLUDED

--- a/src/ncurses_ui.hh
+++ b/src/ncurses_ui.hh
@@ -1,5 +1,4 @@
-#ifndef ncurses_hh_INCLUDED
-#define ncurses_hh_INCLUDED
+#pragma once
 
 #include "array_view.hh"
 #include "coord.hh"
@@ -156,5 +155,3 @@ private:
 };
 
 }
-
-#endif // ncurses_hh_INCLUDED

--- a/src/normal.hh
+++ b/src/normal.hh
@@ -1,5 +1,4 @@
-#ifndef normal_hh_INCLUDED
-#define normal_hh_INCLUDED
+#pragma once
 
 #include "context.hh"
 #include "optional.hh"
@@ -36,5 +35,3 @@ String build_autoinfo_for_mapping(Context& context, KeymapMode mode,
                                   ConstArrayView<KeyInfo> built_ins);
 
 }
-
-#endif // normal_hh_INCLUDED

--- a/src/option.hh
+++ b/src/option.hh
@@ -1,5 +1,4 @@
-#ifndef option_hh_INCLUDED
-#define option_hh_INCLUDED
+#pragma once
 
 #include "enum.hh"
 #include "meta.hh"
@@ -92,5 +91,3 @@ constexpr auto enum_desc(Meta::Type<DebugFlags>)
 }
 
 }
-
-#endif // option_hh_INCLUDED

--- a/src/option_manager.hh
+++ b/src/option_manager.hh
@@ -1,5 +1,4 @@
-#ifndef option_manager_hh_INCLUDED
-#define option_manager_hh_INCLUDED
+#pragma once
 
 #include "completion.hh"
 #include "exception.hh"
@@ -262,5 +261,3 @@ private:
 };
 
 }
-
-#endif // option_manager_hh_INCLUDED

--- a/src/option_types.hh
+++ b/src/option_types.hh
@@ -1,5 +1,4 @@
-#ifndef option_types_hh_INCLUDED
-#define option_types_hh_INCLUDED
+#pragma once
 
 #include "array_view.hh"
 #include "coord.hh"
@@ -364,5 +363,3 @@ inline bool option_add_from_strings(PrefixedList<P, T>& opt, ConstArrayView<Stri
 }
 
 }
-
-#endif // option_types_hh_INCLUDED

--- a/src/optional.hh
+++ b/src/optional.hh
@@ -1,5 +1,4 @@
-#ifndef optional_hh_INCLUDED
-#define optional_hh_INCLUDED
+#pragma once
 
 #include "assert.hh"
 
@@ -99,5 +98,3 @@ private:
 };
 
 }
-
-#endif // optional_hh_INCLUDED

--- a/src/parameters_parser.hh
+++ b/src/parameters_parser.hh
@@ -1,5 +1,4 @@
-#ifndef parameters_parser_hh_INCLUDED
-#define parameters_parser_hh_INCLUDED
+#pragma once
 
 #include "exception.hh"
 #include "hash_map.hh"
@@ -133,5 +132,3 @@ private:
 };
 
 }
-
-#endif // parameters_parser_hh_INCLUDED

--- a/src/ranges.hh
+++ b/src/ranges.hh
@@ -1,5 +1,4 @@
-#ifndef ranges_hh_INCLUDED
-#define ranges_hh_INCLUDED
+#pragma once
 
 #include <algorithm>
 #include <utility>
@@ -449,5 +448,3 @@ auto static_gather()
 }
 
 }
-
-#endif // ranges_hh_INCLUDED

--- a/src/ranked_match.hh
+++ b/src/ranked_match.hh
@@ -1,5 +1,4 @@
-#ifndef ranked_match_hh_INCLUDED
-#define ranked_match_hh_INCLUDED
+#pragma once
 
 #include "string.hh"
 #include "meta.hh"
@@ -54,5 +53,3 @@ private:
 };
 
 }
-
-#endif // ranked_match_hh_INCLUDED

--- a/src/ref_ptr.hh
+++ b/src/ref_ptr.hh
@@ -1,5 +1,4 @@
-#ifndef ref_ptr_hh_INCLUDED
-#define ref_ptr_hh_INCLUDED
+#pragma once
 
 #include <utility>
 
@@ -118,5 +117,3 @@ private:
 };
 
 }
-
-#endif // ref_ptr_hh_INCLUDED

--- a/src/regex.hh
+++ b/src/regex.hh
@@ -1,5 +1,4 @@
-#ifndef regex_hh_INCLUDED
-#define regex_hh_INCLUDED
+#pragma once
 
 #include "string.hh"
 #include "regex_impl.hh"
@@ -248,5 +247,3 @@ private:
 };
 
 }
-
-#endif // regex_hh_INCLUDED

--- a/src/regex_impl.hh
+++ b/src/regex_impl.hh
@@ -1,5 +1,4 @@
-#ifndef regex_impl_hh_INCLUDED
-#define regex_impl_hh_INCLUDED
+#pragma once
 
 #include "exception.hh"
 #include "flags.hh"
@@ -632,5 +631,3 @@ private:
 };
 
 }
-
-#endif // regex_impl_hh_INCLUDED

--- a/src/register_manager.hh
+++ b/src/register_manager.hh
@@ -1,5 +1,4 @@
-#ifndef register_manager_hh_INCLUDED
-#define register_manager_hh_INCLUDED
+#pragma once
 
 #include "array_view.hh"
 #include "exception.hh"
@@ -107,5 +106,3 @@ protected:
 };
 
 }
-
-#endif // register_manager_hh_INCLUDED

--- a/src/remote.hh
+++ b/src/remote.hh
@@ -1,5 +1,4 @@
-#ifndef remote_hh_INCLUDED
-#define remote_hh_INCLUDED
+#pragma once
 
 #include "env_vars.hh"
 #include "exception.hh"
@@ -69,5 +68,3 @@ private:
 bool check_session(StringView session);
 
 }
-
-#endif // remote_hh_INCLUDED

--- a/src/safe_ptr.hh
+++ b/src/safe_ptr.hh
@@ -1,5 +1,4 @@
-#ifndef safe_ptr_hh_INCLUDED
-#define safe_ptr_hh_INCLUDED
+#pragma once
 
 // #define SAFE_PTR_TRACK_CALLSTACKS
 
@@ -98,5 +97,3 @@ template<typename T>
 using SafePtr = RefPtr<T, SafeCountablePolicy>;
 
 }
-
-#endif // safe_ptr_hh_INCLUDED

--- a/src/scope.hh
+++ b/src/scope.hh
@@ -1,5 +1,4 @@
-#ifndef scope_hh_INCLUDED
-#define scope_hh_INCLUDED
+#pragma once
 
 #include "alias_registry.hh"
 #include "face_registry.hh"
@@ -63,5 +62,3 @@ class GlobalScope : public Scope, public OptionManagerWatcher, public Singleton<
 };
 
 }
-
-#endif // scope_hh_INCLUDED

--- a/src/selection.hh
+++ b/src/selection.hh
@@ -1,5 +1,4 @@
-#ifndef selection_hh_INCLUDED
-#define selection_hh_INCLUDED
+#pragma once
 
 #include "buffer.hh"
 
@@ -161,5 +160,3 @@ Selection selection_from_string(StringView desc);
 SelectionList selection_list_from_string(Buffer& buffer, ConstArrayView<String> descs);
 
 }
-
-#endif // selection_hh_INCLUDED

--- a/src/selectors.hh
+++ b/src/selectors.hh
@@ -1,5 +1,4 @@
-#ifndef selectors_hh_INCLUDED
-#define selectors_hh_INCLUDED
+#pragma once
 
 #include "selection.hh"
 
@@ -114,5 +113,3 @@ select_surrounding(const Context& context, const Selection& selection,
                    ObjectFlags flags);
 
 }
-
-#endif // selectors_hh_INCLUDED

--- a/src/shared_string.hh
+++ b/src/shared_string.hh
@@ -1,5 +1,4 @@
-#ifndef shared_string_hh_INCLUDED
-#define shared_string_hh_INCLUDED
+#pragma once
 
 #include "string.hh"
 #include "ref_ptr.hh"
@@ -68,5 +67,3 @@ inline StringDataPtr intern(StringView str)
 }
 
 }
-
-#endif // shared_string_hh_INCLUDED

--- a/src/shell_manager.hh
+++ b/src/shell_manager.hh
@@ -1,5 +1,4 @@
-#ifndef shell_manager_hh_INCLUDED
-#define shell_manager_hh_INCLUDED
+#pragma once
 
 #include "array_view.hh"
 #include "env_vars.hh"
@@ -57,5 +56,3 @@ private:
 };
 
 }
-
-#endif // shell_manager_hh_INCLUDED

--- a/src/string.hh
+++ b/src/string.hh
@@ -1,5 +1,4 @@
-#ifndef string_hh_INCLUDED
-#define string_hh_INCLUDED
+#pragma once
 
 #include "memory.hh"
 #include "hash.hh"
@@ -329,5 +328,3 @@ inline StringView operator"" _sv(const char* str, size_t)
 }
 
 }
-
-#endif // string_hh_INCLUDED

--- a/src/string_utils.hh
+++ b/src/string_utils.hh
@@ -1,5 +1,4 @@
-#ifndef string_utils_hh_INCLUDED
-#define string_utils_hh_INCLUDED
+#pragma once
 
 #include "string.hh"
 #include "vector.hh"
@@ -153,5 +152,3 @@ inline auto quoter(Quoting quoting)
 
 
 }
-
-#endif // string_utils_hh_INCLUDED

--- a/src/unicode.hh
+++ b/src/unicode.hh
@@ -1,5 +1,4 @@
-#ifndef unicode_hh_INCLUDED
-#define unicode_hh_INCLUDED
+#pragma once
 
 #include <cwctype>
 #include <cwchar>
@@ -105,5 +104,3 @@ inline bool is_lower(char c) noexcept { return c >= 'a' and c <= 'z'; }
 inline bool is_upper(char c) noexcept { return c >= 'A' and c <= 'Z'; }
 
 }
-
-#endif // unicode_hh_INCLUDED

--- a/src/unit_tests.hh
+++ b/src/unit_tests.hh
@@ -1,5 +1,4 @@
-#ifndef unit_tests_hh_INCLUDED
-#define unit_tests_hh_INCLUDED
+#pragma once
 
 namespace Kakoune
 {
@@ -15,5 +14,3 @@ struct UnitTest
 };
 
 }
-
-#endif // unit_tests_hh_INCLUDED

--- a/src/units.hh
+++ b/src/units.hh
@@ -1,5 +1,4 @@
-#ifndef units_hh_INCLUDED
-#define units_hh_INCLUDED
+#pragma once
 
 #include "assert.hh"
 #include "hash.hh"
@@ -181,5 +180,3 @@ inline constexpr ColumnCount operator"" _col(unsigned long long int value)
 }
 
 }
-
-#endif // units_hh_INCLUDED

--- a/src/user_interface.hh
+++ b/src/user_interface.hh
@@ -1,5 +1,4 @@
-#ifndef user_interface_hh_INCLUDED
-#define user_interface_hh_INCLUDED
+#pragma once
 
 #include "array_view.hh"
 #include "hash_map.hh"
@@ -82,5 +81,3 @@ public:
 };
 
 }
-
-#endif // user_interface_hh_INCLUDED

--- a/src/utf8.hh
+++ b/src/utf8.hh
@@ -1,5 +1,4 @@
-#ifndef utf8_hh_INCLUDED
-#define utf8_hh_INCLUDED
+#pragma once
 
 #include "assert.hh"
 #include "unicode.hh"
@@ -285,5 +284,3 @@ void dump(OutputIterator&& it, Codepoint cp)
 }
 
 }
-
-#endif // utf8_hh_INCLUDED

--- a/src/utf8_iterator.hh
+++ b/src/utf8_iterator.hh
@@ -1,5 +1,4 @@
-#ifndef utf8_iterator_hh_INCLUDED
-#define utf8_iterator_hh_INCLUDED
+#pragma once
 
 #include "utf8.hh"
 
@@ -144,4 +143,3 @@ private:
 }
 
 }
-#endif // utf8_iterator_hh_INCLUDED

--- a/src/utils.hh
+++ b/src/utils.hh
@@ -1,5 +1,4 @@
-#ifndef utils_hh_INCLUDED
-#define utils_hh_INCLUDED
+#pragma once
 
 #include "assert.hh"
 
@@ -149,5 +148,3 @@ bool skip_while_reverse(Iterator& it, const BeginIterator& begin, T condition)
 }
 
 }
-
-#endif // utils_hh_INCLUDED

--- a/src/value.hh
+++ b/src/value.hh
@@ -1,5 +1,4 @@
-#ifndef value_hh_INCLUDED
-#define value_hh_INCLUDED
+#pragma once
 
 #include "hash_map.hh"
 #include "units.hh"
@@ -79,5 +78,3 @@ inline ValueId get_free_value_id()
 using ValueMap = HashMap<ValueId, Value, MemoryDomain::Values>;
 
 }
-
-#endif // value_hh_INCLUDED

--- a/src/vector.hh
+++ b/src/vector.hh
@@ -1,5 +1,4 @@
-#ifndef vector_hh_INCLUDED
-#define vector_hh_INCLUDED
+#pragma once
 
 #include "memory.hh"
 
@@ -12,5 +11,3 @@ template<typename T, MemoryDomain domain = memory_domain(Meta::Type<T>{})>
 using Vector = std::vector<T, Allocator<T, domain>>;
 
 }
-
-#endif // vector_hh_INCLUDED

--- a/src/window.hh
+++ b/src/window.hh
@@ -1,5 +1,4 @@
-#ifndef window_hh_INCLUDED
-#define window_hh_INCLUDED
+#pragma once
 
 #include "client.hh"
 #include "display_buffer.hh"
@@ -78,5 +77,3 @@ private:
 };
 
 }
-
-#endif // window_hh_INCLUDED

--- a/src/word_db.hh
+++ b/src/word_db.hh
@@ -1,5 +1,4 @@
-#ifndef word_db_hh_INCLUDED
-#define word_db_hh_INCLUDED
+#pragma once
 
 #include "buffer.hh"
 #include "shared_string.hh"
@@ -51,5 +50,3 @@ private:
 WordDB& get_word_db(const Buffer& buffer);
 
 }
-
-#endif // word_db_hh_INCLUDED


### PR DESCRIPTION
Hi,

This prama is widely supported by compilers, and [presents a few advantages](https://en.wikipedia.org/wiki/Pragma_once#Advantages) in large codebases, among which better readability, potentially fast compilation times, and less error prone.

HTH.