### PR TITLE
Remove extra spaces for switches list in info

### DIFF
--- a/src/parameters_parser.cc
+++ b/src/parameters_parser.cc
@@ -16,7 +16,7 @@ String generate_switches_doc(const SwitchMap& switches)
     const ColumnCount maxlen = *std::max_element(switches_len.begin(), switches_len.end());
 
     for (auto& sw : switches) {
-        res += format("  -{} {}{}{}\n",
+        res += format("-{} {}{}{}\n",
                       sw.key,
                       sw.value.takes_arg ? "<arg>" : "",
                       String{' ', maxlen - switch_len(sw) + 1},


### PR DESCRIPTION
Switches indentation is already handled by the `indent()` function. No need for extra spaces.

Before:
![image](https://user-images.githubusercontent.com/39315/47616389-49b36300-dabc-11e8-93a4-9a9bff728f92.png)

After:
![image](https://user-images.githubusercontent.com/39315/47616392-546df800-dabc-11e8-99e6-3318e3caef86.png)
