### PR TITLE
Added expandtab, noexpandtab and smarttab features

### DIFF
--- a/rc/core/expandtab.kak
+++ b/rc/core/expandtab.kak
@@ -1,0 +1,38 @@
+define-command -docstring "noexpandtab: use tab character to indent and align" \
+noexpandtab %{
+    remove-hooks global noexpandtab
+    hook -group noexpandtab global NormalKey <gt> %{ try %{
+        execute-keys -draft "<a-x>s^\h+<ret><a-@>"
+    }}
+    set-option global aligntab true
+    remove-hooks global expandtab
+    remove-hooks global smarttab
+}
+
+define-command -docstring "expandtab: use space character to indent and align" \
+expandtab %{
+    remove-hooks global expandtab
+    hook -group expandtab global InsertChar '\t' %{ execute-keys -draft h@ }
+    hook -group expandtab global InsertKey <backspace> %{ try %{
+        execute-keys -draft <a-h><a-k> "^\h+.\z" <ret>I<space><esc><lt>
+    }}
+    set-option global aligntab false
+    remove-hooks global noexpandtab
+    remove-hooks global smarttab
+}
+
+define-command -docstring "smarttab: use tab character for indentation and space character for alignment" \
+smarttab %{
+    remove-hooks global smarttab
+    hook -group smarttab global InsertKey <tab> %{ try %{
+        execute-keys -draft <a-h><a-k> "^\h*.\z" <ret>
+    } catch %{
+        execute-keys -draft h@
+    }}
+    hook -group smarttab global NormalKey <gt> %{ try %{
+        execute-keys -draft "<a-x>s^\h+<ret><a-@>"
+    }}
+    set-option global aligntab false
+    remove-hooks global expandtab
+    remove-hooks global noexpandtab
+}

--- a/rc/core/expandtab.kak
+++ b/rc/core/expandtab.kak
@@ -1,33 +1,68 @@
+declare-option -docstring "amount of spaces that should be treated as single tab character when deleting spaces" \
+int softtabstop 0
+
+declare-option -docstring "displays current tab handling mode" \
+str smarttab_mode ''
+
+declare-option -hidden int oldindentwidth %opt{indentwidth}
+define-command -hidden smarttab-set %{ evaluate-commands %sh{
+    if [ $kak_opt_indentwidth -eq 0 ]; then
+        echo "set-option window indentwidth $kak_opt_oldindentwidth"
+    else
+        echo "set-option window oldindentwidth $kak_opt_indentwidth"
+    fi
+}}
+
 define-command -docstring "noexpandtab: use tab character to indent and align" \
 noexpandtab %{
-    remove-hooks window tabmode
-    hook -group noexpandtab window NormalKey <gt> %{ try %{
-        execute-keys -draft "<a-x>s^\h+<ret><a-@>"
-    }}
+    set-option window smarttab_mode 'noexpandtab'
+    remove-hooks window smarttab-mode
+    smarttab-set
+    set-option window indentwidth 0
     set-option window aligntab true
+    hook -group smarttab-mode window InsertDelete ' ' %{ try %sh{
+        if [ $kak_opt_softtabstop -gt 1 ]; then
+            echo 'execute-keys -draft <a-h><a-k> "^\h+.\z" <ret>I<space><esc><lt>'
+        fi
+    } catch %{
+        try %{ execute-keys -draft h %opt{softtabstop}<s-h> 2<s-l> s "\h+\z" <ret>d }
+    }}
 }
 
 define-command -docstring "expandtab: use space character to indent and align" \
 expandtab %{
-    remove-hooks window tabmode
-    hook -group tabmode window InsertChar '\t' %{ execute-keys -draft h@ }
-    hook -group tabmode window InsertDelete ' ' %{ try %{
-        execute-keys -draft <a-h><a-k> "^\h+.\z" <ret>I<space><esc><lt>
-    }}
+    set-option window smarttab_mode 'expandtab'
+    remove-hooks window smarttab-mode
+    smarttab-set
     set-option window aligntab false
+    hook -group smarttab-mode window InsertChar '\t' %{ execute-keys -draft h@ }
+    hook -group smarttab-mode window InsertDelete ' ' %{ try %sh{
+        if [ $kak_opt_softtabstop -gt 1 ]; then
+            echo 'execute-keys -draft <a-h><a-k> "^\h+.\z" <ret>I<space><esc><lt>'
+        fi
+    } catch %{
+        try %{ execute-keys -draft h %opt{softtabstop}<s-h> 2<s-l> s "\h+\z" <ret>d }
+    }}
 }
 
 define-command -docstring "smarttab: use tab character for indentation and space character for alignment" \
 smarttab %{
-    remove-hooks window tabmode
-    hook -group tabmode window InsertKey <tab> %{ try %{
+    set-option window smarttab_mode 'smarttab'
+    remove-hooks window smarttab-mode
+    smarttab-set
+    set-option window indentwidth 0
+    set-option window aligntab false
+    hook -group smarttab-mode window InsertChar '\t' %{ try %{
         execute-keys -draft <a-h><a-k> "^\h*.\z" <ret>
     } catch %{
         execute-keys -draft h@
     }}
-    hook -group tabmode window NormalKey <gt> %{ try %{
-        execute-keys -draft "<a-x>s^\h+<ret><a-@>"
+    hook -group smarttab-mode window InsertDelete ' ' %{ try %sh{
+        if [ $kak_opt_softtabstop -gt 1 ]; then
+            echo 'execute-keys -draft <a-h><a-k> "^\h+.\z" <ret>I<space><esc><lt>'
+        fi
+    } catch %{
+        try %{ execute-keys -draft h %opt{softtabstop}<s-h> 2<s-l> s "\h+\z" <ret>d }
     }}
-    set-option window aligntab false
 }
 

--- a/rc/core/expandtab.kak
+++ b/rc/core/expandtab.kak
@@ -1,38 +1,33 @@
 define-command -docstring "noexpandtab: use tab character to indent and align" \
 noexpandtab %{
-    remove-hooks global noexpandtab
-    hook -group noexpandtab global NormalKey <gt> %{ try %{
+    remove-hooks window tabmode
+    hook -group noexpandtab window NormalKey <gt> %{ try %{
         execute-keys -draft "<a-x>s^\h+<ret><a-@>"
     }}
-    set-option global aligntab true
-    remove-hooks global expandtab
-    remove-hooks global smarttab
+    set-option window aligntab true
 }
 
 define-command -docstring "expandtab: use space character to indent and align" \
 expandtab %{
-    remove-hooks global expandtab
-    hook -group expandtab global InsertChar '\t' %{ execute-keys -draft h@ }
-    hook -group expandtab global InsertKey <backspace> %{ try %{
+    remove-hooks window tabmode
+    hook -group tabmode window InsertChar '\t' %{ execute-keys -draft h@ }
+    hook -group tabmode window InsertDelete ' ' %{ try %{
         execute-keys -draft <a-h><a-k> "^\h+.\z" <ret>I<space><esc><lt>
     }}
-    set-option global aligntab false
-    remove-hooks global noexpandtab
-    remove-hooks global smarttab
+    set-option window aligntab false
 }
 
 define-command -docstring "smarttab: use tab character for indentation and space character for alignment" \
 smarttab %{
-    remove-hooks global smarttab
-    hook -group smarttab global InsertKey <tab> %{ try %{
+    remove-hooks window tabmode
+    hook -group tabmode window InsertKey <tab> %{ try %{
         execute-keys -draft <a-h><a-k> "^\h*.\z" <ret>
     } catch %{
         execute-keys -draft h@
     }}
-    hook -group smarttab global NormalKey <gt> %{ try %{
+    hook -group tabmode window NormalKey <gt> %{ try %{
         execute-keys -draft "<a-x>s^\h+<ret><a-@>"
     }}
-    set-option global aligntab false
-    remove-hooks global expandtab
-    remove-hooks global noexpandtab
+    set-option window aligntab false
 }
+


### PR DESCRIPTION
This code addresses already closed issue #1038, however I don't think that this issue was fixed.

The `expandtab.kak` file adds three commands to use:
- `noexpandtab` - use `tab` character for everything.  
  <kbd>Tab</kbd> will insert `\t` character, and <kbd>></kbd> will use `\t` character when indenting. Aligning cursors with <kbd>&</kbd> uses `\t` character.
- `expandtab` - use `space` character for everything.  
  <kbd>Tab</kbd> will insert `%opt{tabstop}` amount of spaces, and <kbd>></kbd> will indent with spaces.
- `smarttab` - indent with `tab` character, align with `space` character.  
  <kbd>Tab</kbd> will insert `\t` character if your cursor is inside indentation area, e.g. before any non-whitespace character, and insert spaces if cursor is after any non-whitespace character. Aligning cursors with <kbd>&</kbd> uses `space`.
The demo can be found in [issue comment](https://github.com/mawww/kakoune/issues/1038#issuecomment-439716724).

I've added this to `rc/core` because it contains most of default things, while `rc/extra` and `rc/base` provide mostly language support. This is really basic functionality that is shipped with most editors, and since it is implemented with hooks it works like most other builtin features.