### PR TITLE
Don't highlight Ruby eigenclass definitions as here docs

### DIFF
--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -23,7 +23,7 @@ add-highlighter shared/ruby/              region -recurse \( '%[iqrswxIQRSWX]\('
 add-highlighter shared/ruby/              region -recurse \{ '%[iqrswxIQRSWX]\{' \} fill meta
 add-highlighter shared/ruby/              region -recurse \[ '%[iqrswxIQRSWX]\[' \] fill meta
 add-highlighter shared/ruby/              region -recurse  < '%[iqrswxIQRSWX]<'   > fill meta
-add-highlighter shared/ruby/heredoc region '<<[-~]?(\w+)'      '^\h*(\w+)$' fill string
+add-highlighter shared/ruby/heredoc region '<<[-~]?(?!self)(\w+)'      '^\h*(\w+)$' fill string
 add-highlighter shared/ruby/division region '[\w\)\]](/|(\h+/\h+))' '\w' group # Help Kakoune to better detect /…/ literals
 
 # Regular expression flags are: i → ignore case, m → multi-lines, o → only interpolate #{} blocks once, x → extended mode (ignore white spaces)


### PR DESCRIPTION
E.g. for the following code snippet, the code was highlighted as a string
```ruby
class Bob
	class <<self
		def hello
		end
	end
end
```