### PR TITLE
Add 'shell' option

### DIFF
--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -307,3 +307,8 @@ are exclusively available to built-in options.
     Controls which messages will be displayed in the startup info box, only messages
     relating to a Kakoune version greater than this value will be displayed. Versions
     are written as a single number: Like `20180413` for version `2018.04.13`
+
+*shell* `str`::
+    path to a POSIX shell to use for shell expansion.  On startup, Kakoune sets this
+    to an appropriately executable `sh` found in a minimal path where "all standard
+    POSIX utilities can be found" -- _not_ the user's `$PATH`.

--- a/src/main.cc
+++ b/src/main.cc
@@ -418,6 +418,7 @@ void register_options()
         "set of pair of characters to be considered as matching pairs",
         { '(', ')', '{', '}', '[', ']', '<', '>' });
     reg.declare_option<int>("startup_info_version", "version up to which startup info changes should be hidden", 0);
+    reg.declare_option("shell", "path to a POSIX shell used for shell expansion", find_shell());
 }
 
 static Client* local_client = nullptr;

--- a/src/shell_manager.hh
+++ b/src/shell_manager.hh
@@ -51,10 +51,10 @@ public:
     CandidateList complete_env_var(StringView prefix, ByteCount cursor_pos) const;
 
 private:
-    String m_shell;
-
     ConstArrayView<EnvVarDesc> m_env_vars;
 };
+
+String find_shell();
 
 }
 


### PR DESCRIPTION
Rationale: On OS X, I don't have a decent way to replace the shell (I get
"Operation not permitted", even as root though I'd rather not much with
the system shell anyhow).  But I'd like to use dash to speed things up,
and the current logic doesn't allow me to put it in the path or
anything.