### PR TITLE
Made share/kak/kakrc look for kakrc.local in current directory

### DIFF
--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -39,8 +39,8 @@ evaluate-commands %sh{
         autoload_directory ${kak_runtime}/autoload
     fi
 
-    if [ -f "${kak_runtime}/kakrc.local" ]; then
-        echo "source '${kak_runtime}/kakrc.local'"
+    if [ -f "kakrc.local" ]; then
+        echo "source 'kakrc.local'"
     fi
 
     if [ -f "${kak_config}/kakrc" ]; then


### PR DESCRIPTION
I'm not too sure why it would always source kakrc.local from the runtime directory as that would have the same effect as the current share/kak/kakrc file does. I assume the intended behavior is sourcing this file in the current directory if it exists, and this commit it restoring that.