### PR TITLE
Reverted gruvbox StatusLine color back to default background color

### DIFF
--- a/colors/gruvbox.kak
+++ b/colors/gruvbox.kak
@@ -63,7 +63,7 @@ evaluate-commands %sh{
         face global MenuInfo           ${bg}
         face global Information        ${bg},${fg}
         face global Error              ${bg},${red}
-        face global StatusLine         ${fg},${bg1}
+        face global StatusLine         ${fg},${bg}
         face global StatusLineMode     ${yellow}+b
         face global StatusLineInfo     ${purple}
         face global StatusLineValue    ${red}


### PR DESCRIPTION
Very small tweak to the gruvbox colorscheme. I decided to make the StatusLine highlighter brighter than the default based on how many of the other colorschemes are setup, but I think the difference in the gruvbox colors is larger than the others so it doesn't look as good and messed with the text contrast on the prompt line too much. Basically, I don't think it looks good.