### PR TITLE
Truncate incomplete debug command docstring

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1208,8 +1208,7 @@ static constexpr auto modes = { "normal", "insert", "menu", "prompt", "goto", "v
 const CommandDesc debug_cmd = {
     "debug",
     nullptr,
-    "debug <command>: write some debug information to the debug buffer\n"
-    "existing commands: info, buffers, options, memory, shared-strings, profile-hash-maps, faces",
+    "debug <command>: write some debug information to the *debug* buffer",
     ParameterDesc{{}, ParameterDesc::Flags::SwitchesOnlyAtStart, 1},
     CommandFlags::None,
     CommandHelper{},


### PR DESCRIPTION
I noticed that the `regex` command was missing in the info.
I was about to add it, but then I decided to simplify the message since it's just repeating what's already provided by the auto-completion.
This will prevent future discrepancy.