### PR TITLE
Simplify handlebars adding/removal hooks

### DIFF
--- a/rc/extra/hbs.kak
+++ b/rc/extra/hbs.kak
@@ -80,29 +80,8 @@ define-command -hidden maybe-add-hbs-to-html %{ evaluate-commands %sh{
     fi
 } }
 
-define-command -hidden remove-hbs-from-html %{
-    remove-highlighter shared/html/hbs
-    remove-highlighter shared/html/tag/hbs
-    set-option global hbs_highlighters_enabled false
-}
-
-# The two hooks below are wrapped in this "-once" so that they only get enabled
-# when atleast one .hbs file is opened.  This way people who don't edit .hbs files
-# aren't paying a performance penality of these hooks always executing.
-hook -once global BufCreate .*\.(hbs) %{
-    
-    hook -group hbs-highlight global WinDisplay .*\.(hbs) %{ evaluate-commands %sh{
-        if [ "$kak_opt_filetype" = "hbs" ]; then
-            printf %s "maybe-add-hbs-to-html"
-        fi
-    } }
-
-    hook -group hbs-highlight global WinDisplay .*\.(?!hbs).* %{ 
-        remove-hbs-from-html
-    } 
-}
-
 hook -group hbs-highlight global WinSetOption filetype=hbs %{
+    maybe-add-hbs-to-html
     add-highlighter window/hbs-file ref hbs-file
 }
 


### PR DESCRIPTION
Removing the handlebars highlighters when a client toggles away from hbs window unintentionally causes other clients attached to hbs windows to no longer highlight correctly.  The only other option is to copy the entire html highlighter and all of it's rules, but that seems like a maintenance headache. 

So instead, just leave the hbs rules injected into the html rules once the user opens any handlebars file. It's not ideal, but I'd say it's the least bad option.

You can see the origional issue I describe above in the following terminal recording.  Pay attention to how highlighting on the top client changes as the lower client toggles back and forth:
![hbs-trimmed](https://user-images.githubusercontent.com/197222/47155064-95d6fa00-d2a9-11e8-9912-86e1d745c60a.gif)


