### PR TITLE
Made all builtin colorschemes set Whitespace highlighter

### DIFF
--- a/colors/base16.kak
+++ b/colors/base16.kak
@@ -69,5 +69,6 @@ evaluate-commands %sh{
         face global Prompt ${black_light},${cyan_light}
         face global MatchingChar ${cyan_light},${black_light}+b
         face global BufferPadding ${cyan_light},${black_lighter}
+        face global Whitespace ${grey_dark}+f
     "
 }

--- a/colors/default.kak
+++ b/colors/default.kak
@@ -47,4 +47,5 @@ face global StatusLineValue green,default
 face global StatusCursor black,cyan
 face global Prompt yellow,default
 face global MatchingChar default,default+b
+face global Whitespace default,default+f
 face global BufferPadding blue,default

--- a/colors/desertex.kak
+++ b/colors/desertex.kak
@@ -77,3 +77,6 @@ face global MatchingChar cyan+b
 
 # EOF tildas (~)
 face global BufferPadding blue,default
+
+# Whitespace characters
+face global Whitespace default+f

--- a/colors/github.kak
+++ b/colors/github.kak
@@ -48,3 +48,4 @@ face global Prompt rgb:F8F8FF,rgb:4078C0
 face global MatchingChar rgb:F8F8FF,rgb:4078C0+b
 face global Search default,default+u
 face global BufferPadding rgb:A0A0A0,rgb:F8F8FF
+face global Whitespace rgb:A0A0A0+f

--- a/colors/lucius.kak
+++ b/colors/lucius.kak
@@ -71,5 +71,6 @@ evaluate-commands %sh{
         face global Prompt ${lucius_lighter_grey}
         face global MatchingChar ${lucius_lighter_grey},${lucius_bright_green}
         face global BufferPadding ${lucius_green},${lucius_darker_grey}
+        face global Whitespace ${lucius_grey}+f
     "
 }

--- a/colors/red-phoenix.kak
+++ b/colors/red-phoenix.kak
@@ -84,5 +84,6 @@ evaluate-commands %sh{
         face global Prompt ${background},${orange2}
         face global MatchingChar ${orange3},${background}+b
         face global BufferPadding ${orange2},${background}
+        face global Whitespace default+f
     "
 }

--- a/colors/reeder.kak
+++ b/colors/reeder.kak
@@ -69,5 +69,6 @@ evaluate-commands %sh{
         face global Prompt             ${black_light}
         face global MatchingChar       default+b
         face global BufferPadding      ${grey_dark},${white}
+        face global Whitespace         ${grey_dark}+f
     "
 }

--- a/colors/solarized-dark-termcolors.kak
+++ b/colors/solarized-dark-termcolors.kak
@@ -50,3 +50,4 @@ face global StatusCursor       bright-yellow,bright-white
 face global Prompt             yellow+b
 face global MatchingChar       red,bright-green+b
 face global BufferPadding      bright-green,bright-black
+face global Whitespace         blue+f

--- a/colors/solarized-dark.kak
+++ b/colors/solarized-dark.kak
@@ -68,5 +68,6 @@ evaluate-commands %sh{
         face global Prompt             ${yellow}+b
         face global MatchingChar       ${red},${base01}+b
         face global BufferPadding      ${base01},${base03}
+        face global Whitespace         ${base01}+f
     "
 }

--- a/colors/solarized-light-termcolors.kak
+++ b/colors/solarized-light-termcolors.kak
@@ -50,3 +50,4 @@ face global StatusCursor       bright-blue,bright-black
 face global Prompt             yellow+b
 face global MatchingChar       red,white+b
 face global BufferPadding      bright-cyan,bright-white
+face global Whitespace         yellow+f

--- a/colors/solarized-light.kak
+++ b/colors/solarized-light.kak
@@ -68,5 +68,6 @@ evaluate-commands %sh{
         face global Prompt             ${yellow}+b
         face global MatchingChar       ${red},${base2}+b
         face global BufferPadding      ${base1},${base3}
+        face global Whitespace         ${base1}+f
     "
 }

--- a/colors/tomorrow-night.kak
+++ b/colors/tomorrow-night.kak
@@ -74,5 +74,6 @@ evaluate-commands %sh{
         face global Prompt ${background},${aqua}
         face global MatchingChar ${yellow},${background}+b
         face global BufferPadding ${aqua},${background}
+        face global Whitespace ${text_light}+f
     "
 }

--- a/colors/zenburn.kak
+++ b/colors/zenburn.kak
@@ -78,5 +78,6 @@ evaluate-commands %sh{
         face global Prompt ${zenconstant}
         face global MatchingChar default+b
         face global BufferPadding ${zenpadding}
+        face global Whitespace ${zensecondaryfg}+f
     "
 }


### PR DESCRIPTION
Seeing as `Whitespace` is a builtin highlighter I figured that the builtin colorschemes should define it. I tried to choose sensible values for each of the colorschemes without defining new colors for them.