### PR TITLE
Support bracketed paste mode in Kakoune

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -27,6 +27,13 @@ released versions.
 * `asciidoc` is not a dependency anymore, the last file that requiered
   it (Kakoune's manpage) has been converted to troff format.
 
+* Kakoune will use "bracketed paste" mode in terminals that support it,
+  allowing pasted text to be treated differently than typed text. You can
+  map the `<paste:begin>` and `<paste:end>` "keys" to control exactly what
+  happens. By default, pasting in normal or insert mode will insert the
+  pasted text with hooks disabled, so it won't get messed up by
+  auto-indenting.
+
 == Kakoune 2018.09.04
 
 This version contains a significant overhaul of various Kakoune

--- a/doc/pages/mapping.asciidoc
+++ b/doc/pages/mapping.asciidoc
@@ -135,6 +135,14 @@ be used:
 *<f1>*, *<f2>*, ...*<f12>*::
     Function keys.
 
+*<paste:begin>*::
+    If Kakoune detects that text is being pasted rather than typed, this
+    key will be "pressed" before the pasted text.
+
+*<paste:end>*::
+    If Kakoune detects that text is being pasted rather than typed, this
+    key will be "pressed" after the pasted text.
+
 NOTE: Although Kakoune allows many key combinations to be mapped, not every
 possible combination can be triggered. For example, due to limitations in
 the way terminals handle control characters, mappings like *<c-s-a>* are

--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -25,6 +25,10 @@ def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
     fi
 }}
 
+map global normal <paste:begin> '\i'
+map global insert <paste:begin> '<a-;>\i'
+map global insert <paste:end>   <esc>
+
 evaluate-commands %sh{
     autoload_directory() {
         find -L "$1" -type f -name '*\.kak' \

--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -27,7 +27,6 @@ def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
 
 map global normal <paste:begin> '\i'
 map global insert <paste:begin> '<a-;>\i'
-map global insert <paste:end>   <esc>
 
 evaluate-commands %sh{
     autoload_directory() {

--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -25,8 +25,6 @@ def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
     fi
 }}
 
-map global insert <paste:begin> '<a-;>\i'
-
 evaluate-commands %sh{
     autoload_directory() {
         find -L "$1" -type f -name '*\.kak' \

--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -25,7 +25,6 @@ def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
     fi
 }}
 
-map global normal <paste:begin> '\i'
 map global insert <paste:begin> '<a-;>\i'
 
 evaluate-commands %sh{

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1353,6 +1353,12 @@ public:
             push_mode(new Normal(context().input_handler(), true));
             return;
         }
+        else if (key == Key::PasteBegin)
+        {
+            push_mode(new Normal(context().input_handler(), true));
+            context().hooks_disabled().set();
+            context().input_handler().insert(InsertMode::Insert, 0);
+        }
 
         context().hooks().run_hook(Hook::InsertKey, key_to_str(key), context());
         if (moved)

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1180,7 +1180,7 @@ public:
             if (not transient)
                 m_idle_timer.set_next_date(Clock::now() + get_idle_timeout(context()));
         }
-        else if (key == Key::Escape or key == ctrl('c'))
+        else if (key == Key::Escape or key == ctrl('c') or key == Key::PasteEnd)
         {
             if (m_in_end)
                 throw runtime_error("asked to exit insert mode while running InsertEnd hook");

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -285,6 +285,19 @@ public:
                               context.faces()["Error"] });
                 }, "enter target register", register_doc);
         }
+        else if (key == Key::PasteBegin)
+        {
+            if (not m_hooks_disabled)
+            {
+                m_hooks_disabled = true;
+                context().hooks_disabled().set();
+            }
+
+            NormalParams params = m_params;
+            m_params = { 0, 0 };
+
+            context().input_handler().insert(InsertMode::Insert, params.count);
+        }
         else
         {
             auto pop_if_single_command = on_scope_end([this] {

--- a/src/keys.cc
+++ b/src/keys.cc
@@ -77,6 +77,8 @@ static constexpr KeyAndName keynamemap[] = {
     { "del", Key::Delete },
     { "plus", '+' },
     { "minus", '-' },
+    { "paste:begin", Key::PasteBegin },
+    { "paste:end", Key::PasteEnd },
 };
 
 KeyList parse_keys(StringView str)
@@ -201,6 +203,8 @@ UnitTest test_keys{[]()
          { ' ' },
          { 'c' },
          { Key::Up },
+         { Key::PasteBegin },
+         { Key::PasteEnd },
          alt('j'),
          ctrl('r'),
          shift(Key::Up),

--- a/src/keys.hh
+++ b/src/keys.hh
@@ -62,6 +62,8 @@ struct Key
         F12,
         FocusIn,
         FocusOut,
+        PasteBegin,
+        PasteEnd,
         Invalid,
     };
 

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -665,7 +665,7 @@ Optional<Key> NCursesUI::get_next_key()
             Codepoint csi_val;
 
             while ((csi_val = wgetch(m_window)) != ERR) {
-                if ('0' <= csi_val && csi_val <= '9')
+                if (is_basic_digit(csi_val))
                 {
                     keycode *= 10;
                     keycode += (csi_val - '0');


### PR DESCRIPTION
Many terminals support "bracketed paste" mode, where the terminal sends a special CSI sequence before and after pasted text, so the application can distinguish it from typed text. This PR teaches Kakoune to request this mode, to recognise the sequences, and to handle them as the new keys `<paste:begin>` and `<paste:end>`.

It also adds default mappings for those keys, so that pasting text will automatically disable hooks, preventing auto-indent messes.

Open questions:

- Should these sequences be handled as keys (like most ncurses input) or as hooks (like `FocusIn`/`FocusOut`)?
- I picked key-names with a colon, vaguely after the pattern of the mouse event "key" syntax, which doesn't actually show up anywhere except the parameter string of various hooks. Perhaps a different naming scheme would be better?
- The state machine for parsing CSI sequences that ncurses doesn't support is a bit of a hack: unrecognised sequences are discarded instead of treated as text, it can't support keys with modifiers (like `CSI 15 ; 2 ~` for `<s-f5>`), and we don't always reset `wtimeout()` if we find a valid sequence. I'd be more than happy for somebody with more C++ skill than I to sort it out.
- Should there be default mappings for `<paste:begin>` and `<paste:end>`? If so, should they be built-in like normal-mode commands, or ordinary mappings? If mappings, should they be in `kakrc`, or a separate `.kak` file?