### PR TITLE
Add '<' and '>' to argument text-object selector

### DIFF
--- a/src/selectors.cc
+++ b/src/selectors.cc
@@ -744,8 +744,8 @@ select_argument(const Context& context, const Selection& selection,
     auto classify = [](Codepoint c) {
         switch (c)
         {
-        case '(': case '[': case '{': return Opening;
-        case ')': case ']': case '}': return Closing;
+        case '(': case '[': case '{': case '<': return Opening;
+        case ')': case ']': case '}': case '>': return Closing;
         case ',': case ';': return Delimiter;
         default: return None;
         }


### PR DESCRIPTION
Hi

This is handy for situation involving template, like in C++. Example from Kakoune source code:

```c++
template<typename Iterator, typename Container>
Optional<std::pair<Iterator, Iterator>>
```