### PR TITLE
gruvbox: show comments in italic

### DIFF
--- a/colors/gruvbox.kak
+++ b/colors/gruvbox.kak
@@ -33,7 +33,7 @@ evaluate-commands %sh{
         face global keyword   ${red}
         face global operator  ${fg}
         face global attribute ${orange}
-        face global comment   ${gray}
+        face global comment   ${gray}+i
         face global meta      ${aqua}
         face global builtin   ${fg}+b
 


### PR DESCRIPTION
Many editors follow a convention of showing comments in italic, would be great if gruvbox theme also did so by default.

I didn't touch the rest of the themes because I wasn't sure it is desirable, let me know if you want me to change all of them. Desertex theme for example already uses italic font.

/cc @laelath because you recently edited this theme too 😉 