### PR TITLE
Give lua block comments higher match precedence

### DIFF
--- a/rc/base/lua.kak
+++ b/rc/base/lua.kak
@@ -13,11 +13,11 @@ hook global BufCreate .*[.](lua) %{
 
 add-highlighter shared/lua regions
 add-highlighter shared/lua/code default-region group
+add-highlighter shared/lua/raw_string  region -match-capture '\[(=*)\['   '\](=*)\]'       fill string
+add-highlighter shared/lua/raw_comment region -match-capture '--\[(=*)\[' '\](=*)\]'       fill comment
 add-highlighter shared/lua/double_string region '"'   (?<!\\)(?:\\\\)*" fill string
 add-highlighter shared/lua/single_string region "'"   (?<!\\)(?:\\\\)*' fill string
 add-highlighter shared/lua/comment       region '--'  $                 fill comment
-add-highlighter shared/lua/raw_string  region -match-capture '\[(=*)\['   '\](=*)\]'       fill string
-add-highlighter shared/lua/raw_comment region -match-capture '--\[(=*)\[' '\](=*)\]'       fill comment
 
 add-highlighter shared/lua/code/ regex \b(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|return|then|true|until|while)\b 0:keyword
 


### PR DESCRIPTION
Lua block comments were not highlighted because the start of a block comment `--[[` matches the single-line comment region. Placing the block comment region highlighter before the single-lien one fixes the problem.