### PR TITLE
src: Build options to compile with sanitizers

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,6 +11,17 @@ endif
 ifeq ($(debug),yes)
     CPPFLAGS += -DKAK_DEBUG
     suffix := .debug
+
+    ifeq ($(debug_asan),yes)
+        CXXFLAGS += -fsanitize=address -fno-omit-frame-pointer
+    else ifeq ($(debug_msan),yes)
+        CXXFLAGS += -fsanitize=memory -fsanitize-memory-track-origins
+        CXXFLAGS += -fno-omit-frame-pointer -fno-optimize-sibling-calls
+    else ifeq ($(debug_ubsan),yes)
+        CXXFLAGS += -fsanitize=undefined -fno-omit-frame-pointer
+    else ifeq ($(debug_leaksan),yes)
+        CXXFLAGS += -fsanitize=leak
+    endif
 else
     ifeq ($(debug),no)
         CXXFLAGS += -O3


### PR DESCRIPTION
This commit adds options to the Makefile that make the compiler
enable sanitizers.

The flags and option names where based on the official upstream
documentation (for `clang` v8 as of writing this):

https://clang.llvm.org/docs/index.html

Note that the `CXX` variable should be forced to `clang++` in theory,
but in practice `g++` seems to support some sanitizers (ASAN for
example), so it's the user's responsibility to pick the right compiler.