### PR TITLE
Expose selection(s) length with a value

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -265,6 +265,14 @@ The following expansions are supported (with required context _in italics_):
     unquoted list of the ranges of all selections, in the same format as
     `%val{selection_desc}`
 
+*%val{selection_length}*::
+    _in window scope_ +
+    length (in codepoints) of the main selection
+
+*%val{selections_length}*::
+    _in window scope_ +
+    unquoted list of the lengths (in codepoints) of the selections
+
 *%val{session}*::
     name of the current session
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -235,6 +235,16 @@ static const EnvVarDesc builtin_env_vars[] = { {
         [](StringView name, const Context& context, Quoting quoting)
         { return selection_list_to_string(context.selections()); }
     }, {
+        "selection_length", false,
+        [](StringView name, const Context& context, Quoting quoting) -> String
+        { return to_string(char_length(context.buffer(), context.selections().main())); }
+    }, {
+        "selections_length", false,
+        [](StringView name, const Context& context, Quoting quoting)
+        { return join(context.selections() |
+                      transform([&](const Selection& s)
+                               { return to_string(char_length(context.buffer(), s)); }), ' ', false); }
+    }, {
         "window_width", false,
         [](StringView name, const Context& context, Quoting quoting) -> String
         { return to_string(context.window().dimensions().column); }


### PR DESCRIPTION
I have a couple of plugins ([expand](https://github.com/occivink/kakoune-expand), [vertical-selection](https://github.com/occivink/kakoune-vertical-selection)) where I need the selections' length. I currently use `exec s.<ret>; echo %reg{#}` as a workaround, but that can get slow with large selections.