### PR TITLE
Parse xterm-keys for motion directly

### DIFF
--- a/src/keys.hh
+++ b/src/keys.hh
@@ -109,6 +109,10 @@ constexpr Key ctrl(Key key)
 {
     return { key.modifiers | Key::Modifiers::Control, key.key };
 }
+constexpr Key shift_alt(Key k) { return shift(alt(k)); }
+constexpr Key shift_ctrl(Key k) { return shift(ctrl(k)); }
+constexpr Key alt_ctrl(Key k) { return alt(ctrl(k)); }
+constexpr Key shift_alt_ctrl(Key k) { return shift(alt(ctrl(k))); }
 
 constexpr Codepoint encode_coord(DisplayCoord coord) { return (Codepoint)(((int)coord.line << 16) | ((int)coord.column & 0x0000FFFF)); }
 

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -26,6 +26,7 @@ namespace Kakoune
 
 using std::min;
 using std::max;
+using std::function;
 
 struct NCursesWin : WINDOW {};
 
@@ -671,11 +672,12 @@ Optional<Key> NCursesUI::get_next_key()
                   const Codepoint c2 = wgetch(m_window);
                   if ( c2 != ';' )
                   {
-                      ungetch(c2); ungetch(c1); break;
+                      ungetch(c2); ungetch(c1);
+                      break;
                   }
 
                   const Codepoint c3 = wgetch(m_window);
-                  Key (*f)(Key) = NULL;
+                  function<Key(Key)> f  = nullptr;
                   switch (c3)
                   {
                       case '2': f = shift; break;
@@ -686,9 +688,10 @@ Optional<Key> NCursesUI::get_next_key()
                       case '7': f = alt_ctrl; break;
                       case '8': f = shift_alt_ctrl; break;
                   }
-                  if ( f == NULL )
+                  if ( f == nullptr )
                   {
-                      ungetch(c3); ungetch(c2); ungetch(c1); break;
+                      ungetch(c3); ungetch(c2); ungetch(c1);
+                      break;
                   }
 
                   const Codepoint c4 = wgetch(m_window);
@@ -702,10 +705,12 @@ Optional<Key> NCursesUI::get_next_key()
                       case 'F': return f(Key::End);
                   }
 
-                  ungetch(c4); ungetch(c3); ungetch(c2); ungetch(c1); break;
+                  ungetch(c4); ungetch(c3); ungetch(c2); ungetch(c1);
+                  break;
                 }
             default:
-              ungetch(c1); break;
+              ungetch(c1);
+              break;
             }
         }
         wtimeout(m_window, -1);

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -661,12 +661,51 @@ Optional<Key> NCursesUI::get_next_key()
         const int new_c = wgetch(m_window);
         if (new_c == '[') // potential CSI
         {
-            const Codepoint csi_val = wgetch(m_window);
-            switch (csi_val)
+            const Codepoint c1 = wgetch(m_window);
+            switch (c1)
             {
                 case 'I': return {Key::FocusIn};
                 case 'O': return {Key::FocusOut};
-                default: break; // nothing
+                case '1':
+                {
+                  const Codepoint c2 = wgetch(m_window);
+                  if ( c2 != ';' )
+                  {
+                      ungetch(c2); ungetch(c1); break;
+                  }
+
+                  const Codepoint c3 = wgetch(m_window);
+                  Key (*f)(Key) = NULL;
+                  switch (c3)
+                  {
+                      case '2': f = shift; break;
+                      case '3': f = alt; break;
+                      case '4': f = shift_alt; break;
+                      case '5': f = ctrl; break;
+                      case '6': f = shift_ctrl; break;
+                      case '7': f = alt_ctrl; break;
+                      case '8': f = shift_alt_ctrl; break;
+                  }
+                  if ( f == NULL )
+                  {
+                      ungetch(c3); ungetch(c2); ungetch(c1); break;
+                  }
+
+                  const Codepoint c4 = wgetch(m_window);
+                  switch (c4)
+                  {
+                      case 'A': return f(Key::Up);
+                      case 'B': return f(Key::Down);
+                      case 'C': return f(Key::Right);
+                      case 'D': return f(Key::Left);
+                      case 'H': return f(Key::Home);
+                      case 'F': return f(Key::End);
+                  }
+
+                  ungetch(c4); ungetch(c3); ungetch(c2); ungetch(c1); break;
+                }
+            default:
+              ungetch(c1); break;
             }
         }
         wtimeout(m_window, -1);

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -670,14 +670,14 @@ Optional<Key> NCursesUI::get_next_key()
                 case '1':
                 {
                   const Codepoint c2 = wgetch(m_window);
-                  if ( c2 != ';' )
+                  if (c2 != ';')
                   {
                       ungetch(c2); ungetch(c1);
                       break;
                   }
 
                   const Codepoint c3 = wgetch(m_window);
-                  function<Key(Key)> f  = nullptr;
+                  function<Key(Key)> f;
                   switch (c3)
                   {
                       case '2': f = shift; break;
@@ -688,7 +688,7 @@ Optional<Key> NCursesUI::get_next_key()
                       case '7': f = alt_ctrl; break;
                       case '8': f = shift_alt_ctrl; break;
                   }
-                  if ( f == nullptr )
+                  if (f)
                   {
                       ungetch(c3); ungetch(c2); ungetch(c1);
                       break;

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -688,7 +688,7 @@ Optional<Key> NCursesUI::get_next_key()
                       case '7': f = alt_ctrl; break;
                       case '8': f = shift_alt_ctrl; break;
                   }
-                  if (f)
+                  if (!f)
                   {
                       ungetch(c3); ungetch(c2); ungetch(c1);
                       break;


### PR DESCRIPTION
Ideally, something better should be done (re #2554) but this is a decent
intermediate step for some useful keys.

Note: NCurses supports parsing these keys when shifted (KEY_SR,
_SLEFT, S_RIGHT, etc), but it does not do the same thing for the other
modifiers.