### PR TITLE
fix hex numbers for gas filetype - add missing a-f letters

### DIFF
--- a/rc/base/gas.kak
+++ b/rc/base/gas.kak
@@ -13,7 +13,7 @@ add-highlighter shared/gas/commentSingle1 region '#'       '$'              fill
 add-highlighter shared/gas/commentSingle2 region ';'       '$'              fill comment
 
 # Constant
-add-highlighter shared/gas/code/ regex (0[xX][0-9]+|\b[0-9]+)\b 0:value
+add-highlighter shared/gas/code/ regex (0[xX][0-9a-fA-F]+|\b[0-9]+)\b 0:value
 
 # Labels
 add-highlighter shared/gas/code/ regex ^\h*([A-Za-z0-9_.-]+): 0:operator


### PR DESCRIPTION
Currently `gas.kak` defines this regex:

```kak
add-highlighter shared/gas/code/ regex (0[xX][0-9]+|\b[0-9]+)\b 0:value
```
It's kinda strange for me, that hex numbers are not highlighted if they contain letters:

![image](https://user-images.githubusercontent.com/19470159/48406184-e6c0fd80-e744-11e8-98f7-ee85cc879c60.png)

I've updated regex to highlight those properly:
```kak
add-highlighter shared/gas/code/ regex (0[xX][0-9a-fA-F]+|\b[0-9]+)\b 0:value
```
![image](https://user-images.githubusercontent.com/19470159/48406376-546d2980-e745-11e8-8c8d-18cb2b83adc5.png)
