### PR TITLE
makefile.kak: highlight .mk files

### DIFF
--- a/rc/core/makefile.kak
+++ b/rc/core/makefile.kak
@@ -1,7 +1,7 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*/?[mM]akefile %{
+hook global BufCreate .*(/?[mM]akefile|\.mk) %{
     set-option buffer filetype makefile
 }
 


### PR DESCRIPTION
This extension is commonly used for helper files, etc.