### PR TITLE
jump command

### DIFF
--- a/rc/core/grep.kak
+++ b/rc/core/grep.kak
@@ -40,16 +40,12 @@ hook global WinSetOption filetype=(?!grep).* %{
     remove-hooks buffer grep-hooks
 }
 
-declare-option -docstring "name of the client in which all source code jumps will be executed" \
-    str jumpclient
-
 define-command -hidden grep-jump %{
     evaluate-commands %{ # use evaluate-commands to ensure jumps are collapsed
         try %{
             execute-keys '<a-x>s^((?:\w:)?[^:]+):(\d+):(\d+)?<ret>'
             set-option buffer grep_current_line %val{cursor_line}
-            evaluate-commands -try-client %opt{jumpclient} edit -existing %reg{1} %reg{2} %reg{3}
-            try %{ focus %opt{jumpclient} }
+            jump -existing %reg{1} %reg{2} %reg{3}
         }
     }
 }

--- a/rc/core/jump.kak
+++ b/rc/core/jump.kak
@@ -1,0 +1,15 @@
+
+declare-option -docstring "name of the client in which all source code jumps will be executed" \
+    str jumpclient
+
+define-command -params 1..3 \
+    -docstring %{jump [<switches>] <file> [<line> [<column>]]: open and focus file
+
+Accepts all switches which can be passed to edit.} \
+    -file-completion \
+    jump %{
+    evaluate-commands -try-client %opt{jumpclient} %{
+        edit %arg{@}
+        try %{ focus }
+    }
+}

--- a/rc/core/make.kak
+++ b/rc/core/make.kak
@@ -40,15 +40,9 @@ hook global WinSetOption filetype=(?!make).* %{
     remove-hooks buffer make-hooks
 }
 
-declare-option -docstring "name of the client in which all source code jumps will be executed" \
-    str jumpclient
-
 define-command -hidden make-open-error -params 4 %{
-    evaluate-commands -try-client %opt{jumpclient} %{
-        edit -existing "%arg{1}" %arg{2} %arg{3}
-        echo -markup "{Information}%arg{4}"
-        try %{ focus }
-    }
+    jump -existing "%arg{1}" %arg{2} %arg{3}
+    echo -markup "{Information}%arg{4}"
 }
 
 define-command -hidden make-jump %{

--- a/rc/extra/go-tools.kak
+++ b/rc/extra/go-tools.kak
@@ -148,8 +148,7 @@ define-command -hidden -params 1..2 gogetdoc-cmd %{
                         line=$(printf %s "${pos}" | cut -d: -f2)
                         col=$(printf %s "${pos}" | cut -d: -f3)
                         printf %s\\n "evaluate-commands -client '${kak_client}' %{
-                            evaluate-commands -try-client '${kak_opt_jumpclient}' edit -existing ${file} ${line} ${col}
-                            try %{ focus '${kak_opt_jumpclient}' }
+                            jump -existing ${file} ${line} ${col}
                         }" | kak -p ${kak_session}
                     fi
                     ;;


### PR DESCRIPTION
Rationale:

I would like jump to behave differently for me, and there's no single command
to override, so I've made one to wrap up the existing behavior.

For reference, my personal override will be somewhat like Vim's
`switchbuf=usetab`: if the file is open in any client, make that client
jump and switch to it, and fall back on jumpclient otherwise.