### PR TITLE
rc: Replace occurrences of `setsid`

### DIFF
--- a/rc/base/x11.kak
+++ b/rc/base/x11.kak
@@ -32,7 +32,7 @@ The optional arguments will be passed as arguments to the new client} \
            exit
         fi
         if [ $# -ne 0 ]; then kakoune_params="-e '$@'"; fi
-        setsid ${kak_opt_termcmd} "kak -c ${kak_session} ${kakoune_params}" < /dev/null > /dev/null 2>&1 &
+        { eval "${kak_opt_termcmd} \"kak -c ${kak_session} ${kakoune_params}\""; } </dev/null >/dev/null 2>&1 &
 }}
 
 define-command -docstring %{x11-focus [<client>]: focus a given client's window

--- a/rc/extra/ranger.kak
+++ b/rc/extra/ranger.kak
@@ -47,13 +47,13 @@ EOF
         < "/dev/$tty"
 
     elif [ -n "$WINDOWID" ]; then
-        setsid $kak_opt_termcmd " \
-            ranger $@ --cmd "'"'" \
+        { eval "$kak_opt_termcmd \" \
+            ranger $@ --cmd \"'\"'\" \
                 map <return> eval \
                     fm.execute_console('shell \
                         echo evaluate-commands -client ' + ranger.ext.shell_escape.shell_escape('$kak_client') + ' edit {file} | \
                         kak -p '.format(file=fm.thisfile.path) + ranger.ext.shell_escape.shell_escape('$kak_session') + '; \
                         xdotool windowactivate $kak_client_env_WINDOWID') \
-                    if fm.thisfile.is_file else fm.execute_console('move right=1')"'"' < /dev/null > /dev/null 2>&1 &
+                    if fm.thisfile.is_file else fm.execute_console('move right=1')\"'\"'"; } </dev/null >/dev/null 2>&1 &
     fi
 }}

--- a/rc/extra/x11-repl.kak
+++ b/rc/extra/x11-repl.kak
@@ -9,7 +9,7 @@ All optional parameters are forwarded to the new window} \
            exit
         fi
         if [ $# -eq 0 ]; then cmd="${SHELL:-sh}"; else cmd="$@"; fi
-        setsid ${kak_opt_termcmd} ${cmd} -t kak_repl_window < /dev/null > /dev/null 2>&1 &
+        { eval "${kak_opt_termcmd} ${cmd} -t kak_repl_window"; } </dev/null >/dev/null 2>&1 &
 }}
 
 define-command x11-send-text -docstring "send the selected text to the repl window" %{


### PR DESCRIPTION
The `setsid` isn't typically installed on BSD systems, so we replace
it with the usual shell pattern using braces.

Fixes #2520