### PR TITLE
Add mark highlighter

### DIFF
--- a/doc/pages/highlighters.asciidoc
+++ b/doc/pages/highlighters.asciidoc
@@ -89,6 +89,9 @@ from the remaining parameters.
 *line* <number> <face>::
     highlight line *number* with face *face*
 
+*mark* <register> <face>::
+    highlight selections saved in register *register* with face *face*
+
 *regex* <regex> <capture_id>:<face> ...::
     highlight a regex, takes the regex as first parameter, followed by
     any number of face parameters.

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -1426,6 +1426,9 @@ InclusiveBufferRange option_from_string(Meta::Type<InclusiveBufferRange>, String
 BufferCoord& get_first(RangeAndString& r) { return std::get<0>(r).first; }
 BufferCoord& get_last(RangeAndString& r) { return std::get<0>(r).last; }
 
+BufferCoord& get_first(InclusiveBufferRange& r) { return r.first; }
+BufferCoord& get_last(InclusiveBufferRange& r) { return r.last; }
+
 void option_list_postprocess(Vector<RangeAndString, MemoryDomain::Options>& opt)
 {
     std::sort(opt.begin(), opt.end(),
@@ -1530,6 +1533,57 @@ private:
     }
 
     const String m_option_name;
+};
+
+struct MarkHighlighter : Highlighter
+{
+    MarkHighlighter(String reg_name, StringView face)
+        : Highlighter{HighlightPass::Colorize}
+        , m_reg_name{std::move(reg_name)}
+        , m_face{face} {}
+
+    static std::unique_ptr<Highlighter> create(HighlighterParameters params, Highlighter*)
+    {
+        if (params.size() != 2)
+            throw runtime_error("wrong parameter count");
+
+        return std::make_unique<MarkHighlighter>(params[0], params[1]);
+    }
+
+private:
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange) override
+    {
+        auto& buffer = context.context.buffer();
+        const Face face = context.context.faces()[m_face];
+
+        auto content = RegisterManager::instance()[m_reg_name].get(context.context);
+        struct error : runtime_error { error(size_t) : runtime_error{"expected <buffer>@<timestamp>@main_index"} {} };
+        const auto desc = content[0] | split<StringView>('@') | static_gather<error, 3>();
+        size_t timestamp = str_to_int(desc[1]);
+
+        if (timestamp > buffer.timestamp())
+            throw runtime_error{"register '{}' refers to an invalid timestamp"};
+
+        Vector<InclusiveBufferRange> ranges = content | skip(1) 
+            | transform([](StringView str){ return option_from_string(Meta::Type<InclusiveBufferRange>{}, str); })
+            | gather<Vector<InclusiveBufferRange>>();
+
+        update_ranges(buffer, timestamp, ranges);
+
+        for (auto& range : ranges)
+        {
+            try
+            {
+                if (buffer.is_valid(range.first) and (buffer.is_valid(range.last) and not buffer.is_end(range.last)))
+                    highlight_range(display_buffer, range.first, buffer.char_next(range.last), false, apply_face(face));
+            }
+            catch (runtime_error&)
+            {}
+        }
+    }
+
+    const String m_reg_name;
+    const String m_face;
 };
 
 HighlightPass parse_passes(StringView str)
@@ -2188,6 +2242,11 @@ void register_highlighters()
           "Parameters: <option name>\n"
           "Use the range-specs option given as parameter to highlight buffer\n"
           "each spec is interpreted as a display line to display in place of the range\n" } });
+    registry.insert({
+        "mark",
+        { MarkHighlighter::create,
+          "Parameters: <register name> <face>\n"
+          "Highlight the selections saved in register <register name> with <face>\n" } });
     registry.insert({
         "line",
         { create_line_highlighter,


### PR DESCRIPTION
Hi

Here's a pull request to add a new convenient *mark* highlighter.

## Usage

```
:add-highlighter buffer/ mark reg face
```

## Example

```
:add-highlighter buffer/ mark ^ red
```

Open a file and save interesting selections with `Z` (which default to the `^` register). Move elsewhere in the buffer. You still have a visual clue (here in red) of the saved selections, so later you'll know what will be the effect of pressing `z` to restore them.

## Rationale

_"Out of sight, out of mind"_

In my daily workflow, I found the `Z`, `z`, `<a-z>` and `<a-Z>` are great commands but can be unfortunately neglected because once selections have been stored in a register, it is hard to remember their precise range after a few minutes of doing something else.

This new highlighter offers a nice way to always have a visual indicator of them. In my example the red color is obviously too aggressive, so it's up to each user to find a more subtle face.

I'm convince that the addition of this interactive feedback fits nicely with Kakoune philosophy.

## Precedent

Some great plugins already offers related helpers around the topic "visual feedback for selections":
- https://github.com/occivink/kakoune-phantom-selection
- https://gitlab.com/fsub/kakoune-mark

So I guess the community has an interest in these functionalities. 

## Technicalities

Why not reusing the `ranges` highlighter instead of introducing a new one? The ranges highlighter accepts an option name which must contain a timestamped list of RangeAndString tuples.

The `Z` command saves selections in the form of `buffer_name@timestamp@main_sel_index list_of_ranges`. The two formats are somehow similar but different enough that converting from one to another involved doing cumbersome string parsing/formatting in a shell context. Also this dance needs to be performed each time the targeted register is updated with hooks that do not exist yet.

I strongly believed that a builtin one-liner `add-highlighter buffer/ mark reg face` like the one proposed here is way more convenient and beneficial for everyone.

Thanks