### PR TITLE
Setup language cleanup hooks only during initialization

### DIFF
--- a/rc/base/clojure.kak
+++ b/rc/base/clojure.kak
@@ -187,15 +187,14 @@ define-command -hidden clojure-indent-on-new-line %{
 
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
-hook -group clojure-highlight global WinSetOption filetype=clojure %{ add-highlighter window/clojure ref clojure }
+hook -group clojure-highlight global WinSetOption filetype=clojure %{
+    add-highlighter window/clojure ref clojure
+    hook -once -always window WinSetOption filetype=(?!clojure).* %{ remove-highlighter window/clojure }
+}
 
 hook global WinSetOption filetype=clojure %[
     hook window ModeChange insert:.* -group clojure-hooks  clojure-filter-around-selections
     hook window InsertChar \n -group clojure-indent clojure-indent-on-new-line
+
+    hook -once -always window WinSetOption filetype=(?!clojure).* %{ remove-hooks window clojure-.+ }
 ]
-
-hook -group clojure-highlight global WinSetOption filetype=(?!clojure).* %{ remove-highlighter window/clojure }
-
-hook global WinSetOption filetype=(?!clojure).* %{
-    remove-hooks window clojure-.+
-}

--- a/rc/base/clojure.kak
+++ b/rc/base/clojure.kak
@@ -189,12 +189,12 @@ define-command -hidden clojure-indent-on-new-line %{
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 hook -group clojure-highlight global WinSetOption filetype=clojure %{
     add-highlighter window/clojure ref clojure
-    hook -once -always window WinSetOption filetype=(?!clojure).* %{ remove-highlighter window/clojure }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/clojure }
 }
 
 hook global WinSetOption filetype=clojure %[
     hook window ModeChange insert:.* -group clojure-hooks  clojure-filter-around-selections
     hook window InsertChar \n -group clojure-indent clojure-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!clojure).* %{ remove-hooks window clojure-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window clojure-.+ }
 ]

--- a/rc/base/css.kak
+++ b/rc/base/css.kak
@@ -61,17 +61,16 @@ define-command -hidden css-indent-on-closing-curly-brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group css-highlight global WinSetOption filetype=css %{ add-highlighter window/css ref css }
+hook -group css-highlight global WinSetOption filetype=css %{
+    add-highlighter window/css ref css
+    hook -once -always window WinSetOption filetype=(?!css).* %{ remove-highlighter window/css }
+}
 
 hook global WinSetOption filetype=css %[
     hook window ModeChange insert:.* -group css-hooks  css-filter-around-selections
     hook window InsertChar \n -group css-indent css-indent-on-new-line
     hook window InsertChar \} -group css-indent css-indent-on-closing-curly-brace
     set-option buffer extra_word_chars '_' '-'
+
+    hook -once -always window WinSetOption filetype=(?!css).* %{ remove-hooks window css-.+ }
 ]
-
-hook -group css-highlight global WinSetOption filetype=(?!css).* %{ remove-highlighter window/css }
-
-hook global WinSetOption filetype=(?!css).* %{
-    remove-hooks window css-.+
-}

--- a/rc/base/css.kak
+++ b/rc/base/css.kak
@@ -63,7 +63,7 @@ define-command -hidden css-indent-on-closing-curly-brace %[
 
 hook -group css-highlight global WinSetOption filetype=css %{
     add-highlighter window/css ref css
-    hook -once -always window WinSetOption filetype=(?!css).* %{ remove-highlighter window/css }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/css }
 }
 
 hook global WinSetOption filetype=css %[
@@ -72,5 +72,5 @@ hook global WinSetOption filetype=css %[
     hook window InsertChar \} -group css-indent css-indent-on-closing-curly-brace
     set-option buffer extra_word_chars '_' '-'
 
-    hook -once -always window WinSetOption filetype=(?!css).* %{ remove-hooks window css-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window css-.+ }
 ]

--- a/rc/base/d.kak
+++ b/rc/base/d.kak
@@ -116,7 +116,10 @@ define-command -hidden d-indent-on-closing-curly-brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group d-highlight global WinSetOption filetype=d %{ add-highlighter window/d ref d }
+hook -group d-highlight global WinSetOption filetype=d %{
+    add-highlighter window/d ref d
+    hook -once -always window WinSetOption filetype=(?!d).* %{ remove-highlighter window/d }
+}
 
 hook global WinSetOption filetype=d %{
     # cleanup trailing whitespaces when exiting insert mode
@@ -124,10 +127,6 @@ hook global WinSetOption filetype=d %{
     hook window InsertChar \n -group d-indent d-indent-on-new-line
     hook window InsertChar \{ -group d-indent d-indent-on-opening-curly-brace
     hook window InsertChar \} -group d-indent d-indent-on-closing-curly-brace
-}
 
-hook -group d-highlight global WinSetOption filetype=(?!d).* %{ remove-highlighter window/d }
-
-hook global WinSetOption filetype=(?!d).* %{
-    remove-hooks window d-.+
+    hook -once -always window WinSetOptionfiletype=(?!d).* %{ remove-hooks window d-.+ }
 }

--- a/rc/base/d.kak
+++ b/rc/base/d.kak
@@ -118,7 +118,7 @@ define-command -hidden d-indent-on-closing-curly-brace %[
 
 hook -group d-highlight global WinSetOption filetype=d %{
     add-highlighter window/d ref d
-    hook -once -always window WinSetOption filetype=(?!d).* %{ remove-highlighter window/d }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/d }
 }
 
 hook global WinSetOption filetype=d %{
@@ -128,5 +128,5 @@ hook global WinSetOption filetype=d %{
     hook window InsertChar \{ -group d-indent d-indent-on-opening-curly-brace
     hook window InsertChar \} -group d-indent d-indent-on-closing-curly-brace
 
-    hook -once -always window WinSetOption filetype=(?!d).* %{ remove-hooks window d-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window d-.+ }
 }

--- a/rc/base/d.kak
+++ b/rc/base/d.kak
@@ -128,5 +128,5 @@ hook global WinSetOption filetype=d %{
     hook window InsertChar \{ -group d-indent d-indent-on-opening-curly-brace
     hook window InsertChar \} -group d-indent d-indent-on-closing-curly-brace
 
-    hook -once -always window WinSetOptionfiletype=(?!d).* %{ remove-hooks window d-.+ }
+    hook -once -always window WinSetOption filetype=(?!d).* %{ remove-hooks window d-.+ }
 }

--- a/rc/base/etc.kak
+++ b/rc/base/etc.kak
@@ -19,7 +19,7 @@ add-highlighter shared/etc-resolv-conf/ regex ^(nameserver|server|domain|sortlis
 
 hook -group etc-resolv-conf-highlight global WinSetOption filetype=etc-resolv-conf %{
     add-highlighter window/etc-resolv-conf ref etc-resolv-conf
-    hook -once -always window WinSetOption filetype=(?!etc-resolv-conf).* %{ remove-highlighter window/etc-resolv-conf }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/etc-resolv-conf }
 }
 
 ## /etc/hosts
@@ -29,7 +29,7 @@ add-highlighter shared/etc-hosts/ regex '#.*?$' 0:comment
 
 hook -group etc-hosts-highlight global WinSetOption filetype=etc-hosts %{
     add-highlighter window/etc-hosts ref etc-hosts
-    hook -once -always window WinSetOption filetype=(?!etc-hosts).* %{ remove-highlighter window/etc-hosts }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/etc-hosts }
 }
 
 ## /etc/fstab
@@ -39,7 +39,7 @@ add-highlighter shared/etc-fstab/ regex '#.*?$' 0:comment
 
 hook -group etc-fstab-highlight global WinSetOption filetype=etc-fstab %{
     add-highlighter window/etc-fstab ref etc-fstab
-    hook -once -always window WinSetOption filetype=(?!etc-fstab).* %{ remove-highlighter window/etc-fstab }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/etc-fstab }
 }
 
 ## /etc/group
@@ -48,7 +48,7 @@ add-highlighter shared/etc-group/ regex ^(\S+?):(\S+?)?:(\S+?)?:(\S+?)?$ 1:keywo
 
 hook -group etc-group-highlight global WinSetOption filetype=etc-group %{
     add-highlighter window/etc-group ref etc-group
-    hook -once -always window WinSetOption filetype=(?!etc-group).* %{ remove-highlighter window/etc-group }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/etc-group }
 }
 
 ## /etc/gshadow
@@ -57,7 +57,7 @@ add-highlighter shared/etc-gshadow/ regex ^(\S+?):(\S+?)?:(\S+?)?:(\S+?)?$ 1:key
 
 hook -group etc-gshadow-highlight global WinSetOption filetype=etc-gshadow %{
     add-highlighter window/etc-gshadow ref etc-gshadow
-    hook -once -always window WinSetOption filetype=(?!etc-gshadow).* %{ remove-highlighter window/etc-gshadow }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/etc-gshadow }
 }
 
 ## /etc/shadow
@@ -66,7 +66,7 @@ add-highlighter shared/etc-shadow/ regex ^(\S+?):(\S+?):([0-9]+?):([0-9]+?)?:([0
 
 hook -group etc-shadow-highlight global WinSetOption filetype=etc-shadow %{
     add-highlighter window/etc-shadow ref etc-shadow
-    hook -once -always window WinSetOption filetype=(?!etc-shadow).* %{ remove-highlighter window/etc-shadow }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/etc-shadow }
 }
 
 ## /etc/passwd
@@ -75,5 +75,5 @@ add-highlighter shared/etc-passwd/ regex ^(\S+?):(\S+?):([0-9]+?):([0-9]+?):(.*?
 
 hook -group etc-passwd-highlight global WinSetOption filetype=etc-passwd %{
     add-highlighter window/etc-passwd ref etc-passwd
-    hook -once -always window WinSetOption filetype=(?!etc-passwd).* %{ remove-highlighter window/etc-passwd }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/etc-passwd }
 }

--- a/rc/base/etc.kak
+++ b/rc/base/etc.kak
@@ -17,49 +17,63 @@ add-highlighter shared/etc-resolv-conf group
 add-highlighter shared/etc-resolv-conf/ regex ^#.*?$ 0:comment
 add-highlighter shared/etc-resolv-conf/ regex ^(nameserver|server|domain|sortlist|options)[\s\t]+(.*?)$ 1:type 2:attribute
 
-hook -group etc-resolv-conf-highlight global WinSetOption filetype=etc-resolv-conf %{ add-highlighter window/etc-resolv-conf ref etc-resolv-conf }
-hook -group etc-resolv-conf-highlight global WinSetOption filetype=(?!etc-resolv-conf).* %{ remove-highlighter window/etc-resolv-conf }
+hook -group etc-resolv-conf-highlight global WinSetOption filetype=etc-resolv-conf %{
+    add-highlighter window/etc-resolv-conf ref etc-resolv-conf
+    hook -once -always window WinSetOption filetype=(?!etc-resolv-conf).* %{ remove-highlighter window/etc-resolv-conf }
+}
 
 ## /etc/hosts
 add-highlighter shared/etc-hosts group
 add-highlighter shared/etc-hosts/ regex ^(.+?)[\s\t]+?(.*?)$ 1:type 2:attribute
 add-highlighter shared/etc-hosts/ regex '#.*?$' 0:comment
 
-hook -group etc-hosts-highlight global WinSetOption filetype=etc-hosts %{ add-highlighter window/etc-hosts ref etc-hosts }
-hook -group etc-hosts-highlight global WinSetOption filetype=(?!etc-hosts).* %{ remove-highlighter window/etc-hosts }
+hook -group etc-hosts-highlight global WinSetOption filetype=etc-hosts %{
+    add-highlighter window/etc-hosts ref etc-hosts
+    hook -once -always window WinSetOption filetype=(?!etc-hosts).* %{ remove-highlighter window/etc-hosts }
+}
 
 ## /etc/fstab
 add-highlighter shared/etc-fstab group
 add-highlighter shared/etc-fstab/ regex ^(\S{1,})\s+?(\S{1,})\s+?(\S{1,})\s+?(\S{1,})\s+?(\S{1,})\s+?(\S{1,})(?:\s+)?$ 1:keyword 2:value 3:type 4:string 5:attribute 6:attribute
 add-highlighter shared/etc-fstab/ regex '#.*?$' 0:comment
 
-hook -group etc-fstab-highlight global WinSetOption filetype=etc-fstab %{ add-highlighter window/etc-fstab ref etc-fstab }
-hook -group etc-fstab-highlight global WinSetOption filetype=(?!etc-fstab).* %{ remove-highlighter window/etc-fstab }
+hook -group etc-fstab-highlight global WinSetOption filetype=etc-fstab %{
+    add-highlighter window/etc-fstab ref etc-fstab
+    hook -once -always window WinSetOption filetype=(?!etc-fstab).* %{ remove-highlighter window/etc-fstab }
+}
 
 ## /etc/group
 add-highlighter shared/etc-group group
 add-highlighter shared/etc-group/ regex ^(\S+?):(\S+?)?:(\S+?)?:(\S+?)?$ 1:keyword 2:type 3:value 4:string
 
-hook -group etc-group-highlight global WinSetOption filetype=etc-group %{ add-highlighter window/etc-group ref etc-group }
-hook -group etc-group-highlight global WinSetOption filetype=(?!etc-group).* %{ remove-highlighter window/etc-group }
+hook -group etc-group-highlight global WinSetOption filetype=etc-group %{
+    add-highlighter window/etc-group ref etc-group
+    hook -once -always window WinSetOption filetype=(?!etc-group).* %{ remove-highlighter window/etc-group }
+}
 
 ## /etc/gshadow
 add-highlighter shared/etc-gshadow group
 add-highlighter shared/etc-gshadow/ regex ^(\S+?):(\S+?)?:(\S+?)?:(\S+?)?$ 1:keyword 2:type 3:value 4:string
 
-hook -group etc-gshadow-highlight global WinSetOption filetype=etc-gshadow %{ add-highlighter window/etc-gshadow ref etc-gshadow }
-hook -group etc-gshadow-highlight global WinSetOption filetype=(?!etc-gshadow).* %{ remove-highlighter window/etc-gshadow }
+hook -group etc-gshadow-highlight global WinSetOption filetype=etc-gshadow %{
+    add-highlighter window/etc-gshadow ref etc-gshadow
+    hook -once -always window WinSetOption filetype=(?!etc-gshadow).* %{ remove-highlighter window/etc-gshadow }
+}
 
 ## /etc/shadow
 add-highlighter shared/etc-shadow group
 add-highlighter shared/etc-shadow/ regex ^(\S+?):(\S+?):([0-9]+?):([0-9]+?)?:([0-9]+?)?:([0-9]+?)?:([0-9]+?)?:([0-9]+?)?:(.*?)?$ 1:keyword 2:type 3:value 4:value 5:value 6:value 7:value 8:value
 
-hook -group etc-shadow-highlight global WinSetOption filetype=etc-shadow %{ add-highlighter window/etc-shadow ref etc-shadow }
-hook -group etc-shadow-highlight global WinSetOption filetype=(?!etc-shadow).* %{ remove-highlighter window/etc-shadow }
+hook -group etc-shadow-highlight global WinSetOption filetype=etc-shadow %{
+    add-highlighter window/etc-shadow ref etc-shadow
+    hook -once -always window WinSetOption filetype=(?!etc-shadow).* %{ remove-highlighter window/etc-shadow }
+}
 
 ## /etc/passwd
 add-highlighter shared/etc-passwd group
 add-highlighter shared/etc-passwd/ regex ^(\S+?):(\S+?):([0-9]+?):([0-9]+?):(.*?)?:(.+?):(.+?)$ 1:keyword 2:type 3:value 4:value 5:string 6:attribute 7:attribute
 
-hook -group etc-passwd-highlight global WinSetOption filetype=etc-passwd %{ add-highlighter window/etc-passwd ref etc-passwd }
-hook -group etc-passwd-highlight global WinSetOption filetype=(?!etc-passwd).* %{ remove-highlighter window/etc-passwd }
+hook -group etc-passwd-highlight global WinSetOption filetype=etc-passwd %{
+    add-highlighter window/etc-passwd ref etc-passwd
+    hook -once -always window WinSetOption filetype=(?!etc-passwd).* %{ remove-highlighter window/etc-passwd }
+}

--- a/rc/base/fish.kak
+++ b/rc/base/fish.kak
@@ -72,7 +72,7 @@ define-command -hidden fish-insert-on-new-line %{
 
 hook -group fish-highlight global WinSetOption filetype=fish %{
     add-highlighter window/fish ref fish
-    hook -once -always window WinSetOption filetype=(?!fish).* %{ remove-highlighter window/fish }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/fish }
 }
 
 hook global WinSetOption filetype=fish %{
@@ -80,5 +80,5 @@ hook global WinSetOption filetype=fish %{
     hook window InsertChar \n -group fish-insert fish-insert-on-new-line
     hook window InsertChar \n -group fish-indent fish-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!fish).* %{ remove-hooks window fish-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window fish-.+ }
 }

--- a/rc/base/fish.kak
+++ b/rc/base/fish.kak
@@ -70,16 +70,15 @@ define-command -hidden fish-insert-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group fish-highlight global WinSetOption filetype=fish %{ add-highlighter window/fish ref fish }
+hook -group fish-highlight global WinSetOption filetype=fish %{
+    add-highlighter window/fish ref fish
+    hook -once -always window WinSetOption filetype=(?!fish).* %{ remove-highlighter window/fish }
+}
 
 hook global WinSetOption filetype=fish %{
     hook window InsertChar .* -group fish-indent fish-indent-on-char
     hook window InsertChar \n -group fish-insert fish-insert-on-new-line
     hook window InsertChar \n -group fish-indent fish-indent-on-new-line
-}
 
-hook -group fish-highlight global WinSetOption filetype=(?!fish).* %{ remove-highlighter window/fish }
-
-hook global WinSetOption filetype=(?!fish).* %{
-    remove-hooks window fish-.+
+    hook -once -always window WinSetOption filetype=(?!fish).* %{ remove-hooks window fish-.+ }
 }

--- a/rc/base/gas.kak
+++ b/rc/base/gas.kak
@@ -82,10 +82,10 @@ define-command -hidden gas-indent-on-new-line %~
 
 hook -group gas-highlight global WinSetOption filetype=gas %{
     add-highlighter window/gas ref gas
-    hook -once -always window WinSetOption filetype=(?!gas).* %{ remove-highlighter window/gas }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/gas }
 }
 
 hook global WinSetOption filetype=gas %{
     hook window InsertChar \n -group gas-indent gas-indent-on-new-line
-    hook -once -always window WinSetOption filetype=(?!gas).* %{ remove-hooks window gas-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window gas-.+ }
 }

--- a/rc/base/gas.kak
+++ b/rc/base/gas.kak
@@ -4,7 +4,6 @@ hook global BufCreate .*\.(s|S|asm)$ %{
     set-option buffer filetype gas
 }
 
-
 add-highlighter shared/gas regions
 add-highlighter shared/gas/code default-region group
 add-highlighter shared/gas/string         region '"' (?<!\\)(\\\\)*"        fill string
@@ -81,14 +80,12 @@ define-command -hidden gas-indent-on-new-line %~
     >
 ~
 
-hook -group gas-highlight global WinSetOption filetype=gas %{ add-highlighter window/gas ref gas }
+hook -group gas-highlight global WinSetOption filetype=gas %{
+    add-highlighter window/gas ref gas
+    hook -once -always window WinSetOption filetype=(?!gas).* %{ remove-highlighter window/gas }
+}
 
 hook global WinSetOption filetype=gas %{
     hook window InsertChar \n -group gas-indent gas-indent-on-new-line
-}
-
-hook -group gas-highlight global WinSetOption filetype=(?!gas).* %{ remove-highlighter window/gas }
-
-hook global WinSetOption filetype=(?!gas).* %{
-    remove-hooks window gas-indent
+    hook -once -always window WinSetOption filetype=(?!gas).* %{ remove-hooks window gas-.+ }
 }

--- a/rc/base/git.kak
+++ b/rc/base/git.kak
@@ -9,12 +9,12 @@ hook global BufCreate .*(\.gitconfig|git/config) %{
 hook -group git-commit-highlight global WinSetOption filetype=git-commit %{
     add-highlighter window/git-commit-highlight regions
     add-highlighter window/git-commit-highlight/diff region '^diff --git' '^(?=diff --git)' ref diff # highlight potential diffs from the -v option
-    add-highlighter window/git-commit-highlight/comments region '^\h*#' '$' group 
+    add-highlighter window/git-commit-highlight/comments region '^\h*#' '$' group
     add-highlighter window/git-commit-highlight/comments/ fill cyan,default
     add-highlighter window/git-commit-highlight/comments/ regex "\b(?:(modified)|(deleted)|(new file)|(renamed|copied)):([^\n]*)$" 1:yellow 2:red 3:green 4:blue 5:magenta
-}
 
-hook -group git-commit-highlight global WinSetOption filetype=(?!git-commit).* %{ remove-highlighter window/git-commit-highlight }
+    hook -once -always window WinSetOption filetype=(?!git-commit).* %{ remove-highlighter window/git-commit-highlight }
+}
 
 hook global BufCreate .*git-rebase-todo %{
     set-option buffer filetype git-rebase
@@ -24,6 +24,6 @@ hook -group git-rebase-highlight global WinSetOption filetype=git-rebase %{
     add-highlighter window/git-rebase-highlight group
     add-highlighter window/git-rebase-highlight/ regex "#[^\n]*\n" 0:cyan,default
     add-highlighter window/git-rebase-highlight/ regex "^(pick|edit|reword|squash|fixup|exec|drop|label|reset|merge|[persfxdltm]) (\w+)" 1:green 2:magenta
-}
 
-hook -group git-rebase-highlight global WinSetOption filetype=(?!git-rebase).* %{ remove-highlighter window/git-rebase-highlight }
+    hook -once -always window WinSetOption filetype=(?!git-rebase).* %{ remove-highlighter window/git-rebase-highlight }
+}

--- a/rc/base/git.kak
+++ b/rc/base/git.kak
@@ -13,7 +13,7 @@ hook -group git-commit-highlight global WinSetOption filetype=git-commit %{
     add-highlighter window/git-commit-highlight/comments/ fill cyan,default
     add-highlighter window/git-commit-highlight/comments/ regex "\b(?:(modified)|(deleted)|(new file)|(renamed|copied)):([^\n]*)$" 1:yellow 2:red 3:green 4:blue 5:magenta
 
-    hook -once -always window WinSetOption filetype=(?!git-commit).* %{ remove-highlighter window/git-commit-highlight }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-commit-highlight }
 }
 
 hook global BufCreate .*git-rebase-todo %{
@@ -25,5 +25,5 @@ hook -group git-rebase-highlight global WinSetOption filetype=git-rebase %{
     add-highlighter window/git-rebase-highlight/ regex "#[^\n]*\n" 0:cyan,default
     add-highlighter window/git-rebase-highlight/ regex "^(pick|edit|reword|squash|fixup|exec|drop|label|reset|merge|[persfxdltm]) (\w+)" 1:green 2:magenta
 
-    hook -once -always window WinSetOption filetype=(?!git-rebase).* %{ remove-highlighter window/git-rebase-highlight }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-rebase-highlight }
 }

--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -81,7 +81,10 @@ define-command -hidden go-indent-on-closing-curly-brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group go-highlight global WinSetOption filetype=go %{ add-highlighter window/go ref go }
+hook -group go-highlight global WinSetOption filetype=go %{
+    add-highlighter window/go ref go
+    hook -once -always window WinSetOption filetype=(?!go).* %{ remove-highlighter window/go }
+}
 
 hook global WinSetOption filetype=go %{
     # cleanup trailing whitespaces when exiting insert mode
@@ -89,10 +92,6 @@ hook global WinSetOption filetype=go %{
     hook window InsertChar \n -group go-indent go-indent-on-new-line
     hook window InsertChar \{ -group go-indent go-indent-on-opening-curly-brace
     hook window InsertChar \} -group go-indent go-indent-on-closing-curly-brace
-}
 
-hook -group go-highlight global WinSetOption filetype=(?!go).* %{ remove-highlighter window/go }
-
-hook global WinSetOption filetype=(?!go).* %{
-    remove-hooks window go-.+
+    hook -once -always window WinSetOption filetype=(?!go).* %{ remove-hooks window go-.+ }
 }

--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -83,7 +83,7 @@ define-command -hidden go-indent-on-closing-curly-brace %[
 
 hook -group go-highlight global WinSetOption filetype=go %{
     add-highlighter window/go ref go
-    hook -once -always window WinSetOption filetype=(?!go).* %{ remove-highlighter window/go }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/go }
 }
 
 hook global WinSetOption filetype=go %{
@@ -93,5 +93,5 @@ hook global WinSetOption filetype=go %{
     hook window InsertChar \{ -group go-indent go-indent-on-opening-curly-brace
     hook window InsertChar \} -group go-indent go-indent-on-closing-curly-brace
 
-    hook -once -always window WinSetOption filetype=(?!go).* %{ remove-hooks window go-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window go-.+ }
 }

--- a/rc/base/haskell.kak
+++ b/rc/base/haskell.kak
@@ -91,16 +91,15 @@ define-command -hidden haskell-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group haskell-highlight global WinSetOption filetype=haskell %{ add-highlighter window/haskell ref haskell }
+hook -group haskell-highlight global WinSetOption filetype=haskell %{
+    add-highlighter window/haskell ref haskell
+    hook -once -always window WinSetOption filetype=(?!haskell).* %{ remove-highlighter window/haskell }
+}
 
 hook global WinSetOption filetype=haskell %{
     set-option window extra_word_chars '_' "'"
     hook window ModeChange insert:.* -group haskell-hooks  haskell-filter-around-selections
     hook window InsertChar \n -group haskell-indent haskell-indent-on-new-line
-}
 
-hook -group haskell-highlight global WinSetOption filetype=(?!haskell).* %{ remove-highlighter window/haskell }
-
-hook global WinSetOption filetype=(?!haskell).* %{
-    remove-hooks window haskell-.+
+    hook -once -always window WinSetOption filetype=(?!haskell).* %{ remove-hooks window haskell-.+ }
 }

--- a/rc/base/haskell.kak
+++ b/rc/base/haskell.kak
@@ -93,7 +93,7 @@ define-command -hidden haskell-indent-on-new-line %{
 
 hook -group haskell-highlight global WinSetOption filetype=haskell %{
     add-highlighter window/haskell ref haskell
-    hook -once -always window WinSetOption filetype=(?!haskell).* %{ remove-highlighter window/haskell }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/haskell }
 }
 
 hook global WinSetOption filetype=haskell %{
@@ -101,5 +101,5 @@ hook global WinSetOption filetype=haskell %{
     hook window ModeChange insert:.* -group haskell-hooks  haskell-filter-around-selections
     hook window InsertChar \n -group haskell-indent haskell-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!haskell).* %{ remove-hooks window haskell-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window haskell-.+ }
 }

--- a/rc/base/html.kak
+++ b/rc/base/html.kak
@@ -57,16 +57,19 @@ define-command -hidden html-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group html-highlight global WinSetOption filetype=(?:html|xml) %{ add-highlighter window/html ref html }
-
-hook global WinSetOption filetype=(?:html|xml) %{
-    hook window ModeChange insert:.* -group html-hooks  html-filter-around-selections
-    hook window InsertChar '>' -group html-indent html-indent-on-greater-than
-    hook window InsertChar \n -group html-indent html-indent-on-new-line
+hook -group html-highlight global WinSetOption filetype=(html|xml) %{
+    add-highlighter "window/%val{hook_param_capture_1}" ref html
+    hook -once -always window WinSetOption "filetype=(?!%val{hook_param_capture_1}).*" "
+        remove-highlighter ""window/%val{hook_param_capture_1}""
+    "
 }
 
-hook -group html-highlight global WinSetOption filetype=(?!html)(?!xml).* %{ remove-highlighter window/html }
+hook global WinSetOption filetype=(html|xml) %{
+    hook window ModeChange insert:.* -group "%val{hook_param_capture_1}-hooks"  html-filter-around-selections
+    hook window InsertChar '>' -group "%val{hook_param_capture_1}-indent" html-indent-on-greater-than
+    hook window InsertChar \n -group "%val{hook_param_capture_1}-indent" html-indent-on-new-line
 
-hook global WinSetOption filetype=(?!html)(?!xml).* %{
-    remove-hooks window html-.+
+    hook -once -always window WinSetOption "filetype=(?!%val{hook_param_capture_1}).*" "
+        remove-hooks window ""%val{hook_param_capture_1}-.+""
+    "
 }

--- a/rc/base/html.kak
+++ b/rc/base/html.kak
@@ -59,7 +59,7 @@ define-command -hidden html-indent-on-new-line %{
 
 hook -group html-highlight global WinSetOption filetype=(html|xml) %{
     add-highlighter "window/%val{hook_param_capture_1}" ref html
-    hook -once -always window WinSetOption "filetype=(?!%val{hook_param_capture_1}).*" "
+    hook -once -always window WinSetOption "filetype=.*" "
         remove-highlighter ""window/%val{hook_param_capture_1}""
     "
 }
@@ -69,7 +69,7 @@ hook global WinSetOption filetype=(html|xml) %{
     hook window InsertChar '>' -group "%val{hook_param_capture_1}-indent" html-indent-on-greater-than
     hook window InsertChar \n -group "%val{hook_param_capture_1}-indent" html-indent-on-new-line
 
-    hook -once -always window WinSetOption "filetype=(?!%val{hook_param_capture_1}).*" "
+    hook -once -always window WinSetOption "filetype=.*" "
         remove-hooks window ""%val{hook_param_capture_1}-.+""
     "
 }

--- a/rc/base/ini.kak
+++ b/rc/base/ini.kak
@@ -9,5 +9,7 @@ add-highlighter shared/ini/comment region '(^|\h)\K[#;]' $ fill comment
 add-highlighter shared/ini/code/ regex "^\h*\[[^\]]*\]" 0:title
 add-highlighter shared/ini/code/ regex "^\h*([^\[][^=\n]*)=([^\n]*)" 1:variable 2:value
 
-hook -group ini-highlight global WinSetOption filetype=ini %{ add-highlighter window/ini ref ini }
-hook -group ini-highlight global WinSetOption filetype=(?!ini).* %{ remove-highlighter window/ini }
+hook -group ini-highlight global WinSetOption filetype=ini %{
+    add-highlighter window/ini ref ini
+    hook -once -always window WinSetOption filetype=(?!ini).* %{ remove-highlighter window/ini }
+}

--- a/rc/base/ini.kak
+++ b/rc/base/ini.kak
@@ -11,5 +11,5 @@ add-highlighter shared/ini/code/ regex "^\h*([^\[][^=\n]*)=([^\n]*)" 1:variable 
 
 hook -group ini-highlight global WinSetOption filetype=ini %{
     add-highlighter window/ini ref ini
-    hook -once -always window WinSetOption filetype=(?!ini).* %{ remove-highlighter window/ini }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/ini }
 }

--- a/rc/base/java.kak
+++ b/rc/base/java.kak
@@ -51,7 +51,7 @@ define-command -hidden java-indent-on-closing-curly-brace %[
 
 hook -group java-highlight global WinSetOption filetype=java %{
     add-highlighter window/java ref java
-    hook -once -always window WinSetOption filetype=(?!java).* %{ remove-highlighter window/java }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/java }
 }
 
 hook global WinSetOption filetype=java %{
@@ -61,5 +61,5 @@ hook global WinSetOption filetype=java %{
     hook window InsertChar \{ -group java-indent java-indent-on-opening-curly-brace
     hook window InsertChar \} -group java-indent java-indent-on-closing-curly-brace
 
-    hook -once -always window WinSetOption filetype=(?!java).* %{ remove-hooks window java-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window java-.+ }
 }

--- a/rc/base/java.kak
+++ b/rc/base/java.kak
@@ -48,16 +48,18 @@ define-command -hidden java-indent-on-closing-curly-brace %[
 
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+hook -group java-highlight global WinSetOption filetype=java %{
+    add-highlighter window/java ref java
+    hook -once -always window WinSetOption filetype=(?!java).* %{ remove-highlighter window/java }
+}
+
 hook global WinSetOption filetype=java %{
     # cleanup trailing whitespaces when exiting insert mode
     hook window ModeChange insert:.* -group java-hooks %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group java-indent java-indent-on-new-line
     hook window InsertChar \{ -group java-indent java-indent-on-opening-curly-brace
     hook window InsertChar \} -group java-indent java-indent-on-closing-curly-brace
-}
 
-hook global WinSetOption filetype=(?!java).* %{
-    remove-hooks window java-.+
+    hook -once -always window WinSetOption filetype=(?!java).* %{ remove-hooks window java-.+ }
 }
-hook -group java-highlight global WinSetOption filetype=java %{ add-highlighter window/java ref java }
-hook -group java-highlight global WinSetOption filetype=(?!java).* %{ remove-highlighter window/java }

--- a/rc/base/javascript.kak
+++ b/rc/base/javascript.kak
@@ -72,7 +72,6 @@ define-command -hidden init-javascript-filetype -params 1 %~
 
     add-highlighter "shared/%arg{1}/jsx/tag"  region -recurse <  <(?=[/a-zA-Z]) (?<!=)> regions
     add-highlighter "shared/%arg{1}/jsx/expr" region -recurse \{ \{             \}      ref %arg{1}
-        
 
     add-highlighter "shared/%arg{1}/jsx/tag/base" default-region group
     add-highlighter "shared/%arg{1}/jsx/tag/double_string" region =\K" (?<!\\)(\\\\)*" fill string
@@ -93,19 +92,18 @@ define-command -hidden init-javascript-filetype -params 1 %~
     # Initialization
     # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-    hook -group "%arg{1}-highlight" global WinSetOption "filetype=%arg{1}" "add-highlighter window/%arg{1} ref %arg{1}"
+    hook -group "%arg{1}-highlight" global WinSetOption "filetype=%arg{1}" "
+        add-highlighter window/%arg{1} ref %arg{1}
 
-    hook global WinSetOption "filetype=%arg{1}" "
-        hook window ModeChange insert:.* -group %arg{1}-hooks  javascript-filter-around-selections
-        hook window InsertChar .* -group %arg{1}-indent javascript-indent-on-char
-        hook window InsertChar \n -group %arg{1}-indent javascript-indent-on-new-line
+        hook -once -always window WinSetOption filetype=(?!%arg{1}).* %%{ remove-highlighter window/%arg{1} }
     "
 
-    hook -group "%arg{1}-highlight" global WinSetOption "filetype=(?!%arg{1}).*" "remove-highlighter window/%arg{1}"
+    hook global WinSetOption "filetype=%arg{1}" "
+        hook window ModeChange insert:.* -group %arg{1}-hooks javascript-filter-around-selections
+        hook window InsertChar .* -group %arg{1}-indent javascript-indent-on-char
+        hook window InsertChar \n -group %arg{1}-indent javascript-indent-on-new-line
 
-    hook global WinSetOption "filetype=(?!%arg{1}).*" "
-        remove-hooks window %arg{1}-indent
-        remove-hooks window %arg{1}-hooks
+        hook -once -always window WinSetOption filetype=(?!%arg{1}).* %%{ remove-hooks window %arg{1}-.+ }
     "
 ~
 

--- a/rc/base/javascript.kak
+++ b/rc/base/javascript.kak
@@ -95,7 +95,7 @@ define-command -hidden init-javascript-filetype -params 1 %~
     hook -group "%arg{1}-highlight" global WinSetOption "filetype=%arg{1}" "
         add-highlighter window/%arg{1} ref %arg{1}
 
-        hook -once -always window WinSetOption filetype=(?!%arg{1}).* %%{ remove-highlighter window/%arg{1} }
+        hook -once -always window WinSetOption filetype=.* %%{ remove-highlighter window/%arg{1} }
     "
 
     hook global WinSetOption "filetype=%arg{1}" "
@@ -103,7 +103,7 @@ define-command -hidden init-javascript-filetype -params 1 %~
         hook window InsertChar .* -group %arg{1}-indent javascript-indent-on-char
         hook window InsertChar \n -group %arg{1}-indent javascript-indent-on-new-line
 
-        hook -once -always window WinSetOption filetype=(?!%arg{1}).* %%{ remove-hooks window %arg{1}-.+ }
+        hook -once -always window WinSetOption filetype=.* %%{ remove-hooks window %arg{1}-.+ }
     "
 ~
 

--- a/rc/base/json.kak
+++ b/rc/base/json.kak
@@ -48,7 +48,7 @@ define-command -hidden json-indent-on-new-line %<
 
 hook -group json-highlight global WinSetOption filetype=json %{
     add-highlighter window/json ref json
-    hook -once -always window WinSetOption filetype=(?!json).* %{ remove-highlighter window/json }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/json }
 }
 
 hook global WinSetOption filetype=json %{
@@ -56,5 +56,5 @@ hook global WinSetOption filetype=json %{
     hook window InsertChar .* -group json-indent json-indent-on-char
     hook window InsertChar \n -group json-indent json-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!json).* %{ remove-hooks window json-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window json-.+ }
 }

--- a/rc/base/json.kak
+++ b/rc/base/json.kak
@@ -46,16 +46,15 @@ define-command -hidden json-indent-on-new-line %<
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group json-highlight global WinSetOption filetype=json %{ add-highlighter window/json ref json }
+hook -group json-highlight global WinSetOption filetype=json %{
+    add-highlighter window/json ref json
+    hook -once -always window WinSetOption filetype=(?!json).* %{ remove-highlighter window/json }
+}
 
 hook global WinSetOption filetype=json %{
     hook window ModeChange insert:.* -group json-hooks  json-filter-around-selections
     hook window InsertChar .* -group json-indent json-indent-on-char
     hook window InsertChar \n -group json-indent json-indent-on-new-line
-}
 
-hook -group json-highlight global WinSetOption filetype=(?!json).* %{ remove-highlighter window/json }
-
-hook global WinSetOption filetype=(?!json).* %{
-    remove-hooks window json-.+
+    hook -once -always window WinSetOption filetype=(?!json).* %{ remove-hooks window json-.+ }
 }

--- a/rc/base/julia.kak
+++ b/rc/base/julia.kak
@@ -24,5 +24,7 @@ add-highlighter shared/julia/code/ regex \b(Number|Real|BigInt|Integer|UInt|UInt
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group julia-highlight global WinSetOption filetype=julia %{ add-highlighter window/julia ref julia }
-hook -group julia-highlight global WinSetOption filetype=(?!julia).* %{ remove-highlighter window/julia }
+hook -group julia-highlight global WinSetOption filetype=julia %{
+    add-highlighter window/julia ref julia
+    hook -once -always window WinSetOption filetype=(?!julia).* %{ remove-highlighter window/julia }
+}

--- a/rc/base/julia.kak
+++ b/rc/base/julia.kak
@@ -26,5 +26,5 @@ add-highlighter shared/julia/code/ regex \b(Number|Real|BigInt|Integer|UInt|UInt
 
 hook -group julia-highlight global WinSetOption filetype=julia %{
     add-highlighter window/julia ref julia
-    hook -once -always window WinSetOption filetype=(?!julia).* %{ remove-highlighter window/julia }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/julia }
 }

--- a/rc/base/lisp.kak
+++ b/rc/base/lisp.kak
@@ -57,15 +57,14 @@ define-command -hidden lisp-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group lisp-highlight global WinSetOption filetype=lisp %{ add-highlighter window/lisp ref lisp }
+hook -group lisp-highlight global WinSetOption filetype=lisp %{
+    add-highlighter window/lisp ref lisp
+    hook -once -always window WinSetOption filetype=(?!lisp).* %{ remove-highlighter window/lisp }
+}
 
 hook global WinSetOption filetype=lisp %{
     hook window ModeChange insert:.* -group lisp-hooks  lisp-filter-around-selections
     hook window InsertChar \n -group lisp-indent lisp-indent-on-new-line
-}
 
-hook -group lisp-highlight global WinSetOption filetype=(?!lisp).* %{ remove-highlighter window/lisp }
-
-hook global WinSetOption filetype=(?!lisp).* %{
-    remove-hooks window lisp-.+
+    hook -once -always window WinSetOption filetype=(?!lisp).* %{ remove-hooks window lisp-.+ }
 }

--- a/rc/base/lisp.kak
+++ b/rc/base/lisp.kak
@@ -59,12 +59,12 @@ define-command -hidden lisp-indent-on-new-line %{
 
 hook -group lisp-highlight global WinSetOption filetype=lisp %{
     add-highlighter window/lisp ref lisp
-    hook -once -always window WinSetOption filetype=(?!lisp).* %{ remove-highlighter window/lisp }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/lisp }
 }
 
 hook global WinSetOption filetype=lisp %{
     hook window ModeChange insert:.* -group lisp-hooks  lisp-filter-around-selections
     hook window InsertChar \n -group lisp-indent lisp-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!lisp).* %{ remove-hooks window lisp-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window lisp-.+ }
 }

--- a/rc/base/lua.kak
+++ b/rc/base/lua.kak
@@ -84,7 +84,10 @@ define-command -hidden lua-insert-on-new-line %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group lua-highlight global WinSetOption filetype=lua %{ add-highlighter window/lua ref lua }
+hook -group lua-highlight global WinSetOption filetype=lua %{
+    add-highlighter window/lua ref lua
+    hook -once -always window WinSetOption filetype=(?!lua).* %{ remove-highlighter window/lua }
+}
 
 hook global WinSetOption filetype=lua %{
     hook window InsertChar .* -group lua-indent lua-indent-on-char
@@ -92,12 +95,9 @@ hook global WinSetOption filetype=lua %{
     hook window InsertChar \n -group lua-insert lua-insert-on-new-line
 
     alias window alt lua-alternative-file
-}
 
-hook -group lua-highlight global WinSetOption filetype=(?!lua).* %{ remove-highlighter window/lua }
-
-hook global WinSetOption filetype=(?!lua).* %{
-    remove-hooks window lua-.+
-
-    unalias window alt lua-alternative-file
+    hook -once -always window WinSetOption filetype=(?!lua).* %{
+        remove-hooks window lua-.+
+        unalias window alt lua-alternative-file
+    }
 }

--- a/rc/base/lua.kak
+++ b/rc/base/lua.kak
@@ -86,7 +86,7 @@ define-command -hidden lua-insert-on-new-line %[
 
 hook -group lua-highlight global WinSetOption filetype=lua %{
     add-highlighter window/lua ref lua
-    hook -once -always window WinSetOption filetype=(?!lua).* %{ remove-highlighter window/lua }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/lua }
 }
 
 hook global WinSetOption filetype=lua %{
@@ -96,7 +96,7 @@ hook global WinSetOption filetype=lua %{
 
     alias window alt lua-alternative-file
 
-    hook -once -always window WinSetOption filetype=(?!lua).* %{
+    hook -once -always window WinSetOption filetype=.* %{
         remove-hooks window lua-.+
         unalias window alt lua-alternative-file
     }

--- a/rc/base/mail.kak
+++ b/rc/base/mail.kak
@@ -7,5 +7,7 @@ add-highlighter shared/mail/ regex ^(From|To|Cc|Bcc|Subject|Reply-To|In-Reply-To
 add-highlighter shared/mail/ regex <[^@>]+@.*?> 0:string
 add-highlighter shared/mail/ regex ^>.*?$ 0:comment
 
-hook -group mail-highlight global WinSetOption filetype=mail %{ add-highlighter window/mail ref mail }
-hook -group mail-highlight global WinSetOption filetype=(?!mail).* %{ remove-highlighter window/mail }
+hook -group mail-highlight global WinSetOption filetype=mail %{
+    add-highlighter window/mail ref mail
+    hook -once -always window WinSetOption filetype=(?!mail).* %{ remove-highlighter window/mail }
+}

--- a/rc/base/mail.kak
+++ b/rc/base/mail.kak
@@ -9,5 +9,5 @@ add-highlighter shared/mail/ regex ^>.*?$ 0:comment
 
 hook -group mail-highlight global WinSetOption filetype=mail %{
     add-highlighter window/mail ref mail
-    hook -once -always window WinSetOption filetype=(?!mail).* %{ remove-highlighter window/mail }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/mail }
 }

--- a/rc/base/markdown.kak
+++ b/rc/base/markdown.kak
@@ -75,14 +75,12 @@ define-command -hidden markdown-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group markdown-highlight global WinSetOption filetype=markdown %{ add-highlighter window/markdown ref markdown }
+hook -group markdown-highlight global WinSetOption filetype=markdown %{
+    add-highlighter window/markdown ref markdown
+    hook -once -always window WinSetOption filetype=(?!markdown).* %{ remove-highlighter window/markdown }
+}
 
 hook global WinSetOption filetype=markdown %{
     hook window InsertChar \n -group markdown-indent markdown-indent-on-new-line
-}
-
-hook -group markdown-highlight global WinSetOption filetype=(?!markdown).* %{ remove-highlighter window/markdown }
-
-hook global WinSetOption filetype=(?!markdown).* %{
-    remove-hooks window markdown-indent
+    hook -once -always window WinSetOption filetype=(?!markdown).* %{ remove-hooks window markdown-.+ }
 }

--- a/rc/base/markdown.kak
+++ b/rc/base/markdown.kak
@@ -77,10 +77,10 @@ define-command -hidden markdown-indent-on-new-line %{
 
 hook -group markdown-highlight global WinSetOption filetype=markdown %{
     add-highlighter window/markdown ref markdown
-    hook -once -always window WinSetOption filetype=(?!markdown).* %{ remove-highlighter window/markdown }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/markdown }
 }
 
 hook global WinSetOption filetype=markdown %{
     hook window InsertChar \n -group markdown-indent markdown-indent-on-new-line
-    hook -once -always window WinSetOption filetype=(?!markdown).* %{ remove-hooks window markdown-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window markdown-.+ }
 }

--- a/rc/base/mercurial.kak
+++ b/rc/base/mercurial.kak
@@ -19,5 +19,5 @@ hook global BufCreate .*hg-editor-\w+\.txt$ %{
 hook -group hg-commit-highlight global WinSetOption filetype=hg-commit %{
     add-highlighter window/ group hg-commit-highlight
     add-highlighter window/hg-commit-highlight regex '^HG:[^\n]*' 0:MercurialCommitComment
-    hook -once -always window WinSetOption filetype=(?!hg-commit).* %{ remove-highlighter window/hg-commit-highlight }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/hg-commit-highlight }
 }

--- a/rc/base/mercurial.kak
+++ b/rc/base/mercurial.kak
@@ -13,14 +13,11 @@ hook global BufCreate .*hg-editor-\w+\.txt$ %{
     set-option buffer filetype hg-commit
 }
 
-hook -group hg-commit-highlight global WinSetOption filetype=(?!hg-commit).* %{
-    remove-highlighter window/hg-commit-highlight
-}
-
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
 hook -group hg-commit-highlight global WinSetOption filetype=hg-commit %{
     add-highlighter window/ group hg-commit-highlight
     add-highlighter window/hg-commit-highlight regex '^HG:[^\n]*' 0:MercurialCommitComment
+    hook -once -always window WinSetOption filetype=(?!hg-commit).* %{ remove-highlighter window/hg-commit-highlight }
 }

--- a/rc/base/ocaml.kak
+++ b/rc/base/ocaml.kak
@@ -21,7 +21,7 @@ add-highlighter shared/ocaml/comment region \Q(* \Q*) fill comment
 
 hook -group ocaml-highlight global WinSetOption filetype=ocaml %{
     add-highlighter window/ocaml ref ocaml
-    hook -once -always window WinSetOption filetype=(?!ocaml).* %{ remove-highlighter window/ocaml }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/ocaml }
 }
 
 # Macro

--- a/rc/base/ocaml.kak
+++ b/rc/base/ocaml.kak
@@ -19,9 +19,10 @@ add-highlighter shared/ocaml/comment region \Q(* \Q*) fill comment
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group ocaml-highlight global WinSetOption filetype=ocaml %{ add-highlighter window/ocaml ref ocaml }
-
-hook -group ocaml-highlight global WinSetOption filetype=(?!ocaml).* %{ remove-highlighter window/ocaml }
+hook -group ocaml-highlight global WinSetOption filetype=ocaml %{
+    add-highlighter window/ocaml ref ocaml
+    hook -once -always window WinSetOption filetype=(?!ocaml).* %{ remove-highlighter window/ocaml }
+}
 
 # Macro
 # ‾‾‾‾‾

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -100,7 +100,7 @@ define-command -hidden perl-indent-on-closing-curly-brace %[
 
 hook -group perl-highlight global WinSetOption filetype=perl %{
     add-highlighter window/perl ref perl
-    hook -once -always window WinSetOption filetype=(?!perl).* %{ remove-highlighter window/perl }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/perl }
 }
 
 hook global WinSetOption filetype=perl %{
@@ -110,5 +110,5 @@ hook global WinSetOption filetype=perl %{
     hook window InsertChar \{ -group perl-indent perl-indent-on-opening-curly-brace
     hook window InsertChar \} -group perl-indent perl-indent-on-closing-curly-brace
 
-    hook -once -always window WinSetOption filetype=(?!perl).* %{ remove-hooks window perl-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window perl-.+ }
 }

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -98,7 +98,10 @@ define-command -hidden perl-indent-on-closing-curly-brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group perl-highlight global WinSetOption filetype=perl %{ add-highlighter window/perl ref perl }
+hook -group perl-highlight global WinSetOption filetype=perl %{
+    add-highlighter window/perl ref perl
+    hook -once -always window WinSetOption filetype=(?!perl).* %{ remove-highlighter window/perl }
+}
 
 hook global WinSetOption filetype=perl %{
     # cleanup trailing whitespaces when exiting insert mode
@@ -106,10 +109,6 @@ hook global WinSetOption filetype=perl %{
     hook window InsertChar \n -group perl-indent perl-indent-on-new-line
     hook window InsertChar \{ -group perl-indent perl-indent-on-opening-curly-brace
     hook window InsertChar \} -group perl-indent perl-indent-on-closing-curly-brace
-}
 
-hook -group perl-highlight global WinSetOption filetype=(?!perl).* %{ remove-highlighter window/perl }
-
-hook global WinSetOption filetype=(?!perl).* %{
-    remove-hooks window perl-.+
+    hook -once -always window WinSetOption filetype=(?!perl).* %{ remove-hooks window perl-.+ }
 }

--- a/rc/base/restructuredtext.kak
+++ b/rc/base/restructuredtext.kak
@@ -67,6 +67,8 @@ add-highlighter shared/restructuredtext/content/ regex [^`](``([^\s`]|([^\s`][^`
 
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
-#
-hook -group restructuredtext-highlight global WinSetOption filetype=restructuredtext %{ add-highlighter window/restructuredtext ref restructuredtext }
-hook -group restructuredtext-highlight global WinSetOption filetype=(?!restructuredtext).* %{ remove-highlighter window/restructuredtext }
+
+hook -group restructuredtext-highlight global WinSetOption filetype=restructuredtext %{
+    add-highlighter window/restructuredtext ref restructuredtext
+    hook -once -always window WinSetOption filetype=(?!restructuredtext).* %{ remove-highlighter window/restructuredtext }
+}

--- a/rc/base/restructuredtext.kak
+++ b/rc/base/restructuredtext.kak
@@ -70,5 +70,5 @@ add-highlighter shared/restructuredtext/content/ regex [^`](``([^\s`]|([^\s`][^`
 
 hook -group restructuredtext-highlight global WinSetOption filetype=restructuredtext %{
     add-highlighter window/restructuredtext ref restructuredtext
-    hook -once -always window WinSetOption filetype=(?!restructuredtext).* %{ remove-highlighter window/restructuredtext }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/restructuredtext }
 }

--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -144,7 +144,10 @@ define-command -hidden ruby-insert-on-new-line %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group ruby-highlight global WinSetOption filetype=ruby %{ add-highlighter window/ruby ref ruby }
+hook -group ruby-highlight global WinSetOption filetype=ruby %{
+    add-highlighter window/ruby ref ruby
+    hook -once -always window WinSetOption filetype=(?!ruby).* %{ remove-highlighter window/ruby }
+}
 
 hook global WinSetOption filetype=ruby %{
     hook window InsertChar .* -group ruby-indent ruby-indent-on-char
@@ -152,12 +155,9 @@ hook global WinSetOption filetype=ruby %{
     hook window InsertChar \n -group ruby-indent ruby-indent-on-new-line
 
     alias window alt ruby-alternative-file
-}
 
-hook -group ruby-highlight global WinSetOption filetype=(?!ruby).* %{ remove-highlighter window/ruby }
-
-hook global WinSetOption filetype=(?!ruby).* %{
-    remove-hooks window ruby-.+
-
-    unalias window alt ruby-alternative-file
+    hook -once -always window WinSetOption filetype=(?!ruby).* %{
+        remove-hooks window ruby-.+
+        unalias window alt ruby-alternative-file
+    }
 }

--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -146,7 +146,7 @@ define-command -hidden ruby-insert-on-new-line %[
 
 hook -group ruby-highlight global WinSetOption filetype=ruby %{
     add-highlighter window/ruby ref ruby
-    hook -once -always window WinSetOption filetype=(?!ruby).* %{ remove-highlighter window/ruby }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/ruby }
 }
 
 hook global WinSetOption filetype=ruby %{
@@ -156,7 +156,7 @@ hook global WinSetOption filetype=ruby %{
 
     alias window alt ruby-alternative-file
 
-    hook -once -always window WinSetOption filetype=(?!ruby).* %{
+    hook -once -always window WinSetOption filetype=.* %{
         remove-hooks window ruby-.+
         unalias window alt ruby-alternative-file
     }

--- a/rc/base/rust.kak
+++ b/rc/base/rust.kak
@@ -76,7 +76,7 @@ define-command -hidden rust-indent-on-closing-curly-brace %[
 
 hook -group rust-highlight global WinSetOption filetype=rust %{
     add-highlighter window/rust ref rust
-    hook -once -always window WinSetOption filetype=(?!rust).* %{ remove-highlighter window/rust }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/rust }
 }
 
 hook global WinSetOption filetype=rust %[
@@ -84,5 +84,5 @@ hook global WinSetOption filetype=rust %[
     hook window InsertChar \n -group rust-indent rust-indent-on-new-line
     hook window InsertChar \{ -group rust-indent rust-indent-on-opening-curly-brace
     hook window InsertChar \} -group rust-indent rust-indent-on-closing-curly-brace
-    hook -once -always window WinSetOption filetype=(?!rust).* %{ remove-hooks window rust-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window rust-.+ }
 ]

--- a/rc/base/rust.kak
+++ b/rc/base/rust.kak
@@ -74,17 +74,15 @@ define-command -hidden rust-indent-on-closing-curly-brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group rust-highlight global WinSetOption filetype=rust %{ add-highlighter window/rust ref rust }
+hook -group rust-highlight global WinSetOption filetype=rust %{
+    add-highlighter window/rust ref rust
+    hook -once -always window WinSetOption filetype=(?!rust).* %{ remove-highlighter window/rust }
+}
 
 hook global WinSetOption filetype=rust %[
     hook window ModeChange insert:.* -group rust-hooks  rust-filter-around-selections
     hook window InsertChar \n -group rust-indent rust-indent-on-new-line
     hook window InsertChar \{ -group rust-indent rust-indent-on-opening-curly-brace
     hook window InsertChar \} -group rust-indent rust-indent-on-closing-curly-brace
+    hook -once -always window WinSetOption filetype=(?!rust).* %{ remove-hooks window rust-.+ }
 ]
-
-hook -group rust-highlight global WinSetOption filetype=(?!rust).* %{ remove-highlighter window/rust }
-
-hook global WinSetOption filetype=(?!rust).* %{
-    remove-hooks window rust-.+
-}

--- a/rc/base/scala.kak
+++ b/rc/base/scala.kak
@@ -61,16 +61,15 @@ define-command -hidden scala-indent-on-closing-curly-brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group scala-highlight global WinSetOption filetype=scala %{ add-highlighter window/scala ref scala }
+hook -group scala-highlight global WinSetOption filetype=scala %{
+    add-highlighter window/scala ref scala
+    hook -once -always window WinSetOption filetype=(?!scala).* %{ remove-highlighter window/scala }
+}
 
 hook global WinSetOption filetype=scala %[
     hook window ModeChange insert:.* -group scala-hooks  scala-filter-around-selections
     hook window InsertChar \n -group scala-indent scala-indent-on-new-line
     hook window InsertChar \} -group scala-indent scala-indent-on-closing-curly-brace
+
+    hook -once -always window WinSetOption filetype=(?!scala).* %{ remove-hooks window scala-.+ }
 ]
-
-hook -group scala-highlight global WinSetOption filetype=(?!scala).* %{ remove-highlighter window/scala }
-
-hook global WinSetOption filetype=(?!scala).* %{
-    remove-hooks window scala-.+
-}

--- a/rc/base/scala.kak
+++ b/rc/base/scala.kak
@@ -63,7 +63,7 @@ define-command -hidden scala-indent-on-closing-curly-brace %[
 
 hook -group scala-highlight global WinSetOption filetype=scala %{
     add-highlighter window/scala ref scala
-    hook -once -always window WinSetOption filetype=(?!scala).* %{ remove-highlighter window/scala }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/scala }
 }
 
 hook global WinSetOption filetype=scala %[
@@ -71,5 +71,5 @@ hook global WinSetOption filetype=scala %[
     hook window InsertChar \n -group scala-indent scala-indent-on-new-line
     hook window InsertChar \} -group scala-indent scala-indent-on-closing-curly-brace
 
-    hook -once -always window WinSetOption filetype=(?!scala).* %{ remove-hooks window scala-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window scala-.+ }
 ]

--- a/rc/base/screen.kak
+++ b/rc/base/screen.kak
@@ -1,6 +1,6 @@
 # http://gnu.org/software/screen/
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
- 
+
 hook -group GNUscreen global KakBegin .* %sh{
     [ -z "${STY}" ] && exit
     echo "
@@ -8,7 +8,6 @@ hook -group GNUscreen global KakBegin .* %sh{
         alias global new screen-new-vertical
     "
 }
-
 
 define-command screen-new-vertical -params .. -command-completion -docstring "Split the current pane into two, left and right" %{
      nop %sh{

--- a/rc/base/sql.kak
+++ b/rc/base/sql.kak
@@ -103,5 +103,5 @@ add-highlighter shared/sql/code/ regex \b\d+(?:\.\d+)?\b 0:value
 
 hook -group sql-highlight global WinSetOption filetype=sql %{
     add-highlighter window/sql ref sql
-    hook -once -always window WinSetOption filetype=(?!sql).* %{ remove-highlighter window/sql }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/sql }
 }

--- a/rc/base/sql.kak
+++ b/rc/base/sql.kak
@@ -103,8 +103,5 @@ add-highlighter shared/sql/code/ regex \b\d+(?:\.\d+)?\b 0:value
 
 hook -group sql-highlight global WinSetOption filetype=sql %{
     add-highlighter window/sql ref sql
-}
-
-hook -group sql-highlight global WinSetOption filetype=(?!sql).* %{
-    remove-highlighter window/sql
+    hook -once -always window WinSetOption filetype=(?!sql).* %{ remove-highlighter window/sql }
 }

--- a/rc/base/swift.kak
+++ b/rc/base/swift.kak
@@ -24,5 +24,5 @@ add-highlighter shared/swift/code/ regex "@\w+\b" 0:attribute
 
 hook -group swift-highlight global WinSetOption filetype=swift %{
     add-highlighter window/swift ref swift
-    hook -once -always window WinSetOption filetype=(?!swift).* %{ remove-highlighter window/swift }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/swift }
 }

--- a/rc/base/swift.kak
+++ b/rc/base/swift.kak
@@ -22,5 +22,7 @@ add-highlighter shared/swift/code/ regex "\b(Bool|String|UInt|UInt16|UInt32|UInt
 add-highlighter shared/swift/code/ regex "\b(IBAction|IBOutlet)\b" 0:attribute
 add-highlighter shared/swift/code/ regex "@\w+\b" 0:attribute
 
-hook -group swift-highlight global WinSetOption filetype=swift %{ add-highlighter window/swift ref swift }
-hook -group swift-highlight global WinSetOption filetype=(?!swift).* %{ remove-highlighter window/swift }
+hook -group swift-highlight global WinSetOption filetype=swift %{
+    add-highlighter window/swift ref swift
+    hook -once -always window WinSetOption filetype=(?!swift).* %{ remove-highlighter window/swift }
+}

--- a/rc/base/yaml.kak
+++ b/rc/base/yaml.kak
@@ -48,11 +48,11 @@ define-command -hidden yaml-indent-on-new-line %{
 
 hook -group yaml-highlight global WinSetOption filetype=yaml %{
     add-highlighter window/yaml ref yaml
-    hook -once -always window WinSetOption filetype=(?!yaml).* %{ remove-highlighter window/yaml }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/yaml }
 }
 
 hook global WinSetOption filetype=yaml %{
     hook window ModeChange insert:.* -group yaml-hooks  yaml-filter-around-selections
     hook window InsertChar \n -group yaml-indent yaml-indent-on-new-line
-    hook -once -always window WinSetOption filetype=(?!yaml).* %{ remove-hooks window yaml-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window yaml-.+ }
 }

--- a/rc/base/yaml.kak
+++ b/rc/base/yaml.kak
@@ -46,15 +46,13 @@ define-command -hidden yaml-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group yaml-highlight global WinSetOption filetype=yaml %{ add-highlighter window/yaml ref yaml }
+hook -group yaml-highlight global WinSetOption filetype=yaml %{
+    add-highlighter window/yaml ref yaml
+    hook -once -always window WinSetOption filetype=(?!yaml).* %{ remove-highlighter window/yaml }
+}
 
 hook global WinSetOption filetype=yaml %{
     hook window ModeChange insert:.* -group yaml-hooks  yaml-filter-around-selections
     hook window InsertChar \n -group yaml-indent yaml-indent-on-new-line
-}
-
-hook -group yaml-highlight global WinSetOption filetype=(?!yaml).* %{ remove-highlighter window/yaml }
-
-hook global WinSetOption filetype=(?!yaml).* %{
-    remove-hooks window yaml-.+
+    hook -once -always window WinSetOption filetype=(?!yaml).* %{ remove-hooks window yaml-.+ }
 }

--- a/rc/core/asciidoc.kak
+++ b/rc/core/asciidoc.kak
@@ -36,6 +36,8 @@ add-highlighter shared/asciidoc/ regex ^:[-\w]+: 0:meta
 
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
-#
-hook -group asciidoc-highlight global WinSetOption filetype=asciidoc %{ add-highlighter window/asciidoc ref asciidoc }
-hook -group asciidoc-highlight global WinSetOption filetype=(?!asciidoc).* %{ remove-highlighter window/asciidoc }
+
+hook -group asciidoc-highlight global WinSetOption filetype=asciidoc %{
+    add-highlighter window/asciidoc ref asciidoc
+    hook -once -always window WinSetOption filetype=(?!asciidoc).* %{ remove-highlighter window/asciidoc }
+}

--- a/rc/core/asciidoc.kak
+++ b/rc/core/asciidoc.kak
@@ -39,5 +39,5 @@ add-highlighter shared/asciidoc/ regex ^:[-\w]+: 0:meta
 
 hook -group asciidoc-highlight global WinSetOption filetype=asciidoc %{
     add-highlighter window/asciidoc ref asciidoc
-    hook -once -always window WinSetOption filetype=(?!asciidoc).* %{ remove-highlighter window/asciidoc }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/asciidoc }
 }

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -325,29 +325,27 @@ hook global WinSetOption filetype=(c|cpp|objc) %[
     hook -group "%val{hook_param_capture_1}-family-indent" window InsertChar \} c-family-indent-on-closing-curly-brace
     hook -group "%val{hook_param_capture_1}-family-insert" window InsertChar \} c-family-insert-on-closing-curly-brace
 
-    alias window alt c-family-alternative-file
+    alias window alt "%val{hook_param_capture_1}-alternative-file"
 
-    hook -once -always window WinSetOption "filetype=(?!%val{hook_param_capture_1}).*" "
-        remove-hooks window c-family-.+
+    hook -once -always window WinSetOption filetype=.* "
+        remove-hooks window %val{hook_param_capture_1}-family-.+
+        unalias window alt %val{hook_param_capture_1}-alternative-file
     "
-    hook -once -always window WinSetOption filetype=(?!c)(?!cpp)(?!objc).* %{
-        unalias window alt c-family-alternative-file
-    }
 ]
 
 hook -group c-highlight global WinSetOption filetype=c %{
     add-highlighter window/c ref c
-    hook -once -always window WinSetOption filetype=(?!c).* %{ remove-highlighter window/c }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/c }
 }
 
 hook -group cpp-highlight global WinSetOption filetype=cpp %{
     add-highlighter window/cpp ref cpp
-    hook -once -always window WinSetOption filetype=(?!cpp).* %{ remove-highlighter window/cpp }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/cpp }
 }
 
 hook -group objc-highlight global WinSetOption filetype=objc %{
     add-highlighter window/objc ref objc
-    hook -once -always window WinSetOption filetype=(?!objc).* %{ remove-highlighter window/objc }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/objc }
 }
 
 declare-option -docstring %{control the type of include guard to be inserted in empty headers
@@ -375,41 +373,53 @@ hook -group c-family-insert global BufNewFile .*\.(h|hh|hpp|hxx|H) c-family-inse
 declare-option -docstring "colon separated list of path in which header files will be looked for" \
     str-list alt_dirs '.' '..'
 
-define-command c-family-alternative-file -docstring "Jump to the alternate file (header/implementation)" %{ evaluate-commands %sh{
-    file="${kak_buffile##*/}"
-    file_noext="${file%.*}"
-    dir=$(dirname "${kak_buffile}")
+define-command -hidden c-family-alternative-file %{
+    evaluate-commands %sh{
+        file="${kak_buffile##*/}"
+        file_noext="${file%.*}"
+        dir=$(dirname "${kak_buffile}")
 
-    # Set $@ to alt_dirs
-    eval "set -- ${kak_opt_alt_dirs}"
+        # Set $@ to alt_dirs
+        eval "set -- ${kak_opt_alt_dirs}"
 
-    case ${file} in
-        *.c|*.cc|*.cpp|*.cxx|*.C|*.inl|*.m)
-            for alt_dir in "$@"; do
-                for ext in h hh hpp hxx H; do
-                    altname="${dir}/${alt_dir}/${file_noext}.${ext}"
-                    if [ -f ${altname} ]; then
-                        printf 'edit %%{%s}\n' "${altname}"
-                        exit
-                    fi
+        case ${file} in
+            *.c|*.cc|*.cpp|*.cxx|*.C|*.inl|*.m)
+                for alt_dir in "$@"; do
+                    for ext in h hh hpp hxx H; do
+                        altname="${dir}/${alt_dir}/${file_noext}.${ext}"
+                        if [ -f ${altname} ]; then
+                            printf 'edit %%{%s}\n' "${altname}"
+                            exit
+                        fi
+                    done
                 done
-            done
-        ;;
-        *.h|*.hh|*.hpp|*.hxx|*.H)
-            for alt_dir in "$@"; do
-                for ext in c cc cpp cxx C m; do
-                    altname="${dir}/${alt_dir}/${file_noext}.${ext}"
-                    if [ -f ${altname} ]; then
-                        printf 'edit %%{%s}\n' "${altname}"
-                        exit
-                    fi
+            ;;
+            *.h|*.hh|*.hpp|*.hxx|*.H)
+                for alt_dir in "$@"; do
+                    for ext in c cc cpp cxx C m; do
+                        altname="${dir}/${alt_dir}/${file_noext}.${ext}"
+                        if [ -f ${altname} ]; then
+                            printf 'edit %%{%s}\n' "${altname}"
+                            exit
+                        fi
+                    done
                 done
-            done
-        ;;
-        *)
-            echo "echo -markup '{Error}extension not recognized'"
-            exit
-        ;;
-    esac
-    echo "echo -markup '{Error}alternative file not found'"
-}}
+            ;;
+            *)
+                echo "echo -markup '{Error}extension not recognized'"
+                exit
+            ;;
+        esac
+        echo "echo -markup '{Error}alternative file not found'"
+    }
+}
+
+define-command c-alternative-file -docstring "Jump to the alternate c file (header/implementation)" %{
+    c-family-alternative-file
+}
+define-command cpp-alternative-file -docstring "Jump to the alternate cpp file (header/implementation)" %{
+    c-family-alternative-file
+}
+define-command objc-alternative-file -docstring "Jump to the alternate objc file (header/implementation)" %{
+    c-family-alternative-file
+}

--- a/rc/core/diff.kak
+++ b/rc/core/diff.kak
@@ -7,5 +7,7 @@ add-highlighter shared/diff/ regex "^\+[^\n]*\n" 0:green,default
 add-highlighter shared/diff/ regex "^-[^\n]*\n" 0:red,default
 add-highlighter shared/diff/ regex "^@@[^\n]*@@" 0:cyan,default
 
-hook -group diff-highlight global WinSetOption filetype=diff %{ add-highlighter window/diff ref diff }
-hook -group diff-highlight global WinSetOption filetype=(?!diff).* %{ remove-highlighter window/diff }
+hook -group diff-highlight global WinSetOption filetype=diff %{
+    add-highlighter window/diff ref diff
+    hook -once -always window WinSetOption filetype=(?!diff).* %{ remove-highlighter window/diff }
+}

--- a/rc/core/diff.kak
+++ b/rc/core/diff.kak
@@ -9,5 +9,5 @@ add-highlighter shared/diff/ regex "^@@[^\n]*@@" 0:cyan,default
 
 hook -group diff-highlight global WinSetOption filetype=diff %{
     add-highlighter window/diff ref diff
-    hook -once -always window WinSetOption filetype=(?!diff).* %{ remove-highlighter window/diff }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/diff }
 }

--- a/rc/core/grep.kak
+++ b/rc/core/grep.kak
@@ -28,12 +28,12 @@ hook -group grep-highlight global WinSetOption filetype=grep %{
     add-highlighter window/grep group
     add-highlighter window/grep/ regex "^((?:\w:)?[^:\n]+):(\d+):(\d+)?" 1:cyan 2:green 3:green
     add-highlighter window/grep/ line %{%opt{grep_current_line}} default+b
-    hook -once -always window WinSetOption filetype=(?!grep).* %{ remove-highlighter window/grep }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/grep }
 }
 
 hook global WinSetOption filetype=grep %{
     hook buffer -group grep-hooks NormalKey <ret> grep-jump
-    hook -once -always window WinSetOption filetype=(?!grep).* %{ remove-hooks buffer grep-hooks }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks buffer grep-hooks }
 }
 
 declare-option -docstring "name of the client in which all source code jumps will be executed" \

--- a/rc/core/grep.kak
+++ b/rc/core/grep.kak
@@ -28,16 +28,12 @@ hook -group grep-highlight global WinSetOption filetype=grep %{
     add-highlighter window/grep group
     add-highlighter window/grep/ regex "^((?:\w:)?[^:\n]+):(\d+):(\d+)?" 1:cyan 2:green 3:green
     add-highlighter window/grep/ line %{%opt{grep_current_line}} default+b
+    hook -once -always window WinSetOption filetype=(?!grep).* %{ remove-highlighter window/grep }
 }
 
 hook global WinSetOption filetype=grep %{
     hook buffer -group grep-hooks NormalKey <ret> grep-jump
-}
-
-hook -group grep-highlight global WinSetOption filetype=(?!grep).* %{ remove-highlighter window/grep }
-
-hook global WinSetOption filetype=(?!grep).* %{
-    remove-hooks buffer grep-hooks
+    hook -once -always window WinSetOption filetype=(?!grep).* %{ remove-hooks buffer grep-hooks }
 }
 
 declare-option -docstring "name of the client in which all source code jumps will be executed" \

--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -94,7 +94,7 @@ define-command -hidden kak-indent-on-closing-char %{
 
 hook -group kak-highlight global WinSetOption filetype=kak %{
     add-highlighter window/kakrc ref kakrc
-    hook -once -always window WinSetOption filetype=(?!kak).* %{ remove-highlighter window/kakrc }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/kakrc }
 }
 
 hook global WinSetOption filetype=kak %~
@@ -105,5 +105,5 @@ hook global WinSetOption filetype=kak %~
     hook window ModeChange insert:.* -group kak-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
     set-option buffer extra_word_chars '_' '-'
 
-    hook -once -always window WinSetOption filetype=(?!kak).* %{ remove-hooks window kak-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window kak-.+ }
 ~

--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -92,7 +92,10 @@ define-command -hidden kak-indent-on-closing-char %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group kak-highlight global WinSetOption filetype=kak %{ add-highlighter window/kakrc ref kakrc }
+hook -group kak-highlight global WinSetOption filetype=kak %{
+    add-highlighter window/kakrc ref kakrc
+    hook -once -always window WinSetOption filetype=(?!kak).* %{ remove-highlighter window/kakrc }
+}
 
 hook global WinSetOption filetype=kak %~
     hook window InsertChar \n -group kak-indent kak-indent-on-new-line
@@ -101,7 +104,6 @@ hook global WinSetOption filetype=kak %~
     # cleanup trailing whitespaces on current line insert end
     hook window ModeChange insert:.* -group kak-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
     set-option buffer extra_word_chars '_' '-'
-~
 
-hook -group kak-highlight global WinSetOption filetype=(?!kak).* %{ remove-highlighter window/kakrc }
-hook global WinSetOption filetype=(?!kak).* %{ remove-hooks window kak-indent }
+    hook -once -always window WinSetOption filetype=(?!kak).* %{ remove-hooks window kak-.+ }
+~

--- a/rc/core/make.kak
+++ b/rc/core/make.kak
@@ -30,12 +30,12 @@ add-highlighter shared/make/ line '%opt{make_current_error_line}' default+b
 
 hook -group make-highlight global WinSetOption filetype=make %{
     add-highlighter window/make ref make
-    hook -once -always window WinSetOption filetype=(?!make).* %{ remove-highlighter window/make }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/make }
 }
 
 hook global WinSetOption filetype=make %{
     hook buffer -group make-hooks NormalKey <ret> make-jump
-    hook -once -always window WinSetOption filetype=(?!make).* %{ remove-hooks buffer make-hooks }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks buffer make-hooks }
 }
 
 declare-option -docstring "name of the client in which all source code jumps will be executed" \

--- a/rc/core/make.kak
+++ b/rc/core/make.kak
@@ -28,16 +28,14 @@ add-highlighter shared/make/ regex "^((?:\w:)?[^:\n]+):(\d+):(?:(\d+):)?\h+(?:((
 add-highlighter shared/make/ regex "^\h*(~*(?:(\^)~*)?)$" 1:green 2:cyan+b
 add-highlighter shared/make/ line '%opt{make_current_error_line}' default+b
 
-hook -group make-highlight global WinSetOption filetype=make %{ add-highlighter window/make ref make }
+hook -group make-highlight global WinSetOption filetype=make %{
+    add-highlighter window/make ref make
+    hook -once -always window WinSetOption filetype=(?!make).* %{ remove-highlighter window/make }
+}
 
 hook global WinSetOption filetype=make %{
     hook buffer -group make-hooks NormalKey <ret> make-jump
-}
-
-hook -group make-highlight global WinSetOption filetype=(?!make).* %{ remove-highlighter window/make }
-
-hook global WinSetOption filetype=(?!make).* %{
-    remove-hooks buffer make-hooks
+    hook -once -always window WinSetOption filetype=(?!make).* %{ remove-hooks buffer make-hooks }
 }
 
 declare-option -docstring "name of the client in which all source code jumps will be executed" \

--- a/rc/core/makefile.kak
+++ b/rc/core/makefile.kak
@@ -49,14 +49,12 @@ define-command -hidden makefile-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group makefile-highlight global WinSetOption filetype=makefile %{ add-highlighter window/makefile ref makefile }
+hook -group makefile-highlight global WinSetOption filetype=makefile %{
+    add-highlighter window/makefile ref makefile
+    hook -once -always window WinSetOption filetype=(?!makefile).* %{ remove-highlighter window/makefile }
+}
 
 hook global WinSetOption filetype=makefile %{
     hook window InsertChar \n -group makefile-indent makefile-indent-on-new-line
-}
-
-hook -group makefile-highlight global WinSetOption filetype=(?!makefile).* %{ remove-highlighter window/makefile }
-
-hook global WinSetOption filetype=(?!makefile).* %{
-    remove-hooks window makefile-indent
+	hook -once -always window WinSetOption filetype=(?!makefile).* %{ remove-hooks window makefile-.+ }
 }

--- a/rc/core/makefile.kak
+++ b/rc/core/makefile.kak
@@ -51,10 +51,10 @@ define-command -hidden makefile-indent-on-new-line %{
 
 hook -group makefile-highlight global WinSetOption filetype=makefile %{
     add-highlighter window/makefile ref makefile
-    hook -once -always window WinSetOption filetype=(?!makefile).* %{ remove-highlighter window/makefile }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/makefile }
 }
 
 hook global WinSetOption filetype=makefile %{
     hook window InsertChar \n -group makefile-indent makefile-indent-on-new-line
-	hook -once -always window WinSetOption filetype=(?!makefile).* %{ remove-hooks window makefile-.+ }
+	hook -once -always window WinSetOption filetype=.* %{ remove-hooks window makefile-.+ }
 }

--- a/rc/core/man.kak
+++ b/rc/core/man.kak
@@ -14,12 +14,12 @@ hook -group man-highlight global WinSetOption filetype=man %{
     # References to other manpages
     add-highlighter window/man-highlight/ regex [-a-zA-Z0-9_.]+\([a-z0-9]+\) 0:green
 
-    hook -once -always window WinSetOption filetype=(?!man).* %{ remove-highlighter window/man-highlight }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/man-highlight }
 }
 
 hook global WinSetOption filetype=man %{
     hook -group man-hooks window WinResize .* %{ man-impl %val{bufname} %opt{manpage} }
-    hook -once -always window WinSetOption filetype=(?!man).* %{ remove-hooks window man-hooks }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window man-hooks }
 }
 
 define-command -hidden -params 2..3 man-impl %{ evaluate-commands %sh{

--- a/rc/core/man.kak
+++ b/rc/core/man.kak
@@ -13,18 +13,13 @@ hook -group man-highlight global WinSetOption filetype=man %{
     add-highlighter window/man-highlight/ regex '^ {7}-[^\s,]+(,\s+-[^\s,]+)*' 0:yellow
     # References to other manpages
     add-highlighter window/man-highlight/ regex [-a-zA-Z0-9_.]+\([a-z0-9]+\) 0:green
+
+    hook -once -always window WinSetOption filetype=(?!man).* %{ remove-highlighter window/man-highlight }
 }
 
 hook global WinSetOption filetype=man %{
-    hook -group man-hooks window WinResize .* %{
-        man-impl %val{bufname} %opt{manpage}
-    }
-}
-
-hook -group man-highlight global WinSetOption filetype=(?!man).* %{ remove-highlighter window/man-highlight }
-
-hook global WinSetOption filetype=(?!man).* %{
-    remove-hooks window man-hooks
+    hook -group man-hooks window WinResize .* %{ man-impl %val{bufname} %opt{manpage} }
+    hook -once -always window WinSetOption filetype=(?!man).* %{ remove-hooks window man-hooks }
 }
 
 define-command -hidden -params 2..3 man-impl %{ evaluate-commands %sh{

--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -137,12 +137,12 @@ define-command -hidden python-indent-on-new-line %{
 
 hook -group python-highlight global WinSetOption filetype=python %{
     add-highlighter window/python ref python
-    hook -once -always window WinSetOption filetype=(?!python).* %{ remove-highlighter window/python }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/python }
 }
 
 hook global WinSetOption filetype=python %{
     hook window InsertChar \n -group python-indent python-indent-on-new-line
     # cleanup trailing whitespaces on current line insert end
     hook window ModeChange insert:.* -group python-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
-    hook -once -always window WinSetOption filetype=(?!python).* %{ remove-hooks window python-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window python-.+ }
 }

--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -135,16 +135,14 @@ define-command -hidden python-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group python-highlight global WinSetOption filetype=python %{ add-highlighter window/python ref python }
+hook -group python-highlight global WinSetOption filetype=python %{
+    add-highlighter window/python ref python
+    hook -once -always window WinSetOption filetype=(?!python).* %{ remove-highlighter window/python }
+}
 
 hook global WinSetOption filetype=python %{
     hook window InsertChar \n -group python-indent python-indent-on-new-line
     # cleanup trailing whitespaces on current line insert end
     hook window ModeChange insert:.* -group python-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
-}
-
-hook -group python-highlight global WinSetOption filetype=(?!python).* %{ remove-highlighter window/python }
-
-hook global WinSetOption filetype=(?!python).* %{
-    remove-hooks window python-indent
+    hook -once -always window WinSetOption filetype=(?!python).* %{ remove-hooks window python-.+ }
 }

--- a/rc/core/sh.kak
+++ b/rc/core/sh.kak
@@ -39,5 +39,5 @@ add-highlighter shared/sh/double_string/expansion regex \$(\w+|\{.+?\}) 0:value
 
 hook -group sh-highlight global WinSetOption filetype=sh %{
     add-highlighter window/sh ref sh
-    hook -once -always window WinSetOption filetype=(?!sh).* %{ remove-highlighter window/sh }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/sh }
 }

--- a/rc/core/sh.kak
+++ b/rc/core/sh.kak
@@ -37,5 +37,7 @@ add-highlighter shared/sh/code/function regex ^\h*(\w+)\h*\(\) 1:function
 add-highlighter shared/sh/code/expansion regex \$(\w+|\{.+?\}|#|@|\?|\$|!|-|\*) 0:value
 add-highlighter shared/sh/double_string/expansion regex \$(\w+|\{.+?\}) 0:value
 
-hook -group sh-highlight global WinSetOption filetype=sh %{ add-highlighter window/sh ref sh }
-hook -group sh-highlight global WinSetOption filetype=(?!sh).* %{ remove-highlighter window/sh }
+hook -group sh-highlight global WinSetOption filetype=sh %{
+    add-highlighter window/sh ref sh
+    hook -once -always window WinSetOption filetype=(?!sh).* %{ remove-highlighter window/sh }
+}

--- a/rc/extra/cabal.kak
+++ b/rc/extra/cabal.kak
@@ -58,17 +58,17 @@ define-command -hidden cabal-indent-on-closing-curly-brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group cabal-highlight global WinSetOption filetype=cabal %{ add-highlighter window/cabal ref cabal }
+hook -group cabal-highlight global WinSetOption filetype=cabal %{
+    add-highlighter window/cabal ref cabal
+    hook -once -always window WinSetOption filetype=(?!cabal).* %{ remove-highlighter window/cabal }
+
+}
 
 hook global WinSetOption filetype=cabal %[
     hook window ModeChange insert:.* -group cabal-hooks  cabal-filter-around-selections
     hook window InsertChar \n -group cabal-indent cabal-indent-on-new-line
     hook window InsertChar \{ -group cabal-indent cabal-indent-on-opening-curly-brace
     hook window InsertChar \} -group cabal-indent cabal-indent-on-closing-curly-brace
+
+    hook -once -always window WinSetOption filetype=(?!cabal).* %{ remove-hooks window cabal-.+ }
 ]
-
-hook -group cabal-highlight global WinSetOption filetype=(?!cabal).* %{ remove-highlighter window/cabal }
-
-hook global WinSetOption filetype=(?!cabal).* %{
-    remove-hooks window cabal-.+
-}

--- a/rc/extra/cabal.kak
+++ b/rc/extra/cabal.kak
@@ -60,7 +60,7 @@ define-command -hidden cabal-indent-on-closing-curly-brace %[
 
 hook -group cabal-highlight global WinSetOption filetype=cabal %{
     add-highlighter window/cabal ref cabal
-    hook -once -always window WinSetOption filetype=(?!cabal).* %{ remove-highlighter window/cabal }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/cabal }
 
 }
 
@@ -70,5 +70,5 @@ hook global WinSetOption filetype=cabal %[
     hook window InsertChar \{ -group cabal-indent cabal-indent-on-opening-curly-brace
     hook window InsertChar \} -group cabal-indent cabal-indent-on-closing-curly-brace
 
-    hook -once -always window WinSetOption filetype=(?!cabal).* %{ remove-hooks window cabal-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window cabal-.+ }
 ]

--- a/rc/extra/cmake.kak
+++ b/rc/extra/cmake.kak
@@ -23,5 +23,5 @@ add-highlighter shared/cmake/argument/quoted/ regex '\w+\h*(?=\()' 0:function
 
 hook -group cmake-highlight global WinSetOption filetype=cmake %{
     add-highlighter window/cmake ref cmake
-    hook -once -always window WinSetOption filetype=(?!cmake).* %{ remove-highlighter window/cmake }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/cmake }
 }

--- a/rc/extra/cmake.kak
+++ b/rc/extra/cmake.kak
@@ -21,5 +21,7 @@ add-highlighter shared/cmake/argument/quoted/ fill string
 add-highlighter shared/cmake/argument/quoted/ regex '\$\{\w+\}' 0:variable
 add-highlighter shared/cmake/argument/quoted/ regex '\w+\h*(?=\()' 0:function
 
-hook -group cmake-highlight global WinSetOption filetype=cmake %{ add-highlighter window/cmake ref cmake }
-hook -group cmake-highlight global WinSetOption filetype=(?!cmake).* %{ remove-highlighter window/cmake }
+hook -group cmake-highlight global WinSetOption filetype=cmake %{
+    add-highlighter window/cmake ref cmake
+    hook -once -always window WinSetOption filetype=(?!cmake).* %{ remove-highlighter window/cmake }
+}

--- a/rc/extra/coffee.kak
+++ b/rc/extra/coffee.kak
@@ -68,12 +68,12 @@ define-command -hidden coffee-indent-on-new-line %{
 
 hook -group coffee-highlight global WinSetOption filetype=coffee %{
     add-highlighter window/coffee ref coffee
-    hook -once -always window WinSetOption filetype=(?!coffee).* %{ remove-highlighter window/coffee }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/coffee }
 }
 
 hook global WinSetOption filetype=coffee %{
     hook window ModeChange insert:.* -group coffee-hooks  coffee-filter-around-selections
     hook window InsertChar \n -group coffee-indent coffee-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!coffee).* %{ remove-hooks window coffee-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window coffee-.+ }
 }

--- a/rc/extra/coffee.kak
+++ b/rc/extra/coffee.kak
@@ -66,15 +66,14 @@ define-command -hidden coffee-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group coffee-highlight global WinSetOption filetype=coffee %{ add-highlighter window/coffee ref coffee }
+hook -group coffee-highlight global WinSetOption filetype=coffee %{
+    add-highlighter window/coffee ref coffee
+    hook -once -always window WinSetOption filetype=(?!coffee).* %{ remove-highlighter window/coffee }
+}
 
 hook global WinSetOption filetype=coffee %{
     hook window ModeChange insert:.* -group coffee-hooks  coffee-filter-around-selections
     hook window InsertChar \n -group coffee-indent coffee-indent-on-new-line
-}
 
-hook -group coffee-highlight global WinSetOption filetype=(?!coffee).* %{ remove-highlighter window/coffee }
-
-hook global WinSetOption filetype=(?!coffee).* %{
-    remove-hooks window coffee-.+
+    hook -once -always window WinSetOption filetype=(?!coffee).* %{ remove-hooks window coffee-.+ }
 }

--- a/rc/extra/cucumber.kak
+++ b/rc/extra/cucumber.kak
@@ -76,15 +76,14 @@ define-command -hidden cucumber-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group cucumber-highlight global WinSetOption filetype=cucumber %{ add-highlighter window/cucumber ref cucumber }
+hook -group cucumber-highlight global WinSetOption filetype=cucumber %{
+    add-highlighter window/cucumber ref cucumber
+    hook -once -always window WinSetOption filetype=(?!cucumber).* %{ remove-highlighter window/cucumber }
+}
 
 hook global WinSetOption filetype=cucumber %{
     hook window ModeChange insert:.* -group cucumber-hooks  cucumber-filter-around-selections
     hook window InsertChar \n -group cucumber-indent cucumber-indent-on-new-line
-}
 
-hook -group cucumber-highlight global WinSetOption filetype=(?!cucumber).* %{ remove-highlighter window/cucumber }
-
-hook global WinSetOption filetype=(?!cucumber).* %{
-    remove-hooks window cucumber-.+
+    hook -once -always window WinSetOption filetype=(?!cucumber).* %{ remove-hooks window cucumber-.+ }
 }

--- a/rc/extra/cucumber.kak
+++ b/rc/extra/cucumber.kak
@@ -78,12 +78,12 @@ define-command -hidden cucumber-indent-on-new-line %{
 
 hook -group cucumber-highlight global WinSetOption filetype=cucumber %{
     add-highlighter window/cucumber ref cucumber
-    hook -once -always window WinSetOption filetype=(?!cucumber).* %{ remove-highlighter window/cucumber }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/cucumber }
 }
 
 hook global WinSetOption filetype=cucumber %{
     hook window ModeChange insert:.* -group cucumber-hooks  cucumber-filter-around-selections
     hook window InsertChar \n -group cucumber-indent cucumber-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!cucumber).* %{ remove-hooks window cucumber-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window cucumber-.+ }
 }

--- a/rc/extra/dart.kak
+++ b/rc/extra/dart.kak
@@ -90,7 +90,10 @@ define-command -hidden dart-indent-on-closing-curly-brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group dart-highlight global WinSetOption filetype=dart %{ add-highlighter window/dart ref dart }
+hook -group dart-highlight global WinSetOption filetype=dart %{
+    add-highlighter window/dart ref dart
+    hook -once -always window WinSetOption filetype=(?!dart).* %{ remove-highlighter window/dart }
+}
 
 hook global WinSetOption filetype=dart %{
     # cleanup trailing whitespaces when exiting insert mode
@@ -98,10 +101,6 @@ hook global WinSetOption filetype=dart %{
     hook window InsertChar \n -group dart-indent dart-indent-on-new-line
     hook window InsertChar \{ -group dart-indent dart-indent-on-opening-curly-brace
     hook window InsertChar \} -group dart-indent dart-indent-on-closing-curly-brace
-}
 
-hook -group dart-highlight global WinSetOption filetype=(?!dart).* %{ remove-highlighter window/dart }
-
-hook global WinSetOption filetype=(?!dart).* %{
-    remove-hooks window dart-.+
+    hook -once -always window WinSetOption filetype=(?!dart).* %{ remove-hooks window dart-.+ }
 }

--- a/rc/extra/dart.kak
+++ b/rc/extra/dart.kak
@@ -92,7 +92,7 @@ define-command -hidden dart-indent-on-closing-curly-brace %[
 
 hook -group dart-highlight global WinSetOption filetype=dart %{
     add-highlighter window/dart ref dart
-    hook -once -always window WinSetOption filetype=(?!dart).* %{ remove-highlighter window/dart }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/dart }
 }
 
 hook global WinSetOption filetype=dart %{
@@ -102,5 +102,5 @@ hook global WinSetOption filetype=dart %{
     hook window InsertChar \{ -group dart-indent dart-indent-on-opening-curly-brace
     hook window InsertChar \} -group dart-indent dart-indent-on-closing-curly-brace
 
-    hook -once -always window WinSetOption filetype=(?!dart).* %{ remove-hooks window dart-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window dart-.+ }
 }

--- a/rc/extra/dockerfile.kak
+++ b/rc/extra/dockerfile.kak
@@ -42,5 +42,7 @@ add-highlighter shared/dockerfile/code/ regex '\$[\w_]+' 0:value
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group dockerfile-highlight global WinSetOption filetype=dockerfile %{ add-highlighter window/dockerfile ref dockerfile }
-hook -group dockerfile-highlight global WinSetOption filetype=(?!dockerfile).* %{ remove-highlighter window/dockerfile }
+hook -group dockerfile-highlight global WinSetOption filetype=dockerfile %{
+    add-highlighter window/dockerfile ref dockerfile
+    hook -once -always window WinSetOption filetype=(?!dockerfile).* %{ remove-highlighter window/dockerfile }
+}

--- a/rc/extra/dockerfile.kak
+++ b/rc/extra/dockerfile.kak
@@ -44,5 +44,5 @@ add-highlighter shared/dockerfile/code/ regex '\$[\w_]+' 0:value
 
 hook -group dockerfile-highlight global WinSetOption filetype=dockerfile %{
     add-highlighter window/dockerfile ref dockerfile
-    hook -once -always window WinSetOption filetype=(?!dockerfile).* %{ remove-highlighter window/dockerfile }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/dockerfile }
 }

--- a/rc/extra/elixir.kak
+++ b/rc/extra/elixir.kak
@@ -66,12 +66,12 @@ define-command -hidden elixir-indent-on-new-line %{
 
 hook -group elixir-highlight global WinSetOption filetype=elixir %{
     add-highlighter window/elixir ref elixir
-    hook -once -always window WinSetOption filetype=(?!elixir).* %{ remove-highlighter window/elixir }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/elixir }
 }
 
 hook global WinSetOption filetype=elixir %{
     hook window ModeChange insert:.* -group elixir-hooks  elixir-filter-around-selections
     hook window InsertChar \n -group elixir-indent elixir-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!elixir).* %{ remove-hooks window elixir-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window elixir-.+ }
 }

--- a/rc/extra/elixir.kak
+++ b/rc/extra/elixir.kak
@@ -64,12 +64,14 @@ define-command -hidden elixir-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group elixir-highlight global WinSetOption filetype=elixir %{ add-highlighter window/elixir ref elixir }
+hook -group elixir-highlight global WinSetOption filetype=elixir %{
+    add-highlighter window/elixir ref elixir
+    hook -once -always window WinSetOption filetype=(?!elixir).* %{ remove-highlighter window/elixir }
+}
 
 hook global WinSetOption filetype=elixir %{
     hook window ModeChange insert:.* -group elixir-hooks  elixir-filter-around-selections
     hook window InsertChar \n -group elixir-indent elixir-indent-on-new-line
+
+    hook -once -always window WinSetOption filetype=(?!elixir).* %{ remove-hooks window elixir-.+ }
 }
-
-hook -group elixir-highlight global WinSetOption filetype=(?!elixir).* %{ remove-highlighter window/elixir }
-

--- a/rc/extra/elm.kak
+++ b/rc/extra/elm.kak
@@ -56,12 +56,12 @@ define-command -hidden elm-indent-on-new-line %{
 
 hook -group elm-highlight global WinSetOption filetype=elm %{
     add-highlighter window/elm ref elm
-    hook -once -always window WinSetOption filetype=(?!elm).* %{ remove-highlighter window/elm }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/elm }
 }
 
 hook global WinSetOption filetype=elm %{
     hook window ModeChange insert:.* -group elm-hooks  elm-filter-around-selections
     hook window InsertChar \n -group elm-indent elm-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!elm).* %{ remove-hooks window elm-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window elm-.+ }
 }

--- a/rc/extra/elm.kak
+++ b/rc/extra/elm.kak
@@ -54,15 +54,14 @@ define-command -hidden elm-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group elm-highlight global WinSetOption filetype=elm %{ add-highlighter window/elm ref elm }
+hook -group elm-highlight global WinSetOption filetype=elm %{
+    add-highlighter window/elm ref elm
+    hook -once -always window WinSetOption filetype=(?!elm).* %{ remove-highlighter window/elm }
+}
 
 hook global WinSetOption filetype=elm %{
     hook window ModeChange insert:.* -group elm-hooks  elm-filter-around-selections
     hook window InsertChar \n -group elm-indent elm-indent-on-new-line
-}
 
-hook -group elm-highlight global WinSetOption filetype=(?!elm).* %{ remove-highlighter window/elm }
-
-hook global WinSetOption filetype=(?!elm).* %{
-    remove-hooks window elm-.+
+    hook -once -always window WinSetOption filetype=(?!elm).* %{ remove-hooks window elm-.+ }
 }

--- a/rc/extra/exherbo.kak
+++ b/rc/extra/exherbo.kak
@@ -34,8 +34,10 @@ add-highlighter shared/exheres-0-metadata/ regex ^(?:[\s\t]+)?[\S]+[\s\t]+=[\s\t
 add-highlighter shared/exheres-0-metadata/ regex ^(?:[\s\t]+)?(\S+)\s\[\[$ 0:type
 add-highlighter shared/exheres-0-metadata/ regex ^(?:[\s\t]+)?\]\]$ 0:type
 
-hook -group exheres-0-metadata-highlight global WinSetOption filetype=exheres-0-metadata %{ add-highlighter window/exheres-0-metadata ref exheres-0-metadata }
-hook -group exheres-0-metadata-highlight global WinSetOption filetype=(?!exheres-0-metadata).* %{ remove-highlighter window/exheres-0-metadata }
+hook -group exheres-0-metadata-highlight global WinSetOption filetype=exheres-0-metadata %{
+    add-highlighter window/exheres-0-metadata ref exheres-0-metadata
+    hook -once -always window WinSetOption filetype=(?!exheres-0-metadata).* %{ remove-highlighter window/exheres-0-metadata }
+}
 
 ## exheres-0 options descriptions
 add-highlighter shared/exheres-0-options-descriptions group
@@ -44,8 +46,10 @@ add-highlighter shared/exheres-0-options-descriptions/ regex ^(?:[\s\t]+)?[\S]+[
 add-highlighter shared/exheres-0-options-descriptions/ regex ^(?:[\s\t]+)?(\S+)\s\[\[$ 0:type
 add-highlighter shared/exheres-0-options-descriptions/ regex ^(?:[\s\t]+)?\]\]$ 0:type
 
-hook -group exheres-0-options-descriptions-highlight global WinSetOption filetype=exheres-0-options-descriptions %{ add-highlighter window/exheres-0-options-descriptions ref exheres-0-options-descriptions }
-hook -group exheres-0-options-descriptions-highlight global WinSetOption filetype=(?!exheres-0-options-descriptions).* %{ remove-highlighter window/exheres-0-options-descriptions }
+hook -group exheres-0-options-descriptions-highlight global WinSetOption filetype=exheres-0-options-descriptions %{
+    add-highlighter window/exheres-0-options-descriptions ref exheres-0-options-descriptions
+    hook -once -always window WinSetOption filetype=(?!exheres-0-options-descriptions).* %{ remove-highlighter window/exheres-0-options-descriptions }
+}
 
 ## metadata/licence_groups.conf
 add-highlighter shared/exheres-0-licence-groups group
@@ -53,8 +57,10 @@ add-highlighter shared/exheres-0-licence-groups/ regex [\s\t]+(\S+(?:[\s\t]+))*$
 add-highlighter shared/exheres-0-licence-groups/ regex ^(\S+) 0:type
 add-highlighter shared/exheres-0-licence-groups/ regex ^#.*?$ 0:comment
 
-hook -group exheres-0-licence-groups-highlight global WinSetOption filetype=exheres-0-licence-groups %{ add-highlighter window/exheres-0-licence-groups ref exheres-0-licence-groups }
-hook -group exheres-0-licence-groups-highlight global WinSetOption filetype=(?!exheres-0-licence-groups).* %{ remove-highlighter window/exheres-0-licence-groups }
+hook -group exheres-0-licence-groups-highlight global WinSetOption filetype=exheres-0-licence-groups %{
+    add-highlighter window/exheres-0-licence-groups ref exheres-0-licence-groups
+    hook -once -always window WinSetOption filetype=(?!exheres-0-licence-groups).* %{ remove-highlighter window/exheres-0-licence-groups }
+}
 
 ## Paludis configurations
 ### options.conf
@@ -67,24 +73,30 @@ add-highlighter shared/paludis-options-conf/ regex [\s\t](-\S+)(.*?) 1:red
 add-highlighter shared/paludis-options-conf/ regex ^(\S+/\S+) 0:type
 add-highlighter shared/paludis-options-conf/ regex ^#.*?$ 0:comment
 
-hook -group paludis-options-conf-highlight global WinSetOption filetype=paludis-options-conf %{ add-highlighter window/paludis-options-conf ref paludis-options-conf }
-hook -group paludis-options-conf-highlight global WinSetOption filetype=(?!paludis-options-conf).* %{ remove-highlighter window/paludis-options-conf }
+hook -group paludis-options-conf-highlight global WinSetOption filetype=paludis-options-conf %{
+    add-highlighter window/paludis-options-conf ref paludis-options-conf
+    hook -once -always window WinSetOption filetype=(?!paludis-options-conf).* %{ remove-highlighter window/paludis-options-conf }
+}
 
 ## general.conf, repository.template
 add-highlighter shared/paludis-key-value-conf group
 add-highlighter shared/paludis-key-value-conf/ regex ^[\s\t]?(\S+)[\s\t+]=[\s\t+](.*?)$ 1:attribute 2:value
 add-highlighter shared/paludis-key-value-conf/ regex ^#.*?$ 0:comment
 
-hook -group paludis-key-value-conf-highlight global WinSetOption filetype=paludis-key-value-conf %{ add-highlighter window/paludis-key-value-conf ref paludis-key-value-conf }
-hook -group paludis-key-value-conf-highlight global WinSetOption filetype=(?!paludis-key-value-conf).* %{ remove-highlighter window/paludis-key-value-conf }
+hook -group paludis-key-value-conf-highlight global WinSetOption filetype=paludis-key-value-conf %{
+    add-highlighter window/paludis-key-value-conf ref paludis-key-value-conf
+    hook -once -always window WinSetOption filetype=(?!paludis-key-value-conf).* %{ remove-highlighter window/paludis-key-value-conf }
+}
 
 ## mirrors.conf
 add-highlighter shared/paludis-mirrors-conf group
 add-highlighter shared/paludis-mirrors-conf/ regex ^[\s\t+]?(\S+)[\s\t+](.*?)$ 1:type 2:value
 add-highlighter shared/paludis-mirrors-conf/ regex ^#.*?$ 0:comment
 
-hook -group paludis-mirrors-conf-highlight global WinSetOption filetype=paludis-mirrors-conf %{ add-highlighter window/paludis-mirrors-conf ref paludis-mirrors-conf }
-hook -group paludis-mirrors-conf-highlight global WinSetOption filetype=(?!paludis-mirrors-conf).* %{ remove-highlighter window/paludis-mirrors-conf }
+hook -group paludis-mirrors-conf-highlight global WinSetOption filetype=paludis-mirrors-conf %{
+    add-highlighter window/paludis-mirrors-conf ref paludis-mirrors-conf
+    hook -once -always window WinSetOption filetype=(?!paludis-mirrors-conf).* %{ remove-highlighter window/paludis-mirrors-conf }
+}
 
 ## package_(unmask|mask).conf, platforms.conf
 add-highlighter shared/paludis-specs-conf group
@@ -92,8 +104,10 @@ add-highlighter shared/paludis-specs-conf/ regex [\s\t]+(\S+(?:[\s\t]+))*$ 0:att
 add-highlighter shared/paludis-specs-conf/ regex ^(\S+/\S+) 0:type
 add-highlighter shared/paludis-specs-conf/ regex ^#.*?$ 0:comment
 
-hook -group paludis-specs-conf-highlight global WinSetOption filetype=paludis-specs-conf %{ add-highlighter window/paludis-specs-conf ref paludis-specs-conf }
-hook -group paludis-specs-conf-highlight global WinSetOption filetype=(?!paludis-specs-conf).* %{ remove-highlighter window/paludis-specs-conf }
+hook -group paludis-specs-conf-highlight global WinSetOption filetype=paludis-specs-conf %{
+    add-highlighter window/paludis-specs-conf ref paludis-specs-conf
+    hook -once -always window WinSetOption filetype=(?!paludis-specs-conf).* %{ remove-highlighter window/paludis-specs-conf }
+}
 
 ## News items (GLEP42)
 add-highlighter shared/glep42 group
@@ -101,5 +115,7 @@ add-highlighter shared/glep42/ regex ^(Title|Author|Translator|Content-Type|Post
 add-highlighter shared/glep42/ regex <[^@>]+@.*?> 0:string
 add-highlighter shared/glep42/ regex ^>.*?$ 0:comment
 
-hook -group glep42-highlight global WinSetOption filetype=glep42 %{ add-highlighter window/glep42 ref glep42 }
-hook -group glep42-highlight global WinSetOption filetype=(?!glep42).* %{ remove-highlighter window/glep42 }
+hook -group glep42-highlight global WinSetOption filetype=glep42 %{
+    add-highlighter window/glep42 ref glep42
+    hook -once -always window WinSetOption filetype=(?!glep42).* %{ remove-highlighter window/glep42 }
+}

--- a/rc/extra/exherbo.kak
+++ b/rc/extra/exherbo.kak
@@ -36,7 +36,7 @@ add-highlighter shared/exheres-0-metadata/ regex ^(?:[\s\t]+)?\]\]$ 0:type
 
 hook -group exheres-0-metadata-highlight global WinSetOption filetype=exheres-0-metadata %{
     add-highlighter window/exheres-0-metadata ref exheres-0-metadata
-    hook -once -always window WinSetOption filetype=(?!exheres-0-metadata).* %{ remove-highlighter window/exheres-0-metadata }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/exheres-0-metadata }
 }
 
 ## exheres-0 options descriptions
@@ -48,7 +48,7 @@ add-highlighter shared/exheres-0-options-descriptions/ regex ^(?:[\s\t]+)?\]\]$ 
 
 hook -group exheres-0-options-descriptions-highlight global WinSetOption filetype=exheres-0-options-descriptions %{
     add-highlighter window/exheres-0-options-descriptions ref exheres-0-options-descriptions
-    hook -once -always window WinSetOption filetype=(?!exheres-0-options-descriptions).* %{ remove-highlighter window/exheres-0-options-descriptions }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/exheres-0-options-descriptions }
 }
 
 ## metadata/licence_groups.conf
@@ -59,7 +59,7 @@ add-highlighter shared/exheres-0-licence-groups/ regex ^#.*?$ 0:comment
 
 hook -group exheres-0-licence-groups-highlight global WinSetOption filetype=exheres-0-licence-groups %{
     add-highlighter window/exheres-0-licence-groups ref exheres-0-licence-groups
-    hook -once -always window WinSetOption filetype=(?!exheres-0-licence-groups).* %{ remove-highlighter window/exheres-0-licence-groups }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/exheres-0-licence-groups }
 }
 
 ## Paludis configurations
@@ -75,7 +75,7 @@ add-highlighter shared/paludis-options-conf/ regex ^#.*?$ 0:comment
 
 hook -group paludis-options-conf-highlight global WinSetOption filetype=paludis-options-conf %{
     add-highlighter window/paludis-options-conf ref paludis-options-conf
-    hook -once -always window WinSetOption filetype=(?!paludis-options-conf).* %{ remove-highlighter window/paludis-options-conf }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/paludis-options-conf }
 }
 
 ## general.conf, repository.template
@@ -85,7 +85,7 @@ add-highlighter shared/paludis-key-value-conf/ regex ^#.*?$ 0:comment
 
 hook -group paludis-key-value-conf-highlight global WinSetOption filetype=paludis-key-value-conf %{
     add-highlighter window/paludis-key-value-conf ref paludis-key-value-conf
-    hook -once -always window WinSetOption filetype=(?!paludis-key-value-conf).* %{ remove-highlighter window/paludis-key-value-conf }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/paludis-key-value-conf }
 }
 
 ## mirrors.conf
@@ -95,7 +95,7 @@ add-highlighter shared/paludis-mirrors-conf/ regex ^#.*?$ 0:comment
 
 hook -group paludis-mirrors-conf-highlight global WinSetOption filetype=paludis-mirrors-conf %{
     add-highlighter window/paludis-mirrors-conf ref paludis-mirrors-conf
-    hook -once -always window WinSetOption filetype=(?!paludis-mirrors-conf).* %{ remove-highlighter window/paludis-mirrors-conf }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/paludis-mirrors-conf }
 }
 
 ## package_(unmask|mask).conf, platforms.conf
@@ -106,7 +106,7 @@ add-highlighter shared/paludis-specs-conf/ regex ^#.*?$ 0:comment
 
 hook -group paludis-specs-conf-highlight global WinSetOption filetype=paludis-specs-conf %{
     add-highlighter window/paludis-specs-conf ref paludis-specs-conf
-    hook -once -always window WinSetOption filetype=(?!paludis-specs-conf).* %{ remove-highlighter window/paludis-specs-conf }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/paludis-specs-conf }
 }
 
 ## News items (GLEP42)
@@ -117,5 +117,5 @@ add-highlighter shared/glep42/ regex ^>.*?$ 0:comment
 
 hook -group glep42-highlight global WinSetOption filetype=glep42 %{
     add-highlighter window/glep42 ref glep42
-    hook -once -always window WinSetOption filetype=(?!glep42).* %{ remove-highlighter window/glep42 }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/glep42 }
 }

--- a/rc/extra/git-tools.kak
+++ b/rc/extra/git-tools.kak
@@ -6,16 +6,18 @@ hook -group git-log-highlight global WinSetOption filetype=git-log %{
     add-highlighter window/git-log/ regex '^(commit) ([0-9a-f]+)$' 1:yellow 2:red
     add-highlighter window/git-log/ regex '^([a-zA-Z_-]+:) (.*?)$' 1:green 2:magenta
     add-highlighter window/git-log/ ref diff # highlight potential diffs from the -p option
+
+    hook -once -always window WinSetOption filetype=(?!git-log).* %{ remove-highlighter window/git-log }
 }
 
-hook -group git-log-highlight global WinSetOption filetype=(?!git-log).* %{ remove-highlighter window/git-log }
 
 hook -group git-status-highlight global WinSetOption filetype=git-status %{
     add-highlighter window/git-status group
     add-highlighter window/git-status/ regex '^\h+(?:((?:both )?modified:)|(added:|new file:)|(deleted(?: by \w+)?:)|(renamed:)|(copied:))(?:.*?)$' 1:yellow 2:green 3:red 4:cyan 5:blue 6:magenta
+
+    hook -once -always window WinSetOption filetype=(?!git-status).* %{ remove-highlighter window/git-status }
 }
 
-hook -group git-status-highlight global WinSetOption filetype=(?!git-status).* %{ remove-highlighter window/git-status }
 
 declare-option -hidden line-specs git_blame_flags
 declare-option -hidden line-specs git_diff_flags

--- a/rc/extra/git-tools.kak
+++ b/rc/extra/git-tools.kak
@@ -7,7 +7,7 @@ hook -group git-log-highlight global WinSetOption filetype=git-log %{
     add-highlighter window/git-log/ regex '^([a-zA-Z_-]+:) (.*?)$' 1:green 2:magenta
     add-highlighter window/git-log/ ref diff # highlight potential diffs from the -p option
 
-    hook -once -always window WinSetOption filetype=(?!git-log).* %{ remove-highlighter window/git-log }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-log }
 }
 
 
@@ -15,7 +15,7 @@ hook -group git-status-highlight global WinSetOption filetype=git-status %{
     add-highlighter window/git-status group
     add-highlighter window/git-status/ regex '^\h+(?:((?:both )?modified:)|(added:|new file:)|(deleted(?: by \w+)?:)|(renamed:)|(copied:))(?:.*?)$' 1:yellow 2:green 3:red 4:cyan 5:blue 6:magenta
 
-    hook -once -always window WinSetOption filetype=(?!git-status).* %{ remove-highlighter window/git-status }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-status }
 }
 
 

--- a/rc/extra/haml.kak
+++ b/rc/extra/haml.kak
@@ -49,15 +49,14 @@ define-command -hidden haml-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group haml-highlight global WinSetOption filetype=haml %{ add-highlighter window/haml ref haml }
+hook -group haml-highlight global WinSetOption filetype=haml %{
+    add-highlighter window/haml ref haml
+    hook -once -always window WinSetOption filetype=(?!haml).* %{ remove-highlighter window/haml }
+}
 
 hook global WinSetOption filetype=haml %{
     hook window ModeChange insert:.* -group haml-hooks  haml-filter-around-selections
     hook window InsertChar \n -group haml-indent haml-indent-on-new-line
-}
 
-hook -group haml-highlight global WinSetOption filetype=(?!haml).* %{ remove-highlighter window/haml }
-
-hook global WinSetOption filetype=(?!haml).* %{
-    remove-hooks window haml-.+
+    hook -once -always window WinSetOption filetype=(?!haml).* %{ remove-hooks window haml-.+ }
 }

--- a/rc/extra/haml.kak
+++ b/rc/extra/haml.kak
@@ -51,12 +51,12 @@ define-command -hidden haml-indent-on-new-line %{
 
 hook -group haml-highlight global WinSetOption filetype=haml %{
     add-highlighter window/haml ref haml
-    hook -once -always window WinSetOption filetype=(?!haml).* %{ remove-highlighter window/haml }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/haml }
 }
 
 hook global WinSetOption filetype=haml %{
     hook window ModeChange insert:.* -group haml-hooks  haml-filter-around-selections
     hook window InsertChar \n -group haml-indent haml-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!haml).* %{ remove-hooks window haml-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window haml-.+ }
 }

--- a/rc/extra/hbs.kak
+++ b/rc/extra/hbs.kak
@@ -83,6 +83,7 @@ define-command -hidden maybe-add-hbs-to-html %{ evaluate-commands %sh{
 hook -group hbs-highlight global WinSetOption filetype=hbs %{
     maybe-add-hbs-to-html
     add-highlighter window/hbs-file ref hbs-file
+    hook -once -always window WinSetOption filetype=(?!hbs).* %{ remove-highlighter window/hbs-file }
 }
 
 hook global WinSetOption filetype=hbs %{
@@ -92,12 +93,6 @@ hook global WinSetOption filetype=hbs %{
     hook window ModeChange insert:.* -group hbs-hooks  html-filter-around-selections
     hook window InsertChar '>' -group hbs-indent html-indent-on-greater-than
     hook window InsertChar \n -group hbs-indent html-indent-on-new-line
-}
 
-hook -group hbs-highlight global WinSetOption filetype=(?!hbs).* %{
-    remove-highlighter window/hbs-file
-}
-
-hook global WinSetOption filetype=(?!hbs).* %{
-    remove-hooks window hbs-.+
+    hook -once -always window WinSetOption filetype=(?!hbs).* %{ remove-hooks window hbs-.+ }
 }

--- a/rc/extra/hbs.kak
+++ b/rc/extra/hbs.kak
@@ -83,7 +83,7 @@ define-command -hidden maybe-add-hbs-to-html %{ evaluate-commands %sh{
 hook -group hbs-highlight global WinSetOption filetype=hbs %{
     maybe-add-hbs-to-html
     add-highlighter window/hbs-file ref hbs-file
-    hook -once -always window WinSetOption filetype=(?!hbs).* %{ remove-highlighter window/hbs-file }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/hbs-file }
 }
 
 hook global WinSetOption filetype=hbs %{
@@ -94,5 +94,5 @@ hook global WinSetOption filetype=hbs %{
     hook window InsertChar '>' -group hbs-indent html-indent-on-greater-than
     hook window InsertChar \n -group hbs-indent html-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!hbs).* %{ remove-hooks window hbs-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window hbs-.+ }
 }

--- a/rc/extra/i3.kak
+++ b/rc/extra/i3.kak
@@ -66,17 +66,16 @@ define-command -hidden i3-indent-on-closing-curly-brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group i3-highlight global WinSetOption filetype=i3 %{ add-highlighter window/i3 ref i3 }
+hook -group i3-highlight global WinSetOption filetype=i3 %{
+    add-highlighter window/i3 ref i3
+    hook -once -always window WinSetOption filetype=(?!i3).* %{ remove-highlighter window/i3 }
+}
 
 hook global WinSetOption filetype=i3 %[
     # cleanup trailing whitespaces when exiting insert mode
     hook window ModeChange insert:.* -group i3-hooks %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group i3-indent i3-indent-on-new-line
     hook window InsertChar \} -group i3-indent i3-indent-on-closing-curly-brace
+
+    hook -once -always window WinSetOption filetype=(?!i3).* %{ remove-hooks window i3-.+ }
 ]
-
-hook -group i3-highlight global WinSetOption filetype=(?!i3).* %{ remove-highlighter window/i3 }
-
-hook global WinSetOption filetype=(?!i3).* %{
-    remove-hooks window i3-.+
-}

--- a/rc/extra/i3.kak
+++ b/rc/extra/i3.kak
@@ -68,7 +68,7 @@ define-command -hidden i3-indent-on-closing-curly-brace %[
 
 hook -group i3-highlight global WinSetOption filetype=i3 %{
     add-highlighter window/i3 ref i3
-    hook -once -always window WinSetOption filetype=(?!i3).* %{ remove-highlighter window/i3 }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/i3 }
 }
 
 hook global WinSetOption filetype=i3 %[
@@ -77,5 +77,5 @@ hook global WinSetOption filetype=i3 %[
     hook window InsertChar \n -group i3-indent i3-indent-on-new-line
     hook window InsertChar \} -group i3-indent i3-indent-on-closing-curly-brace
 
-    hook -once -always window WinSetOption filetype=(?!i3).* %{ remove-hooks window i3-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window i3-.+ }
 ]

--- a/rc/extra/just.kak
+++ b/rc/extra/just.kak
@@ -28,25 +28,21 @@ add-highlighter shared/justfile/comment  region '#' '$'  fill comment
 add-highlighter shared/justfile/double_string region '"' (?<!\\)(\\\\)*" fill string
 add-highlighter shared/justfile/single_string region "'" (?<!\\)(\\\\)*' fill string
 add-highlighter shared/justfile/inline   region '`' '`' ref sh
-add-highlighter shared/justfile/shell    region '^\h+' '^[^\h]' group
 
+add-highlighter shared/justfile/shell  region '^\h+' '^[^\h]' group
 add-highlighter shared/justfile/shell/ ref sh
+add-highlighter shared/justfile/shell/ regex '(\{{2})([\w-]+)(\}{2})' 1:operator 2:variable 3:operator
 
 add-highlighter shared/justfile/content/ regex '^(@)?([\w-]+)(?:\s(.+))?\s?(:)(.+)?$' 1:operator 2:function 3:value 4:operator 5:type
 add-highlighter shared/justfile/content/ regex '([=+])' 1:operator
 add-highlighter shared/justfile/content/ regex '^([\w-]+)\s=' 1:value
 
+hook -group justfile-highlight global WinSetOption filetype=justfile %{
+    add-highlighter window/justfile ref justfile
+    hook -once -always window WinSetOption filetype=(?!justfile).* %{ remove-highlighter window/justfile }
+}
+
 hook global WinSetOption filetype=justfile %{
     hook window InsertChar \n -group justfile-indent just-indent-on-new-line
-    add-highlighter window/justfile ref justfile
-
-    # variable substititution highlighting
-    add-highlighter shared/justfile/shell regex '(\{{2})([\w-]+)(\}{2})' 1:operator 2:variable 3:operator
-
+    hook -once -always window WinSetOption filetype=(?!justfile).* %{ remove-hooks window justfile-.+ }
 }
-
-hook global WinSetOption filetype=(?!justfile).* %{
-    remove-highlighter window/justfile
-    remove-hooks window justfile-indent
-}
-

--- a/rc/extra/just.kak
+++ b/rc/extra/just.kak
@@ -39,10 +39,10 @@ add-highlighter shared/justfile/content/ regex '^([\w-]+)\s=' 1:value
 
 hook -group justfile-highlight global WinSetOption filetype=justfile %{
     add-highlighter window/justfile ref justfile
-    hook -once -always window WinSetOption filetype=(?!justfile).* %{ remove-highlighter window/justfile }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/justfile }
 }
 
 hook global WinSetOption filetype=justfile %{
     hook window InsertChar \n -group justfile-indent just-indent-on-new-line
-    hook -once -always window WinSetOption filetype=(?!justfile).* %{ remove-hooks window justfile-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window justfile-.+ }
 }

--- a/rc/extra/kickstart.kak
+++ b/rc/extra/kickstart.kak
@@ -24,5 +24,7 @@ add-highlighter shared/kickstart/shell/ regex '^\h*%end\b' 0:type
 add-highlighter shared/kickstart/shell/ ref sh
 
 
-hook -group kickstart-highlight global WinSetOption filetype=kickstart %{ add-highlighter window/kickstart ref kickstart }
-hook -group kickstart-highlight global WinSetOption filetype=(?!kickstart).* %{ remove-highlighter window/kickstart }
+hook -group kickstart-highlight global WinSetOption filetype=kickstart %{
+    add-highlighter window/kickstart ref kickstart
+    hook -once -always window WinSetOption filetype=(?!kickstart).* %{ remove-highlighter window/kickstart }
+}

--- a/rc/extra/kickstart.kak
+++ b/rc/extra/kickstart.kak
@@ -26,5 +26,5 @@ add-highlighter shared/kickstart/shell/ ref sh
 
 hook -group kickstart-highlight global WinSetOption filetype=kickstart %{
     add-highlighter window/kickstart ref kickstart
-    hook -once -always window WinSetOption filetype=(?!kickstart).* %{ remove-highlighter window/kickstart }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/kickstart }
 }

--- a/rc/extra/latex.kak
+++ b/rc/extra/latex.kak
@@ -31,5 +31,5 @@ add-highlighter shared/latex/content/ regex '\\textbf\{([^}]+)\}' 1:default+b
 
 hook -group latex-highlight global WinSetOption filetype=latex %{
     add-highlighter window/latex ref latex
-    hook -once -always window WinSetOption filetype=(?!latex).* %{ remove-highlighter window/latex }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/latex }
 }

--- a/rc/extra/latex.kak
+++ b/rc/extra/latex.kak
@@ -29,6 +29,7 @@ add-highlighter shared/latex/content/ regex '\\textbf\{([^}]+)\}' 1:default+b
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group latex-highlight global WinSetOption filetype=latex %{ add-highlighter window/latex ref latex }
-
-hook -group latex-highlight global WinSetOption filetype=(?!latex).* %{ remove-highlighter window/latex }
+hook -group latex-highlight global WinSetOption filetype=latex %{
+    add-highlighter window/latex ref latex
+    hook -once -always window WinSetOption filetype=(?!latex).* %{ remove-highlighter window/latex }
+}

--- a/rc/extra/moon.kak
+++ b/rc/extra/moon.kak
@@ -88,7 +88,10 @@ define-command -hidden moon-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group moon-highlight global WinSetOption filetype=moon %{ add-highlighter window/moon ref moon }
+hook -group moon-highlight global WinSetOption filetype=moon %{
+    add-highlighter window/moon ref moon
+    hook -once -always window WinSetOption filetype=(?!moon).* %{ remove-highlighter window/moon }
+}
 
 hook global WinSetOption filetype=moon %{
     hook window ModeChange insert:.* -group moon-hooks  moon-filter-around-selections
@@ -96,12 +99,9 @@ hook global WinSetOption filetype=moon %{
     hook window InsertChar \n -group moon-indent moon-indent-on-new-line
 
     alias window alt moon-alternative-file
-}
 
-hook -group moon-highlight global WinSetOption filetype=(?!moon).* %{ remove-highlighter window/moon }
-
-hook global WinSetOption filetype=(?!moon).* %{
-    remove-hooks window moon-.+
-
-    unalias window alt moon-alternative-file
+    hook global WinSetOption filetype=(?!moon).* %{
+        remove-hooks window moon-.+
+        unalias window alt moon-alternative-file
+    }
 }

--- a/rc/extra/moon.kak
+++ b/rc/extra/moon.kak
@@ -90,7 +90,7 @@ define-command -hidden moon-indent-on-new-line %{
 
 hook -group moon-highlight global WinSetOption filetype=moon %{
     add-highlighter window/moon ref moon
-    hook -once -always window WinSetOption filetype=(?!moon).* %{ remove-highlighter window/moon }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/moon }
 }
 
 hook global WinSetOption filetype=moon %{
@@ -100,7 +100,7 @@ hook global WinSetOption filetype=moon %{
 
     alias window alt moon-alternative-file
 
-    hook -once -always window WinSetOption filetype=(?!moon).* %{
+    hook -once -always window WinSetOption filetype=.* %{
         remove-hooks window moon-.+
         unalias window alt moon-alternative-file
     }

--- a/rc/extra/moon.kak
+++ b/rc/extra/moon.kak
@@ -100,7 +100,7 @@ hook global WinSetOption filetype=moon %{
 
     alias window alt moon-alternative-file
 
-    hook global WinSetOption filetype=(?!moon).* %{
+    hook -once -always window WinSetOption filetype=(?!moon).* %{
         remove-hooks window moon-.+
         unalias window alt moon-alternative-file
     }

--- a/rc/extra/nim.kak
+++ b/rc/extra/nim.kak
@@ -71,16 +71,15 @@ def -hidden nim-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group nim-highlight global WinSetOption filetype=nim %{ add-highlighter window/nim ref nim }
+hook -group nim-highlight global WinSetOption filetype=nim %{
+    add-highlighter window/nim ref nim
+    hook -once -always window WinSetOption filetype=(?!nim).* %{ remove-highlighter window/nim }
+}
 
 hook global WinSetOption filetype=nim %{
     hook window InsertChar \n -group nim-indent nim-indent-on-new-line
     # cleanup trailing whitespaces on current line insert end
     hook window ModeChange insert:.* -group nim-indent %{ try %{ exec -draft \; <a-x> s ^\h+$ <ret> d } }
-}
 
-hook -group nim-highlight global WinSetOption filetype=(?!nim).* %{ remove-highlighter window/nim }
-
-hook global WinSetOption filetype=(?!nim).* %{
-    remove-hooks window nim-indent
+    hook -once -always window WinSetOption filetype=(?!nim).* %{ remove-hooks window nim-.+ }
 }

--- a/rc/extra/nim.kak
+++ b/rc/extra/nim.kak
@@ -73,7 +73,7 @@ def -hidden nim-indent-on-new-line %{
 
 hook -group nim-highlight global WinSetOption filetype=nim %{
     add-highlighter window/nim ref nim
-    hook -once -always window WinSetOption filetype=(?!nim).* %{ remove-highlighter window/nim }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/nim }
 }
 
 hook global WinSetOption filetype=nim %{
@@ -81,5 +81,5 @@ hook global WinSetOption filetype=nim %{
     # cleanup trailing whitespaces on current line insert end
     hook window ModeChange insert:.* -group nim-indent %{ try %{ exec -draft \; <a-x> s ^\h+$ <ret> d } }
 
-    hook -once -always window WinSetOption filetype=(?!nim).* %{ remove-hooks window nim-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window nim-.+ }
 }

--- a/rc/extra/php.kak
+++ b/rc/extra/php.kak
@@ -78,7 +78,7 @@ define-command -hidden php-indent-on-new-line %<
 
 hook -group php-highlight global WinSetOption filetype=php %{
     add-highlighter window/php-file ref php-file
-    hook -once -always window WinSetOption filetype=(?!php).* %{ remove-highlighter window/php-file }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/php-file }
 }
 
 hook global WinSetOption filetype=php %{
@@ -86,5 +86,5 @@ hook global WinSetOption filetype=php %{
     hook window InsertChar .* -group php-indent php-indent-on-char
     hook window InsertChar \n -group php-indent php-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!php).* %{ remove-hooks window php-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window php-.+ }
 }

--- a/rc/extra/php.kak
+++ b/rc/extra/php.kak
@@ -76,16 +76,15 @@ define-command -hidden php-indent-on-new-line %<
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group php-highlight global WinSetOption filetype=php %{ add-highlighter window/php-file ref php-file }
+hook -group php-highlight global WinSetOption filetype=php %{
+    add-highlighter window/php-file ref php-file
+    hook -once -always window WinSetOption filetype=(?!php).* %{ remove-highlighter window/php-file }
+}
 
 hook global WinSetOption filetype=php %{
     hook window ModeChange insert:.* -group php-hooks  php-filter-around-selections
     hook window InsertChar .* -group php-indent php-indent-on-char
     hook window InsertChar \n -group php-indent php-indent-on-new-line
-}
 
-hook -group php-highlight global WinSetOption filetype=(?!php).* %{ remove-highlighter window/php-file }
-
-hook global WinSetOption filetype=(?!php).* %{
-    remove-hooks window php-.+
+    hook -once -always window WinSetOption filetype=(?!php).* %{ remove-hooks window php-.+ }
 }

--- a/rc/extra/pony.kak
+++ b/rc/extra/pony.kak
@@ -80,7 +80,7 @@ define-command -hidden pony-indent-on-new-line %{
 
 hook -group pony-highlight global WinSetOption filetype=pony %{
     add-highlighter window/pony ref pony
-    hook -once -always window WinSetOption filetype=(?!pony).* %{ remove-highlighter pony }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter pony }
 }
 
 hook global WinSetOption filetype=pony %{
@@ -88,5 +88,5 @@ hook global WinSetOption filetype=pony %{
     # cleanup trailing whitespaces on current line insert end
     hook window ModeChange insert:.* -group pony-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
 
-    hook -once -always window WinSetOption filetype=(?!pony).* %{ remove-hooks window pony-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window pony-.+ }
 }

--- a/rc/extra/pony.kak
+++ b/rc/extra/pony.kak
@@ -78,16 +78,15 @@ define-command -hidden pony-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group pony-highlight global WinSetOption filetype=pony %{ add-highlighter window/pony ref pony }
+hook -group pony-highlight global WinSetOption filetype=pony %{
+    add-highlighter window/pony ref pony
+    hook -once -always window WinSetOption filetype=(?!pony).* %{ remove-highlighter pony }
+}
 
 hook global WinSetOption filetype=pony %{
     hook window InsertChar \n -group pony-indent pony-indent-on-new-line
     # cleanup trailing whitespaces on current line insert end
     hook window ModeChange insert:.* -group pony-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
-}
 
-hook -group pony-highlight global WinSetOption filetype=(?!pony).* %{ remove-highlighter pony }
-
-hook global WinSetOption filetype=(?!pony).* %{
-    remove-hooks window pony-indent
+    hook -once -always window WinSetOption filetype=(?!pony).* %{ remove-hooks window pony-.+ }
 }

--- a/rc/extra/protobuf.kak
+++ b/rc/extra/protobuf.kak
@@ -71,16 +71,15 @@ define-command -hidden protobuf-indent-on-closing-curly-brace %[
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group protobuf-highlight global WinSetOption filetype=protobuf %{ add-highlighter window/protobuf ref protobuf }
+hook -group protobuf-highlight global WinSetOption filetype=protobuf %{
+    add-highlighter window/protobuf ref protobuf
+    hook -once -always window WinSetOption filetype=(?!protobuf).* %{ remove-highlighter window/protobuf }
+}
 
 hook global WinSetOption filetype=protobuf %[
     hook -group protobuf-indent window InsertChar \n protobuf-indent-on-newline
     hook -group protobuf-indent window InsertChar \{ protobuf-indent-on-opening-curly-brace
     hook -group protobuf-indent window InsertChar \} protobuf-indent-on-closing-curly-brace
+
+    hook -once -always window WinSetOption filetype=(?!protobuf).* %{ remove-hooks window protobuf-.+ }
 ]
-
-hook -group protobuf-highlight global WinSetOption filetype=(?!protobuf).* %{ remove-highlighter window/protobuf }
-
-hook global WinSetOption filetype=(?!protobuf).* %{
-    remove-hooks window protobuf-.+
-}

--- a/rc/extra/protobuf.kak
+++ b/rc/extra/protobuf.kak
@@ -73,7 +73,7 @@ define-command -hidden protobuf-indent-on-closing-curly-brace %[
 
 hook -group protobuf-highlight global WinSetOption filetype=protobuf %{
     add-highlighter window/protobuf ref protobuf
-    hook -once -always window WinSetOption filetype=(?!protobuf).* %{ remove-highlighter window/protobuf }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/protobuf }
 }
 
 hook global WinSetOption filetype=protobuf %[
@@ -81,5 +81,5 @@ hook global WinSetOption filetype=protobuf %[
     hook -group protobuf-indent window InsertChar \{ protobuf-indent-on-opening-curly-brace
     hook -group protobuf-indent window InsertChar \} protobuf-indent-on-closing-curly-brace
 
-    hook -once -always window WinSetOption filetype=(?!protobuf).* %{ remove-hooks window protobuf-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window protobuf-.+ }
 ]

--- a/rc/extra/pug.kak
+++ b/rc/extra/pug.kak
@@ -61,15 +61,14 @@ define-command -hidden pug-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group pug-highlight global WinSetOption filetype=pug %{ add-highlighter window/pug ref pug }
+hook -group pug-highlight global WinSetOption filetype=pug %{
+    add-highlighter window/pug ref pug
+    hook -once -always window WinSetOption filetype=(?!pug).* %{ remove-highlighter window/pug }
+}
 
 hook global WinSetOption filetype=pug %{
     hook window ModeChange insert:.* -group pug-hooks  pug-filter-around-selections
     hook window InsertChar \n -group pug-indent pug-indent-on-new-line
-}
 
-hook -group pug-highlight global WinSetOption filetype=(?!pug).* %{ remove-highlighter window/pug }
-
-hook global WinSetOption filetype=(?!pug).* %{
-    remove-hooks window pug-.+
+    hook -once -always window WinSetOption filetype=(?!pug).* %{ remove-hooks window pug-.+ }
 }

--- a/rc/extra/pug.kak
+++ b/rc/extra/pug.kak
@@ -63,12 +63,12 @@ define-command -hidden pug-indent-on-new-line %{
 
 hook -group pug-highlight global WinSetOption filetype=pug %{
     add-highlighter window/pug ref pug
-    hook -once -always window WinSetOption filetype=(?!pug).* %{ remove-highlighter window/pug }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/pug }
 }
 
 hook global WinSetOption filetype=pug %{
     hook window ModeChange insert:.* -group pug-hooks  pug-filter-around-selections
     hook window InsertChar \n -group pug-indent pug-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!pug).* %{ remove-hooks window pug-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window pug-.+ }
 }

--- a/rc/extra/ragel.kak
+++ b/rc/extra/ragel.kak
@@ -56,16 +56,15 @@ define-command -hidden ragel-indent-on-new-line %<
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group ragel-highlight global WinSetOption filetype=ragel %{ add-highlighter window/ragel ref ragel }
+hook -group ragel-highlight global WinSetOption filetype=ragel %{
+    add-highlighter window/ragel ref ragel
+    hook -once -always window WinSetOption filetype=(?!ragel).* %{ remove-highlighter window/ragel }
+}
 
 hook global WinSetOption filetype=ragel %{
     hook window ModeChange insert:.* -group ragel-hooks  ragel-filter-around-selections
     hook window InsertChar .* -group ragel-indent ragel-indent-on-char
     hook window InsertChar \n -group ragel-indent ragel-indent-on-new-line
-}
 
-hook -group ragel-highlight global WinSetOption filetype=(?!ragel).* %{ remove-highlighter window/ragel }
-
-hook global WinSetOption filetype=(?!ragel).* %{
-    remove-hooks window ragel-.+
+    hook -once -always window WinSetOption filetype=(?!ragel).* %{ remove-hooks window ragel-.+ }
 }

--- a/rc/extra/ragel.kak
+++ b/rc/extra/ragel.kak
@@ -58,7 +58,7 @@ define-command -hidden ragel-indent-on-new-line %<
 
 hook -group ragel-highlight global WinSetOption filetype=ragel %{
     add-highlighter window/ragel ref ragel
-    hook -once -always window WinSetOption filetype=(?!ragel).* %{ remove-highlighter window/ragel }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/ragel }
 }
 
 hook global WinSetOption filetype=ragel %{
@@ -66,5 +66,5 @@ hook global WinSetOption filetype=ragel %{
     hook window InsertChar .* -group ragel-indent ragel-indent-on-char
     hook window InsertChar \n -group ragel-indent ragel-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!ragel).* %{ remove-hooks window ragel-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window ragel-.+ }
 }

--- a/rc/extra/sass.kak
+++ b/rc/extra/sass.kak
@@ -48,16 +48,15 @@ define-command -hidden sass-indent-on-new-line %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group sass-highlight global WinSetOption filetype=sass %{ add-highlighter window/sass ref sass }
+hook -group sass-highlight global WinSetOption filetype=sass %{
+    add-highlighter window/sass ref sass
+    hook -once -always window WinSetOption filetype=(?!sass).* %{ remove-highlighter window/sass }
+}
 
 hook global WinSetOption filetype=sass %{
     hook window ModeChange insert:.* -group sass-hooks  sass-filter-around-selections
     hook window InsertChar \n -group sass-indent sass-indent-on-new-line
     set-option buffer extra_word_chars '_' '-'
-}
 
-hook -group sass-highlight global WinSetOption filetype=(?!sass).* %{ remove-highlighter window/sass }
-
-hook global WinSetOption filetype=(?!sass).* %{
-    remove-hooks window sass-.+
+    hook -once -always window WinSetOption filetype=(?!sass).* %{ remove-hooks window sass-.+ }
 }

--- a/rc/extra/sass.kak
+++ b/rc/extra/sass.kak
@@ -50,7 +50,7 @@ define-command -hidden sass-indent-on-new-line %{
 
 hook -group sass-highlight global WinSetOption filetype=sass %{
     add-highlighter window/sass ref sass
-    hook -once -always window WinSetOption filetype=(?!sass).* %{ remove-highlighter window/sass }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/sass }
 }
 
 hook global WinSetOption filetype=sass %{
@@ -58,5 +58,5 @@ hook global WinSetOption filetype=sass %{
     hook window InsertChar \n -group sass-indent sass-indent-on-new-line
     set-option buffer extra_word_chars '_' '-'
 
-    hook -once -always window WinSetOption filetype=(?!sass).* %{ remove-hooks window sass-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window sass-.+ }
 }

--- a/rc/extra/scheme.kak
+++ b/rc/extra/scheme.kak
@@ -114,18 +114,14 @@ evaluate-commands %sh{
 
 hook -group scheme-highlight global WinSetOption filetype=scheme %{
     add-highlighter window/scheme ref scheme
+    hook -once -always window WinSetOption filetype=(?!scheme).* %{ remove-highlighter window/scheme }
 }
 
-hook -group scheme-highlight global WinSetOption filetype=(?!scheme).* %{
-    remove-highlighter window/scheme
-}
 
 hook global WinSetOption filetype=scheme %{
     set-option buffer extra_word_chars '_' '-' '!' '%' '?' '<' '>' '='
     hook window InsertEnd  .* -group scheme-hooks  lisp-filter-around-selections
     hook window InsertChar \n -group scheme-indent lisp-indent-on-new-line
-}
 
-hook global WinSetOption filetype=(?!scheme).* %{
-    remove-hooks window scheme-.+
+    hook -once -always window WinSetOption filetype=(?!scheme).* %{ remove-hooks window scheme-.+ }
 }

--- a/rc/extra/scheme.kak
+++ b/rc/extra/scheme.kak
@@ -114,7 +114,7 @@ evaluate-commands %sh{
 
 hook -group scheme-highlight global WinSetOption filetype=scheme %{
     add-highlighter window/scheme ref scheme
-    hook -once -always window WinSetOption filetype=(?!scheme).* %{ remove-highlighter window/scheme }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/scheme }
 }
 
 
@@ -123,5 +123,5 @@ hook global WinSetOption filetype=scheme %{
     hook window InsertEnd  .* -group scheme-hooks  lisp-filter-around-selections
     hook window InsertChar \n -group scheme-indent lisp-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!scheme).* %{ remove-hooks window scheme-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window scheme-.+ }
 }

--- a/rc/extra/scss.kak
+++ b/rc/extra/scss.kak
@@ -30,17 +30,16 @@ define-command -hidden scss-indent-on-closing-curly-brace css-indent-on-closing-
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group scss-highlight global WinSetOption filetype=scss %{ add-highlighter window/scss ref scss }
+hook -group scss-highlight global WinSetOption filetype=scss %{
+    add-highlighter window/scss ref scss
+    hook -once -always window WinSetOption filetype=(?!scss).* %{ remove-highlighter window/scss }
+}
 
 hook global WinSetOption filetype=scss %[
     hook window ModeChange insert:.* -group scss-hooks  scss-filter-around-selections
     hook window InsertChar \n -group scss-indent scss-indent-on-new-line
     hook window InsertChar \} -group scss-indent scss-indent-on-closing-curly-brace
     set-option buffer extra_word_chars '_' '-'
+
+    hook -once -always window WinSetOption filetype=(?!scss).* %{ remove-hooks window scss-.+ }
 ]
-
-hook -group scss-highlight global WinSetOption filetype=(?!scss).* %{ remove-highlighter window/scss }
-
-hook global WinSetOption filetype=(?!scss).* %{
-    remove-hooks window scss-.+
-}

--- a/rc/extra/scss.kak
+++ b/rc/extra/scss.kak
@@ -32,7 +32,7 @@ define-command -hidden scss-indent-on-closing-curly-brace css-indent-on-closing-
 
 hook -group scss-highlight global WinSetOption filetype=scss %{
     add-highlighter window/scss ref scss
-    hook -once -always window WinSetOption filetype=(?!scss).* %{ remove-highlighter window/scss }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/scss }
 }
 
 hook global WinSetOption filetype=scss %[
@@ -41,5 +41,5 @@ hook global WinSetOption filetype=scss %[
     hook window InsertChar \} -group scss-indent scss-indent-on-closing-curly-brace
     set-option buffer extra_word_chars '_' '-'
 
-    hook -once -always window WinSetOption filetype=(?!scss).* %{ remove-hooks window scss-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window scss-.+ }
 ]

--- a/rc/extra/taskpaper.kak
+++ b/rc/extra/taskpaper.kak
@@ -38,10 +38,10 @@ define-command -hidden taskpaper-indent-on-new-line %{
 
 hook -group taskpaper-highlight global WinSetOption filetype=taskpaper %{
     add-highlighter window/taskpaper ref taskpaper
-    hook -once -always window WinSetOption filetype=(?!taskpaper).* %{ remove-highlighter window/taskpaper }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/taskpaper }
 }
 
 hook global WinSetOption filetype=taskpaper %{
     hook window InsertChar \n -group taskpaper-indent taskpaper-indent-on-new-line
-    hook -once -always window WinSetOption filetype=(?!taskpaper).* %{ remove-hooks window taskpaper-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window taskpaper-.+ }
 }

--- a/rc/extra/taskpaper.kak
+++ b/rc/extra/taskpaper.kak
@@ -38,9 +38,10 @@ define-command -hidden taskpaper-indent-on-new-line %{
 
 hook -group taskpaper-highlight global WinSetOption filetype=taskpaper %{
     add-highlighter window/taskpaper ref taskpaper
-    hook window InsertChar \n -group taskpaper-indent taskpaper-indent-on-new-line
+    hook -once -always window WinSetOption filetype=(?!taskpaper).* %{ remove-highlighter window/taskpaper }
 }
-hook -group taskpaper-highlight global WinSetOption filetype=(?!taskpaper).* %{
-    remove-highlighter window/taskpaper
-    remove-hooks window taskpaper-indent
+
+hook global WinSetOption filetype=taskpaper %{
+    hook window InsertChar \n -group taskpaper-indent taskpaper-indent-on-new-line
+    hook -once -always window WinSetOption filetype=(?!taskpaper).* %{ remove-hooks window taskpaper-.+ }
 }

--- a/rc/extra/toml.kak
+++ b/rc/extra/toml.kak
@@ -52,18 +52,12 @@ define-command -hidden toml-indent-on-new-line %{
 
 hook -group toml-highlight global WinSetOption filetype=toml %{
     add-highlighter window/toml ref toml
+    hook -once -always window WinSetOption filetype=(?!toml).* %{ remove-highlighter window/toml }
 }
 
 hook global WinSetOption filetype=toml %{
     hook window ModeChange insert:.* -group toml-hooks toml-filter-around-selections
     hook window InsertChar \n -group toml-indent toml-indent-on-new-line
-}
 
-hook -group toml-highlight global WinSetOption filetype=(?!toml).* %{
-    remove-highlighter window/toml
+    hook -once -always window WinSetOption filetype=(?!toml).* %{ remove-hooks window toml-.+ }
 }
-
-hook global WinSetOption filetype=(?!toml).* %{
-    remove-hooks window toml-.+
-}
-

--- a/rc/extra/toml.kak
+++ b/rc/extra/toml.kak
@@ -52,12 +52,12 @@ define-command -hidden toml-indent-on-new-line %{
 
 hook -group toml-highlight global WinSetOption filetype=toml %{
     add-highlighter window/toml ref toml
-    hook -once -always window WinSetOption filetype=(?!toml).* %{ remove-highlighter window/toml }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/toml }
 }
 
 hook global WinSetOption filetype=toml %{
     hook window ModeChange insert:.* -group toml-hooks toml-filter-around-selections
     hook window InsertChar \n -group toml-indent toml-indent-on-new-line
 
-    hook -once -always window WinSetOption filetype=(?!toml).* %{ remove-hooks window toml-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window toml-.+ }
 }

--- a/rc/extra/troff.kak
+++ b/rc/extra/troff.kak
@@ -24,6 +24,7 @@ add-highlighter shared/troff/ regex '^\.B\s+([^\n]+)' 1:+b
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group troff-highlight global WinSetOption filetype=troff %{ add-highlighter window/troff ref troff }
-
-hook -group troff-highlight global WinSetOption filetype=(?!troff).* %{ remove-highlighter window/troff }
+hook -group troff-highlight global WinSetOption filetype=troff %{
+    add-highlighter window/troff ref troff
+    hook -once -always window WinSetOption filetype=(?!troff).* %{ remove-highlighter window/troff }
+}

--- a/rc/extra/troff.kak
+++ b/rc/extra/troff.kak
@@ -26,5 +26,5 @@ add-highlighter shared/troff/ regex '^\.B\s+([^\n]+)' 1:+b
 
 hook -group troff-highlight global WinSetOption filetype=troff %{
     add-highlighter window/troff ref troff
-    hook -once -always window WinSetOption filetype=(?!troff).* %{ remove-highlighter window/troff }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/troff }
 }

--- a/rc/extra/tupfile.kak
+++ b/rc/extra/tupfile.kak
@@ -27,5 +27,7 @@ add-highlighter shared/tupfile/code/ regex '`[^`\n]+`' 0:meta
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group tupfile-highlight global WinSetOption filetype=tupfile %{ add-highlighter window/tupfile ref tupfile }
-hook -group tupfile-highlight global WinSetOption filetype=(?!tupfile).* %{ remove-highlighter window/tupfile }
+hook -group tupfile-highlight global WinSetOption filetype=tupfile %{
+    add-highlighter window/tupfile ref tupfile
+    hook -once -always window WinSetOption filetype=(?!tupfile).* %{ remove-highlighter window/tupfile }
+}

--- a/rc/extra/tupfile.kak
+++ b/rc/extra/tupfile.kak
@@ -29,5 +29,5 @@ add-highlighter shared/tupfile/code/ regex '`[^`\n]+`' 0:meta
 
 hook -group tupfile-highlight global WinSetOption filetype=tupfile %{
     add-highlighter window/tupfile ref tupfile
-    hook -once -always window WinSetOption filetype=(?!tupfile).* %{ remove-highlighter window/tupfile }
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/tupfile }
 }


### PR DESCRIPTION
With all plugins loaded, this lowers the numbers of hooks executed when doing `set buffer filetype kak` from 130 to 3. 
I tried to make the setup consistent in all languages.

I manually tested all the languages in core/, some in base/ (javascript in particular, which has an unusual setup), and only a few in extra/. 