### PR TITLE
src: Implement a `clang-format` configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,37 @@
+---
+BasedOnStyle: Google
+IndentWidth: 4
+---
+Language: Cpp
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterClass: true
+    AfterControlStatement: true
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    AfterStruct: true
+    AfterUnion: true
+    AfterExternBlock: true
+    BeforeCatch: true
+    BeforeElse: true
+    IndentBraces: false
+    SplitEmptyFunction: false
+    SplitEmptyRecord: false
+    SplitEmptyNamespace: false
+SortIncludes: false
+SpaceAfterTemplateKeyword: false
+AlignAfterOpenBracket: Align
+KeepEmptyLinesAtTheStartOfBlocks: true
+SpaceBeforeParens: ControlStatements
+AlignConsecutiveAssignments: true
+BreakBeforeBinaryOperators: All
+Cpp11BracedListStyle: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+FixNamespaceComments: false
+SpacesBeforeTrailingComments: 1
+AccessModifierOffset: -4
+AlignConsecutiveAssignments: true
+IndentPPDirectives: AfterHash
+...

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,7 @@ version ?= $(shell if [ -f .version ]; then cat .version; elif  [ -d ../.git ]; 
 sources := $(sort $(wildcard *.cc))
 objects := $(addprefix ., $(sources:.cc=$(suffix).o))
 deps := $(addprefix ., $(sources:.cc=$(suffix).d))
+headers := $(sort $(wildcard *.hh))
 
 PKG_CONFIG ?= $(shell command -v pkg-config 2>/dev/null)
 
@@ -109,6 +110,9 @@ TAGS: tags
 tags:
 	ctags -R
 
+format: $(sources) $(headers)
+	clang-format -style=file -i $^
+
 clean:
 	rm -f .*.o .*.d
 
@@ -164,4 +168,4 @@ uninstall:
 		$(mandir)/kak.1
 
 .PHONY: check TAGS clean dist distclean installdirs install install-strip uninstall
-.PHONY: tags test man kak FORCE
+.PHONY: tags format test man kak FORCE

--- a/src/alias_registry.cc
+++ b/src/alias_registry.cc
@@ -12,15 +12,12 @@ void AliasRegistry::add_alias(String alias, String command)
     kak_assert(CommandManager::instance().command_defined(command));
     auto it = m_aliases.find(alias);
     if (it == m_aliases.end())
-        m_aliases.insert({std::move(alias), std::move(command) });
+        m_aliases.insert({std::move(alias), std::move(command)});
     else
         it->value = std::move(command);
 }
 
-void AliasRegistry::remove_alias(StringView alias)
-{
-    m_aliases.remove(alias);
-}
+void AliasRegistry::remove_alias(StringView alias) { m_aliases.remove(alias); }
 
 StringView AliasRegistry::operator[](StringView alias) const
 {

--- a/src/alias_registry.hh
+++ b/src/alias_registry.hh
@@ -22,12 +22,16 @@ public:
     {
         auto merge = [](auto&& first, const AliasMap& second) {
             return concatenated(std::forward<decltype(first)>(first)
-                                | filter([&second](auto& i) { return not second.contains(i.key); }),
+                                    | filter([&second](auto& i) {
+                                          return not second.contains(i.key);
+                                      }),
                                 second);
         };
         static const AliasMap empty;
-        auto& parent = m_parent ? m_parent->m_aliases : empty;
-        auto& grand_parent = (m_parent and m_parent->m_parent) ? m_parent->m_parent->m_aliases : empty;
+        auto& parent       = m_parent ? m_parent->m_aliases : empty;
+        auto& grand_parent = (m_parent and m_parent->m_parent)
+                                 ? m_parent->m_parent->m_aliases
+                                 : empty;
         return merge(merge(grand_parent, parent), m_aliases);
     }
 

--- a/src/array_view.hh
+++ b/src/array_view.hh
@@ -16,44 +16,55 @@ class ArrayView
 public:
     using size_t = std::size_t;
 
-    constexpr ArrayView()
-        : m_pointer(nullptr), m_size(0) {}
+    constexpr ArrayView() : m_pointer(nullptr), m_size(0) {}
 
-    constexpr ArrayView(T& oneval)
-        : m_pointer(&oneval), m_size(1) {}
+    constexpr ArrayView(T& oneval) : m_pointer(&oneval), m_size(1) {}
 
     constexpr ArrayView(T* pointer, size_t size)
-        : m_pointer(pointer), m_size(size) {}
+        : m_pointer(pointer), m_size(size)
+    {}
 
     constexpr ArrayView(T* begin, T* end)
-        : m_pointer(begin), m_size(end - begin) {}
+        : m_pointer(begin), m_size(end - begin)
+    {}
 
     template<size_t N>
-    constexpr ArrayView(T(&array)[N]) : m_pointer(array), m_size(N) {}
+    constexpr ArrayView(T (&array)[N]) : m_pointer(array), m_size(N)
+    {}
 
     template<typename Alloc, typename U,
              typename = std::enable_if_t<sizeof(U) == sizeof(T)>>
     constexpr ArrayView(const std::vector<U, Alloc>& v)
-        : m_pointer(v.data()), m_size(v.size()) {}
+        : m_pointer(v.data()), m_size(v.size())
+    {}
 
     constexpr ArrayView(const std::initializer_list<T>& v)
-        : m_pointer(v.begin()), m_size(v.size()) {}
+        : m_pointer(v.begin()), m_size(v.size())
+    {}
 
     constexpr T* pointer() const { return m_pointer; }
     constexpr size_t size() const { return m_size; }
 
-    [[gnu::always_inline]]
-    constexpr T& operator[](size_t n) const { return *(m_pointer + n); }
+    [[gnu::always_inline]] constexpr T& operator[](size_t n) const
+    {
+        return *(m_pointer + n);
+    }
 
     constexpr T* begin() const { return m_pointer; }
-    constexpr T* end()   const { return m_pointer+m_size; }
+    constexpr T* end() const { return m_pointer + m_size; }
 
     using reverse_iterator = std::reverse_iterator<T*>;
-    constexpr reverse_iterator rbegin() const { return reverse_iterator(m_pointer+m_size); }
-    constexpr reverse_iterator rend()   const { return reverse_iterator(m_pointer); }
+    constexpr reverse_iterator rbegin() const
+    {
+        return reverse_iterator(m_pointer + m_size);
+    }
+    constexpr reverse_iterator rend() const
+    {
+        return reverse_iterator(m_pointer);
+    }
 
     constexpr T& front() const { return *m_pointer; }
-    constexpr T& back()  const { return *(m_pointer + m_size - 1); }
+    constexpr T& back() const { return *(m_pointer + m_size - 1); }
 
     constexpr bool empty() const { return m_size == 0; }
 
@@ -87,7 +98,7 @@ bool operator==(ArrayView<T> lhs, ArrayView<T> rhs)
 template<typename T>
 bool operator!=(ArrayView<T> lhs, ArrayView<T> rhs)
 {
-    return not (lhs == rhs);
+    return not(lhs == rhs);
 }
 
 }

--- a/src/assert.cc
+++ b/src/assert.cc
@@ -5,7 +5,7 @@
 #include "exception.hh"
 
 #if defined(__CYGWIN__)
-#include <windows.h>
+#    include <windows.h>
 #endif
 
 #include <sys/types.h>
@@ -17,10 +17,10 @@ namespace Kakoune
 
 struct assert_failed : logic_error
 {
-    assert_failed(String message)
-        : m_message(std::move(message)) {}
+    assert_failed(String message) : m_message(std::move(message)) {}
 
     StringView what() const override { return m_message; }
+
 private:
     String m_message;
 };
@@ -29,9 +29,10 @@ bool notify_fatal_error(StringView msg)
 {
 #if defined(__CYGWIN__)
     return MessageBox(NULL, msg.zstr(), "Kakoune: fatal error",
-                      MB_OKCANCEL | MB_ICONERROR) == IDOK;
+                      MB_OKCANCEL | MB_ICONERROR)
+           == IDOK;
 #elif defined(__linux__)
-    auto cmd = format("xmessage -buttons 'quit:0,ignore:1' '{}'", msg);
+    auto cmd   = format("xmessage -buttons 'quit:0,ignore:1' '{}'", msg);
     int status = system(cmd.c_str());
     return (WIFEXITED(status)) ? (WEXITSTATUS(status)) == 1 : false;
 #else
@@ -41,8 +42,10 @@ bool notify_fatal_error(StringView msg)
 
 void on_assert_failed(const char* message)
 {
-    String debug_info = format("pid: {}\ncallstack:\n{}", getpid(), Backtrace{}.desc());
-    write_to_debug_buffer(format("assert failed: '{}'\n{}", message, debug_info));
+    String debug_info
+        = format("pid: {}\ncallstack:\n{}", getpid(), Backtrace{}.desc());
+    write_to_debug_buffer(
+        format("assert failed: '{}'\n{}", message, debug_info));
 
     const auto msg = format("{}\n[Debug Infos]\n{}", message, debug_info);
     if (not notify_fatal_error(msg))

--- a/src/assert.hh
+++ b/src/assert.hh
@@ -17,22 +17,35 @@ void on_assert_failed(const char* message);
 #define TOSTRING(X) STRINGIFY(X)
 
 #ifdef KAK_DEBUG
-    #define kak_assert(...) do { \
-        if (not (__VA_ARGS__)) \
-            on_assert_failed("assert failed \"" #__VA_ARGS__ \
+#    define kak_assert(...)                                                 \
+        do                                                                  \
+        {                                                                   \
+            if (not(__VA_ARGS__))                                           \
+                on_assert_failed("assert failed \"" #__VA_ARGS__            \
+                                 "\" at " __FILE__ ":" TOSTRING(__LINE__)); \
+        } while (false)
+
+#    define kak_expect_throw(exception_type, ...)                       \
+        try                                                             \
+        {                                                               \
+            __VA_ARGS__;                                                \
+            on_assert_failed("expression \"" #__VA_ARGS__               \
+                             "\" did not throw \"" #exception_type      \
                              "\" at " __FILE__ ":" TOSTRING(__LINE__)); \
-    } while (false)
-
-    #define kak_expect_throw(exception_type, ...) try {\
-        __VA_ARGS__; \
-        on_assert_failed("expression \"" #__VA_ARGS__ \
-                         "\" did not throw \"" #exception_type \
-                         "\" at " __FILE__ ":" TOSTRING(__LINE__)); \
-    } catch (exception_type &err) {}
+        }                                                               \
+        catch (exception_type & err)                                    \
+        {}
 #else
-    #define kak_assert(...) do { (void)sizeof(__VA_ARGS__); } while(false)
-    #define kak_expect_throw(_, ...) do { (void)sizeof(__VA_ARGS__); } while(false)
+#    define kak_assert(...)            \
+        do                             \
+        {                              \
+            (void)sizeof(__VA_ARGS__); \
+        } while (false)
+#    define kak_expect_throw(_, ...)   \
+        do                             \
+        {                              \
+            (void)sizeof(__VA_ARGS__); \
+        } while (false)
 #endif
-
 
 #endif // assert_hh_INCLUDED

--- a/src/backtrace.cc
+++ b/src/backtrace.cc
@@ -3,15 +3,15 @@
 #include "string.hh"
 
 #if defined(__GLIBC__) || defined(__APPLE__)
-# include <execinfo.h>
+#    include <execinfo.h>
 #elif defined(__CYGWIN__)
-# include <windows.h>
-# include <dbghelp.h>
-# include <stdio.h>
+#    include <windows.h>
+#    include <dbghelp.h>
+#    include <stdio.h>
 #endif
 
 #if defined(__linux__) || defined(__APPLE__)
-# include <cstdlib>
+#    include <cstdlib>
 #endif
 
 namespace Kakoune
@@ -19,22 +19,23 @@ namespace Kakoune
 
 Backtrace::Backtrace()
 {
-    #if defined(__GLIBC__) || defined(__APPLE__)
+#if defined(__GLIBC__) || defined(__APPLE__)
     num_frames = backtrace(stackframes, max_frames);
-    #elif defined(__CYGWIN__)
-    num_frames = CaptureStackBackTrace(0, max_frames, stackframes, nullptr);
-    #endif
+#elif defined(__CYGWIN__)
+    num_frames     = CaptureStackBackTrace(0, max_frames, stackframes, nullptr);
+#endif
 }
 
 String Backtrace::desc() const
 {
-    #if defined(__GLIBC__) || defined(__APPLE__)
+#if defined(__GLIBC__) || defined(__APPLE__)
     char** symbols = backtrace_symbols(stackframes, num_frames);
     ByteCount size = 0;
     for (int i = 0; i < num_frames; ++i)
         size += strlen(symbols[i]) + 1;
 
-    String res; res.reserve(size);
+    String res;
+    res.reserve(size);
     for (int i = 0; i < num_frames; ++i)
     {
         res += symbols[i];
@@ -42,7 +43,7 @@ String Backtrace::desc() const
     }
     free(symbols);
     return res;
-    #elif defined(__CYGWIN__)
+#elif defined(__CYGWIN__)
     HANDLE process = GetCurrentProcess();
 
     static bool symbols_initialized = false;
@@ -53,8 +54,9 @@ String Backtrace::desc() const
     }
 
     alignas(SYMBOL_INFO) char symbol_info_buffer[sizeof(SYMBOL_INFO) + 256];
-    SYMBOL_INFO* symbol_info = reinterpret_cast<SYMBOL_INFO*>(symbol_info_buffer);
-    symbol_info->MaxNameLen = 255;
+    SYMBOL_INFO* symbol_info
+        = reinterpret_cast<SYMBOL_INFO*>(symbol_info_buffer);
+    symbol_info->MaxNameLen   = 255;
     symbol_info->SizeOfStruct = sizeof(SYMBOL_INFO);
 
     String res; // res.reserve(num_frames * 276);
@@ -62,13 +64,14 @@ String Backtrace::desc() const
     {
         SymFromAddr(process, (DWORD64)stackframes[i], 0, symbol_info);
         char desc[276];
-        snprintf(desc, 276, "0x%0llx (%s)\n", symbol_info->Address, symbol_info->Name);
+        snprintf(desc, 276, "0x%0llx (%s)\n", symbol_info->Address,
+                 symbol_info->Name);
         res += desc;
     }
     return res;
-    #else
+#else
     return "<not implemented>";
-    #endif
+#endif
 }
 
 }

--- a/src/backtrace.hh
+++ b/src/backtrace.hh
@@ -19,4 +19,3 @@ struct Backtrace
 }
 
 #endif // backtrace_hh_INCLUDED
-

--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -23,7 +23,7 @@ namespace Kakoune
 struct ParsedLines
 {
     BufferLines lines;
-    ByteOrderMark bom = ByteOrderMark::None;
+    ByteOrderMark bom   = ByteOrderMark::None;
     EolFormat eolformat = EolFormat::Lf;
 };
 
@@ -34,29 +34,31 @@ static ParsedLines parse_lines(StringView data)
     if (data.substr(0, 3_byte) == "\xEF\xBB\xBF")
     {
         res.bom = ByteOrderMark::Utf8;
-        pos = data.begin() + 3;
+        pos     = data.begin() + 3;
     }
 
     bool has_crlf = false, has_lf = false;
     for (auto it = pos; it != data.end(); ++it)
     {
         if (*it == '\n')
-            ((it != pos and *(it-1) == '\r') ? has_crlf : has_lf) = true;
+            ((it != pos and *(it - 1) == '\r') ? has_crlf : has_lf) = true;
     }
     const bool crlf = has_crlf and not has_lf;
-    res.eolformat = crlf ? EolFormat::Crlf : EolFormat::Lf;
+    res.eolformat   = crlf ? EolFormat::Crlf : EolFormat::Lf;
 
     while (pos < data.end())
     {
         const char* eol = std::find(pos, data.end(), '\n');
-        res.lines.emplace_back(StringData::create({{pos, eol - (crlf and eol != data.end() ? 1 : 0)}, "\n"}));
+        res.lines.emplace_back(StringData::create(
+            {{pos, eol - (crlf and eol != data.end() ? 1 : 0)}, "\n"}));
         pos = eol + 1;
     }
 
     return res;
 }
 
-static void apply_options(OptionManager& options, const ParsedLines& parsed_lines)
+static void apply_options(OptionManager& options,
+                          const ParsedLines& parsed_lines)
 {
     options.get_local_option("eolformat").set(parsed_lines.eolformat);
     options.get_local_option("BOM").set(parsed_lines.bom);
@@ -66,10 +68,10 @@ Buffer::HistoryNode::HistoryNode(HistoryId parent)
     : parent{parent}, timepoint{Clock::now()}
 {}
 
-Buffer::Buffer(String name, Flags flags, StringView data,
-               timespec fs_timestamp)
+Buffer::Buffer(String name, Flags flags, StringView data, timespec fs_timestamp)
     : Scope{GlobalScope::instance()},
-      m_name{(flags & Flags::File) ? real_path(parse_filename(name)) : std::move(name)},
+      m_name{(flags & Flags::File) ? real_path(parse_filename(name))
+                                   : std::move(name)},
       m_display_name{(flags & Flags::File) ? compact_path(m_name) : m_name},
       m_flags{flags | Flags::NoUndo},
       m_history{{HistoryId::Invalid}},
@@ -82,19 +84,19 @@ Buffer::Buffer(String name, Flags flags, StringView data,
     if (parsed_lines.lines.empty())
         parsed_lines.lines.emplace_back(StringData::create({"\n"}));
 
-    #ifdef KAK_DEBUG
+#ifdef KAK_DEBUG
     for (auto& line : parsed_lines.lines)
-        kak_assert(not (line->length == 0) and
-                   line->data()[line->length-1] == '\n');
-    #endif
+        kak_assert(not(line->length == 0)
+                   and line->data()[line->length - 1] == '\n');
+#endif
     static_cast<BufferLines&>(m_lines) = std::move(parsed_lines.lines);
 
-    m_changes.push_back({ Change::Insert, {0,0}, line_count() });
+    m_changes.push_back({Change::Insert, {0, 0}, line_count()});
 
     apply_options(options(), parsed_lines);
 
     // now we may begin to record undo data
-    if (not (flags & Flags::NoUndo))
+    if (not(flags & Flags::NoUndo))
         m_flags &= ~Flags::NoUndo;
 }
 
@@ -128,8 +130,8 @@ void Buffer::on_registered()
     }
 
     for (auto& option : options().flatten_options()
-                      | transform(&std::unique_ptr<Option>::get)
-                      | gather<Vector<Option*>>())
+                            | transform(&std::unique_ptr<Option>::get)
+                            | gather<Vector<Option*>>())
         on_option_changed(*option);
 }
 
@@ -142,10 +144,7 @@ void Buffer::on_unregistered()
     run_hook_in_own_context(Hook::BufClose, m_name);
 }
 
-Buffer::~Buffer()
-{
-    m_values.clear();
-}
+Buffer::~Buffer() { m_values.clear(); }
 
 bool Buffer::set_name(String name)
 {
@@ -154,12 +153,12 @@ bool Buffer::set_name(String name)
     {
         if (m_flags & Flags::File)
         {
-            m_name = real_path(name);
+            m_name         = real_path(name);
             m_display_name = compact_path(m_name);
         }
         else
         {
-            m_name = std::move(name);
+            m_name         = std::move(name);
             m_display_name = m_name;
         }
         return true;
@@ -191,28 +190,38 @@ BufferCoord Buffer::clamp(BufferCoord coord) const
         coord = back_coord();
     kak_assert(coord.line >= 0 and coord.line < line_count());
     ByteCount max_col = std::max(0_byte, m_lines[coord.line].length() - 1);
-    coord.column = Kakoune::clamp(coord.column, 0_byte, max_col);
+    coord.column      = Kakoune::clamp(coord.column, 0_byte, max_col);
     return coord;
 }
 
-BufferCoord Buffer::offset_coord(BufferCoord coord, CharCount offset, ColumnCount, bool)
+BufferCoord Buffer::offset_coord(BufferCoord coord, CharCount offset,
+                                 ColumnCount, bool)
 {
-    return utf8::advance(iterator_at(coord), offset < 0 ? begin() : end()-1, offset).coord();
+    return utf8::advance(iterator_at(coord), offset < 0 ? begin() : end() - 1,
+                         offset)
+        .coord();
 }
 
-BufferCoordAndTarget Buffer::offset_coord(BufferCoordAndTarget coord, LineCount offset, ColumnCount tabstop, bool avoid_eol)
+BufferCoordAndTarget Buffer::offset_coord(BufferCoordAndTarget coord,
+                                          LineCount offset, ColumnCount tabstop,
+                                          bool avoid_eol)
 {
-    const auto column = coord.target == -1 ? get_column(*this, tabstop, coord) : coord.target;
-    const auto line = Kakoune::clamp(coord.line + offset, 0_line, line_count()-1);
-    const auto max_column = get_column(*this, tabstop, {line, m_lines[line].length()-1});
-    const auto final_column = std::max(0_col, std::min(column, max_column - (avoid_eol ? 1 : 0)));
-    return {line, get_byte_to_column(*this, tabstop, {line, final_column}), column};
+    const auto column
+        = coord.target == -1 ? get_column(*this, tabstop, coord) : coord.target;
+    const auto line
+        = Kakoune::clamp(coord.line + offset, 0_line, line_count() - 1);
+    const auto max_column
+        = get_column(*this, tabstop, {line, m_lines[line].length() - 1});
+    const auto final_column
+        = std::max(0_col, std::min(column, max_column - (avoid_eol ? 1 : 0)));
+    return {line, get_byte_to_column(*this, tabstop, {line, final_column}),
+            column};
 }
 
 String Buffer::string(BufferCoord begin, BufferCoord end) const
 {
     String res;
-    const auto last_line = std::min(end.line, line_count()-1);
+    const auto last_line = std::min(end.line, line_count() - 1);
     for (auto line = begin.line; line <= last_line; ++line)
     {
         ByteCount start = 0;
@@ -229,7 +238,11 @@ String Buffer::string(BufferCoord begin, BufferCoord end) const
 // A Modification holds a single atomic modification to Buffer
 struct Buffer::Modification
 {
-    enum Type { Insert, Erase };
+    enum Type
+    {
+        Insert,
+        Erase
+    };
 
     Type type;
     BufferCoord coord;
@@ -248,27 +261,29 @@ void Buffer::reload(StringView data, timespec fs_timestamp)
     if (parsed_lines.lines.empty())
         parsed_lines.lines.emplace_back(StringData::create({"\n"}));
 
-    const bool record_undo = not (m_flags & Flags::NoUndo);
+    const bool record_undo = not(m_flags & Flags::NoUndo);
 
     commit_undo_group();
 
     if (not record_undo)
     {
         // Erase history about to be invalidated history
-        m_history_id = HistoryId::First;
+        m_history_id           = HistoryId::First;
         m_last_save_history_id = HistoryId::First;
-        m_history = {HistoryNode{HistoryId::Invalid}};
+        m_history              = {HistoryNode{HistoryId::Invalid}};
 
-        m_changes.push_back({ Change::Erase, {0,0}, line_count() });
+        m_changes.push_back({Change::Erase, {0, 0}, line_count()});
         static_cast<BufferLines&>(m_lines) = std::move(parsed_lines.lines);
-        m_changes.push_back({ Change::Insert, {0,0}, line_count() });
+        m_changes.push_back({Change::Insert, {0, 0}, line_count()});
     }
     else
     {
-        auto diff = find_diff(m_lines.begin(), m_lines.size(),
-                              parsed_lines.lines.begin(), parsed_lines.lines.size(),
-                              [](const StringDataPtr& lhs, const StringDataPtr& rhs)
-                              { return lhs->strview() == rhs->strview(); });
+        auto diff
+            = find_diff(m_lines.begin(), m_lines.size(),
+                        parsed_lines.lines.begin(), parsed_lines.lines.size(),
+                        [](const StringDataPtr& lhs, const StringDataPtr& rhs) {
+                            return lhs->strview() == rhs->strview();
+                        });
 
         auto it = m_lines.begin();
         for (auto& d : diff)
@@ -280,25 +295,28 @@ void Buffer::reload(StringView data, timespec fs_timestamp)
                 const LineCount cur_line = (int)(it - m_lines.begin());
 
                 for (LineCount line = 0; line < d.len; ++line)
-                    m_current_undo_group.push_back({
-                        Modification::Insert, cur_line + line,
-                        parsed_lines.lines[(int)(d.posB + line)]});
+                    m_current_undo_group.push_back(
+                        {Modification::Insert, cur_line + line,
+                         parsed_lines.lines[(int)(d.posB + line)]});
 
-                m_changes.push_back({ Change::Insert, cur_line, cur_line + d.len });
-                m_lines.insert(it, &parsed_lines.lines[d.posB], &parsed_lines.lines[d.posB + d.len]);
+                m_changes.push_back(
+                    {Change::Insert, cur_line, cur_line + d.len});
+                m_lines.insert(it, &parsed_lines.lines[d.posB],
+                               &parsed_lines.lines[d.posB + d.len]);
                 it = m_lines.begin() + (int)(cur_line + d.len);
             }
             else if (d.mode == Diff::Remove)
             {
                 const LineCount cur_line = (int)(it - m_lines.begin());
 
-                for (LineCount line = d.len-1; line >= 0; --line)
-                    m_current_undo_group.push_back({
-                        Modification::Erase, cur_line + line,
-                        m_lines.get_storage(cur_line + line)});
+                for (LineCount line = d.len - 1; line >= 0; --line)
+                    m_current_undo_group.push_back(
+                        {Modification::Erase, cur_line + line,
+                         m_lines.get_storage(cur_line + line)});
 
                 it = m_lines.erase(it, it + d.len);
-                m_changes.push_back({ Change::Erase, cur_line, cur_line + d.len });
+                m_changes.push_back(
+                    {Change::Erase, cur_line, cur_line + d.len});
             }
         }
     }
@@ -308,7 +326,7 @@ void Buffer::reload(StringView data, timespec fs_timestamp)
     apply_options(options(), parsed_lines);
 
     m_last_save_history_id = m_history_id;
-    m_fs_timestamp = fs_timestamp;
+    m_fs_timestamp         = fs_timestamp;
 }
 
 void Buffer::commit_undo_group()
@@ -324,7 +342,7 @@ void Buffer::commit_undo_group()
     m_history.back().undo_group = std::move(m_current_undo_group);
     m_current_undo_group.clear();
     current_history_node().redo_child = id;
-    m_history_id = id;
+    m_history_id                      = id;
 }
 
 bool Buffer::undo(size_t count)
@@ -338,7 +356,8 @@ bool Buffer::undo(size_t count)
 
     while (count-- != 0 and current_history_node().parent != HistoryId::Invalid)
     {
-        for (const Modification& modification : current_history_node().undo_group | reverse())
+        for (const Modification& modification :
+             current_history_node().undo_group | reverse())
             apply_modification(modification.inverse());
 
         m_history_id = current_history_node().parent;
@@ -356,11 +375,13 @@ bool Buffer::redo(size_t count)
 
     kak_assert(m_current_undo_group.empty());
 
-    while (count-- != 0 and current_history_node().redo_child != HistoryId::Invalid)
+    while (count-- != 0
+           and current_history_node().redo_child != HistoryId::Invalid)
     {
         m_history_id = current_history_node().redo_child;
 
-        for (const Modification& modification : current_history_node().undo_group)
+        for (const Modification& modification :
+             current_history_node().undo_group)
             apply_modification(modification);
     }
     return true;
@@ -378,7 +399,8 @@ bool Buffer::move_to(HistoryId id)
     auto find_lowest_common_parent = [this](HistoryId a, HistoryId b) {
         auto depth_of = [this](HistoryId id) {
             size_t depth = 0;
-            for (; history_node(id).parent != HistoryId::Invalid; id = history_node(id).parent)
+            for (; history_node(id).parent != HistoryId::Invalid;
+                 id = history_node(id).parent)
                 ++depth;
             return depth;
         };
@@ -404,23 +426,24 @@ bool Buffer::move_to(HistoryId id)
     // undo up to common parent
     for (auto id = m_history_id; id != parent; id = history_node(id).parent)
     {
-        for (const Modification& modification : history_node(id).undo_group | reverse())
+        for (const Modification& modification :
+             history_node(id).undo_group | reverse())
             apply_modification(modification.inverse());
     }
 
-    static void (*apply_from_parent)(Buffer&, HistoryId, HistoryId) =
-    [](Buffer& buffer, HistoryId parent, HistoryId id) {
-        if (id == parent)
-            return;
+    static void (*apply_from_parent)(Buffer&, HistoryId, HistoryId)
+        = [](Buffer& buffer, HistoryId parent, HistoryId id) {
+              if (id == parent)
+                  return;
 
-        auto& node = buffer.history_node(id);
-        apply_from_parent(buffer, parent, node.parent);
+              auto& node = buffer.history_node(id);
+              apply_from_parent(buffer, parent, node.parent);
 
-        buffer.history_node(node.parent).redo_child = id;
+              buffer.history_node(node.parent).redo_child = id;
 
-        for (const Modification& modification : node.undo_group)
-            buffer.apply_modification(modification);
-    };
+              for (const Modification& modification : node.undo_group)
+                  buffer.apply_modification(modification);
+          };
 
     apply_from_parent(*this, parent, id);
     m_history_id = id;
@@ -447,12 +470,13 @@ BufferCoord Buffer::do_insert(BufferCoord pos, StringView content)
         return pos;
 
     const bool at_end = is_end(pos);
-    const bool append_lines = at_end and (m_lines.empty() or byte_at(back_coord()) == '\n');
+    const bool append_lines
+        = at_end and (m_lines.empty() or byte_at(back_coord()) == '\n');
 
-    const StringView prefix = append_lines ?
-        StringView{} : m_lines[pos.line].substr(0, pos.column);
-    const StringView suffix = at_end ?
-        StringView{} : m_lines[pos.line].substr(pos.column);
+    const StringView prefix
+        = append_lines ? StringView{} : m_lines[pos.line].substr(0, pos.column);
+    const StringView suffix
+        = at_end ? StringView{} : m_lines[pos.line].substr(pos.column);
 
     LineList new_lines;
     ByteCount start = 0;
@@ -461,29 +485,31 @@ BufferCoord Buffer::do_insert(BufferCoord pos, StringView content)
         if (content[i] == '\n')
         {
             StringView line = content.substr(start, i + 1 - start);
-            new_lines.push_back(StringData::create(start == 0 ? prefix + line : line));
+            new_lines.push_back(
+                StringData::create(start == 0 ? prefix + line : line));
             start = i + 1;
         }
     }
     if (start == 0)
         new_lines.push_back(StringData::create({prefix, content, suffix}));
     else if (start != content.length() or not suffix.empty())
-        new_lines.push_back(StringData::create({content.substr(start), suffix}));
+        new_lines.push_back(
+            StringData::create({content.substr(start), suffix}));
 
-    auto line_it = m_lines.begin() + (int)pos.line;
+    auto line_it      = m_lines.begin() + (int)pos.line;
     auto new_lines_it = new_lines.begin();
     if (not append_lines) // replace first line with new first line
         *line_it++ = std::move(*new_lines_it++);
 
-    m_lines.insert(line_it,
-                   std::make_move_iterator(new_lines_it),
+    m_lines.insert(line_it, std::make_move_iterator(new_lines_it),
                    std::make_move_iterator(new_lines.end()));
 
     const LineCount last_line = pos.line + new_lines.size() - 1;
-    const auto end = at_end ? line_count()
-                            : BufferCoord{ last_line, m_lines[last_line].length() - suffix.length() };
+    const auto end            = at_end ? line_count()
+                            : BufferCoord{last_line, m_lines[last_line].length()
+                                                         - suffix.length()};
 
-    m_changes.push_back({ Change::Insert, pos, end });
+    m_changes.push_back({Change::Insert, pos, end});
     return pos;
 }
 
@@ -495,46 +521,50 @@ BufferCoord Buffer::do_erase(BufferCoord begin, BufferCoord end)
     kak_assert(is_valid(begin));
     kak_assert(is_valid(end));
     StringView prefix = m_lines[begin.line].substr(0, begin.column);
-    StringView suffix = end.line == line_count() ? StringView{} : m_lines[end.line].substr(end.column);
+    StringView suffix = end.line == line_count()
+                            ? StringView{}
+                            : m_lines[end.line].substr(end.column);
 
     BufferCoord next;
     if (not prefix.empty() or not suffix.empty())
     {
         auto new_line = StringData::create({prefix, suffix});
-        m_lines.erase(m_lines.begin() + (int)begin.line, m_lines.begin() + (int)end.line);
+        m_lines.erase(m_lines.begin() + (int)begin.line,
+                      m_lines.begin() + (int)end.line);
         m_lines.get_storage(begin.line) = std::move(new_line);
-        next = begin;
+        next                            = begin;
     }
     else
     {
-        m_lines.erase(m_lines.begin() + (int)begin.line, m_lines.begin() + (int)end.line);
+        m_lines.erase(m_lines.begin() + (int)begin.line,
+                      m_lines.begin() + (int)end.line);
         next = begin.line;
     }
 
-    m_changes.push_back({ Change::Erase, begin, end });
+    m_changes.push_back({Change::Erase, begin, end});
     return next;
 }
 
 void Buffer::apply_modification(const Modification& modification)
 {
     StringView content = modification.content->strview();
-    BufferCoord coord = modification.coord;
+    BufferCoord coord  = modification.coord;
 
     kak_assert(is_valid(coord));
     switch (modification.type)
     {
-    case Modification::Insert:
-        do_insert(coord, content);
-        break;
-    case Modification::Erase:
-    {
-        auto end = advance(coord, content.length());
-        kak_assert(string(coord, end) == content);
-        do_erase(coord, end);
-        break;
-    }
-    default:
-        kak_assert(false);
+        case Modification::Insert:
+            do_insert(coord, content);
+            break;
+        case Modification::Erase:
+        {
+            auto end = advance(coord, content.length());
+            kak_assert(string(coord, end) == content);
+            do_erase(coord, end);
+            break;
+        }
+        default:
+            kak_assert(false);
     }
 }
 
@@ -555,8 +585,9 @@ BufferCoord Buffer::insert(BufferCoord pos, StringView content)
     // for undo and redo purpose it is better to use one past last line rather
     // than one past last char coord.
     auto coord = is_end(pos) ? line_count() : pos;
-    if (not (m_flags & Flags::NoUndo))
-        m_current_undo_group.push_back({Modification::Insert, coord, real_content});
+    if (not(m_flags & Flags::NoUndo))
+        m_current_undo_group.push_back(
+            {Modification::Insert, coord, real_content});
     return do_insert(pos, real_content->strview());
 }
 
@@ -565,31 +596,34 @@ BufferCoord Buffer::erase(BufferCoord begin, BufferCoord end)
     throw_if_read_only();
 
     kak_assert(is_valid(begin) and is_valid(end));
-    // do not erase last \n except if we erase from the start of a line, and normalize
-    // end coord
+    // do not erase last \n except if we erase from the start of a line, and
+    // normalize end coord
     if (is_end(end))
-        end = (begin.column != 0 or begin == BufferCoord{0,0}) ? prev(end) : end_coord();
+        end = (begin.column != 0 or begin == BufferCoord{0, 0}) ? prev(end)
+                                                                : end_coord();
 
     if (begin >= end) // use >= to handle case where begin is {line_count}
         return begin;
 
-    if (not (m_flags & Flags::NoUndo))
-        m_current_undo_group.push_back({Modification::Erase, begin,
-                                        intern(string(begin, end))});
+    if (not(m_flags & Flags::NoUndo))
+        m_current_undo_group.push_back(
+            {Modification::Erase, begin, intern(string(begin, end))});
     return do_erase(begin, end);
 }
 
-BufferCoord Buffer::replace(BufferCoord begin, BufferCoord end, StringView content)
+BufferCoord Buffer::replace(BufferCoord begin, BufferCoord end,
+                            StringView content)
 {
     throw_if_read_only();
 
     if (is_end(end) and not content.empty() and content.back() == '\n')
     {
-        end = back_coord();
+        end     = back_coord();
         content = content.substr(0, content.length() - 1);
     }
 
-    if (std::equal(iterator_at(begin), iterator_at(end), content.begin(), content.end()))
+    if (std::equal(iterator_at(begin), iterator_at(end), content.begin(),
+                   content.end()))
         return begin;
 
     auto pos = erase(begin, end);
@@ -598,9 +632,9 @@ BufferCoord Buffer::replace(BufferCoord begin, BufferCoord end, StringView conte
 
 bool Buffer::is_modified() const
 {
-    return m_flags & Flags::File and
-           (m_history_id != m_last_save_history_id or
-            not m_current_undo_group.empty());
+    return m_flags & Flags::File
+           and (m_history_id != m_last_save_history_id
+                or not m_current_undo_group.empty());
 }
 
 void Buffer::notify_saved()
@@ -610,7 +644,7 @@ void Buffer::notify_saved()
 
     m_flags &= ~Flags::New;
     m_last_save_history_id = m_history_id;
-    m_fs_timestamp = get_fs_timestamp(m_name);
+    m_fs_timestamp         = get_fs_timestamp(m_name);
 }
 
 BufferCoord Buffer::advance(BufferCoord coord, ByteCount count) const
@@ -625,7 +659,7 @@ BufferCoord Buffer::advance(BufferCoord coord, ByteCount count) const
             if (line == line_count())
                 return end_coord();
         }
-        return { line, count };
+        return {line, count};
     }
     else if (count < 0)
     {
@@ -637,7 +671,7 @@ BufferCoord Buffer::advance(BufferCoord coord, ByteCount count) const
             if (line < 0)
                 return {0, 0};
         }
-        return { line, count };
+        return {line, count};
     }
     return coord;
 }
@@ -646,24 +680,26 @@ BufferCoord Buffer::char_next(BufferCoord coord) const
 {
     if (coord.column < m_lines[coord.line].length() - 1)
     {
-        auto line = m_lines[coord.line];
+        auto line   = m_lines[coord.line];
         auto column = coord.column + utf8::codepoint_size(line[coord.column]);
         if (column >= line.length()) // Handle invalid utf-8
-            return { coord.line + 1, 0 };
-        return { coord.line, column };
+            return {coord.line + 1, 0};
+        return {coord.line, column};
     }
-    return { coord.line + 1, 0 };
+    return {coord.line + 1, 0};
 }
 
 BufferCoord Buffer::char_prev(BufferCoord coord) const
 {
     kak_assert(is_valid(coord));
     if (coord.column == 0)
-        return { coord.line - 1, m_lines[coord.line - 1].length() - 1 };
+        return {coord.line - 1, m_lines[coord.line - 1].length() - 1};
 
-    auto line = m_lines[coord.line];
-    auto column = (int)(utf8::character_start(line.begin() + (int)coord.column - 1, line.begin()) - line.begin());
-    return { coord.line, column };
+    auto line   = m_lines[coord.line];
+    auto column = (int)(utf8::character_start(
+                            line.begin() + (int)coord.column - 1, line.begin())
+                        - line.begin());
+    return {coord.line, column};
 }
 
 timespec Buffer::fs_timestamp() const
@@ -687,18 +723,19 @@ void Buffer::on_option_changed(const Option& option)
         else
             m_flags &= ~Flags::ReadOnly;
     }
-    run_hook_in_own_context(Hook::BufSetOption,
-                            format("{}={}", option.name(), option.get_as_string(Quoting::Kakoune)));
+    run_hook_in_own_context(
+        Hook::BufSetOption,
+        format("{}={}", option.name(), option.get_as_string(Quoting::Kakoune)));
 }
 
-void Buffer::run_hook_in_own_context(Hook hook, StringView param, String client_name)
+void Buffer::run_hook_in_own_context(Hook hook, StringView param,
+                                     String client_name)
 {
     if (m_flags & Buffer::Flags::NoHooks)
         return;
 
-    InputHandler hook_handler{{ *this, Selection{} },
-                              Context::Flags::Draft,
-                              std::move(client_name)};
+    InputHandler hook_handler{
+        {*this, Selection{}}, Context::Flags::Draft, std::move(client_name)};
     hooks().run_hook(hook, param, hook_handler.context());
 }
 
@@ -715,21 +752,25 @@ String Buffer::debug_description() const
     for (auto& line : m_lines)
         content_size += (int)line->strview().length();
 
-    const size_t additional_size = accumulate(m_history, 0, [](size_t s, auto&& history) {
-            return sizeof(history) + history.undo_group.size() * sizeof(Modification) + s;
-        }) + m_changes.size() * sizeof(Change);
+    const size_t additional_size
+        = accumulate(
+              m_history, 0,
+              [](size_t s, auto&& history) {
+                  return sizeof(history)
+                         + history.undo_group.size() * sizeof(Modification) + s;
+              })
+          + m_changes.size() * sizeof(Change);
 
     return format("{}\nFlags: {}{}{}{}\nUsed mem: content={} additional={}\n",
                   display_name(),
                   (m_flags & Flags::File) ? "File (" + name() + ") " : "",
                   (m_flags & Flags::New) ? "New " : "",
                   (m_flags & Flags::Fifo) ? "Fifo " : "",
-                  (m_flags & Flags::NoUndo) ? "NoUndo " : "",
-                  content_size, additional_size);
+                  (m_flags & Flags::NoUndo) ? "NoUndo " : "", content_size,
+                  additional_size);
 }
 
-UnitTest test_parse_line{[]
-{
+UnitTest test_parse_line{[] {
     {
         auto lines = parse_lines("foo\nbar\nbaz\n");
         kak_assert(lines.eolformat == EolFormat::Lf);
@@ -741,7 +782,9 @@ UnitTest test_parse_line{[]
     }
 
     {
-        auto lines = parse_lines("\xEF\xBB\xBF" "foo\nbar\r\nbaz");
+        auto lines = parse_lines(
+            "\xEF\xBB\xBF"
+            "foo\nbar\r\nbaz");
         kak_assert(lines.eolformat == EolFormat::Lf);
         kak_assert(lines.bom == ByteOrderMark::Utf8);
         kak_assert(lines.lines.size() == 3);
@@ -761,11 +804,11 @@ UnitTest test_parse_line{[]
     }
 }};
 
-UnitTest test_buffer{[]()
-{
+UnitTest test_buffer{[]() {
     Buffer empty_buffer("empty", Buffer::Flags::None, {});
 
-    Buffer buffer("test", Buffer::Flags::None, "allo ?\nmais que fais la police\n hein ?\n youpi\n");
+    Buffer buffer("test", Buffer::Flags::None,
+                  "allo ?\nmais que fais la police\n hein ?\n youpi\n");
     kak_assert(buffer.line_count() == 4);
 
     BufferIterator pos = buffer.begin();
@@ -784,46 +827,51 @@ UnitTest test_buffer{[]()
     pos2 -= 9;
     kak_assert(*pos2 == '?');
 
-    String str = buffer.string({ 4, 1 }, buffer.next({ 4, 5 }));
+    String str = buffer.string({4, 1}, buffer.next({4, 5}));
     kak_assert(str == "youpi");
 
     // check insert at end behaviour: auto add end of line if necessary
-    pos = buffer.end()-1;
+    pos = buffer.end() - 1;
     buffer.insert(pos.coord(), "tchou");
     kak_assert(buffer.string(pos.coord(), buffer.end_coord()) == "tchou\n"_sv);
 
-    pos = buffer.end()-1;
+    pos = buffer.end() - 1;
     buffer.insert(buffer.end_coord(), "kanaky\n");
-    kak_assert(buffer.string((pos+1).coord(), buffer.end_coord()) == "kanaky\n"_sv);
+    kak_assert(buffer.string((pos + 1).coord(), buffer.end_coord())
+               == "kanaky\n"_sv);
 
     buffer.commit_undo_group();
-    buffer.erase((pos+1).coord(), buffer.end_coord());
+    buffer.erase((pos + 1).coord(), buffer.end_coord());
     buffer.insert(buffer.end_coord(), "mutch\n");
     buffer.commit_undo_group();
     buffer.undo();
-    kak_assert(buffer.string(buffer.advance(buffer.end_coord(), -7), buffer.end_coord()) == "kanaky\n"_sv);
+    kak_assert(buffer.string(buffer.advance(buffer.end_coord(), -7),
+                             buffer.end_coord())
+               == "kanaky\n"_sv);
     buffer.redo();
-    kak_assert(buffer.string(buffer.advance(buffer.end_coord(), -6), buffer.end_coord()) == "mutch\n"_sv);
+    kak_assert(buffer.string(buffer.advance(buffer.end_coord(), -6),
+                             buffer.end_coord())
+               == "mutch\n"_sv);
 }};
 
-UnitTest test_undo{[]()
-{
-    Buffer buffer("test", Buffer::Flags::None, "allo ?\nmais que fais la police\n hein ?\n youpi\n");
+UnitTest test_undo{[]() {
+    Buffer buffer("test", Buffer::Flags::None,
+                  "allo ?\nmais que fais la police\n hein ?\n youpi\n");
     auto pos = buffer.insert(buffer.end_coord(), "kanaky\n"); // change 1
     buffer.commit_undo_group();
-    buffer.erase(pos, buffer.end_coord());                    // change 2
+    buffer.erase(pos, buffer.end_coord()); // change 2
     buffer.commit_undo_group();
-    buffer.insert(2_line, "tchou\n");                         // change 3
+    buffer.insert(2_line, "tchou\n"); // change 3
     buffer.commit_undo_group();
     buffer.undo();
-    buffer.insert(2_line, "mutch\n");                         // change 4
+    buffer.insert(2_line, "mutch\n"); // change 4
     buffer.commit_undo_group();
-    buffer.erase({2, 1}, {2, 5});                             // change 5
+    buffer.erase({2, 1}, {2, 5}); // change 5
     buffer.commit_undo_group();
     buffer.undo(2);
     buffer.redo(2);
     buffer.undo();
-    buffer.replace(2_line, buffer.end_coord(), "foo");        // change 6
+    buffer.replace(2_line, buffer.end_coord(), "foo"); // change 6
     buffer.commit_undo_group();
 
     kak_assert((int)buffer.line_count() == 3);

--- a/src/buffer.hh
+++ b/src/buffer.hh
@@ -26,8 +26,8 @@ enum class EolFormat
 constexpr auto enum_desc(Meta::Type<EolFormat>)
 {
     return make_array<EnumDesc<EolFormat>, 2>({
-        { EolFormat::Lf, "lf" },
-        { EolFormat::Crlf, "crlf" },
+        {EolFormat::Lf, "lf"},
+        {EolFormat::Crlf, "crlf"},
     });
 }
 
@@ -40,23 +40,23 @@ enum class ByteOrderMark
 constexpr auto enum_desc(Meta::Type<ByteOrderMark>)
 {
     return make_array<EnumDesc<ByteOrderMark>, 2>({
-        { ByteOrderMark::None, "none" },
-        { ByteOrderMark::Utf8, "utf8" },
+        {ByteOrderMark::None, "none"},
+        {ByteOrderMark::Utf8, "utf8"},
     });
 }
 
 class Buffer;
 
-constexpr timespec InvalidTime = { -1, -1 };
+constexpr timespec InvalidTime = {-1, -1};
 
 // A BufferIterator permits to iterate over the characters of a buffer
 class BufferIterator
 {
 public:
-    using value_type = char;
+    using value_type      = char;
     using difference_type = ssize_t;
-    using pointer = const value_type*;
-    using reference = const value_type&;
+    using pointer         = const value_type*;
+    using reference       = const value_type&;
     // computing the distance between two iterator can be
     // costly, so this is not strictly random access
     using iterator_category = std::bidirectional_iterator_tag;
@@ -64,31 +64,31 @@ public:
     BufferIterator() noexcept : m_buffer(nullptr) {}
     BufferIterator(const Buffer& buffer, BufferCoord coord) noexcept;
 
-    bool operator== (const BufferIterator& iterator) const noexcept;
-    bool operator!= (const BufferIterator& iterator) const noexcept;
-    bool operator<  (const BufferIterator& iterator) const noexcept;
-    bool operator<= (const BufferIterator& iterator) const noexcept;
-    bool operator>  (const BufferIterator& iterator) const noexcept;
-    bool operator>= (const BufferIterator& iterator) const noexcept;
+    bool operator==(const BufferIterator& iterator) const noexcept;
+    bool operator!=(const BufferIterator& iterator) const noexcept;
+    bool operator<(const BufferIterator& iterator) const noexcept;
+    bool operator<=(const BufferIterator& iterator) const noexcept;
+    bool operator>(const BufferIterator& iterator) const noexcept;
+    bool operator>=(const BufferIterator& iterator) const noexcept;
 
-    bool operator== (const BufferCoord& coord) const noexcept;
-    bool operator!= (const BufferCoord& coord) const noexcept;
+    bool operator==(const BufferCoord& coord) const noexcept;
+    bool operator!=(const BufferCoord& coord) const noexcept;
 
-    const char& operator* () const noexcept;
+    const char& operator*() const noexcept;
     const char& operator[](size_t n) const noexcept;
-    size_t operator- (const BufferIterator& iterator) const;
+    size_t operator-(const BufferIterator& iterator) const;
 
-    BufferIterator operator+ (ByteCount size) const;
-    BufferIterator operator- (ByteCount size) const;
+    BufferIterator operator+(ByteCount size) const;
+    BufferIterator operator-(ByteCount size) const;
 
-    BufferIterator& operator+= (ByteCount size);
-    BufferIterator& operator-= (ByteCount size);
+    BufferIterator& operator+=(ByteCount size);
+    BufferIterator& operator-=(ByteCount size);
 
-    BufferIterator& operator++ ();
-    BufferIterator& operator-- ();
+    BufferIterator& operator++();
+    BufferIterator& operator--();
 
-    BufferIterator operator++ (int);
-    BufferIterator operator-- (int);
+    BufferIterator operator++(int);
+    BufferIterator operator--(int);
 
     const BufferCoord& coord() const noexcept { return m_coord; }
     explicit operator BufferCoord() const noexcept { return m_coord; }
@@ -107,7 +107,9 @@ using BufferLines = Vector<StringDataPtr, MemoryDomain::BufferContent>;
 // The Buffer class permits to read and mutate this file
 // representation. It also manage modifications undo/redo and
 // provides tools to deal with the line/column nature of text.
-class Buffer final : public SafeCountable, public Scope, private OptionManagerWatcher
+class Buffer final : public SafeCountable,
+                     public Scope,
+                     private OptionManagerWatcher
 {
 public:
     enum class Flags
@@ -123,12 +125,16 @@ public:
     };
     friend constexpr bool with_bit_ops(Meta::Type<Flags>) { return true; }
 
-    enum class HistoryId : size_t { First = 0, Invalid = (size_t)-1 };
+    enum class HistoryId : size_t
+    {
+        First   = 0,
+        Invalid = (size_t)-1
+    };
 
     Buffer(String name, Flags flags, StringView data = {},
            timespec fs_timestamp = InvalidTime);
     Buffer(const Buffer&) = delete;
-    Buffer& operator= (const Buffer&) = delete;
+    Buffer& operator=(const Buffer&) = delete;
     ~Buffer();
 
     Flags flags() const { return m_flags; }
@@ -141,46 +147,50 @@ public:
     BufferCoord erase(BufferCoord begin, BufferCoord end);
     BufferCoord replace(BufferCoord begin, BufferCoord end, StringView content);
 
-    size_t         timestamp() const;
-    timespec       fs_timestamp() const;
-    void           set_fs_timestamp(timespec ts);
+    size_t timestamp() const;
+    timespec fs_timestamp() const;
+    void set_fs_timestamp(timespec ts);
 
-    void           commit_undo_group();
-    bool           undo(size_t count = 1);
-    bool           redo(size_t count = 1);
-    bool           move_to(HistoryId id);
-    HistoryId      current_history_id() const noexcept { return m_history_id; }
-    HistoryId      next_history_id() const noexcept { return (HistoryId)m_history.size(); }
+    void commit_undo_group();
+    bool undo(size_t count = 1);
+    bool redo(size_t count = 1);
+    bool move_to(HistoryId id);
+    HistoryId current_history_id() const noexcept { return m_history_id; }
+    HistoryId next_history_id() const noexcept
+    {
+        return (HistoryId)m_history.size();
+    }
 
-    String         string(BufferCoord begin, BufferCoord end) const;
-    StringView     substr(BufferCoord begin, BufferCoord end) const;
+    String string(BufferCoord begin, BufferCoord end) const;
+    StringView substr(BufferCoord begin, BufferCoord end) const;
 
-    const char&    byte_at(BufferCoord c) const;
-    ByteCount      distance(BufferCoord begin, BufferCoord end) const;
-    BufferCoord    advance(BufferCoord coord, ByteCount count) const;
-    BufferCoord    next(BufferCoord coord) const;
-    BufferCoord    prev(BufferCoord coord) const;
+    const char& byte_at(BufferCoord c) const;
+    ByteCount distance(BufferCoord begin, BufferCoord end) const;
+    BufferCoord advance(BufferCoord coord, ByteCount count) const;
+    BufferCoord next(BufferCoord coord) const;
+    BufferCoord prev(BufferCoord coord) const;
 
-    BufferCoord    char_next(BufferCoord coord) const;
-    BufferCoord    char_prev(BufferCoord coord) const;
+    BufferCoord char_next(BufferCoord coord) const;
+    BufferCoord char_prev(BufferCoord coord) const;
 
-    BufferCoord    back_coord() const;
-    BufferCoord    end_coord() const;
+    BufferCoord back_coord() const;
+    BufferCoord end_coord() const;
 
-    bool           is_valid(BufferCoord c) const;
-    bool           is_end(BufferCoord c) const;
+    bool is_valid(BufferCoord c) const;
+    bool is_end(BufferCoord c) const;
 
     BufferIterator begin() const;
     BufferIterator end() const;
-    LineCount      line_count() const;
+    LineCount line_count() const;
 
     Optional<BufferCoord> last_modification_coord() const;
 
-    StringView operator[](LineCount line) const
-    { return m_lines[line]; }
+    StringView operator[](LineCount line) const { return m_lines[line]; }
 
     const StringDataPtr& line_storage(LineCount line) const
-    { return m_lines.get_storage(line); }
+    {
+        return m_lines.get_storage(line);
+    }
 
     // returns an iterator at given coordinates. clamp line_and_column
     BufferIterator iterator_at(BufferCoord coord) const;
@@ -188,8 +198,11 @@ public:
     // returns nearest valid coordinates from given ones
     BufferCoord clamp(BufferCoord coord) const;
 
-    BufferCoord offset_coord(BufferCoord coord, CharCount offset, ColumnCount, bool);
-    BufferCoordAndTarget offset_coord(BufferCoordAndTarget coord, LineCount offset, ColumnCount tabstop, bool avoid_eol);
+    BufferCoord offset_coord(BufferCoord coord, CharCount offset, ColumnCount,
+                             bool);
+    BufferCoordAndTarget offset_coord(BufferCoordAndTarget coord,
+                                      LineCount offset, ColumnCount tabstop,
+                                      bool avoid_eol);
 
     const String& name() const { return m_name; }
     const String& display_name() const { return m_display_name; }
@@ -212,7 +225,11 @@ public:
 
     struct Change
     {
-        enum Type : char { Insert, Erase };
+        enum Type : char
+        {
+            Insert,
+            Erase
+        };
         Type type;
         BufferCoord begin;
         BufferCoord end;
@@ -226,6 +243,7 @@ public:
     void on_unregistered();
 
     void throw_if_read_only() const;
+
 private:
     void on_option_changed(const Option& option) override;
 
@@ -239,17 +257,21 @@ private:
 
     struct LineList : BufferLines
     {
-        [[gnu::always_inline]]
-        StringDataPtr& get_storage(LineCount line)
-        { return BufferLines::operator[]((int)line); }
+        [[gnu::always_inline]] StringDataPtr& get_storage(LineCount line)
+        {
+            return BufferLines::operator[]((int)line);
+        }
 
-        [[gnu::always_inline]]
-        const StringDataPtr& get_storage(LineCount line) const
-        { return BufferLines::operator[]((int)line); }
+        [[gnu::always_inline]] const StringDataPtr& get_storage(
+            LineCount line) const
+        {
+            return BufferLines::operator[]((int)line);
+        }
 
-        [[gnu::always_inline]]
-        StringView operator[](LineCount line) const
-        { return get_storage(line)->strview(); }
+        [[gnu::always_inline]] StringView operator[](LineCount line) const
+        {
+            return get_storage(line)->strview();
+        }
 
         StringView front() const { return BufferLines::front()->strview(); }
         StringView back() const { return BufferLines::back()->strview(); }
@@ -258,7 +280,7 @@ private:
 
     String m_name;
     String m_display_name;
-    Flags  m_flags;
+    Flags m_flags;
 
     using UndoGroup = Vector<Modification, MemoryDomain::BufferMeta>;
 
@@ -273,14 +295,23 @@ private:
     };
 
     Vector<HistoryNode> m_history;
-    HistoryId           m_history_id = HistoryId::Invalid;
-    HistoryId           m_last_save_history_id = HistoryId::Invalid;
-    UndoGroup           m_current_undo_group;
+    HistoryId m_history_id           = HistoryId::Invalid;
+    HistoryId m_last_save_history_id = HistoryId::Invalid;
+    UndoGroup m_current_undo_group;
 
-          HistoryNode& history_node(HistoryId id)       { return m_history[(size_t)id]; }
-    const HistoryNode& history_node(HistoryId id) const { return m_history[(size_t)id]; }
-          HistoryNode& current_history_node()           { return m_history[(size_t)m_history_id]; }
-    const HistoryNode& current_history_node()     const { return m_history[(size_t)m_history_id]; }
+    HistoryNode& history_node(HistoryId id) { return m_history[(size_t)id]; }
+    const HistoryNode& history_node(HistoryId id) const
+    {
+        return m_history[(size_t)id];
+    }
+    HistoryNode& current_history_node()
+    {
+        return m_history[(size_t)m_history_id];
+    }
+    const HistoryNode& current_history_node() const
+    {
+        return m_history[(size_t)m_history_id];
+    }
 
     Vector<Change, MemoryDomain::BufferMeta> m_changes;
 

--- a/src/buffer.inl.hh
+++ b/src/buffer.inl.hh
@@ -6,8 +6,7 @@
 namespace Kakoune
 {
 
-[[gnu::always_inline]]
-inline const char& Buffer::byte_at(BufferCoord c) const
+[[gnu::always_inline]] inline const char& Buffer::byte_at(BufferCoord c) const
 {
     kak_assert(c.line < line_count() and c.column < m_lines[c.line].length());
     return m_lines[c.line][c.column];
@@ -17,14 +16,14 @@ inline BufferCoord Buffer::next(BufferCoord coord) const
 {
     if (coord.column < m_lines[coord.line].length() - 1)
         return {coord.line, coord.column + 1};
-    return { coord.line + 1, 0 };
+    return {coord.line + 1, 0};
 }
 
 inline BufferCoord Buffer::prev(BufferCoord coord) const
 {
     if (coord.column == 0)
-        return { coord.line - 1, m_lines[coord.line - 1].length() - 1 };
-    return { coord.line, coord.column - 1 };
+        return {coord.line - 1, m_lines[coord.line - 1].length() - 1};
+    return {coord.line, coord.column - 1};
 }
 
 inline ByteCount Buffer::distance(BufferCoord begin, BufferCoord end) const
@@ -35,7 +34,7 @@ inline ByteCount Buffer::distance(BufferCoord begin, BufferCoord end) const
         return end.column - begin.column;
 
     ByteCount res = m_lines[begin.line].length() - begin.column;
-    for (LineCount l = begin.line+1; l < end.line; ++l)
+    for (LineCount l = begin.line + 1; l < end.line; ++l)
         res += m_lines[l].length();
     res += end.column;
     return res;
@@ -43,36 +42,23 @@ inline ByteCount Buffer::distance(BufferCoord begin, BufferCoord end) const
 
 inline bool Buffer::is_valid(BufferCoord c) const
 {
-    return (c.line >= 0 and c.column >= 0) and
-           ((c.line < line_count() and c.column < m_lines[c.line].length()) or
-            (c.line == line_count() and c.column == 0));
+    return (c.line >= 0 and c.column >= 0)
+           and ((c.line < line_count() and c.column < m_lines[c.line].length())
+                or (c.line == line_count() and c.column == 0));
 }
 
-inline bool Buffer::is_end(BufferCoord c) const
-{
-    return c >= end_coord();
-}
+inline bool Buffer::is_end(BufferCoord c) const { return c >= end_coord(); }
 
-inline BufferIterator Buffer::begin() const
-{
-    return {*this, { 0, 0 }};
-}
+inline BufferIterator Buffer::begin() const { return {*this, {0, 0}}; }
 
-inline BufferIterator Buffer::end() const
-{
-    return {*this, end_coord()};
-}
+inline BufferIterator Buffer::end() const { return {*this, end_coord()}; }
 
-[[gnu::always_inline]]
-inline LineCount Buffer::line_count() const
+[[gnu::always_inline]] inline LineCount Buffer::line_count() const
 {
     return LineCount{(int)m_lines.size()};
 }
 
-inline size_t Buffer::timestamp() const
-{
-    return m_changes.size();
-}
+inline size_t Buffer::timestamp() const { return m_changes.size(); }
 
 inline StringView Buffer::substr(BufferCoord begin, BufferCoord end) const
 {
@@ -80,57 +66,65 @@ inline StringView Buffer::substr(BufferCoord begin, BufferCoord end) const
     return m_lines[begin.line].substr(begin.column, end.column - begin.column);
 }
 
-inline ConstArrayView<Buffer::Change> Buffer::changes_since(size_t timestamp) const
+inline ConstArrayView<Buffer::Change> Buffer::changes_since(
+    size_t timestamp) const
 {
     if (timestamp < m_changes.size())
-        return { m_changes.data() + timestamp,
-                 m_changes.data() + m_changes.size() };
+        return {m_changes.data() + timestamp,
+                m_changes.data() + m_changes.size()};
     return {};
 }
 
 inline BufferCoord Buffer::back_coord() const
 {
-    return { line_count() - 1, m_lines.back().length() - 1 };
+    return {line_count() - 1, m_lines.back().length() - 1};
 }
 
-inline BufferCoord Buffer::end_coord() const
-{
-    return line_count();
-}
+inline BufferCoord Buffer::end_coord() const { return line_count(); }
 
-inline BufferIterator::BufferIterator(const Buffer& buffer, BufferCoord coord) noexcept
-    : m_buffer{&buffer}, m_coord{coord},
-      m_line{coord.line < buffer.line_count() ? (*m_buffer)[coord.line] : StringView{}} {}
+inline BufferIterator::BufferIterator(const Buffer& buffer,
+                                      BufferCoord coord) noexcept
+    : m_buffer{&buffer},
+      m_coord{coord},
+      m_line{coord.line < buffer.line_count() ? (*m_buffer)[coord.line]
+                                              : StringView{}}
+{}
 
-inline bool BufferIterator::operator==(const BufferIterator& iterator) const noexcept
+inline bool BufferIterator::operator==(const BufferIterator& iterator) const
+    noexcept
 {
     return m_buffer == iterator.m_buffer and m_coord == iterator.m_coord;
 }
 
-inline bool BufferIterator::operator!=(const BufferIterator& iterator) const noexcept
+inline bool BufferIterator::operator!=(const BufferIterator& iterator) const
+    noexcept
 {
     return m_buffer != iterator.m_buffer or m_coord != iterator.m_coord;
 }
 
-inline bool BufferIterator::operator<(const BufferIterator& iterator) const noexcept
+inline bool BufferIterator::operator<(const BufferIterator& iterator) const
+    noexcept
 {
     kak_assert(m_buffer == iterator.m_buffer);
     return (m_coord < iterator.m_coord);
 }
 
-inline bool BufferIterator::operator<=(const BufferIterator& iterator) const noexcept
+inline bool BufferIterator::operator<=(const BufferIterator& iterator) const
+    noexcept
 {
     kak_assert(m_buffer == iterator.m_buffer);
     return (m_coord <= iterator.m_coord);
 }
 
-inline bool BufferIterator::operator>(const BufferIterator& iterator) const noexcept
+inline bool BufferIterator::operator>(const BufferIterator& iterator) const
+    noexcept
 {
     kak_assert(m_buffer == iterator.m_buffer);
     return (m_coord > iterator.m_coord);
 }
 
-inline bool BufferIterator::operator>=(const BufferIterator& iterator) const noexcept
+inline bool BufferIterator::operator>=(const BufferIterator& iterator) const
+    noexcept
 {
     kak_assert(m_buffer == iterator.m_buffer);
     return (m_coord >= iterator.m_coord);
@@ -146,8 +140,8 @@ inline bool BufferIterator::operator!=(const BufferCoord& coord) const noexcept
     return m_coord != coord;
 }
 
-[[gnu::always_inline]]
-inline const char& BufferIterator::operator*() const noexcept
+[[gnu::always_inline]] inline const char& BufferIterator::operator*() const
+    noexcept
 {
     return m_line[m_coord.column];
 }
@@ -166,25 +160,25 @@ inline size_t BufferIterator::operator-(const BufferIterator& iterator) const
 inline BufferIterator BufferIterator::operator+(ByteCount size) const
 {
     kak_assert(m_buffer);
-    return { *m_buffer, m_buffer->advance(m_coord, size) };
+    return {*m_buffer, m_buffer->advance(m_coord, size)};
 }
 
 inline BufferIterator BufferIterator::operator-(ByteCount size) const
 {
-    return { *m_buffer, m_buffer->advance(m_coord, -size) };
+    return {*m_buffer, m_buffer->advance(m_coord, -size)};
 }
 
 inline BufferIterator& BufferIterator::operator+=(ByteCount size)
 {
     m_coord = m_buffer->advance(m_coord, size);
-    m_line = (*m_buffer)[m_coord.line];
+    m_line  = (*m_buffer)[m_coord.line];
     return *this;
 }
 
 inline BufferIterator& BufferIterator::operator-=(ByteCount size)
 {
     m_coord = m_buffer->advance(m_coord, -size);
-    m_line = (*m_buffer)[m_coord.line];
+    m_line  = (*m_buffer)[m_coord.line];
     return *this;
 }
 
@@ -192,8 +186,9 @@ inline BufferIterator& BufferIterator::operator++()
 {
     if (++m_coord.column == m_line.length())
     {
-        m_line = (++m_coord.line < m_buffer->line_count()) ?
-            (*m_buffer)[m_coord.line] : StringView{};
+        m_line = (++m_coord.line < m_buffer->line_count())
+                     ? (*m_buffer)[m_coord.line]
+                     : StringView{};
         m_coord.column = 0;
     }
     return *this;
@@ -203,11 +198,11 @@ inline BufferIterator& BufferIterator::operator--()
 {
     if (m_coord.column == 0)
     {
-        m_line = (*m_buffer)[--m_coord.line];
+        m_line         = (*m_buffer)[--m_coord.line];
         m_coord.column = m_line.length() - 1;
     }
     else
-       --m_coord.column;
+        --m_coord.column;
     return *this;
 }
 

--- a/src/buffer_manager.cc
+++ b/src/buffer_manager.cc
@@ -13,7 +13,8 @@ namespace Kakoune
 
 BufferManager::~BufferManager()
 {
-    // Move buffers to avoid running BufClose with buffers remaining in that list
+    // Move buffers to avoid running BufClose with buffers remaining in that
+    // list
     BufferList buffers = std::move(m_buffers);
 
     for (auto& buffer : buffers)
@@ -30,12 +31,13 @@ Buffer* BufferManager::create_buffer(String name, Buffer::Flags flags,
     auto path = real_path(parse_filename(name));
     for (auto& buf : m_buffers)
     {
-        if (buf->name() == name or
-            (buf->flags() & Buffer::Flags::File and buf->name() == path))
+        if (buf->name() == name
+            or (buf->flags() & Buffer::Flags::File and buf->name() == path))
             throw runtime_error{"buffer name is already in use"};
     }
 
-    m_buffers.push_back(std::make_unique<Buffer>(std::move(name), flags, data, fs_timestamp));
+    m_buffers.push_back(
+        std::make_unique<Buffer>(std::move(name), flags, data, fs_timestamp));
     auto* buffer = m_buffers.back().get();
     buffer->on_registered();
 
@@ -64,8 +66,8 @@ Buffer* BufferManager::get_buffer_ifp(StringView name)
     auto path = real_path(parse_filename(name));
     for (auto& buf : m_buffers)
     {
-        if (buf->name() == name or
-            (buf->flags() & Buffer::Flags::File and buf->name() == path))
+        if (buf->name() == name
+            or (buf->flags() & Buffer::Flags::File and buf->name() == path))
             return buf.get();
     }
     return nullptr;
@@ -81,7 +83,8 @@ Buffer& BufferManager::get_buffer(StringView name)
 
 Buffer& BufferManager::get_first_buffer()
 {
-    if (all_of(m_buffers, [](auto& b) { return (b->flags() & Buffer::Flags::Debug); }))
+    if (all_of(m_buffers,
+               [](auto& b) { return (b->flags() & Buffer::Flags::Debug); }))
         create_buffer("*scratch*", Buffer::Flags::None);
 
     return *m_buffers.back();
@@ -92,7 +95,7 @@ void BufferManager::backup_modified_buffers()
     for (auto& buf : m_buffers)
     {
         if ((buf->flags() & Buffer::Flags::File) and buf->is_modified()
-            and not (buf->flags() & Buffer::Flags::ReadOnly))
+            and not(buf->flags() & Buffer::Flags::ReadOnly))
             write_buffer_to_backup_file(*buf);
     }
 }

--- a/src/buffer_manager.hh
+++ b/src/buffer_manager.hh
@@ -12,20 +12,21 @@ namespace Kakoune
 class BufferManager : public Singleton<BufferManager>
 {
 public:
-    using BufferList = Vector<std::unique_ptr<Buffer>, MemoryDomain::BufferMeta>;
+    using BufferList
+        = Vector<std::unique_ptr<Buffer>, MemoryDomain::BufferMeta>;
     using iterator = BufferList::const_iterator;
 
     ~BufferManager();
 
     Buffer* create_buffer(String name, Buffer::Flags flags,
-                          StringView data = {},
+                          StringView data       = {},
                           timespec fs_timestamp = InvalidTime);
 
     void delete_buffer(Buffer& buffer);
 
     iterator begin() const { return m_buffers.cbegin(); }
     iterator end() const { return m_buffers.cend(); }
-    size_t   count() const { return m_buffers.size(); }
+    size_t count() const { return m_buffers.size(); }
 
     Buffer* get_buffer_ifp(StringView name);
     Buffer& get_buffer(StringView name);
@@ -35,6 +36,7 @@ public:
     void backup_modified_buffers();
 
     void clear_buffer_trash();
+
 private:
     BufferList m_buffers;
     BufferList m_buffer_trash;

--- a/src/buffer_utils.cc
+++ b/src/buffer_utils.cc
@@ -8,20 +8,19 @@
 #include <unistd.h>
 
 #if defined(__APPLE__)
-#define st_mtim st_mtimespec
+#    define st_mtim st_mtimespec
 #endif
-
 
 namespace Kakoune
 {
 
-ColumnCount get_column(const Buffer& buffer,
-                       ColumnCount tabstop, BufferCoord coord)
+ColumnCount get_column(const Buffer& buffer, ColumnCount tabstop,
+                       BufferCoord coord)
 {
     auto line = buffer[coord.line];
-    auto col = 0_col;
+    auto col  = 0_col;
     for (auto it = line.begin();
-         it != line.end() and coord.column > (int)(it - line.begin()); )
+         it != line.end() and coord.column > (int)(it - line.begin());)
     {
         if (*it == '\t')
         {
@@ -34,11 +33,12 @@ ColumnCount get_column(const Buffer& buffer,
     return col;
 }
 
-ByteCount get_byte_to_column(const Buffer& buffer, ColumnCount tabstop, DisplayCoord coord)
+ByteCount get_byte_to_column(const Buffer& buffer, ColumnCount tabstop,
+                             DisplayCoord coord)
 {
     auto line = buffer[coord.line];
-    auto col = 0_col;
-    auto it = line.begin();
+    auto col  = 0_col;
+    auto it   = line.begin();
     while (it != line.end() and coord.column > col)
     {
         if (*it == '\t')
@@ -64,22 +64,24 @@ Buffer* open_file_buffer(StringView filename, Buffer::Flags flags)
 {
     MappedFile file_data{parse_filename(filename)};
     return BufferManager::instance().create_buffer(
-        filename.str(), Buffer::Flags::File | flags, file_data, file_data.st.st_mtim);
+        filename.str(), Buffer::Flags::File | flags, file_data,
+        file_data.st.st_mtim);
 }
 
 Buffer* open_or_create_file_buffer(StringView filename, Buffer::Flags flags)
 {
     auto& buffer_manager = BufferManager::instance();
-    auto path = parse_filename(filename);
+    auto path            = parse_filename(filename);
     if (file_exists(path))
     {
         MappedFile file_data{path};
-        return buffer_manager.create_buffer(filename.str(), Buffer::Flags::File | flags,
+        return buffer_manager.create_buffer(filename.str(),
+                                            Buffer::Flags::File | flags,
                                             file_data, file_data.st.st_mtim);
     }
     return buffer_manager.create_buffer(
-        filename.str(), Buffer::Flags::File | Buffer::Flags::New,
-        {}, InvalidTime);
+        filename.str(), Buffer::Flags::File | Buffer::Flags::New, {},
+        InvalidTime);
 }
 
 void reload_file_buffer(Buffer& buffer)
@@ -90,12 +92,13 @@ void reload_file_buffer(Buffer& buffer)
     buffer.flags() &= ~Buffer::Flags::New;
 }
 
-Buffer* create_fifo_buffer(String name, int fd, Buffer::Flags flags, bool scroll)
+Buffer* create_fifo_buffer(String name, int fd, Buffer::Flags flags,
+                           bool scroll)
 {
     static ValueId s_fifo_watcher_id = get_free_value_id();
 
     auto& buffer_manager = BufferManager::instance();
-    Buffer* buffer = buffer_manager.get_buffer_ifp(name);
+    Buffer* buffer       = buffer_manager.get_buffer_ifp(name);
     if (buffer)
     {
         buffer->flags() |= Buffer::Flags::NoUndo | flags;
@@ -103,7 +106,8 @@ Buffer* create_fifo_buffer(String name, int fd, Buffer::Flags flags, bool scroll
     }
     else
         buffer = buffer_manager.create_buffer(
-            std::move(name), flags | Buffer::Flags::Fifo | Buffer::Flags::NoUndo);
+            std::move(name),
+            flags | Buffer::Flags::Fifo | Buffer::Flags::NoUndo);
 
     auto watcher_deleter = [buffer](FDWatcher* watcher) {
         kak_assert(buffer->flags() & Buffer::Flags::Fifo);
@@ -117,54 +121,59 @@ Buffer* create_fifo_buffer(String name, int fd, Buffer::Flags flags, bool scroll
     ValueId fifo_watcher_id = s_fifo_watcher_id;
 
     std::unique_ptr<FDWatcher, decltype(watcher_deleter)> watcher(
-        new FDWatcher(fd, FdEvents::Read,
-                      [buffer, scroll, fifo_watcher_id](FDWatcher& watcher, FdEvents, EventMode mode) {
-        if (mode != EventMode::Normal)
-            return;
+        new FDWatcher(
+            fd, FdEvents::Read,
+            [buffer, scroll, fifo_watcher_id](FDWatcher& watcher, FdEvents,
+                                              EventMode mode) {
+                if (mode != EventMode::Normal)
+                    return;
 
-        kak_assert(buffer->flags() & Buffer::Flags::Fifo);
+                kak_assert(buffer->flags() & Buffer::Flags::Fifo);
 
-        constexpr size_t buffer_size = 2048;
-        // if we read data slower than it arrives in the fifo, limiting the
-        // iteration number allows us to go back go back to the event loop and
-        // handle other events sources (such as input)
-        constexpr size_t max_loop = 16;
-        size_t loop = 0;
-        char data[buffer_size];
-        BufferCoord insert_coord;
-        const int fifo = watcher.fd();
-        do
-        {
-            const ssize_t count = ::read(fifo, data, buffer_size);
-            if (count <= 0)
-            {
-                buffer->values().erase(fifo_watcher_id); // will delete this
-                return;
-            }
+                constexpr size_t buffer_size = 2048;
+                // if we read data slower than it arrives in the fifo, limiting
+                // the iteration number allows us to go back go back to the
+                // event loop and handle other events sources (such as input)
+                constexpr size_t max_loop = 16;
+                size_t loop               = 0;
+                char data[buffer_size];
+                BufferCoord insert_coord;
+                const int fifo = watcher.fd();
+                do
+                {
+                    const ssize_t count = ::read(fifo, data, buffer_size);
+                    if (count <= 0)
+                    {
+                        buffer->values().erase(
+                            fifo_watcher_id); // will delete this
+                        return;
+                    }
 
-            auto pos = buffer->back_coord();
-            const bool prevent_scrolling = pos == BufferCoord{0,0} and not scroll;
-            if (prevent_scrolling)
-                pos = buffer->next(pos);
+                    auto pos = buffer->back_coord();
+                    const bool prevent_scrolling
+                        = pos == BufferCoord{0, 0} and not scroll;
+                    if (prevent_scrolling)
+                        pos = buffer->next(pos);
 
-            if (loop == 0)
-                insert_coord = pos;
-            buffer->insert(pos, StringView(data, data+count));
+                    if (loop == 0)
+                        insert_coord = pos;
+                    buffer->insert(pos, StringView(data, data + count));
 
-            if (prevent_scrolling)
-            {
-                buffer->erase({0,0}, buffer->next({0,0}));
-                // in the other case, the buffer will have automatically
-                // inserted a \n to guarantee its invariant.
-                if (data[count-1] == '\n')
-                    buffer->insert(buffer->end_coord(), "\n");
-            }
-        }
-        while (++loop < max_loop  and fd_readable(fifo));
+                    if (prevent_scrolling)
+                    {
+                        buffer->erase({0, 0}, buffer->next({0, 0}));
+                        // in the other case, the buffer will have automatically
+                        // inserted a \n to guarantee its invariant.
+                        if (data[count - 1] == '\n')
+                            buffer->insert(buffer->end_coord(), "\n");
+                    }
+                } while (++loop < max_loop and fd_readable(fifo));
 
-        buffer->run_hook_in_own_context(Hook::BufReadFifo,
-                                        selection_to_string({insert_coord, buffer->back_coord()}));
-    }), std::move(watcher_deleter));
+                buffer->run_hook_in_own_context(
+                    Hook::BufReadFifo,
+                    selection_to_string({insert_coord, buffer->back_coord()}));
+            }),
+        std::move(watcher_deleter));
 
     buffer->values()[fifo_watcher_id] = Value(std::move(watcher));
     buffer->flags() = flags | Buffer::Flags::Fifo | Buffer::Flags::NoUndo;
@@ -186,19 +195,23 @@ void write_to_debug_buffer(StringView str)
     // Try to ensure we keep an empty line at the end of the debug buffer
     // where the user can put its cursor to scroll with new messages
     const bool eol_back = not str.empty() and str.back() == '\n';
-    if (Buffer* buffer = BufferManager::instance().get_buffer_ifp(debug_buffer_name))
+    if (Buffer* buffer
+        = BufferManager::instance().get_buffer_ifp(debug_buffer_name))
     {
         buffer->flags() &= ~Buffer::Flags::ReadOnly;
-        auto restore = on_scope_end([buffer] { buffer->flags() |= Buffer::Flags::ReadOnly; });
+        auto restore = on_scope_end(
+            [buffer] { buffer->flags() |= Buffer::Flags::ReadOnly; });
 
         buffer->insert(buffer->back_coord(), eol_back ? str : str + "\n");
     }
     else
     {
         String line = str + (eol_back ? "\n" : "\n\n");
-        BufferManager::instance().create_buffer(
-            debug_buffer_name.str(), Buffer::Flags::NoUndo | Buffer::Flags::Debug | Buffer::Flags::ReadOnly,
-            line, InvalidTime);
+        BufferManager::instance().create_buffer(debug_buffer_name.str(),
+                                                Buffer::Flags::NoUndo
+                                                    | Buffer::Flags::Debug
+                                                    | Buffer::Flags::ReadOnly,
+                                                line, InvalidTime);
     }
 }
 

--- a/src/buffer_utils.hh
+++ b/src/buffer_utils.hh
@@ -20,7 +20,8 @@ inline BufferCoord erase(Buffer& buffer, const Selection& range)
     return buffer.erase(range.min(), buffer.char_next(range.max()));
 }
 
-inline BufferCoord replace(Buffer& buffer, const Selection& range, StringView content)
+inline BufferCoord replace(Buffer& buffer, const Selection& range,
+                           StringView content)
 {
     return buffer.replace(range.min(), buffer.char_next(range.max()), content);
 }
@@ -31,51 +32,53 @@ inline CharCount char_length(const Buffer& buffer, const Selection& range)
                           buffer.iterator_at(buffer.char_next(range.max())));
 }
 
-inline CharCount char_length(const Buffer& buffer, const BufferCoord& begin, const BufferCoord& end)
+inline CharCount char_length(const Buffer& buffer, const BufferCoord& begin,
+                             const BufferCoord& end)
 {
     return utf8::distance(buffer.iterator_at(begin), buffer.iterator_at(end));
 }
 
-inline ColumnCount column_length(const Buffer& buffer, const BufferCoord& begin, const BufferCoord& end)
+inline ColumnCount column_length(const Buffer& buffer, const BufferCoord& begin,
+                                 const BufferCoord& end)
 {
-    return utf8::column_distance(buffer.iterator_at(begin), buffer.iterator_at(end));
+    return utf8::column_distance(buffer.iterator_at(begin),
+                                 buffer.iterator_at(end));
 }
 
-inline bool is_bol(BufferCoord coord)
-{
-    return coord.column == 0;
-}
+inline bool is_bol(BufferCoord coord) { return coord.column == 0; }
 
 inline bool is_eol(const Buffer& buffer, BufferCoord coord)
 {
-    return buffer.is_end(coord) or buffer[coord.line].length() == coord.column+1;
+    return buffer.is_end(coord)
+           or buffer[coord.line].length() == coord.column + 1;
 }
 
 inline bool is_bow(const Buffer& buffer, BufferCoord coord)
 {
     auto it = utf8::iterator<BufferIterator>(buffer.iterator_at(coord), buffer);
-    if (coord == BufferCoord{0,0})
+    if (coord == BufferCoord{0, 0})
         return is_word(*it);
 
-    return not is_word(*(it-1)) and is_word(*it);
+    return not is_word(*(it - 1)) and is_word(*it);
 }
 
 inline bool is_eow(const Buffer& buffer, BufferCoord coord)
 {
-    if (buffer.is_end(coord) or coord == BufferCoord{0,0})
+    if (buffer.is_end(coord) or coord == BufferCoord{0, 0})
         return false;
 
     auto it = utf8::iterator<BufferIterator>(buffer.iterator_at(coord), buffer);
-    return is_word(*(it-1)) and not is_word(*it);
+    return is_word(*(it - 1)) and not is_word(*it);
 }
 
-ColumnCount get_column(const Buffer& buffer,
-                       ColumnCount tabstop, BufferCoord coord);
+ColumnCount get_column(const Buffer& buffer, ColumnCount tabstop,
+                       BufferCoord coord);
 
 ByteCount get_byte_to_column(const Buffer& buffer, ColumnCount tabstop,
                              DisplayCoord coord);
 
-Buffer* create_fifo_buffer(String name, int fd, Buffer::Flags flags, bool scroll = false);
+Buffer* create_fifo_buffer(String name, int fd, Buffer::Flags flags,
+                           bool scroll = false);
 Buffer* open_file_buffer(StringView filename,
                          Buffer::Flags flags = Buffer::Flags::None);
 Buffer* open_or_create_file_buffer(StringView filename,

--- a/src/changes.cc
+++ b/src/changes.cc
@@ -53,26 +53,33 @@ BufferCoord ForwardChangesTracker::get_new_coord(BufferCoord coord) const
     return coord;
 }
 
-BufferCoord ForwardChangesTracker::get_new_coord_tolerant(BufferCoord coord) const
+BufferCoord ForwardChangesTracker::get_new_coord_tolerant(
+    BufferCoord coord) const
 {
     if (coord < old_pos)
         return cur_pos;
     return get_new_coord(coord);
 }
 
-bool ForwardChangesTracker::relevant(const Buffer::Change& change, BufferCoord old_coord) const
+bool ForwardChangesTracker::relevant(const Buffer::Change& change,
+                                     BufferCoord old_coord) const
 {
     auto new_coord = get_new_coord_tolerant(old_coord);
     return change.type == Buffer::Change::Insert ? change.begin <= new_coord
                                                  : change.begin < new_coord;
 }
 
-const Buffer::Change* forward_sorted_until(const Buffer::Change* first, const Buffer::Change* last)
+const Buffer::Change* forward_sorted_until(const Buffer::Change* first,
+                                           const Buffer::Change* last)
 {
-    if (first != last) {
+    if (first != last)
+    {
         const Buffer::Change* next = first;
-        while (++next != last) {
-            const auto& ref = first->type == Buffer::Change::Insert ? first->end : first->begin;
+        while (++next != last)
+        {
+            const auto& ref = first->type == Buffer::Change::Insert
+                                  ? first->end
+                                  : first->begin;
             if (next->begin <= ref)
                 return next;
             first = next;
@@ -81,11 +88,14 @@ const Buffer::Change* forward_sorted_until(const Buffer::Change* first, const Bu
     return last;
 }
 
-const Buffer::Change* backward_sorted_until(const Buffer::Change* first, const Buffer::Change* last)
+const Buffer::Change* backward_sorted_until(const Buffer::Change* first,
+                                            const Buffer::Change* last)
 {
-    if (first != last) {
+    if (first != last)
+    {
         const Buffer::Change* next = first;
-        while (++next != last) {
+        while (++next != last)
+        {
             if (first->begin < next->end)
                 return next;
             first = next;

--- a/src/client.hh
+++ b/src/client.hh
@@ -24,14 +24,11 @@ enum class MenuStyle;
 class Client final : public SafeCountable, public OptionManagerWatcher
 {
 public:
-    using OnExitCallback = std::function<void (int status)>;
+    using OnExitCallback = std::function<void(int status)>;
 
     Client(std::unique_ptr<UserInterface>&& ui,
-           std::unique_ptr<Window>&& window,
-           SelectionList selections,
-           int pid, EnvVarMap env_vars,
-           String name,
-           OnExitCallback on_exit);
+           std::unique_ptr<Window>&& window, SelectionList selections, int pid,
+           EnvVarMap env_vars, String name, OnExitCallback on_exit);
     ~Client();
 
     Client(Client&&) = delete;
@@ -41,11 +38,13 @@ public:
     bool process_pending_inputs();
     bool has_pending_inputs() const { return not m_pending_keys.empty(); }
 
-    void menu_show(Vector<DisplayLine> choices, BufferCoord anchor, MenuStyle style);
+    void menu_show(Vector<DisplayLine> choices, BufferCoord anchor,
+                   MenuStyle style);
     void menu_select(int selected);
     void menu_hide();
 
-    void info_show(String title, String content, BufferCoord anchor, InfoStyle style);
+    void info_show(String title, String content, BufferCoord anchor,
+                   InfoStyle style);
     void info_hide(bool even_modal = false);
 
     void print_status(DisplayLine status_line);
@@ -145,13 +144,11 @@ enum class Autoreload
 
 constexpr auto enum_desc(Meta::Type<Autoreload>)
 {
-    return make_array<EnumDesc<Autoreload>, 5>({
-        { Autoreload::Yes, "yes" },
-        { Autoreload::No, "no" },
-        { Autoreload::Ask, "ask" },
-        { Autoreload::Yes, "true" },
-        { Autoreload::No, "false" }
-    });
+    return make_array<EnumDesc<Autoreload>, 5>({{Autoreload::Yes, "yes"},
+                                                {Autoreload::No, "no"},
+                                                {Autoreload::Ask, "ask"},
+                                                {Autoreload::Yes, "true"},
+                                                {Autoreload::No, "false"}});
 }
 
 }

--- a/src/client_manager.hh
+++ b/src/client_manager.hh
@@ -24,7 +24,7 @@ public:
                           Optional<BufferCoord> init_coord,
                           Client::OnExitCallback on_exit);
 
-    bool   empty() const { return m_clients.empty(); }
+    bool empty() const { return m_clients.empty(); }
     size_t count() const { return m_clients.size(); }
 
     void clear();
@@ -32,19 +32,20 @@ public:
     void ensure_no_client_uses_buffer(Buffer& buffer);
 
     WindowAndSelections get_free_window(Buffer& buffer);
-    void add_free_window(std::unique_ptr<Window>&& window, SelectionList selections);
+    void add_free_window(std::unique_ptr<Window>&& window,
+                         SelectionList selections);
 
     void redraw_clients() const;
     void process_pending_inputs() const;
     bool has_pending_inputs() const;
 
-    Client*  get_client_ifp(StringView name);
-    Client&  get_client(StringView name);
+    Client* get_client_ifp(StringView name);
+    Client& get_client(StringView name);
     bool client_name_exists(StringView name) const;
     void remove_client(Client& client, bool graceful, int status);
 
     using ClientList = Vector<std::unique_ptr<Client>, MemoryDomain::Client>;
-    using iterator = ClientList::const_iterator;
+    using iterator   = ClientList::const_iterator;
 
     iterator begin() const { return m_clients.begin(); }
     iterator end() const { return m_clients.end(); }
@@ -54,6 +55,7 @@ public:
 
     void clear_window_trash();
     void clear_client_trash();
+
 private:
     String generate_name() const;
 

--- a/src/clock.hh
+++ b/src/clock.hh
@@ -6,7 +6,7 @@
 namespace Kakoune
 {
 
-using Clock = std::chrono::steady_clock;
+using Clock     = std::chrono::steady_clock;
 using TimePoint = Clock::time_point;
 
 }

--- a/src/color.cc
+++ b/src/color.cc
@@ -10,38 +10,23 @@ namespace Kakoune
 {
 
 static constexpr const char* color_names[] = {
-    "default",
-    "black",
-    "red",
-    "green",
-    "yellow",
-    "blue",
-    "magenta",
-    "cyan",
-    "white",
-    "bright-black",
-    "bright-red",
-    "bright-green",
-    "bright-yellow",
-    "bright-blue",
-    "bright-magenta",
-    "bright-cyan",
-    "bright-white",
+    "default",       "black",        "red",
+    "green",         "yellow",       "blue",
+    "magenta",       "cyan",         "white",
+    "bright-black",  "bright-red",   "bright-green",
+    "bright-yellow", "bright-blue",  "bright-magenta",
+    "bright-cyan",   "bright-white",
 };
 
-bool is_color_name(StringView color)
-{
-    return contains(color_names, color);
-}
+bool is_color_name(StringView color) { return contains(color_names, color); }
 
 Color str_to_color(StringView color)
 {
-    auto it = find_if(color_names, [&](const char* c){ return color == c; });
+    auto it = find_if(color_names, [&](const char* c) { return color == c; });
     if (it != std::end(color_names))
         return static_cast<Color::NamedColor>(it - color_names);
 
-    auto hval = [&color](char c) -> int
-    {
+    auto hval = [&color](char c) -> int {
         if (c >= 'A' and c <= 'F')
             return 10 + c - 'A';
         else if (c >= 'a' and c <= 'f')
@@ -52,9 +37,9 @@ Color str_to_color(StringView color)
     };
 
     if (color.length() == 10 and color.substr(0_byte, 4_byte) == "rgb:")
-        return { (unsigned char)(hval(color[4]) * 16 + hval(color[5])),
-                 (unsigned char)(hval(color[6]) * 16 + hval(color[7])),
-                 (unsigned char)(hval(color[8]) * 16 + hval(color[9])) };
+        return {(unsigned char)(hval(color[4]) * 16 + hval(color[5])),
+                (unsigned char)(hval(color[6]) * 16 + hval(color[7])),
+                (unsigned char)(hval(color[8]) * 16 + hval(color[9]))};
 
     throw runtime_error(format("unable to parse color: '{}'", color));
     return Color::Default;
@@ -76,10 +61,7 @@ String to_string(Color color)
     }
 }
 
-String option_to_string(Color color)
-{
-    return to_string(color);
-}
+String option_to_string(Color color) { return to_string(color); }
 
 Color option_from_string(Meta::Type<Color>, StringView str)
 {

--- a/src/color.hh
+++ b/src/color.hh
@@ -42,19 +42,17 @@ struct Color
     constexpr Color() : Color{Default} {}
     constexpr Color(NamedColor c) : color{c} {}
     constexpr Color(unsigned char r, unsigned char g, unsigned char b)
-        : color{RGB}, r{r}, g{g}, b{b} {}
+        : color{RGB}, r{r}, g{g}, b{b}
+    {}
 };
 
 constexpr bool operator==(Color lhs, Color rhs)
 {
-    return lhs.color == rhs.color and
-           lhs.r == rhs.r and lhs.g == rhs.g and lhs.b == rhs.b;
+    return lhs.color == rhs.color and lhs.r == rhs.r and lhs.g == rhs.g
+           and lhs.b == rhs.b;
 }
 
-constexpr bool operator!=(Color lhs, Color rhs)
-{
-    return not (lhs == rhs);
-}
+constexpr bool operator!=(Color lhs, Color rhs) { return not(lhs == rhs); }
 
 Color str_to_color(StringView color);
 String to_string(Color color);
@@ -66,9 +64,8 @@ bool is_color_name(StringView color);
 
 constexpr size_t hash_value(const Color& val)
 {
-    return val.color == Color::RGB ?
-        hash_values(val.color, val.r, val.g, val.b)
-      : hash_value(val.color);
+    return val.color == Color::RGB ? hash_values(val.color, val.r, val.g, val.b)
+                                   : hash_value(val.color);
 }
 
 }

--- a/src/command_manager.hh
+++ b/src/command_manager.hh
@@ -19,16 +19,16 @@ namespace Kakoune
 
 class Context;
 using CommandParameters = ConstArrayView<String>;
-using CommandFunc = std::function<void (const ParametersParser& parser,
-                                        Context& context,
-                                        const ShellContext& shell_context)>;
+using CommandFunc
+    = std::function<void(const ParametersParser& parser, Context& context,
+                         const ShellContext& shell_context)>;
 
-using CommandCompleter = std::function<Completions (const Context& context,
-                                                    CompletionFlags,
-                                                    CommandParameters,
-                                                    size_t, ByteCount)>;
+using CommandCompleter
+    = std::function<Completions(const Context& context, CompletionFlags,
+                                CommandParameters, size_t, ByteCount)>;
 
-using CommandHelper = std::function<String (const Context& context, CommandParameters)>;
+using CommandHelper
+    = std::function<String(const Context& context, CommandParameters)>;
 
 enum class CommandFlags
 {
@@ -37,7 +37,10 @@ enum class CommandFlags
 };
 constexpr bool with_bit_ops(Meta::Type<CommandFlags>) { return true; }
 
-struct CommandInfo { String name, info; };
+struct CommandInfo
+{
+    String name, info;
+};
 
 struct Token
 {
@@ -63,7 +66,8 @@ struct Token
 struct Reader
 {
 public:
-    Reader(StringView s) : str{s}, pos{s.begin()}, line_start{s.begin()}, line{} {}
+    Reader(StringView s) : str{s}, pos{s.begin()}, line_start{s.begin()}, line{}
+    {}
 
     Codepoint operator*() const;
     Codepoint peek_next() const;
@@ -103,8 +107,8 @@ public:
                          StringView command_line, ByteCount cursor_pos);
 
     Completions complete(const Context& context, CompletionFlags flags,
-                         CommandParameters params,
-                         size_t token_to_complete, ByteCount pos_in_token);
+                         CommandParameters params, size_t token_to_complete,
+                         ByteCount pos_in_token);
 
     Optional<CommandInfo> command_info(const Context& context,
                                        StringView command_line) const;
@@ -112,19 +116,18 @@ public:
     bool command_defined(StringView command_name) const;
 
     void register_command(String command_name, CommandFunc func,
-                          String docstring,
-                          ParameterDesc param_desc,
-                          CommandFlags flags = CommandFlags::None,
-                          CommandHelper helper = CommandHelper(),
+                          String docstring, ParameterDesc param_desc,
+                          CommandFlags flags         = CommandFlags::None,
+                          CommandHelper helper       = CommandHelper(),
                           CommandCompleter completer = CommandCompleter());
 
-    Completions complete_command_name(const Context& context, StringView query) const;
+    Completions complete_command_name(const Context& context,
+                                      StringView query) const;
 
     void clear_last_complete_command() { m_last_complete_command = String{}; }
 
 private:
-    void execute_single_command(CommandParameters params,
-                                Context& context,
+    void execute_single_command(CommandParameters params, Context& context,
                                 const ShellContext& shell_context,
                                 BufferCoord pos);
 
@@ -151,7 +154,7 @@ String expand(StringView str, const Context& context,
 
 String expand(StringView str, const Context& context,
               const ShellContext& shell_context,
-              const std::function<String (String)>& postprocess);
+              const std::function<String(String)>& postprocess);
 
 }
 

--- a/src/completion.cc
+++ b/src/completion.cc
@@ -11,14 +11,15 @@ Completions shell_complete(const Context& context, CompletionFlags flags,
                            StringView prefix, ByteCount cursor_pos)
 {
     ByteCount word_start = 0;
-    ByteCount word_end = 0;
+    ByteCount word_end   = 0;
 
-    bool command = true;
+    bool command        = true;
     const ByteCount len = prefix.length();
     for (ByteCount pos = 0; pos < cursor_pos and pos < len;)
     {
-        command = (pos == 0 or prefix[pos-1] == ';' or prefix[pos-1] == '|' or
-                   (pos > 1 and prefix[pos-1] == '&' and prefix[pos-2] == '&'));
+        command = (pos == 0 or prefix[pos - 1] == ';' or prefix[pos - 1] == '|'
+                   or (pos > 1 and prefix[pos - 1] == '&'
+                       and prefix[pos - 2] == '&'));
         while (pos != len and is_horizontal_blank(prefix[pos]))
             ++pos;
         word_start = pos;
@@ -28,12 +29,13 @@ Completions shell_complete(const Context& context, CompletionFlags flags,
     }
     Completions completions{word_start, word_end};
     if (command)
-        completions.candidates = complete_command(prefix.substr(word_start, word_end),
-                                                  cursor_pos - word_start);
+        completions.candidates = complete_command(
+            prefix.substr(word_start, word_end), cursor_pos - word_start);
     else
-        completions.candidates = complete_filename(prefix.substr(word_start, word_end),
-                                                   context.options()["ignored_files"].get<Regex>(),
-                                                   cursor_pos - word_start);
+        completions.candidates
+            = complete_filename(prefix.substr(word_start, word_end),
+                                context.options()["ignored_files"].get<Regex>(),
+                                cursor_pos - word_start);
     return completions;
 }
 

--- a/src/completion.hh
+++ b/src/completion.hh
@@ -23,41 +23,44 @@ struct Completions
     ByteCount end;
     bool quoted = false;
 
-    Completions()
-        : start(0), end(0) {}
+    Completions() : start(0), end(0) {}
 
-    Completions(ByteCount start, ByteCount end)
-        : start(start), end(end) {}
+    Completions(ByteCount start, ByteCount end) : start(start), end(end) {}
 
-    Completions(ByteCount start, ByteCount end, CandidateList candidates, bool quoted = false)
-        : candidates(std::move(candidates)), start(start), end(end), quoted{quoted} {}
+    Completions(ByteCount start, ByteCount end, CandidateList candidates,
+                bool quoted = false)
+        : candidates(std::move(candidates)),
+          start(start),
+          end(end),
+          quoted{quoted}
+    {}
 };
 
 enum class CompletionFlags
 {
-    None = 0,
-    Fast = 1 << 0,
+    None  = 0,
+    Fast  = 1 << 0,
     Start = 1 << 2,
 };
 
 constexpr bool with_bit_ops(Meta::Type<CompletionFlags>) { return true; }
 
-using Completer = std::function<Completions (const Context&, CompletionFlags,
-                                             StringView, ByteCount)>;
+using Completer = std::function<Completions(const Context&, CompletionFlags,
+                                            StringView, ByteCount)>;
 
-inline Completions complete_nothing(const Context&, CompletionFlags,
-                                    StringView, ByteCount cursor_pos)
+inline Completions complete_nothing(const Context&, CompletionFlags, StringView,
+                                    ByteCount cursor_pos)
 {
     return {cursor_pos, cursor_pos};
 }
 
-Completions shell_complete(const Context& context, CompletionFlags,
-                           StringView, ByteCount cursor_pos);
+Completions shell_complete(const Context& context, CompletionFlags, StringView,
+                           ByteCount cursor_pos);
 
 inline Completions offset_pos(Completions completion, ByteCount offset)
 {
-    return { completion.start + offset, completion.end + offset,
-             std::move(completion.candidates), completion.quoted };
+    return {completion.start + offset, completion.end + offset,
+            std::move(completion.candidates), completion.quoted};
 }
 
 template<typename Container>

--- a/src/constexpr_utils.hh
+++ b/src/constexpr_utils.hh
@@ -16,11 +16,11 @@ struct Array
     constexpr size_t size() const { return N; }
     constexpr const T& operator[](int i) const { return m_data[i]; }
     constexpr const T* begin() const { return m_data; }
-    constexpr const T* end() const { return m_data+N; }
+    constexpr const T* end() const { return m_data + N; }
 
     constexpr T& operator[](int i) { return m_data[i]; }
     constexpr T* begin() { return m_data; }
-    constexpr T* end() { return m_data+N; }
+    constexpr T* end() { return m_data + N; }
 
     constexpr operator ArrayView<T>() { return {m_data, N}; }
     constexpr operator ConstArrayView<T>() const { return {m_data, N}; }
@@ -29,7 +29,8 @@ struct Array
 };
 
 template<typename T, size_t N, size_t... Indices>
-constexpr Array<T, N> make_array(const T (&data)[N], std::index_sequence<Indices...>)
+constexpr Array<T, N> make_array(const T (&data)[N],
+                                 std::index_sequence<Indices...>)
 {
     static_assert(sizeof...(Indices) == N, "size mismatch");
     return {{data[Indices]...}};
@@ -44,7 +45,7 @@ constexpr Array<T, N> make_array(const T (&data)[N])
 template<typename T, size_t capacity>
 struct ConstexprVector
 {
-    using iterator = T*;
+    using iterator       = T*;
     using const_iterator = const T*;
 
     constexpr ConstexprVector() : m_size{0} {}
@@ -66,7 +67,10 @@ struct ConstexprVector
         for (int i = m_size; i < n; ++i)
             m_data[i] = val;
         m_size = n;
-        kak_assert(this->size() == m_size); // check for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79520
+        kak_assert(
+            this->size()
+            == m_size); // check for
+                        // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79520
     }
 
     constexpr T& operator[](size_t i) { return m_data[i]; }

--- a/src/context.cc
+++ b/src/context.cc
@@ -79,24 +79,23 @@ void Context::print_status(DisplayLine status) const
 void JumpList::push(SelectionList jump)
 {
     if (m_current != m_jumps.size())
-        m_jumps.erase(m_jumps.begin()+m_current+1, m_jumps.end());
+        m_jumps.erase(m_jumps.begin() + m_current + 1, m_jumps.end());
     m_jumps.erase(std::remove(begin(m_jumps), end(m_jumps), jump),
-                      end(m_jumps));
+                  end(m_jumps));
     m_jumps.push_back(jump);
     m_current = m_jumps.size();
 }
 
 const SelectionList& JumpList::forward(Context& context, int count)
 {
-    if (m_current != m_jumps.size() and
-        m_current + count < m_jumps.size())
+    if (m_current != m_jumps.size() and m_current + count < m_jumps.size())
     {
         m_current += count;
         SelectionList& res = m_jumps[m_current];
         res.update();
-        context.print_status({ format("jumped to #{} ({})",
-                               m_current, m_jumps.size() - 1),
-                               context.faces()["Information"] });
+        context.print_status(
+            {format("jumped to #{} ({})", m_current, m_jumps.size() - 1),
+             context.faces()["Information"]});
         return res;
     }
     throw runtime_error("no next jump");
@@ -108,16 +107,15 @@ const SelectionList& JumpList::backward(Context& context, int count)
         throw runtime_error("no previous jump");
 
     const SelectionList& current = context.selections();
-    if (m_current != m_jumps.size() and
-        m_jumps[m_current] != current)
+    if (m_current != m_jumps.size() and m_jumps[m_current] != current)
     {
         push(current);
         m_current -= count;
         SelectionList& res = m_jumps[m_current];
         res.update();
-        context.print_status({ format("jumped to #{} ({})",
-                               m_current, m_jumps.size() - 1),
-                               context.faces()["Information"] });
+        context.print_status(
+            {format("jumped to #{} ({})", m_current, m_jumps.size() - 1),
+             context.faces()["Information"]});
         return res;
     }
     if (m_current != 0)
@@ -131,9 +129,9 @@ const SelectionList& JumpList::backward(Context& context, int count)
         m_current -= count;
         SelectionList& res = m_jumps[m_current];
         res.update();
-        context.print_status({ format("jumped to #{} ({})",
-                               m_current, m_jumps.size() - 1),
-                               context.faces()["Information"] });
+        context.print_status(
+            {format("jumped to #{} ({})", m_current, m_jumps.size() - 1),
+             context.faces()["Information"]});
         return res;
     }
     throw runtime_error("no previous jump");
@@ -148,7 +146,7 @@ void JumpList::forget_buffer(Buffer& buffer)
             if (i < m_current)
                 --m_current;
             else if (i == m_current)
-                m_current = m_jumps.size()-1;
+                m_current = m_jumps.size() - 1;
 
             m_jumps.erase(m_jumps.begin() + i);
         }
@@ -163,7 +161,7 @@ void Context::change_buffer(Buffer& buffer)
         return;
 
     if (has_buffer() and m_edition_level > 0)
-       this->buffer().commit_undo_group();
+        this->buffer().commit_undo_group();
 
     m_window.reset();
     if (has_client())
@@ -224,8 +222,7 @@ void Context::end_edition()
         return;
 
     kak_assert(m_edition_level != 0);
-    if (m_edition_level == 1 and
-        buffer().timestamp() != m_edition_timestamp)
+    if (m_edition_level == 1 and buffer().timestamp() != m_edition_timestamp)
         buffer().commit_undo_group();
 
     --m_edition_level;
@@ -237,7 +234,7 @@ StringView Context::main_sel_register_value(StringView reg) const
     size_t index = m_selections ? (*m_selections).main_index() : 0;
     if (strings.size() <= index)
         index = strings.size() - 1;
-   return strings[index];
+    return strings[index];
 }
 
 }

--- a/src/context.hh
+++ b/src/context.hh
@@ -29,7 +29,10 @@ struct JumpList
         return lhs.m_jumps == rhs.m_jumps and lhs.m_current == rhs.m_current;
     }
 
-    friend bool operator!=(const JumpList& lhs, const JumpList& rhs) { return not (lhs == rhs); }
+    friend bool operator!=(const JumpList& lhs, const JumpList& rhs)
+    {
+        return not(lhs == rhs);
+    }
 
 private:
     using Contents = Vector<SelectionList, MemoryDomain::Selections>;
@@ -37,7 +40,7 @@ private:
     size_t m_current = 0;
 };
 
-using LastSelectFunc = std::function<void (Context&)>;
+using LastSelectFunc = std::function<void(Context&)>;
 
 // A Context is used to access non singleton objects for various services
 // in commands.
@@ -55,10 +58,11 @@ public:
     };
     friend constexpr bool with_bit_ops(Meta::Type<Flags>) { return true; }
 
-    Context(InputHandler& input_handler, SelectionList selections,
-            Flags flags, String name = "");
+    Context(InputHandler& input_handler, SelectionList selections, Flags flags,
+            String name = "");
 
-    struct EmptyContextFlag {};
+    struct EmptyContextFlag
+    {};
     explicit Context(EmptyContextFlag);
     ~Context();
 
@@ -79,7 +83,7 @@ public:
 
     SelectionList& selections();
     const SelectionList& selections() const;
-    Vector<String>  selections_content() const;
+    Vector<String> selections_content() const;
 
     // Return potentially out of date selections
     SelectionList& selections_write_only();
@@ -92,10 +96,10 @@ public:
     Scope& scope() const;
 
     OptionManager& options() const { return scope().options(); }
-    HookManager&   hooks()   const { return scope().hooks(); }
+    HookManager& hooks() const { return scope().hooks(); }
     KeymapManager& keymaps() const { return scope().keymaps(); }
     AliasRegistry& aliases() const { return scope().aliases(); }
-    FaceRegistry&  faces()   const { return scope().faces(); }
+    FaceRegistry& faces() const { return scope().faces(); }
 
     void print_status(DisplayLine status) const;
 
@@ -104,7 +108,7 @@ public:
     const String& name() const { return m_name; }
     void set_name(String name) { m_name = std::move(name); }
 
-    bool is_editing() const { return m_edition_level!= 0; }
+    bool is_editing() const { return m_edition_level != 0; }
     void disable_undo_handling() { m_edition_level = -1; }
 
     NestedBool& hooks_disabled() { return m_hooks_disabled; }
@@ -121,19 +125,26 @@ public:
     JumpList& jump_list() { return m_jump_list; }
     void push_jump(bool force = false)
     {
-        if (force or not (m_flags & Flags::Draft))
+        if (force or not(m_flags & Flags::Draft))
             m_jump_list.push(selections());
     }
 
     template<typename Func>
-    void set_last_select(Func&& last_select) { m_last_select = std::forward<Func>(last_select); }
+    void set_last_select(Func&& last_select)
+    {
+        m_last_select = std::forward<Func>(last_select);
+    }
 
-    void repeat_last_select() { if (m_last_select) m_last_select(*this); }
+    void repeat_last_select()
+    {
+        if (m_last_select)
+            m_last_select(*this);
+    }
 
 private:
     void begin_edition();
     void end_edition();
-    int m_edition_level = 0;
+    int m_edition_level        = 0;
     size_t m_edition_timestamp = 0;
 
     friend struct ScopedEdition;
@@ -141,8 +152,8 @@ private:
     Flags m_flags = Flags::None;
 
     SafePtr<InputHandler> m_input_handler;
-    SafePtr<Window>       m_window;
-    SafePtr<Client>       m_client;
+    SafePtr<Window> m_window;
+    SafePtr<Client> m_client;
 
     Optional<SelectionList> m_selections;
 
@@ -162,11 +173,19 @@ struct ScopedEdition
     ScopedEdition(Context& context)
         : m_context{context},
           m_buffer{context.has_buffer() ? &context.buffer() : nullptr}
-    { if (m_buffer) m_context.begin_edition(); }
+    {
+        if (m_buffer)
+            m_context.begin_edition();
+    }
 
-    ~ScopedEdition() { if (m_buffer) m_context.end_edition(); }
+    ~ScopedEdition()
+    {
+        if (m_buffer)
+            m_context.end_edition();
+    }
 
     Context& context() const { return m_context; }
+
 private:
     Context& m_context;
     SafePtr<Buffer> m_buffer;

--- a/src/coord.hh
+++ b/src/coord.hh
@@ -10,73 +10,63 @@ namespace Kakoune
 template<typename EffectiveType, typename LineType, typename ColumnType>
 struct LineAndColumn
 {
-    LineType   line = 0;
+    LineType line     = 0;
     ColumnType column = 0;
 
-    [[gnu::always_inline]]
-    constexpr EffectiveType operator+(EffectiveType other) const
+    [[gnu::always_inline]] constexpr EffectiveType operator+(
+        EffectiveType other) const
     {
         return {line + other.line, column + other.column};
     }
 
-    [[gnu::always_inline]]
-    EffectiveType& operator+=(EffectiveType other)
+    [[gnu::always_inline]] EffectiveType& operator+=(EffectiveType other)
     {
-        line   += other.line;
+        line += other.line;
         column += other.column;
         return *static_cast<EffectiveType*>(this);
     }
 
-    [[gnu::always_inline]]
-    constexpr EffectiveType operator-(EffectiveType other) const
+    [[gnu::always_inline]] constexpr EffectiveType operator-(
+        EffectiveType other) const
     {
         return {line - other.line, column - other.column};
     }
 
-    [[gnu::always_inline]]
-    EffectiveType& operator-=(EffectiveType other)
+    [[gnu::always_inline]] EffectiveType& operator-=(EffectiveType other)
     {
-        line   -= other.line;
+        line -= other.line;
         column -= other.column;
         return *static_cast<EffectiveType*>(this);
     }
 
-    [[gnu::always_inline]]
-    constexpr bool operator< (EffectiveType other) const
+    [[gnu::always_inline]] constexpr bool operator<(EffectiveType other) const
     {
-        return (line != other.line) ? line < other.line
-                                    : column < other.column;
+        return (line != other.line) ? line < other.line : column < other.column;
     }
 
-    [[gnu::always_inline]]
-    constexpr bool operator<= (EffectiveType other) const
+    [[gnu::always_inline]] constexpr bool operator<=(EffectiveType other) const
     {
         return (line != other.line) ? line < other.line
                                     : column <= other.column;
     }
 
-    [[gnu::always_inline]]
-    constexpr bool operator> (EffectiveType other) const
+    [[gnu::always_inline]] constexpr bool operator>(EffectiveType other) const
     {
-        return (line != other.line) ? line > other.line
-                                    : column > other.column;
+        return (line != other.line) ? line > other.line : column > other.column;
     }
 
-    [[gnu::always_inline]]
-    constexpr bool operator>= (EffectiveType other) const
+    [[gnu::always_inline]] constexpr bool operator>=(EffectiveType other) const
     {
         return (line != other.line) ? line > other.line
                                     : column >= other.column;
     }
 
-    [[gnu::always_inline]]
-    constexpr bool operator== (EffectiveType other) const
+    [[gnu::always_inline]] constexpr bool operator==(EffectiveType other) const
     {
         return line == other.line and column == other.column;
     }
 
-    [[gnu::always_inline]]
-    constexpr bool operator!= (EffectiveType other) const
+    [[gnu::always_inline]] constexpr bool operator!=(EffectiveType other) const
     {
         return line != other.line or column != other.column;
     }
@@ -89,29 +79,36 @@ struct LineAndColumn
 
 struct BufferCoord : LineAndColumn<BufferCoord, LineCount, ByteCount>
 {
-    [[gnu::always_inline]]
-    constexpr BufferCoord(LineCount line = 0, ByteCount column = 0)
-        : LineAndColumn{line, column} {}
+    [[gnu::always_inline]] constexpr BufferCoord(LineCount line   = 0,
+                                                 ByteCount column = 0)
+        : LineAndColumn{line, column}
+    {}
 };
 
 struct DisplayCoord : LineAndColumn<DisplayCoord, LineCount, ColumnCount>
 {
-    [[gnu::always_inline]]
-    constexpr DisplayCoord(LineCount line = 0, ColumnCount column = 0)
-        : LineAndColumn{line, column} {}
+    [[gnu::always_inline]] constexpr DisplayCoord(LineCount line     = 0,
+                                                  ColumnCount column = 0)
+        : LineAndColumn{line, column}
+    {}
 
     static constexpr const char* option_type_name = "coord";
 };
 
 struct BufferCoordAndTarget : BufferCoord
 {
-    [[gnu::always_inline]]
-    constexpr BufferCoordAndTarget(LineCount line = 0, ByteCount column = 0, ColumnCount target = -1)
-        : BufferCoord{line, column}, target{target} {}
+    [[gnu::always_inline]] constexpr BufferCoordAndTarget(LineCount line   = 0,
+                                                          ByteCount column = 0,
+                                                          ColumnCount target
+                                                          = -1)
+        : BufferCoord{line, column}, target{target}
+    {}
 
-    [[gnu::always_inline]]
-    constexpr BufferCoordAndTarget(BufferCoord coord, ColumnCount target = -1)
-        : BufferCoord{coord}, target{target} {}
+    [[gnu::always_inline]] constexpr BufferCoordAndTarget(BufferCoord coord,
+                                                          ColumnCount target
+                                                          = -1)
+        : BufferCoord{coord}, target{target}
+    {}
 
     ColumnCount target;
 };

--- a/src/display_buffer.cc
+++ b/src/display_buffer.cc
@@ -14,8 +14,9 @@ namespace Kakoune
 BufferIterator get_iterator(const Buffer& buffer, BufferCoord coord)
 {
     // Correct one past the end of line as next line
-    if (not buffer.is_end(coord) and coord.column == buffer[coord.line].length())
-        coord = coord.line+1;
+    if (not buffer.is_end(coord)
+        and coord.column == buffer[coord.line].length())
+        coord = coord.line + 1;
     return buffer.iterator_at(coord);
 }
 
@@ -27,8 +28,10 @@ StringView DisplayAtom::content() const
         {
             auto line = (*m_buffer)[m_range.begin.line];
             if (m_range.begin.line == m_range.end.line)
-                return line.substr(m_range.begin.column, m_range.end.column - m_range.begin.column);
-            else if (m_range.begin.line+1 == m_range.end.line and m_range.end.column == 0)
+                return line.substr(m_range.begin.column,
+                                   m_range.end.column - m_range.begin.column);
+            else if (m_range.begin.line + 1 == m_range.end.line
+                     and m_range.end.column == 0)
                 return line.substr(m_range.begin.column);
             break;
         }
@@ -58,9 +61,10 @@ ColumnCount DisplayAtom::length() const
 void DisplayAtom::trim_begin(ColumnCount count)
 {
     if (m_type == Range)
-        m_range.begin = utf8::advance(get_iterator(*m_buffer, m_range.begin),
-                                      get_iterator(*m_buffer, m_range.end),
-                                      count).coord();
+        m_range.begin
+            = utf8::advance(get_iterator(*m_buffer, m_range.begin),
+                            get_iterator(*m_buffer, m_range.end), count)
+                  .coord();
     else
         m_text = m_text.substr(count).str();
 }
@@ -68,15 +72,15 @@ void DisplayAtom::trim_begin(ColumnCount count)
 void DisplayAtom::trim_end(ColumnCount count)
 {
     if (m_type == Range)
-        m_range.end = utf8::advance(get_iterator(*m_buffer, m_range.end),
-                                    get_iterator(*m_buffer, m_range.begin),
-                                    -count).coord();
+        m_range.end
+            = utf8::advance(get_iterator(*m_buffer, m_range.end),
+                            get_iterator(*m_buffer, m_range.begin), -count)
+                  .coord();
     else
         m_text = m_text.substr(0, m_text.column_length() - count).str();
 }
 
-DisplayLine::DisplayLine(AtomList atoms)
-    : m_atoms(std::move(atoms))
+DisplayLine::DisplayLine(AtomList atoms) : m_atoms(std::move(atoms))
 {
     compute_range();
 }
@@ -87,8 +91,8 @@ DisplayLine::iterator DisplayLine::split(iterator it, BufferCoord pos)
     kak_assert(it->begin() < pos);
     kak_assert(it->end() > pos);
 
-    DisplayAtom atom = *it;
-    atom.m_range.end = pos;
+    DisplayAtom atom  = *it;
+    atom.m_range.end  = pos;
     it->m_range.begin = pos;
     return m_atoms.insert(it, std::move(atom));
 }
@@ -98,16 +102,17 @@ DisplayLine::iterator DisplayLine::split(iterator it, ColumnCount count)
     kak_assert(count > 0);
     kak_assert(count < it->length());
 
-    if (it->type() == DisplayAtom::Text or it->type() == DisplayAtom::ReplacedRange)
+    if (it->type() == DisplayAtom::Text
+        or it->type() == DisplayAtom::ReplacedRange)
     {
         DisplayAtom atom = *it;
-        atom.m_text = atom.m_text.substr(0, count).str();
-        it->m_text = it->m_text.substr(count).str();
+        atom.m_text      = atom.m_text.substr(0, count).str();
+        it->m_text       = it->m_text.substr(count).str();
         return m_atoms.insert(it, std::move(atom));
     }
     auto pos = utf8::advance(get_iterator(it->buffer(), it->begin()),
-                             get_iterator(it->buffer(), it->end()),
-                             count).coord();
+                             get_iterator(it->buffer(), it->end()), count)
+                   .coord();
     return split(it, pos);
 }
 
@@ -115,8 +120,8 @@ DisplayLine::iterator DisplayLine::insert(iterator it, DisplayAtom atom)
 {
     if (atom.has_buffer_range())
     {
-        m_range.begin  = std::min(m_range.begin, atom.begin());
-        m_range.end = std::max(m_range.end, atom.end());
+        m_range.begin = std::min(m_range.begin, atom.begin());
+        m_range.end   = std::max(m_range.end, atom.end());
     }
     return m_atoms.insert(it, std::move(atom));
 }
@@ -125,8 +130,8 @@ void DisplayLine::push_back(DisplayAtom atom)
 {
     if (atom.has_buffer_range())
     {
-        m_range.begin  = std::min(m_range.begin, atom.begin());
-        m_range.end = std::max(m_range.end, atom.end());
+        m_range.begin = std::min(m_range.begin, atom.begin());
+        m_range.end   = std::max(m_range.end, atom.end());
     }
     m_atoms.push_back(std::move(atom));
 }
@@ -154,9 +159,9 @@ void DisplayLine::optimize()
         {
             if (type == DisplayAtom::Text)
                 atom.m_text += next.m_text;
-            else if ((type == DisplayAtom::Range or
-                      type == DisplayAtom::ReplacedRange) and
-                     next.begin() == atom.end())
+            else if ((type == DisplayAtom::Range
+                      or type == DisplayAtom::ReplacedRange)
+                     and next.begin() == atom.end())
             {
                 atom.m_range.end = next.end();
                 if (type == DisplayAtom::ReplacedRange)
@@ -168,7 +173,7 @@ void DisplayLine::optimize()
         else
             *++atom_it = std::move(*next_it);
     }
-    m_atoms.erase(atom_it+1, m_atoms.end());
+    m_atoms.erase(atom_it + 1, m_atoms.end());
 }
 
 ColumnCount DisplayLine::length() const
@@ -181,7 +186,7 @@ ColumnCount DisplayLine::length() const
 
 void DisplayLine::trim(ColumnCount first_col, ColumnCount col_count)
 {
-    for (auto it = begin(); first_col > 0 and it != end(); )
+    for (auto it = begin(); first_col > 0 and it != end();)
     {
         auto len = it->length();
         if (len <= first_col)
@@ -200,13 +205,13 @@ void DisplayLine::trim(ColumnCount first_col, ColumnCount col_count)
         col_count -= it->length();
 
     if (col_count < 0)
-        (it-1)->trim_end(-col_count);
+        (it - 1)->trim_end(-col_count);
     m_atoms.erase(it, end());
 
     compute_range();
 }
 
-const BufferRange init_range{ {INT_MAX, INT_MAX}, {INT_MIN, INT_MIN} };
+const BufferRange init_range{{INT_MAX, INT_MAX}, {INT_MIN, INT_MIN}};
 
 void DisplayLine::compute_range()
 {
@@ -215,11 +220,11 @@ void DisplayLine::compute_range()
     {
         if (not atom.has_buffer_range())
             continue;
-        m_range.begin  = std::min(m_range.begin, atom.begin());
-        m_range.end = std::max(m_range.end, atom.end());
+        m_range.begin = std::min(m_range.begin, atom.begin());
+        m_range.end   = std::max(m_range.end, atom.end());
     }
     if (m_range == init_range)
-        m_range = { { 0, 0 }, { 0, 0 } };
+        m_range = {{0, 0}, {0, 0}};
     kak_assert(m_range.begin <= m_range.end);
 }
 
@@ -228,11 +233,11 @@ void DisplayBuffer::compute_range()
     m_range = init_range;
     for (auto& line : m_lines)
     {
-        m_range.begin  = std::min(line.range().begin, m_range.begin);
-        m_range.end = std::max(line.range().end, m_range.end);
+        m_range.begin = std::min(line.range().begin, m_range.begin);
+        m_range.end   = std::max(line.range().end, m_range.end);
     }
     if (m_range == init_range)
-        m_range = { { 0, 0 }, { 0, 0 } };
+        m_range = {{0, 0}, {0, 0}};
     kak_assert(m_range.begin <= m_range.end);
 }
 
@@ -242,11 +247,12 @@ void DisplayBuffer::optimize()
         line.optimize();
 }
 
-DisplayLine parse_display_line(StringView line, const FaceRegistry& faces, const HashMap<String, DisplayLine>& builtins)
+DisplayLine parse_display_line(StringView line, const FaceRegistry& faces,
+                               const HashMap<String, DisplayLine>& builtins)
 {
     DisplayLine res;
     bool was_antislash = false;
-    auto pos = line.begin();
+    auto pos           = line.begin();
     String content;
     Face face;
     for (auto it = line.begin(), end = line.end(); it != end; ++it)
@@ -258,37 +264,41 @@ DisplayLine parse_display_line(StringView line, const FaceRegistry& faces, const
             {
                 content += StringView{pos, it};
                 content.back() = '{';
-                pos = it + 1;
+                pos            = it + 1;
             }
             else
             {
                 content += StringView{pos, it};
                 res.push_back({std::move(content), face});
                 content.clear();
-                auto closing = std::find(it+1, end, '}');
+                auto closing = std::find(it + 1, end, '}');
                 if (closing == end)
                     throw runtime_error("unclosed face definition");
-                if (*(it+1) == '{' and closing+1 != end and *(closing+1) == '}')
+                if (*(it + 1) == '{' and closing + 1 != end
+                    and *(closing + 1) == '}')
                 {
-                    auto builtin_it = builtins.find(StringView{it+2, closing});
+                    auto builtin_it
+                        = builtins.find(StringView{it + 2, closing});
                     if (builtin_it == builtins.end())
-                        throw runtime_error(format("undefined atom {}", StringView{it+2, closing}));
+                        throw runtime_error(format(
+                            "undefined atom {}", StringView{it + 2, closing}));
                     for (auto& atom : builtin_it->value)
                         res.push_back(atom);
-                    // closing is now at the first char of "}}", advance it to the second
+                    // closing is now at the first char of "}}", advance it to
+                    // the second
                     ++closing;
                 }
                 else
-                    face = faces[{it+1, closing}];
-                it = closing;
+                    face = faces[{it + 1, closing}];
+                it  = closing;
                 pos = closing + 1;
             }
         }
         if (c == '\n') // line breaks are forbidden, replace with space
         {
-            content += StringView{pos, it+1};
+            content += StringView{pos, it + 1};
             content.back() = ' ';
-            pos = it + 1;
+            pos            = it + 1;
         }
 
         if (c == '\\')
@@ -296,7 +306,7 @@ DisplayLine parse_display_line(StringView line, const FaceRegistry& faces, const
             if (was_antislash)
             {
                 content += StringView{pos, it};
-                pos = it + 1;
+                pos           = it + 1;
                 was_antislash = false;
             }
             else
@@ -322,7 +332,7 @@ String fix_atom_text(StringView str)
         {
             res += StringView{pos, it};
             res += c == '\n' ? "␤" : "␍";
-            pos = it+1;
+            pos = it + 1;
         }
     }
     res += StringView{pos, str.end()};

--- a/src/display_buffer.hh
+++ b/src/display_buffer.hh
@@ -22,13 +22,20 @@ BufferIterator get_iterator(const Buffer& buffer, BufferCoord coord);
 struct DisplayAtom : public UseMemoryDomain<MemoryDomain::Display>
 {
 public:
-    enum Type { Range, ReplacedRange, Text };
+    enum Type
+    {
+        Range,
+        ReplacedRange,
+        Text
+    };
 
     DisplayAtom(const Buffer& buffer, BufferCoord begin, BufferCoord end)
-        : m_type(Range), m_buffer(&buffer), m_range{begin, end} {}
+        : m_type(Range), m_buffer(&buffer), m_range{begin, end}
+    {}
 
     DisplayAtom(String str, Face face)
-        : m_type(Text), m_text(std::move(str)), face(face) {}
+        : m_type(Text), m_text(std::move(str)), face(face)
+    {}
 
     StringView content() const;
     ColumnCount length() const;
@@ -57,7 +64,11 @@ public:
         return m_type == Range or m_type == ReplacedRange;
     }
 
-    const Buffer& buffer() const { kak_assert(m_buffer); return *m_buffer; }
+    const Buffer& buffer() const
+    {
+        kak_assert(m_buffer);
+        return *m_buffer;
+    }
 
     Type type() const { return m_type; }
 
@@ -66,8 +77,8 @@ public:
 
     bool operator==(const DisplayAtom& other) const
     {
-        return face == other.face and type() == other.type() and
-               content() == other.content();
+        return face == other.face and type() == other.type()
+               and content() == other.content();
     }
 
 public:
@@ -88,14 +99,13 @@ using AtomList = Vector<DisplayAtom, MemoryDomain::Display>;
 class DisplayLine : public UseMemoryDomain<MemoryDomain::Display>
 {
 public:
-    using iterator = AtomList::iterator;
+    using iterator       = AtomList::iterator;
     using const_iterator = AtomList::const_iterator;
-    using value_type = AtomList::value_type;
+    using value_type     = AtomList::value_type;
 
     DisplayLine() = default;
     DisplayLine(AtomList atoms);
-    DisplayLine(String str, Face face)
-    { push_back({ std::move(str), face }); }
+    DisplayLine(String str, Face face) { push_back({std::move(str), face}); }
 
     iterator begin() { return m_atoms.begin(); }
     iterator end() { return m_atoms.end(); }
@@ -118,24 +128,27 @@ public:
 
     iterator insert(iterator it, DisplayAtom atom);
     iterator erase(iterator beg, iterator end);
-    void     push_back(DisplayAtom atom);
+    void push_back(DisplayAtom atom);
 
     // remove first_col from the begining of the line, and make sure
     // the line is less that col_count character
     void trim(ColumnCount first_col, ColumnCount col_count);
 
     // Merge together consecutive atoms sharing the same display attributes
-    void     optimize();
+    void optimize();
+
 private:
     void compute_range();
-    BufferRange m_range = { { INT_MAX, INT_MAX }, { INT_MIN, INT_MIN } };
-    AtomList  m_atoms;
+    BufferRange m_range = {{INT_MAX, INT_MAX}, {INT_MIN, INT_MIN}};
+    AtomList m_atoms;
 };
 
 class FaceRegistry;
 
 String fix_atom_text(StringView str);
-DisplayLine parse_display_line(StringView line, const FaceRegistry& faces, const HashMap<String, DisplayLine>& builtins = {});
+DisplayLine parse_display_line(StringView line, const FaceRegistry& faces,
+                               const HashMap<String, DisplayLine>& builtins
+                               = {});
 
 class DisplayBuffer : public UseMemoryDomain<MemoryDomain::Display>
 {

--- a/src/enum.hh
+++ b/src/enum.hh
@@ -6,7 +6,12 @@
 namespace Kakoune
 {
 
-template<typename T> struct EnumDesc { T value; StringView name; };
+template<typename T>
+struct EnumDesc
+{
+    T value;
+    StringView name;
+};
 
 }
 

--- a/src/env_vars.cc
+++ b/src/env_vars.cc
@@ -2,7 +2,7 @@
 
 #include "string.hh"
 
-extern char **environ;
+extern char** environ;
 
 namespace Kakoune
 {
@@ -12,11 +12,12 @@ EnvVarMap get_env_vars()
     EnvVarMap env_vars;
     for (char** it = environ; *it; ++it)
     {
-        const char* name = *it;
+        const char* name  = *it;
         const char* value = name;
         while (*value != 0 and *value != '=')
             ++value;
-        env_vars.insert({{name, value}, (*value == '=') ? value+1 : String{}});
+        env_vars.insert(
+            {{name, value}, (*value == '=') ? value + 1 : String{}});
     }
     return env_vars;
 }

--- a/src/event_manager.cc
+++ b/src/event_manager.cc
@@ -58,10 +58,7 @@ void Timer::run(EventMode mode)
         m_date = Clock::now() + std::chrono::milliseconds{10};
 }
 
-EventManager::EventManager()
-{
-    FD_ZERO(&m_forced_fd);
-}
+EventManager::EventManager() { FD_ZERO(&m_forced_fd); }
 
 EventManager::~EventManager()
 {
@@ -69,17 +66,20 @@ EventManager::~EventManager()
     kak_assert(m_timers.empty());
 }
 
-bool EventManager::handle_next_events(EventMode mode, sigset_t* sigmask, bool block)
+bool EventManager::handle_next_events(EventMode mode, sigset_t* sigmask,
+                                      bool block)
 {
     int max_fd = 0;
     fd_set rfds, wfds, efds;
-    FD_ZERO(&rfds); FD_ZERO(&wfds); FD_ZERO(&efds);
+    FD_ZERO(&rfds);
+    FD_ZERO(&wfds);
+    FD_ZERO(&efds);
     for (auto& watcher : m_fd_watchers)
     {
         const int fd = watcher->fd();
         if (fd != -1)
         {
-            max_fd = std::max(fd, max_fd);
+            max_fd      = std::max(fd, max_fd);
             auto events = watcher->events();
             if (events & FdEvents::Read)
                 FD_SET(fd, &rfds);
@@ -97,18 +97,22 @@ bool EventManager::handle_next_events(EventMode mode, sigset_t* sigmask, bool bl
     timespec ts{};
     if (block and not m_timers.empty())
     {
-        auto next_date = (*std::min_element(
-            m_timers.begin(), m_timers.end(), [](Timer* lhs, Timer* rhs) {
-                return lhs->next_date() < rhs->next_date();
-        }))->next_date();
+        auto next_date
+            = (*std::min_element(m_timers.begin(), m_timers.end(),
+                                 [](Timer* lhs, Timer* rhs) {
+                                     return lhs->next_date() < rhs->next_date();
+                                 }))
+                  ->next_date();
 
         if (next_date != TimePoint::max())
         {
             with_timeout = true;
-            using namespace std::chrono; using ns = std::chrono::nanoseconds;
-            auto nsecs = std::max(ns(0), duration_cast<ns>(next_date - Clock::now()));
+            using namespace std::chrono;
+            using ns = std::chrono::nanoseconds;
+            auto nsecs
+                = std::max(ns(0), duration_cast<ns>(next_date - Clock::now()));
             auto secs = duration_cast<seconds>(nsecs);
-            ts = timespec{ (time_t)secs.count(), (long)(nsecs - secs).count() };
+            ts = timespec{(time_t)secs.count(), (long)(nsecs - secs).count()};
         }
     }
     int res = pselect(max_fd + 1, &rfds, &wfds, &efds,
@@ -117,28 +121,30 @@ bool EventManager::handle_next_events(EventMode mode, sigset_t* sigmask, bool bl
     // copy forced fds *after* select, so that signal handlers can write to
     // m_forced_fd, interupt select, and directly be serviced.
     m_has_forced_fd = false;
-    fd_set forced = m_forced_fd;
+    fd_set forced   = m_forced_fd;
     FD_ZERO(&m_forced_fd);
 
     for (int fd = 0; fd < max_fd + 1; ++fd)
     {
-        auto events =  FD_ISSET(fd, &forced) ? FdEvents::Read : FdEvents::None;
+        auto events = FD_ISSET(fd, &forced) ? FdEvents::Read : FdEvents::None;
         if (res > 0)
-            events |= (FD_ISSET(fd, &rfds) ? FdEvents::Read : FdEvents::None) |
-                      (FD_ISSET(fd, &wfds) ? FdEvents::Write : FdEvents::None) |
-                      (FD_ISSET(fd, &efds) ? FdEvents::Except : FdEvents::None);
+            events
+                |= (FD_ISSET(fd, &rfds) ? FdEvents::Read : FdEvents::None)
+                   | (FD_ISSET(fd, &wfds) ? FdEvents::Write : FdEvents::None)
+                   | (FD_ISSET(fd, &efds) ? FdEvents::Except : FdEvents::None);
 
         if (events != FdEvents::None)
         {
-            auto it = find_if(m_fd_watchers,
-                              [fd](const FDWatcher* w){return w->fd() == fd; });
+            auto it = find_if(m_fd_watchers, [fd](const FDWatcher* w) {
+                return w->fd() == fd;
+            });
             if (it != m_fd_watchers.end())
                 (*it)->run(events, mode);
         }
     }
 
     TimePoint now = Clock::now();
-    auto timers = m_timers; // copy timers in case m_timers gets mutated
+    auto timers   = m_timers; // copy timers in case m_timers gets mutated
     for (auto& timer : timers)
     {
         if (contains(m_timers, timer) and timer->next_date() <= now)
@@ -160,7 +166,7 @@ SignalHandler set_signal_handler(int signum, SignalHandler handler)
 
     sigemptyset(&new_action.sa_mask);
     new_action.sa_handler = handler;
-    new_action.sa_flags = SA_RESTART;
+    new_action.sa_flags   = SA_RESTART;
     sigaction(signum, &new_action, &old_action);
     return old_action.sa_handler;
 }

--- a/src/event_manager.hh
+++ b/src/event_manager.hh
@@ -22,9 +22,9 @@ enum class EventMode
 
 enum class FdEvents
 {
-    None = 0,
-    Read = 1 << 0,
-    Write = 1 << 1,
+    None   = 0,
+    Read   = 1 << 0,
+    Write  = 1 << 1,
     Except = 1 << 2,
 };
 
@@ -33,7 +33,8 @@ constexpr bool with_bit_ops(Meta::Type<FdEvents>) { return true; }
 class FDWatcher
 {
 public:
-    using Callback = std::function<void (FDWatcher& watcher, FdEvents events, EventMode mode)>;
+    using Callback = std::function<void(FDWatcher& watcher, FdEvents events,
+                                        EventMode mode)>;
     FDWatcher(int fd, FdEvents events, Callback callback);
     FDWatcher(const FDWatcher&) = delete;
     FDWatcher& operator=(const FDWatcher&) = delete;
@@ -49,7 +50,7 @@ public:
     void disable() { m_fd = -1; }
 
 private:
-    int      m_fd;
+    int m_fd;
     FdEvents m_events;
     Callback m_callback;
 };
@@ -57,7 +58,7 @@ private:
 class Timer
 {
 public:
-    using Callback = std::function<void (Timer& timer)>;
+    using Callback = std::function<void(Timer& timer)>;
 
     Timer(TimePoint date, Callback callback,
           EventMode mode = EventMode::Normal);
@@ -66,13 +67,13 @@ public:
     ~Timer();
 
     TimePoint next_date() const { return m_date; }
-    void      set_next_date(TimePoint date) { m_date = date; }
+    void set_next_date(TimePoint date) { m_date = date; }
     void run(EventMode mode);
 
 private:
     TimePoint m_date;
     EventMode m_mode;
-    Callback  m_callback;
+    Callback m_callback;
 };
 
 // The EventManager provides an interface to file descriptor
@@ -86,7 +87,8 @@ public:
     EventManager();
     ~EventManager();
 
-    bool handle_next_events(EventMode mode, sigset_t* sigmask = nullptr, bool block = true);
+    bool handle_next_events(EventMode mode, sigset_t* sigmask = nullptr,
+                            bool block = true);
 
     // force the watchers associated with fd to be executed
     // on next handle_next_events call.
@@ -96,14 +98,14 @@ private:
     friend class FDWatcher;
     friend class Timer;
     Vector<FDWatcher*, MemoryDomain::Events> m_fd_watchers;
-    Vector<Timer*, MemoryDomain::Events>     m_timers;
+    Vector<Timer*, MemoryDomain::Events> m_timers;
     fd_set m_forced_fd;
-    bool   m_has_forced_fd = false;
+    bool m_has_forced_fd = false;
 
     TimePoint m_last;
 };
 
-using SignalHandler = void(*)(int);
+using SignalHandler = void (*)(int);
 
 SignalHandler set_signal_handler(int signum, SignalHandler handler);
 

--- a/src/exception.cc
+++ b/src/exception.cc
@@ -7,9 +7,6 @@
 namespace Kakoune
 {
 
-StringView exception::what() const
-{
-    return typeid(*this).name();
-}
+StringView exception::what() const { return typeid(*this).name(); }
 
 }

--- a/src/exception.hh
+++ b/src/exception.hh
@@ -14,8 +14,7 @@ struct exception
 
 struct runtime_error : exception
 {
-    runtime_error(String what)
-        : m_what(std::move(what)) {}
+    runtime_error(String what) : m_what(std::move(what)) {}
 
     StringView what() const override { return m_what; }
     void set_what(String what) { m_what = std::move(what); }
@@ -30,8 +29,7 @@ struct failure : runtime_error
 };
 
 struct logic_error : exception
-{
-};
+{};
 
 }
 

--- a/src/face.hh
+++ b/src/face.hh
@@ -31,20 +31,20 @@ struct Face
     Attribute attributes;
 
     constexpr Face(Color fg = Color::Default, Color bg = Color::Default,
-         Attribute attributes = Attribute::Normal)
-      : fg{fg}, bg{bg}, attributes{attributes} {}
+                   Attribute attributes = Attribute::Normal)
+        : fg{fg}, bg{bg}, attributes{attributes}
+    {}
 };
 
 constexpr bool operator==(const Face& lhs, const Face& rhs)
 {
-    return lhs.fg == rhs.fg and
-           lhs.bg == rhs.bg and
-           lhs.attributes == rhs.attributes;
+    return lhs.fg == rhs.fg and lhs.bg == rhs.bg
+           and lhs.attributes == rhs.attributes;
 }
 
 constexpr bool operator!=(const Face& lhs, const Face& rhs)
 {
-    return not (lhs == rhs);
+    return not(lhs == rhs);
 }
 
 constexpr size_t hash_value(const Face& val)
@@ -64,11 +64,13 @@ inline Face merge_faces(const Face& base, const Face& face)
         return face.*color;
     };
 
-    return Face{ choose(&Face::fg, Attribute::FinalFg),
-                 choose(&Face::bg, Attribute::FinalBg),
-                 face.attributes & Attribute::FinalAttr ? face.attributes :
-                 base.attributes & Attribute::FinalAttr ? base.attributes :
-                 face.attributes | base.attributes };
+    return Face{choose(&Face::fg, Attribute::FinalFg),
+                choose(&Face::bg, Attribute::FinalBg),
+                face.attributes & Attribute::FinalAttr
+                    ? face.attributes
+                    : base.attributes & Attribute::FinalAttr
+                          ? base.attributes
+                          : face.attributes | base.attributes};
 }
 
 }

--- a/src/face_registry.hh
+++ b/src/face_registry.hh
@@ -22,7 +22,7 @@ public:
 
     struct FaceOrAlias
     {
-        Face face = {};
+        Face face    = {};
         String alias = {};
     };
     using FaceMap = HashMap<String, FaceOrAlias, MemoryDomain::Faces>;
@@ -31,12 +31,16 @@ public:
     {
         auto merge = [](auto&& first, const FaceMap& second) {
             return concatenated(std::forward<decltype(first)>(first)
-                                | filter([&second](auto& i) { return not second.contains(i.key); }),
+                                    | filter([&second](auto& i) {
+                                          return not second.contains(i.key);
+                                      }),
                                 second);
         };
         static const FaceMap empty;
-        auto& parent = m_parent ? m_parent->m_faces : empty;
-        auto& grand_parent = (m_parent and m_parent->m_parent) ? m_parent->m_parent->m_faces : empty;
+        auto& parent       = m_parent ? m_parent->m_faces : empty;
+        auto& grand_parent = (m_parent and m_parent->m_parent)
+                                 ? m_parent->m_parent->m_faces
+                                 : empty;
         return merge(merge(grand_parent, parent), m_faces);
     }
 

--- a/src/file.hh
+++ b/src/file.hh
@@ -48,14 +48,17 @@ struct MappedFile
 
     int fd;
     const char* data;
-    struct stat st {};
+    struct stat st
+    {};
 };
 
-void write_buffer_to_file(Buffer& buffer, StringView filename, bool force = false, bool sync = false);
+void write_buffer_to_file(Buffer& buffer, StringView filename,
+                          bool force = false, bool sync = false);
 void write_buffer_to_fd(Buffer& buffer, int fd, bool sync = false);
 void write_buffer_to_backup_file(Buffer& buffer);
 
-String find_file(StringView filename, StringView buf_dir, ConstArrayView<String> paths);
+String find_file(StringView filename, StringView buf_dir,
+                 ConstArrayView<String> paths);
 bool file_exists(StringView filename);
 
 Vector<String> list_files(StringView directory);
@@ -71,20 +74,20 @@ constexpr bool operator==(const timespec& lhs, const timespec& rhs)
 
 constexpr bool operator!=(const timespec& lhs, const timespec& rhs)
 {
-    return not (lhs == rhs);
+    return not(lhs == rhs);
 }
 
 enum class FilenameFlags
 {
-    None = 0,
+    None            = 0,
     OnlyDirectories = 1 << 0,
-    Expand = 1 << 1
+    Expand          = 1 << 1
 };
 constexpr bool with_bit_ops(Meta::Type<FilenameFlags>) { return true; }
 
 CandidateList complete_filename(StringView prefix, const Regex& ignore_regex,
                                 ByteCount cursor_pos = -1,
-                                FilenameFlags flags = FilenameFlags::None);
+                                FilenameFlags flags  = FilenameFlags::None);
 
 CandidateList complete_command(StringView prefix, ByteCount cursor_pos = -1);
 

--- a/src/flags.hh
+++ b/src/flags.hh
@@ -9,27 +9,32 @@ namespace Kakoune
 {
 
 template<typename Flags>
-constexpr bool with_bit_ops(Meta::Type<Flags>) { return false; }
+constexpr bool with_bit_ops(Meta::Type<Flags>)
+{
+    return false;
+}
 
 template<typename Flags>
 using UnderlyingType = std::underlying_type_t<Flags>;
 
 template<typename Flags, typename T = void>
-using EnableIfWithBitOps = std::enable_if_t<with_bit_ops(Meta::Type<Flags>{}), T>;
+using EnableIfWithBitOps
+    = std::enable_if_t<with_bit_ops(Meta::Type<Flags>{}), T>;
 
 template<typename Flags, typename T = void>
-using EnableIfWithoutBitOps = std::enable_if_t<not with_bit_ops(Meta::Type<Flags>{}), T>;
+using EnableIfWithoutBitOps
+    = std::enable_if_t<not with_bit_ops(Meta::Type<Flags>{}), T>;
 
 template<typename Flags, typename = EnableIfWithBitOps<Flags>>
 constexpr Flags operator|(Flags lhs, Flags rhs)
 {
-    return (Flags)((UnderlyingType<Flags>) lhs | (UnderlyingType<Flags>) rhs);
+    return (Flags)((UnderlyingType<Flags>)lhs | (UnderlyingType<Flags>)rhs);
 }
 
 template<typename Flags, typename = EnableIfWithBitOps<Flags>>
 constexpr Flags& operator|=(Flags& lhs, Flags rhs)
 {
-    (UnderlyingType<Flags>&) lhs |= (UnderlyingType<Flags>) rhs;
+    (UnderlyingType<Flags>&)lhs |= (UnderlyingType<Flags>)rhs;
     return lhs;
 }
 
@@ -39,22 +44,31 @@ struct TestableFlags
     Flags value;
     constexpr operator bool() const { return (UnderlyingType<Flags>)value; }
     constexpr operator Flags() const { return value; }
-    constexpr operator UnderlyingType<Flags>() const { return (UnderlyingType<Flags>)value; }
+    constexpr operator UnderlyingType<Flags>() const
+    {
+        return (UnderlyingType<Flags>)value;
+    }
 
-    constexpr bool operator==(const TestableFlags<Flags>& other) const { return value == other.value; }
-    constexpr bool operator!=(const TestableFlags<Flags>& other) const { return value != other.value; }
+    constexpr bool operator==(const TestableFlags<Flags>& other) const
+    {
+        return value == other.value;
+    }
+    constexpr bool operator!=(const TestableFlags<Flags>& other) const
+    {
+        return value != other.value;
+    }
 };
 
 template<typename Flags, typename = EnableIfWithBitOps<Flags>>
 constexpr TestableFlags<Flags> operator&(Flags lhs, Flags rhs)
 {
-    return { (Flags)((UnderlyingType<Flags>) lhs & (UnderlyingType<Flags>) rhs) };
+    return {(Flags)((UnderlyingType<Flags>)lhs & (UnderlyingType<Flags>)rhs)};
 }
 
 template<typename Flags, typename = EnableIfWithBitOps<Flags>>
 constexpr Flags& operator&=(Flags& lhs, Flags rhs)
 {
-    (UnderlyingType<Flags>&) lhs &= (UnderlyingType<Flags>) rhs;
+    (UnderlyingType<Flags>&)lhs &= (UnderlyingType<Flags>)rhs;
     return lhs;
 }
 
@@ -67,13 +81,13 @@ constexpr Flags operator~(Flags lhs)
 template<typename Flags, typename = EnableIfWithBitOps<Flags>>
 constexpr Flags operator^(Flags lhs, Flags rhs)
 {
-    return (Flags)((UnderlyingType<Flags>) lhs ^ (UnderlyingType<Flags>) rhs);
+    return (Flags)((UnderlyingType<Flags>)lhs ^ (UnderlyingType<Flags>)rhs);
 }
 
 template<typename Flags, typename = EnableIfWithBitOps<Flags>>
 constexpr Flags& operator^=(Flags& lhs, Flags rhs)
 {
-    (UnderlyingType<Flags>&) lhs ^= (UnderlyingType<Flags>) rhs;
+    (UnderlyingType<Flags>&)lhs ^= (UnderlyingType<Flags>)rhs;
     return lhs;
 }
 

--- a/src/hash.cc
+++ b/src/hash.cc
@@ -6,14 +6,12 @@
 namespace Kakoune
 {
 
-[[gnu::always_inline]]
-static inline uint32_t rotl(uint32_t x, int8_t r)
+[[gnu::always_inline]] static inline uint32_t rotl(uint32_t x, int8_t r)
 {
     return (x << r) | (x >> (32 - r));
 }
 
-[[gnu::always_inline]]
-static inline uint32_t fmix(uint32_t h)
+[[gnu::always_inline]] static inline uint32_t fmix(uint32_t h)
 {
     h ^= h >> 16;
     h *= 0x85ebca6b;
@@ -27,18 +25,18 @@ static inline uint32_t fmix(uint32_t h)
 // murmur3 hash, based on https://github.com/PeterScott/murmur3
 size_t hash_data(const char* input, size_t len)
 {
-    const uint8_t* data = reinterpret_cast<const uint8_t*>(input);
-    uint32_t hash = 0x1235678;
+    const uint8_t* data   = reinterpret_cast<const uint8_t*>(input);
+    uint32_t hash         = 0x1235678;
     constexpr uint32_t c1 = 0xcc9e2d51;
     constexpr uint32_t c2 = 0x1b873593;
 
-    const int nblocks = len / 4;
-    const uint8_t* blocks = data + nblocks*4;
+    const int nblocks     = len / 4;
+    const uint8_t* blocks = data + nblocks * 4;
 
     for (int i = -nblocks; i; ++i)
     {
         uint32_t key;
-        memcpy(&key, blocks + 4*i, 4);
+        memcpy(&key, blocks + 4 * i, 4);
         key *= c1;
         key = rotl(key, 15);
         key *= c2;
@@ -49,16 +47,19 @@ size_t hash_data(const char* input, size_t len)
     }
 
     const uint8_t* tail = data + nblocks * 4;
-    uint32_t key = 0;
+    uint32_t key        = 0;
     switch (len & 3)
     {
-        case 3: key ^= tail[2] << 16; /* fallthrough */
-        case 2: key ^= tail[1] << 8;  /* fallthrough */
-        case 1: key ^= tail[0];
-                key *= c1;
-                key = rotl(key,15);
-                key *= c2;
-                hash ^= key;
+        case 3:
+            key ^= tail[2] << 16; /* fallthrough */
+        case 2:
+            key ^= tail[1] << 8; /* fallthrough */
+        case 1:
+            key ^= tail[0];
+            key *= c1;
+            key = rotl(key, 15);
+            key *= c2;
+            hash ^= key;
     }
 
     hash ^= len;

--- a/src/hash.hh
+++ b/src/hash.hh
@@ -19,15 +19,15 @@ constexpr size_t hash_value(const Type&... val)
 }
 
 template<typename Type>
-std::enable_if_t<std::is_integral<Type>::value, size_t>
-constexpr hash_value(const Type& val)
+std::enable_if_t<std::is_integral<Type>::value, size_t> constexpr hash_value(
+    const Type& val)
 {
     return (size_t)val;
 }
 
 template<typename Type>
-std::enable_if_t<std::is_enum<Type>::value, size_t>
-constexpr hash_value(const Type& val)
+std::enable_if_t<std::is_enum<Type>::value, size_t> constexpr hash_value(
+    const Type& val)
 {
     return hash_value((std::underlying_type_t<Type>)val);
 }
@@ -68,9 +68,12 @@ struct Hash
 // Traits specifying if two types have compatible hashing, that is,
 // if lhs == rhs => hash_value(lhs) == hash_value(rhs)
 template<typename Lhs, typename Rhs>
-struct HashCompatible : std::false_type {};
+struct HashCompatible : std::false_type
+{};
 
-template<typename T> struct HashCompatible<T, T> : std::true_type {};
+template<typename T>
+struct HashCompatible<T, T> : std::true_type
+{};
 
 template<typename Lhs, typename Rhs>
 constexpr bool IsHashCompatible = HashCompatible<Lhs, Rhs>::value;

--- a/src/hash_map.cc
+++ b/src/hash_map.cc
@@ -116,17 +116,17 @@ void do_profile(size_t count, StringView type)
     auto after_find = Clock::now();
 
     using namespace std::chrono;
-    write_to_debug_buffer(format("{} ({}) -- inserts: {}us, reads: {}us, remove: {}us, find: {}us ({})", type, count,
-                                 duration_cast<microseconds>(after_insert - start).count(),
-                                 duration_cast<microseconds>(after_read - after_insert).count(),
-                                 duration_cast<microseconds>(after_remove - after_read).count(),
-                                 duration_cast<microseconds>(after_find - after_remove).count(),
-                                 c));
+    write_to_debug_buffer(format(
+        "{} ({}) -- inserts: {}us, reads: {}us, remove: {}us, find: {}us ({})",
+        type, count, duration_cast<microseconds>(after_insert - start).count(),
+        duration_cast<microseconds>(after_read - after_insert).count(),
+        duration_cast<microseconds>(after_remove - after_read).count(),
+        duration_cast<microseconds>(after_find - after_remove).count(), c));
 }
 
 void profile_hash_maps()
 {
-    for (auto i : { 1000, 10000, 100000, 1000000, 10000000 })
+    for (auto i : {1000, 10000, 100000, 1000000, 10000000})
     {
         do_profile<std::unordered_map<size_t, size_t>>(i, "UnorderedMap");
         do_profile<HashMap<size_t, size_t>>(i, "     HashMap");

--- a/src/highlighter.cc
+++ b/src/highlighter.cc
@@ -5,29 +5,29 @@
 namespace Kakoune
 {
 
-void Highlighter::highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range)
+void Highlighter::highlight(HighlightContext context,
+                            DisplayBuffer& display_buffer, BufferRange range)
 {
-    if (context.pass & m_passes) try
-    {
-        do_highlight(context, display_buffer, range);
-    }
-    catch (runtime_error& error)
-    {
-        write_to_debug_buffer(format("Error while highlighting: {}", error.what()));
-    }
+    if (context.pass & m_passes)
+        try
+        {
+            do_highlight(context, display_buffer, range);
+        }
+        catch (runtime_error& error)
+        {
+            write_to_debug_buffer(
+                format("Error while highlighting: {}", error.what()));
+        }
 }
 
-void Highlighter::compute_display_setup(HighlightContext context, DisplaySetup& setup) const
+void Highlighter::compute_display_setup(HighlightContext context,
+                                        DisplaySetup& setup) const
 {
     if (context.pass & m_passes)
         do_compute_display_setup(context, setup);
 }
 
-
-bool Highlighter::has_children() const
-{
-    return false;
-}
+bool Highlighter::has_children() const { return false; }
 
 Highlighter& Highlighter::get_child(StringView path)
 {
@@ -44,12 +44,12 @@ void Highlighter::remove_child(StringView id)
     throw runtime_error("this highlighter does not hold children");
 }
 
-Completions Highlighter::complete_child(StringView path, ByteCount cursor_pos, bool group) const
+Completions Highlighter::complete_child(StringView path, ByteCount cursor_pos,
+                                        bool group) const
 {
     throw runtime_error("this highlighter does not hold children");
 }
 
-void Highlighter::fill_unique_ids(Vector<StringView>& unique_ids) const
-{}
+void Highlighter::fill_unique_ids(Vector<StringView>& unique_ids) const {}
 
 }

--- a/src/highlighter.hh
+++ b/src/highlighter.hh
@@ -20,8 +20,8 @@ class Context;
 
 enum class HighlightPass
 {
-    Wrap = 1 << 0,
-    Move = 1 << 1,
+    Wrap     = 1 << 0,
+    Move     = 1 << 1,
     Colorize = 1 << 2,
 
     All = Wrap | Move | Colorize,
@@ -64,27 +64,35 @@ struct Highlighter
     Highlighter(HighlightPass passes) : m_passes{passes} {}
     virtual ~Highlighter() = default;
 
-    void highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range);
-    void compute_display_setup(HighlightContext context, DisplaySetup& setup) const;
+    void highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                   BufferRange range);
+    void compute_display_setup(HighlightContext context,
+                               DisplaySetup& setup) const;
 
     virtual bool has_children() const;
     virtual Highlighter& get_child(StringView path);
     virtual void add_child(String name, std::unique_ptr<Highlighter>&& hl);
     virtual void remove_child(StringView id);
-    virtual Completions complete_child(StringView path, ByteCount cursor_pos, bool group) const;
+    virtual Completions complete_child(StringView path, ByteCount cursor_pos,
+                                       bool group) const;
     virtual void fill_unique_ids(Vector<StringView>& unique_ids) const;
 
     HighlightPass passes() const { return m_passes; }
 
 private:
-    virtual void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range) = 0;
-    virtual void do_compute_display_setup(HighlightContext context, DisplaySetup& setup) const {}
+    virtual void do_highlight(HighlightContext context,
+                              DisplayBuffer& display_buffer, BufferRange range)
+        = 0;
+    virtual void do_compute_display_setup(HighlightContext context,
+                                          DisplaySetup& setup) const
+    {}
 
     const HighlightPass m_passes;
 };
 
 using HighlighterParameters = ConstArrayView<String>;
-using HighlighterFactory = std::function<std::unique_ptr<Highlighter> (HighlighterParameters params, Highlighter* parent)>;
+using HighlighterFactory    = std::function<std::unique_ptr<Highlighter>(
+    HighlighterParameters params, Highlighter* parent)>;
 
 struct HighlighterFactoryAndDocstring
 {
@@ -92,8 +100,9 @@ struct HighlighterFactoryAndDocstring
     String docstring;
 };
 
-struct HighlighterRegistry : HashMap<String, HighlighterFactoryAndDocstring, MemoryDomain::Highlight>,
-                             Singleton<HighlighterRegistry>
+struct HighlighterRegistry
+    : HashMap<String, HighlighterFactoryAndDocstring, MemoryDomain::Highlight>,
+      Singleton<HighlighterRegistry>
 {};
 
 }

--- a/src/highlighter_group.cc
+++ b/src/highlighter_group.cc
@@ -6,13 +6,16 @@
 namespace Kakoune
 {
 
-void HighlighterGroup::do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range)
+void HighlighterGroup::do_highlight(HighlightContext context,
+                                    DisplayBuffer& display_buffer,
+                                    BufferRange range)
 {
     for (auto& hl : m_highlighters)
         hl.value->highlight(context, display_buffer, range);
 }
 
-void HighlighterGroup::do_compute_display_setup(HighlightContext context, DisplaySetup& setup) const
+void HighlighterGroup::do_compute_display_setup(HighlightContext context,
+                                                DisplaySetup& setup) const
 {
     for (auto& hl : m_highlighters)
         hl.value->compute_display_setup(context, setup);
@@ -27,7 +30,8 @@ void HighlighterGroup::fill_unique_ids(Vector<StringView>& unique_ids) const
 void HighlighterGroup::add_child(String name, std::unique_ptr<Highlighter>&& hl)
 {
     if ((hl->passes() & passes()) != hl->passes())
-        throw runtime_error{"cannot add that highlighter to this group, passes don't match"};
+        throw runtime_error{
+            "cannot add that highlighter to this group, passes don't match"};
 
     if (m_highlighters.contains(name))
         throw runtime_error(format("duplicate id: '{}'", name));
@@ -50,45 +54,60 @@ Highlighter& HighlighterGroup::get_child(StringView path)
     if (sep_it == path.end())
         return *it->value;
     else
-        return it->value->get_child({sep_it+1, path.end()});
+        return it->value->get_child({sep_it + 1, path.end()});
 }
 
-Completions HighlighterGroup::complete_child(StringView path, ByteCount cursor_pos, bool group) const
+Completions HighlighterGroup::complete_child(StringView path,
+                                             ByteCount cursor_pos,
+                                             bool group) const
 {
     auto sep_it = find(path, '/');
     if (sep_it != path.end())
     {
-        ByteCount offset = sep_it+1 - path.begin();
-        Highlighter& hl = const_cast<HighlighterGroup*>(this)->get_child({path.begin(), sep_it});
-        return offset_pos(hl.complete_child(path.substr(offset), cursor_pos - offset, group), offset);
+        ByteCount offset = sep_it + 1 - path.begin();
+        Highlighter& hl  = const_cast<HighlighterGroup*>(this)->get_child(
+            {path.begin(), sep_it});
+        return offset_pos(
+            hl.complete_child(path.substr(offset), cursor_pos - offset, group),
+            offset);
     }
 
-    auto candidates = complete(
-        path, cursor_pos,
-        m_highlighters | filter([=](auto& hl) { return not group or hl.value->has_children(); })
-                       | transform([](auto& hl) { return hl.value->has_children() ? hl.key + "/" : hl.key; })
-                       | gather<Vector<String>>());
+    auto candidates
+        = complete(path, cursor_pos,
+                   m_highlighters | filter([=](auto& hl) {
+                       return not group or hl.value->has_children();
+                   }) | transform([](auto& hl) {
+                       return hl.value->has_children() ? hl.key + "/" : hl.key;
+                   }) | gather<Vector<String>>());
 
-    return { 0, 0, std::move(candidates) };
+    return {0, 0, std::move(candidates)};
 }
 
-void Highlighters::highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range)
+void Highlighters::highlight(HighlightContext context,
+                             DisplayBuffer& display_buffer, BufferRange range)
 {
-    Vector<StringView> disabled_ids(context.disabled_ids.begin(), context.disabled_ids.end());
+    Vector<StringView> disabled_ids(context.disabled_ids.begin(),
+                                    context.disabled_ids.end());
     m_group.fill_unique_ids(disabled_ids);
 
     if (m_parent)
-        m_parent->highlight({context.context, context.setup, context.pass, disabled_ids}, display_buffer, range);
+        m_parent->highlight(
+            {context.context, context.setup, context.pass, disabled_ids},
+            display_buffer, range);
     m_group.highlight(context, display_buffer, range);
 }
 
-void Highlighters::compute_display_setup(HighlightContext context, DisplaySetup& setup) const
+void Highlighters::compute_display_setup(HighlightContext context,
+                                         DisplaySetup& setup) const
 {
-    Vector<StringView> disabled_ids(context.disabled_ids.begin(), context.disabled_ids.end());
+    Vector<StringView> disabled_ids(context.disabled_ids.begin(),
+                                    context.disabled_ids.end());
     m_group.fill_unique_ids(disabled_ids);
 
     if (m_parent)
-        m_parent->compute_display_setup({context.context, context.setup, context.pass, disabled_ids}, setup);
+        m_parent->compute_display_setup(
+            {context.context, context.setup, context.pass, disabled_ids},
+            setup);
     m_group.compute_display_setup(context, setup);
 }
 

--- a/src/highlighter_group.hh
+++ b/src/highlighter_group.hh
@@ -26,28 +26,36 @@ public:
 
     Highlighter& get_child(StringView path) override;
 
-    Completions complete_child(StringView path, ByteCount cursor_pos, bool group) const override;
+    Completions complete_child(StringView path, ByteCount cursor_pos,
+                               bool group) const override;
 
     void fill_unique_ids(Vector<StringView>& unique_ids) const override;
 
 protected:
-    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range) override;
-    void do_compute_display_setup(HighlightContext context, DisplaySetup& setup) const override;
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                      BufferRange range) override;
+    void do_compute_display_setup(HighlightContext context,
+                                  DisplaySetup& setup) const override;
 
-    using HighlighterMap = HashMap<String, std::unique_ptr<Highlighter>, MemoryDomain::Highlight>;
+    using HighlighterMap = HashMap<String, std::unique_ptr<Highlighter>,
+                                   MemoryDomain::Highlight>;
     HighlighterMap m_highlighters;
 };
 
 class Highlighters : public SafeCountable
 {
 public:
-    Highlighters(Highlighters& parent) : SafeCountable{}, m_parent{&parent}, m_group{HighlightPass::All} {}
+    Highlighters(Highlighters& parent)
+        : SafeCountable{}, m_parent{&parent}, m_group{HighlightPass::All}
+    {}
 
     HighlighterGroup& group() { return m_group; }
     const HighlighterGroup& group() const { return m_group; }
 
-    void highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range);
-    void compute_display_setup(HighlightContext context, DisplaySetup& setup) const;
+    void highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                   BufferRange range);
+    void compute_display_setup(HighlightContext context,
+                               DisplaySetup& setup) const;
 
 private:
     friend class Scope;

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -30,15 +30,20 @@ namespace Kakoune
 using Utf8Iterator = utf8::iterator<BufferIterator>;
 
 template<typename Func>
-std::unique_ptr<Highlighter> make_highlighter(Func func, HighlightPass pass = HighlightPass::Colorize)
+std::unique_ptr<Highlighter> make_highlighter(Func func,
+                                              HighlightPass pass
+                                              = HighlightPass::Colorize)
 {
     struct SimpleHighlighter : public Highlighter
     {
         SimpleHighlighter(Func func, HighlightPass pass)
-          : Highlighter{pass}, m_func{std::move(func)} {}
+            : Highlighter{pass}, m_func{std::move(func)}
+        {}
 
     private:
-        void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range) override
+        void do_highlight(HighlightContext context,
+                          DisplayBuffer& display_buffer,
+                          BufferRange range) override
         {
             m_func(context, display_buffer, range);
         }
@@ -48,28 +53,27 @@ std::unique_ptr<Highlighter> make_highlighter(Func func, HighlightPass pass = Hi
 }
 
 template<typename T>
-void highlight_range(DisplayBuffer& display_buffer,
-                     BufferCoord begin, BufferCoord end,
-                     bool skip_replaced, T func)
+void highlight_range(DisplayBuffer& display_buffer, BufferCoord begin,
+                     BufferCoord end, bool skip_replaced, T func)
 {
     // tolerate begin > end as that can be triggered by wrong encodings
     if (begin >= end or end <= display_buffer.range().begin
-                     or begin >= display_buffer.range().end)
+        or begin >= display_buffer.range().end)
         return;
 
     for (auto& line : display_buffer.lines())
     {
         auto& range = line.range();
-        if (range.end <= begin or  end < range.begin)
+        if (range.end <= begin or end < range.begin)
             continue;
 
         for (auto atom_it = line.begin(); atom_it != line.end(); ++atom_it)
         {
             bool is_replaced = atom_it->type() == DisplayAtom::ReplacedRange;
 
-            if (not atom_it->has_buffer_range() or
-                (skip_replaced and is_replaced) or
-                end <= atom_it->begin() or begin >= atom_it->end())
+            if (not atom_it->has_buffer_range()
+                or (skip_replaced and is_replaced) or end <= atom_it->begin()
+                or begin >= atom_it->end())
                 continue;
 
             if (not is_replaced and begin > atom_it->begin())
@@ -88,25 +92,25 @@ void highlight_range(DisplayBuffer& display_buffer,
 }
 
 template<typename T>
-void replace_range(DisplayBuffer& display_buffer,
-                   BufferCoord begin, BufferCoord end, T func)
+void replace_range(DisplayBuffer& display_buffer, BufferCoord begin,
+                   BufferCoord end, T func)
 {
     // tolerate begin > end as that can be triggered by wrong encodings
     if (begin >= end or end <= display_buffer.range().begin
-                     or begin >= display_buffer.range().end)
+        or begin >= display_buffer.range().end)
         return;
 
     for (auto& line : display_buffer.lines())
     {
         auto& range = line.range();
-        if (range.end <= begin or  end < range.begin)
+        if (range.end <= begin or end < range.begin)
             continue;
 
         int beg_idx = -1, end_idx = -1;
         for (auto atom_it = line.begin(); atom_it != line.end(); ++atom_it)
         {
-            if (not atom_it->has_buffer_range() or
-                end <= atom_it->begin() or begin >= atom_it->end())
+            if (not atom_it->has_buffer_range() or end <= atom_it->begin()
+                or begin >= atom_it->end())
                 continue;
 
             if (begin >= atom_it->begin())
@@ -128,8 +132,7 @@ void replace_range(DisplayBuffer& display_buffer,
     }
 }
 
-void apply_highlighter(HighlightContext context,
-                       DisplayBuffer& display_buffer,
+void apply_highlighter(HighlightContext context, DisplayBuffer& display_buffer,
                        BufferCoord begin, BufferCoord end,
                        Highlighter& highlighter)
 {
@@ -143,9 +146,10 @@ void apply_highlighter(HighlightContext context,
 
     DisplayBuffer region_display;
     auto& region_lines = region_display.lines();
-    for (auto line_it = display_buffer.lines().begin(); line_it != line_end; ++line_it)
+    for (auto line_it = display_buffer.lines().begin(); line_it != line_end;
+         ++line_it)
     {
-        auto& line = *line_it;
+        auto& line  = *line_it;
         auto& range = line.range();
         if (range.end <= begin or end <= range.begin)
             continue;
@@ -162,10 +166,12 @@ void apply_highlighter(HighlightContext context,
 
             for (auto atom_it = line.begin(); atom_it != line.end(); ++atom_it)
             {
-                if (not atom_it->has_buffer_range() or end <= atom_it->begin() or begin >= atom_it->end())
+                if (not atom_it->has_buffer_range() or end <= atom_it->begin()
+                    or begin >= atom_it->end())
                     continue;
 
-                bool is_replaced = atom_it->type() == DisplayAtom::ReplacedRange;
+                bool is_replaced
+                    = atom_it->type() == DisplayAtom::ReplacedRange;
                 if (atom_it->begin() <= begin)
                 {
                     if (is_replaced or atom_it->begin() == begin)
@@ -191,12 +197,13 @@ void apply_highlighter(HighlightContext context,
             }
             std::move(line.begin() + beg_idx, line.begin() + end_idx,
                       std::back_inserter(region_lines.back()));
-            insert_pos.back() = line.erase(line.begin() + beg_idx, line.begin() + end_idx);
+            insert_pos.back()
+                = line.erase(line.begin() + beg_idx, line.begin() + end_idx);
         }
         else
         {
             region_lines.back() = std::move(line);
-            insert_pos.back() = line.begin();
+            insert_pos.back()   = line.begin();
         }
     }
 
@@ -209,28 +216,28 @@ void apply_highlighter(HighlightContext context,
     for (size_t i = 0; i < region_lines.size(); ++i)
     {
         auto& line = *(first_line + i);
-        auto pos = insert_pos[i];
+        auto pos   = insert_pos[i];
         for (auto& atom : region_lines[i])
             pos = ++line.insert(pos, std::move(atom));
     }
     display_buffer.compute_range();
 }
 
-auto apply_face = [](const Face& face)
-{
+auto apply_face = [](const Face& face) {
     return [&face](DisplayAtom& atom) {
         atom.face = merge_faces(atom.face, face);
     };
 };
 
-static std::unique_ptr<Highlighter> create_fill_highlighter(HighlighterParameters params, Highlighter*)
+static std::unique_ptr<Highlighter> create_fill_highlighter(
+    HighlighterParameters params, Highlighter*)
 {
     if (params.size() != 1)
         throw runtime_error("wrong parameter count");
 
     const String& facespec = params[0];
-    auto func = [facespec](HighlightContext context, DisplayBuffer& display_buffer, BufferRange range)
-    {
+    auto func              = [facespec](HighlightContext context,
+                           DisplayBuffer& display_buffer, BufferRange range) {
         highlight_range(display_buffer, range.begin, range.end, false,
                         apply_face(context.context.faces()[facespec]));
     };
@@ -249,6 +256,7 @@ struct BufferSideCache
             cache_val = Value(T{});
         return cache_val.as<T>();
     }
+
 private:
     ValueId m_id;
 };
@@ -266,7 +274,8 @@ public:
         ensure_first_face_is_capture_0();
     }
 
-    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range) override
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                      BufferRange range) override
     {
         auto overlaps = [](const BufferRange& lhs, const BufferRange& rhs) {
             return lhs.begin < rhs.begin ? lhs.end > rhs.begin
@@ -276,11 +285,15 @@ public:
         if (not overlaps(display_buffer.range(), range))
             return;
 
-        const auto faces = m_faces | transform([&faces = context.context.faces()](auto&& spec) {
-                return spec.second.empty() ? Face{} : faces[spec.second];
-            }) | gather<Vector<Face>>();
+        const auto faces
+            = m_faces
+              | transform([& faces = context.context.faces()](auto&& spec) {
+                    return spec.second.empty() ? Face{} : faces[spec.second];
+                })
+              | gather<Vector<Face>>();
 
-        const auto& matches = get_matches(context.context.buffer(), display_buffer.range(), range);
+        const auto& matches = get_matches(context.context.buffer(),
+                                          display_buffer.range(), range);
         kak_assert(matches.size() % m_faces.size() == 0);
         for (size_t m = 0; m < matches.size(); ++m)
         {
@@ -288,8 +301,7 @@ public:
             if (face == Face{})
                 continue;
 
-            highlight_range(display_buffer,
-                            matches[m].begin, matches[m].end,
+            highlight_range(display_buffer, matches[m].begin, matches[m].end,
                             false, apply_face(face));
         }
     }
@@ -302,7 +314,8 @@ public:
         ++m_regex_version;
     }
 
-    static std::unique_ptr<Highlighter> create(HighlighterParameters params, Highlighter*)
+    static std::unique_ptr<Highlighter> create(HighlighterParameters params,
+                                               Highlighter*)
     {
         if (params.size() < 2)
             throw runtime_error("wrong parameter count");
@@ -312,14 +325,17 @@ public:
         {
             auto colon = find(spec, ':');
             if (colon == spec.end())
-                throw runtime_error(format("wrong face spec: '{}' expected <capture>:<facespec>", spec));
+                throw runtime_error(format(
+                    "wrong face spec: '{}' expected <capture>:<facespec>",
+                    spec));
             int capture = str_to_int({spec.begin(), colon});
-            faces.emplace_back(capture, String{colon+1, spec.end()});
+            faces.emplace_back(capture, String{colon + 1, spec.end()});
         }
 
         Regex ex{params[0], RegexCompileFlags::Optimize};
 
-        return std::make_unique<RegexHighlighter>(std::move(ex), std::move(faces));
+        return std::make_unique<RegexHighlighter>(std::move(ex),
+                                                  std::move(faces));
     }
 
 private:
@@ -327,14 +343,18 @@ private:
     using MatchList = Vector<BufferRange, MemoryDomain::Highlight>;
     struct Cache
     {
-        size_t m_timestamp = -1;
+        size_t m_timestamp     = -1;
         size_t m_regex_version = -1;
-        struct RangeAndMatches { BufferRange range; MatchList matches; };
+        struct RangeAndMatches
+        {
+            BufferRange range;
+            MatchList matches;
+        };
         Vector<RangeAndMatches, MemoryDomain::Highlight> m_matches;
     };
     BufferSideCache<Cache> m_cache;
 
-    Regex     m_regex;
+    Regex m_regex;
     FacesSpec m_faces;
 
     size_t m_regex_version = 0;
@@ -346,23 +366,27 @@ private:
 
         std::sort(m_faces.begin(), m_faces.end(),
                   [](const std::pair<size_t, String>& lhs,
-                     const std::pair<size_t, String>& rhs)
-                  { return lhs.first < rhs.first; });
+                     const std::pair<size_t, String>& rhs) {
+                      return lhs.first < rhs.first;
+                  });
         if (m_faces[0].first != 0)
             m_faces.emplace(m_faces.begin(), 0, String{});
     }
 
-    void add_matches(const Buffer& buffer, MatchList& matches, BufferRange range)
+    void add_matches(const Buffer& buffer, MatchList& matches,
+                     BufferRange range)
     {
         kak_assert(matches.size() % m_faces.size() == 0);
         using RegexIt = RegexIterator<BufferIterator>;
-        RegexIt re_it{get_iterator(buffer, range.begin),
-                      get_iterator(buffer, range.end),
-                      buffer.begin(), buffer.end(), m_regex,
-                      match_flags(is_bol(range.begin),
-                                  is_eol(buffer, range.end),
-                                  is_bow(buffer, range.begin),
-                                  is_eow(buffer, range.end))};
+        RegexIt re_it{
+            get_iterator(buffer, range.begin),
+            get_iterator(buffer, range.end),
+            buffer.begin(),
+            buffer.end(),
+            m_regex,
+            match_flags(is_bol(range.begin), is_eol(buffer, range.end),
+                        is_bow(buffer, range.begin),
+                        is_eow(buffer, range.end))};
         RegexIt re_end;
         for (; re_it != re_end; ++re_it)
         {
@@ -374,27 +398,33 @@ private:
         }
     }
 
-    const MatchList& get_matches(const Buffer& buffer, BufferRange display_range, BufferRange buffer_range)
+    const MatchList& get_matches(const Buffer& buffer,
+                                 BufferRange display_range,
+                                 BufferRange buffer_range)
     {
-        Cache& cache = m_cache.get(buffer);
+        Cache& cache  = m_cache.get(buffer);
         auto& matches = cache.m_matches;
 
-        if (cache.m_regex_version != m_regex_version or
-            cache.m_timestamp != buffer.timestamp() or
-            matches.size() > 1000)
+        if (cache.m_regex_version != m_regex_version
+            or cache.m_timestamp != buffer.timestamp() or matches.size() > 1000)
         {
             matches.clear();
-            cache.m_timestamp = buffer.timestamp();
+            cache.m_timestamp     = buffer.timestamp();
             cache.m_regex_version = m_regex_version;
         }
 
         const LineCount line_offset = 3;
-        BufferRange range{std::max<BufferCoord>(buffer_range.begin, display_range.begin.line - line_offset),
-                          std::min<BufferCoord>(buffer_range.end, display_range.end.line + line_offset)};
+        BufferRange range{
+            std::max<BufferCoord>(buffer_range.begin,
+                                  display_range.begin.line - line_offset),
+            std::min<BufferCoord>(buffer_range.end,
+                                  display_range.end.line + line_offset)};
 
-        auto it = std::upper_bound(matches.begin(), matches.end(), range.begin,
-                                   [](const BufferCoord& lhs, const Cache::RangeAndMatches& rhs)
-                                   { return lhs < rhs.range.end; });
+        auto it = std::upper_bound(
+            matches.begin(), matches.end(), range.begin,
+            [](const BufferCoord& lhs, const Cache::RangeAndMatches& rhs) {
+                return lhs < rhs.range.end;
+            });
 
         if (it == matches.end() or it->range.begin > range.end)
         {
@@ -413,22 +443,24 @@ private:
             // greatly reduces regex parsing. To change if we encounter
             // regex that do not work great with that.
             BufferRange& old_range = it->range;
-            MatchList& matches = it->matches;
+            MatchList& matches     = it->matches;
 
             // Thanks to the ensure_first_face_is_capture_0 method, we know
             // these point to the first/last matches capture 0.
             auto first_end = matches.begin()->end;
-            auto last_end = (matches.end() - m_faces.size())->end;
+            auto last_end  = (matches.end() - m_faces.size())->end;
 
             // add regex matches from new begin to old first match end
             if (range.begin < old_range.begin)
             {
-                matches.erase(matches.begin(), matches.begin() + m_faces.size());
-                size_t pivot = matches.size();
+                matches.erase(matches.begin(),
+                              matches.begin() + m_faces.size());
+                size_t pivot    = matches.size();
                 old_range.begin = range.begin;
                 add_matches(buffer, matches, {range.begin, first_end});
 
-                std::rotate(matches.begin(), matches.begin() + pivot, matches.end());
+                std::rotate(matches.begin(), matches.begin() + pivot,
+                            matches.end());
             }
             // add regex matches from old last match begin to new end
             if (old_range.end < range.end)
@@ -446,19 +478,21 @@ class DynamicRegexHighlighter : public Highlighter
 {
 public:
     DynamicRegexHighlighter(RegexGetter regex_getter, FaceGetter face_getter)
-      : Highlighter{HighlightPass::Colorize},
-        m_regex_getter(std::move(regex_getter)),
-        m_face_getter(std::move(face_getter)),
-        m_highlighter(Regex{}, FacesSpec{}) {}
+        : Highlighter{HighlightPass::Colorize},
+          m_regex_getter(std::move(regex_getter)),
+          m_face_getter(std::move(face_getter)),
+          m_highlighter(Regex{}, FacesSpec{})
+    {}
 
-    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range) override
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                      BufferRange range) override
     {
-        Regex regex = m_regex_getter(context.context);
+        Regex regex    = m_regex_getter(context.context);
         FacesSpec face = m_face_getter(context.context);
         if (regex != m_last_regex or face != m_last_face)
         {
             m_last_regex = std::move(regex);
-            m_last_face = face;
+            m_last_face  = face;
             if (not m_last_regex.empty())
                 m_highlighter.reset(m_last_regex, m_last_face);
         }
@@ -467,16 +501,17 @@ public:
     }
 
 private:
-    Regex       m_last_regex;
+    Regex m_last_regex;
     RegexGetter m_regex_getter;
 
-    FacesSpec   m_last_face;
-    FaceGetter  m_face_getter;
+    FacesSpec m_last_face;
+    FaceGetter m_face_getter;
 
     RegexHighlighter m_highlighter;
 };
 
-std::unique_ptr<Highlighter> create_dynamic_regex_highlighter(HighlighterParameters params, Highlighter*)
+std::unique_ptr<Highlighter> create_dynamic_regex_highlighter(
+    HighlighterParameters params, Highlighter*)
 {
     if (params.size() < 2)
         throw runtime_error("wrong parameter count");
@@ -486,32 +521,35 @@ std::unique_ptr<Highlighter> create_dynamic_regex_highlighter(HighlighterParamet
     {
         auto colon = find(spec, ':');
         if (colon == spec.end())
-            throw runtime_error("wrong face spec: '" + spec +
-                                 "' expected <capture>:<facespec>");
+            throw runtime_error("wrong face spec: '" + spec
+                                + "' expected <capture>:<facespec>");
         int capture = str_to_int({spec.begin(), colon});
-        faces.emplace_back(capture, String{colon+1, spec.end()});
+        faces.emplace_back(capture, String{colon + 1, spec.end()});
     }
 
-
     auto make_hl = [](auto& regex_getter, auto& face_getter) {
-        return std::make_unique<DynamicRegexHighlighter<std::decay_t<decltype(regex_getter)>,
-                                                        std::decay_t<decltype(face_getter)>>>(
+        return std::make_unique<
+            DynamicRegexHighlighter<std::decay_t<decltype(regex_getter)>,
+                                    std::decay_t<decltype(face_getter)>>>(
             std::move(regex_getter), std::move(face_getter));
     };
-    auto get_face = [faces](const Context& context){ return faces; };
+    auto get_face = [faces](const Context& context) { return faces; };
 
     CommandParser parser{params[0]};
     auto token = parser.read_token(true);
-    if (token and parser.done() and token->type == Token::Type::OptionExpand and
-        GlobalScope::instance().options()[token->content].is_of_type<Regex>())
+    if (token and parser.done() and token->type == Token::Type::OptionExpand
+        and GlobalScope::instance()
+                .options()[token->content]
+                .is_of_type<Regex>())
     {
-        auto get_regex = [option_name = token->content](const Context& context) {
-            return context.options()[option_name].get<Regex>();
-        };
+        auto get_regex
+            = [option_name = token->content](const Context& context) {
+                  return context.options()[option_name].get<Regex>();
+              };
         return make_hl(get_regex, get_face);
     }
 
-    auto get_regex = [expr = params[0]](const Context& context){
+    auto get_regex = [expr = params[0]](const Context& context) {
         try
         {
             auto re = expand(expr, context);
@@ -519,42 +557,47 @@ std::unique_ptr<Highlighter> create_dynamic_regex_highlighter(HighlighterParamet
         }
         catch (runtime_error& err)
         {
-            write_to_debug_buffer(format("Error while evaluating dynamic regex expression: {}", err.what()));
+            write_to_debug_buffer(
+                format("Error while evaluating dynamic regex expression: {}",
+                       err.what()));
             return Regex{};
         }
     };
     return make_hl(get_regex, get_face);
 }
 
-std::unique_ptr<Highlighter> create_line_highlighter(HighlighterParameters params, Highlighter*)
+std::unique_ptr<Highlighter> create_line_highlighter(
+    HighlighterParameters params, Highlighter*)
 {
     if (params.size() != 2)
         throw runtime_error("wrong parameter count");
 
-    auto func = [line_expr=params[0], facespec=params[1]]
-                (HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
-    {
+    auto func = [line_expr = params[0], facespec = params[1]](
+                    HighlightContext context, DisplayBuffer& display_buffer,
+                    BufferRange) {
         LineCount line = -1;
         try
         {
-            line = str_to_int_ifp(expand(line_expr, context.context)).value_or(0) - 1;
+            line
+                = str_to_int_ifp(expand(line_expr, context.context)).value_or(0)
+                  - 1;
         }
         catch (runtime_error& err)
         {
-            write_to_debug_buffer(
-                format("Error evaluating highlight line expression: {}", err.what()));
+            write_to_debug_buffer(format(
+                "Error evaluating highlight line expression: {}", err.what()));
         }
 
         if (line < 0)
             return;
 
-        auto it = find_if(display_buffer.lines(),
-                          [line](const DisplayLine& l)
-                          { return l.range().begin.line == line; });
+        auto it = find_if(display_buffer.lines(), [line](const DisplayLine& l) {
+            return l.range().begin.line == line;
+        });
         if (it == display_buffer.lines().end())
             return;
 
-        auto face = context.context.faces()[facespec];
+        auto face          = context.context.faces()[facespec];
         ColumnCount column = 0;
         for (auto& atom : *it)
         {
@@ -565,37 +608,42 @@ std::unique_ptr<Highlighter> create_line_highlighter(HighlighterParameters param
             kak_assert(atom.begin().line == line);
             apply_face(face)(atom);
         }
-        const ColumnCount remaining = context.context.window().dimensions().column - column;
+        const ColumnCount remaining
+            = context.context.window().dimensions().column - column;
         if (remaining > 0)
-            it->push_back({ String{' ', remaining}, face });
+            it->push_back({String{' ', remaining}, face});
     };
 
     return make_highlighter(std::move(func));
 }
 
-std::unique_ptr<Highlighter> create_column_highlighter(HighlighterParameters params, Highlighter*)
+std::unique_ptr<Highlighter> create_column_highlighter(
+    HighlighterParameters params, Highlighter*)
 {
     if (params.size() != 2)
         throw runtime_error("wrong parameter count");
 
-    auto func = [col_expr=params[0], facespec=params[1]]
-                (HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
-    {
+    auto func = [col_expr = params[0], facespec = params[1]](
+                    HighlightContext context, DisplayBuffer& display_buffer,
+                    BufferRange) {
         ColumnCount column = -1;
         try
         {
-            column = str_to_int_ifp(expand(col_expr, context.context)).value_or(0) - 1;
+            column
+                = str_to_int_ifp(expand(col_expr, context.context)).value_or(0)
+                  - 1;
         }
         catch (runtime_error& err)
         {
             write_to_debug_buffer(
-                format("Error evaluating highlight column expression: {}", err.what()));
+                format("Error evaluating highlight column expression: {}",
+                       err.what()));
         }
 
         if (column < 0)
             return;
 
-        const auto face = context.context.faces()[facespec];
+        const auto face       = context.context.faces()[facespec];
         const auto win_column = context.setup.window_pos.column;
         const auto target_col = column - win_column;
         if (target_col < 0 or target_col >= context.setup.window_range.column)
@@ -604,8 +652,9 @@ std::unique_ptr<Highlighter> create_column_highlighter(HighlighterParameters par
         for (auto& line : display_buffer.lines())
         {
             auto remaining_col = target_col;
-            bool found = false;
-            auto first_buf = find_if(line, [](auto& atom) { return atom.has_buffer_range(); });
+            bool found         = false;
+            auto first_buf     = find_if(
+                line, [](auto& atom) { return atom.has_buffer_range(); });
             for (auto atom_it = first_buf; atom_it != line.end(); ++atom_it)
             {
                 const auto atom_len = atom_it->length();
@@ -616,7 +665,7 @@ std::unique_ptr<Highlighter> create_column_highlighter(HighlighterParameters par
                     if (atom_it->length() > 1)
                         atom_it = line.split(atom_it, 1_col);
                     atom_it->face = merge_faces(atom_it->face, face);
-                    found = true;
+                    found         = true;
                     break;
                 }
                 remaining_col -= atom_len;
@@ -635,47 +684,60 @@ std::unique_ptr<Highlighter> create_column_highlighter(HighlighterParameters par
 
 struct WrapHighlighter : Highlighter
 {
-    WrapHighlighter(ColumnCount max_width, bool word_wrap, bool preserve_indent, String marker)
-        : Highlighter{HighlightPass::Wrap}, m_max_width{max_width},
-          m_word_wrap{word_wrap}, m_preserve_indent{preserve_indent},
-          m_marker{std::move(marker)} {}
+    WrapHighlighter(ColumnCount max_width, bool word_wrap, bool preserve_indent,
+                    String marker)
+        : Highlighter{HighlightPass::Wrap},
+          m_max_width{max_width},
+          m_word_wrap{word_wrap},
+          m_preserve_indent{preserve_indent},
+          m_marker{std::move(marker)}
+    {}
 
     static constexpr StringView ms_id = "wrap";
 
-    struct SplitPos{ ByteCount byte; ColumnCount column; };
+    struct SplitPos
+    {
+        ByteCount byte;
+        ColumnCount column;
+    };
 
-    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange) override
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                      BufferRange) override
     {
         if (contains(context.disabled_ids, ms_id))
             return;
 
-        const ColumnCount wrap_column = std::min(m_max_width, context.setup.window_range.column);
+        const ColumnCount wrap_column
+            = std::min(m_max_width, context.setup.window_range.column);
         if (wrap_column <= 0)
             return;
 
         const Buffer& buffer = context.context.buffer();
-        const auto& cursor = context.context.selections().main().cursor();
-        const int tabstop = context.context.options()["tabstop"].get<int>();
+        const auto& cursor   = context.context.selections().main().cursor();
+        const int tabstop    = context.context.options()["tabstop"].get<int>();
         const LineCount win_height = context.context.window().dimensions().line;
         const ColumnCount marker_len = m_marker.column_length();
         const Face face_marker = context.context.faces()["StatusLineInfo"];
         for (auto it = display_buffer.lines().begin();
              it != display_buffer.lines().end(); ++it)
         {
-            const LineCount buf_line = it->range().begin.line;
+            const LineCount buf_line    = it->range().begin.line;
             const ByteCount line_length = buffer[buf_line].length();
-            const ColumnCount indent = m_preserve_indent ? line_indent(buffer, tabstop, buf_line) : 0_col;
+            const ColumnCount indent
+                = m_preserve_indent ? line_indent(buffer, tabstop, buf_line)
+                                    : 0_col;
 
-            auto pos = next_split_pos(buffer, wrap_column, tabstop, buf_line, {0, 0});
+            auto pos = next_split_pos(buffer, wrap_column, tabstop, buf_line,
+                                      {0, 0});
             if (pos.byte == line_length)
                 continue;
 
             for (auto atom_it = it->begin();
-                 pos.byte != line_length and atom_it != it->end(); )
+                 pos.byte != line_length and atom_it != it->end();)
             {
                 const BufferCoord coord{buf_line, pos.byte};
-                if (!atom_it->has_buffer_range() or
-                    coord < atom_it->begin() or coord >= atom_it->end())
+                if (!atom_it->has_buffer_range() or coord < atom_it->begin()
+                    or coord >= atom_it->end())
                 {
                     ++atom_it;
                     continue;
@@ -686,7 +748,7 @@ struct WrapHighlighter : Highlighter
                 if (coord > atom_it->begin())
                     atom_it = ++line.split(atom_it, coord);
 
-                DisplayLine new_line{ AtomList{ atom_it, line.end() } };
+                DisplayLine new_line{AtomList{atom_it, line.end()}};
                 line.erase(atom_it, line.end());
 
                 ColumnCount prefix_len = 0;
@@ -697,53 +759,64 @@ struct WrapHighlighter : Highlighter
                 }
                 if (indent > marker_len and indent < wrap_column)
                 {
-                    auto it = new_line.insert(new_line.begin() + (marker_len > 0), {buffer, coord, coord});
+                    auto it
+                        = new_line.insert(new_line.begin() + (marker_len > 0),
+                                          {buffer, coord, coord});
                     it->replace(String{' ', indent - marker_len});
                     prefix_len = indent;
                 }
 
-                if (it+1 - display_buffer.lines().begin() == win_height)
+                if (it + 1 - display_buffer.lines().begin() == win_height)
                 {
-                    if (cursor >= new_line.range().begin) // strip first lines if cursor is not visible
+                    if (cursor
+                        >= new_line.range().begin) // strip first lines if
+                                                   // cursor is not visible
                     {
-                        display_buffer.lines().erase(display_buffer.lines().begin(), display_buffer.lines().begin()+1);
+                        display_buffer.lines().erase(
+                            display_buffer.lines().begin(),
+                            display_buffer.lines().begin() + 1);
                         --it;
                     }
                     else
                     {
-                        display_buffer.lines().erase(it+1, display_buffer.lines().end());
+                        display_buffer.lines().erase(
+                            it + 1, display_buffer.lines().end());
                         return;
                     }
                 }
-                it = display_buffer.lines().insert(it+1, new_line);
+                it = display_buffer.lines().insert(it + 1, new_line);
 
-                pos = next_split_pos(buffer, wrap_column - prefix_len, tabstop, buf_line, pos);
+                pos = next_split_pos(buffer, wrap_column - prefix_len, tabstop,
+                                     buf_line, pos);
                 atom_it = it->begin();
             }
         }
     }
 
-    void do_compute_display_setup(HighlightContext context, DisplaySetup& setup) const override
+    void do_compute_display_setup(HighlightContext context,
+                                  DisplaySetup& setup) const override
     {
         if (contains(context.disabled_ids, ms_id))
             return;
 
-        const ColumnCount wrap_column = std::min(setup.window_range.column, m_max_width);
+        const ColumnCount wrap_column
+            = std::min(setup.window_range.column, m_max_width);
         if (wrap_column <= 0)
             return;
 
         const Buffer& buffer = context.context.buffer();
-        const auto& cursor = context.context.selections().main().cursor();
-        const int tabstop = context.context.options()["tabstop"].get<int>();
+        const auto& cursor   = context.context.selections().main().cursor();
+        const int tabstop    = context.context.options()["tabstop"].get<int>();
 
         auto line_wrap_count = [&](LineCount line, ColumnCount indent) {
-            LineCount count = 0;
+            LineCount count             = 0;
             const ByteCount line_length = buffer[line].length();
             SplitPos pos{0, 0};
             while (true)
             {
-                pos = next_split_pos(buffer, wrap_column - (pos.byte == 0 ? 0_col : indent),
-                                     tabstop, line, pos);
+                pos = next_split_pos(
+                    buffer, wrap_column - (pos.byte == 0 ? 0_col : indent),
+                    tabstop, line, pos);
                 if (pos.byte == line_length)
                     break;
                 ++count;
@@ -754,10 +827,10 @@ struct WrapHighlighter : Highlighter
         const auto win_height = context.context.window().dimensions().line;
 
         // Disable horizontal scrolling when using a WrapHighlighter
-        setup.window_pos.column = 0;
-        setup.window_range.line = 0;
+        setup.window_pos.column    = 0;
+        setup.window_range.line    = 0;
         setup.scroll_offset.column = 0;
-        setup.full_lines = true;
+        setup.full_lines           = true;
 
         const ColumnCount marker_len = m_marker.column_length();
 
@@ -768,7 +841,9 @@ struct WrapHighlighter : Highlighter
             if (buf_line >= buffer.line_count())
                 break;
 
-            const ColumnCount indent = m_preserve_indent ? line_indent(buffer, tabstop, buf_line) : 0_col;
+            const ColumnCount indent
+                = m_preserve_indent ? line_indent(buffer, tabstop, buf_line)
+                                    : 0_col;
 
             ColumnCount prefix_len = 0;
             if (marker_len < wrap_column)
@@ -781,29 +856,37 @@ struct WrapHighlighter : Highlighter
                 SplitPos pos{0, 0};
                 for (LineCount count = 0; true; ++count)
                 {
-                    auto next_pos = next_split_pos(buffer, wrap_column - (pos.byte != 0 ? prefix_len : 0_col),
-                                                   tabstop, buf_line, pos);
+                    auto next_pos = next_split_pos(
+                        buffer,
+                        wrap_column - (pos.byte != 0 ? prefix_len : 0_col),
+                        tabstop, buf_line, pos);
                     if (next_pos.byte > cursor.column)
                     {
                         setup.cursor_pos = DisplayCoord{
                             win_line + count,
-                            get_column(buffer, tabstop, cursor) -
-                            pos.column + (pos.byte != 0 ? indent : 0_col)
-                        };
+                            get_column(buffer, tabstop, cursor) - pos.column
+                                + (pos.byte != 0 ? indent : 0_col)};
                         break;
                     }
                     pos = next_pos;
                 }
-                kak_assert(setup.cursor_pos.column >= 0 and setup.cursor_pos.column < setup.window_range.column);
+                kak_assert(setup.cursor_pos.column >= 0
+                           and setup.cursor_pos.column
+                                   < setup.window_range.column);
             }
             const auto wrap_count = line_wrap_count(buf_line, prefix_len);
             win_line += wrap_count + 1;
 
-            // scroll window to keep cursor visible, and update range as lines gets removed
-            while (buf_line >= cursor.line and setup.window_pos.line < cursor.line and
-                   setup.cursor_pos.line + setup.scroll_offset.line >= win_height)
+            // scroll window to keep cursor visible, and update range as lines
+            // gets removed
+            while (buf_line >= cursor.line
+                   and setup.window_pos.line < cursor.line
+                   and setup.cursor_pos.line + setup.scroll_offset.line
+                           >= win_height)
             {
-                auto remove_count = std::min(win_height, 1 + line_wrap_count(setup.window_pos.line, indent));
+                auto remove_count = std::min(
+                    win_height,
+                    1 + line_wrap_count(setup.window_pos.line, indent));
                 ++setup.window_pos.line;
                 --setup.window_range.line;
                 setup.cursor_pos.line -= remove_count;
@@ -818,20 +901,24 @@ struct WrapHighlighter : Highlighter
         unique_ids.push_back(ms_id);
     }
 
-    SplitPos next_split_pos(const Buffer& buffer,  ColumnCount wrap_column, int tabstop, LineCount line, SplitPos current) const
+    SplitPos next_split_pos(const Buffer& buffer, ColumnCount wrap_column,
+                            int tabstop, LineCount line, SplitPos current) const
     {
         const ColumnCount target_column = current.column + wrap_column;
-        StringView content = buffer[line];
+        StringView content              = buffer[line];
 
-        SplitPos pos = current;
+        SplitPos pos           = current;
         SplitPos last_boundary = {0, 0};
 
         while (pos.byte < content.length() and pos.column < target_column)
         {
             if (content[pos.byte] == '\t')
             {
-                const ColumnCount next_column = (pos.column / tabstop + 1) * tabstop;
-                if (next_column > target_column and pos.byte != current.byte) // the target column was in the tab
+                const ColumnCount next_column
+                    = (pos.column / tabstop + 1) * tabstop;
+                if (next_column > target_column
+                    and pos.byte
+                            != current.byte) // the target column was in the tab
                     break;
                 pos.column = next_column;
                 ++pos.byte;
@@ -839,10 +926,13 @@ struct WrapHighlighter : Highlighter
             }
             else
             {
-                const char* it = &content[pos.byte];
+                const char* it     = &content[pos.byte];
                 const Codepoint cp = utf8::read_codepoint(it, content.end());
                 const ColumnCount width = codepoint_width(cp);
-                if (pos.column + width > target_column and pos.byte != current.byte) // the target column was in the char
+                if (pos.column + width > target_column
+                    and pos.byte
+                            != current
+                                   .byte) // the target column was in the char
                 {
                     if (!is_word<WORD>(cp))
                         last_boundary = pos;
@@ -855,40 +945,45 @@ struct WrapHighlighter : Highlighter
             }
         }
 
-        if (m_word_wrap and pos.byte < content.length()) // find a word boundary before current position
+        if (m_word_wrap
+            and pos.byte < content.length()) // find a word boundary before
+                                             // current position
             if (last_boundary.byte > 0)
                 pos = last_boundary;
 
         return pos;
     };
 
-    ColumnCount line_indent(const Buffer& buffer, int tabstop, LineCount line) const
+    ColumnCount line_indent(const Buffer& buffer, int tabstop,
+                            LineCount line) const
     {
         StringView l = buffer[line];
-        auto col = 0_byte;
+        auto col     = 0_byte;
         while (is_horizontal_blank(l[col]))
-               ++col;
+            ++col;
         return get_column(buffer, tabstop, {line, col});
     }
 
-    static std::unique_ptr<Highlighter> create(HighlighterParameters params, Highlighter*)
+    static std::unique_ptr<Highlighter> create(HighlighterParameters params,
+                                               Highlighter*)
     {
-        static const ParameterDesc param_desc{
-            { { "word", { false, "" } },
-              { "indent", { false, "" } },
-              { "width", { true, "" } },
-              { "marker", { true, "" } } },
-            ParameterDesc::Flags::None, 0, 0
-        };
+        static const ParameterDesc param_desc{{{"word", {false, ""}},
+                                               {"indent", {false, ""}},
+                                               {"width", {true, ""}},
+                                               {"marker", {true, ""}}},
+                                              ParameterDesc::Flags::None,
+                                              0,
+                                              0};
         ParametersParser parser(params, param_desc);
 
         ColumnCount max_width{std::numeric_limits<int>::max()};
         if (auto width = parser.get_switch("width"))
             max_width = str_to_int(*width);
 
-        return std::make_unique<WrapHighlighter>(max_width, (bool)parser.get_switch("word"),
-                                                 (bool)parser.get_switch("indent"),
-                                                 parser.get_switch("marker").value_or("").str());
+        return std::make_unique<WrapHighlighter>(
+            max_width, (bool)parser.get_switch("word"),
+            (bool)parser.get_switch("indent"),
+            parser.get_switch("marker").value_or("").str());
     }
 
     const bool m_word_wrap;
@@ -903,10 +998,12 @@ struct TabulationHighlighter : Highlighter
 {
     TabulationHighlighter() : Highlighter{HighlightPass::Move} {}
 
-    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange) override
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                      BufferRange) override
     {
-        const ColumnCount tabstop = context.context.options()["tabstop"].get<int>();
-        auto& buffer = context.context.buffer();
+        const ColumnCount tabstop
+            = context.context.options()["tabstop"].get<int>();
+        auto& buffer    = context.context.buffer();
         auto win_column = context.setup.window_pos.column;
         for (auto& line : display_buffer.lines())
         {
@@ -916,19 +1013,21 @@ struct TabulationHighlighter : Highlighter
                     continue;
 
                 auto begin = get_iterator(buffer, atom_it->begin());
-                auto end = get_iterator(buffer, atom_it->end());
+                auto end   = get_iterator(buffer, atom_it->end());
                 for (BufferIterator it = begin; it != end; ++it)
                 {
                     if (*it == '\t')
                     {
                         if (it != begin)
                             atom_it = ++line.split(atom_it, it.coord());
-                        if (it+1 != end)
-                            atom_it = line.split(atom_it, (it+1).coord());
+                        if (it + 1 != end)
+                            atom_it = line.split(atom_it, (it + 1).coord());
 
-                        const ColumnCount column = get_column(buffer, tabstop, it.coord());
-                        const ColumnCount count = tabstop - (column % tabstop) -
-                                                  std::max(win_column - column, 0_col);
+                        const ColumnCount column
+                            = get_column(buffer, tabstop, it.coord());
+                        const ColumnCount count
+                            = tabstop - (column % tabstop)
+                              - std::max(win_column - column, 0_col);
                         atom_it->replace(String{' ', count});
                         break;
                     }
@@ -937,18 +1036,22 @@ struct TabulationHighlighter : Highlighter
         }
     }
 
-    void do_compute_display_setup(HighlightContext context, DisplaySetup& setup) const override
+    void do_compute_display_setup(HighlightContext context,
+                                  DisplaySetup& setup) const override
     {
         auto& buffer = context.context.buffer();
-        // Ensure that a cursor on a tab character makes the full tab character visible
+        // Ensure that a cursor on a tab character makes the full tab character
+        // visible
         auto cursor = context.context.selections().main().cursor();
         if (buffer.byte_at(cursor) != '\t')
             return;
 
-        const ColumnCount tabstop = context.context.options()["tabstop"].get<int>();
+        const ColumnCount tabstop
+            = context.context.options()["tabstop"].get<int>();
         const ColumnCount column = get_column(buffer, tabstop, cursor);
-        const ColumnCount width = tabstop - (column % tabstop);
-        const ColumnCount win_end = setup.window_pos.column + setup.window_range.column;
+        const ColumnCount width  = tabstop - (column % tabstop);
+        const ColumnCount win_end
+            = setup.window_pos.column + setup.window_range.column;
         const ColumnCount offset = std::max(column + width - win_end, 0_col);
 
         setup.window_pos.column += offset;
@@ -958,42 +1061,51 @@ struct TabulationHighlighter : Highlighter
 
 struct ShowWhitespacesHighlighter : Highlighter
 {
-    ShowWhitespacesHighlighter(String tab, String tabpad, String spc, String lf, String nbsp)
-      : Highlighter{HighlightPass::Move}, m_tab{std::move(tab)}, m_tabpad{std::move(tabpad)},
-        m_spc{std::move(spc)}, m_lf{std::move(lf)}, m_nbsp{std::move(nbsp)}
+    ShowWhitespacesHighlighter(String tab, String tabpad, String spc, String lf,
+                               String nbsp)
+        : Highlighter{HighlightPass::Move},
+          m_tab{std::move(tab)},
+          m_tabpad{std::move(tabpad)},
+          m_spc{std::move(spc)},
+          m_lf{std::move(lf)},
+          m_nbsp{std::move(nbsp)}
     {}
 
-    static std::unique_ptr<Highlighter> create(HighlighterParameters params, Highlighter*)
+    static std::unique_ptr<Highlighter> create(HighlighterParameters params,
+                                               Highlighter*)
     {
-        static const ParameterDesc param_desc{
-            { { "tab", { true, "" } },
-              { "tabpad", { true, "" } },
-              { "spc", { true, "" } },
-              { "lf", { true, "" } },
-              { "nbsp", { true, "" } } },
-            ParameterDesc::Flags::None, 0, 0
-        };
+        static const ParameterDesc param_desc{{{"tab", {true, ""}},
+                                               {"tabpad", {true, ""}},
+                                               {"spc", {true, ""}},
+                                               {"lf", {true, ""}},
+                                               {"nbsp", {true, ""}}},
+                                              ParameterDesc::Flags::None,
+                                              0,
+                                              0};
         ParametersParser parser(params, param_desc);
 
-        auto get_param = [&](StringView param,  StringView fallback) {
+        auto get_param = [&](StringView param, StringView fallback) {
             StringView value = parser.get_switch(param).value_or(fallback);
             if (value.char_length() != 1)
-                throw runtime_error{format("-{} expects a single character parameter", param)};
+                throw runtime_error{
+                    format("-{} expects a single character parameter", param)};
             return value.str();
         };
 
         return std::make_unique<ShowWhitespacesHighlighter>(
-            get_param("tab", "→"), get_param("tabpad", " "), get_param("spc", "·"),
-            get_param("lf", "¬"), get_param("nbsp", "⍽"));
+            get_param("tab", "→"), get_param("tabpad", " "),
+            get_param("spc", "·"), get_param("lf", "¬"),
+            get_param("nbsp", "⍽"));
     }
 
 private:
-    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                      BufferRange)
     {
-        const int tabstop = context.context.options()["tabstop"].get<int>();
+        const int tabstop   = context.context.options()["tabstop"].get<int>();
         auto whitespaceface = context.context.faces()["Whitespace"];
-        auto& buffer = context.context.buffer();
-        auto win_column = context.setup.window_pos.column;
+        auto& buffer        = context.context.buffer();
+        auto win_column     = context.setup.window_pos.column;
         for (auto& line : display_buffer.lines())
         {
             for (auto atom_it = line.begin(); atom_it != line.end(); ++atom_it)
@@ -1002,10 +1114,10 @@ private:
                     continue;
 
                 auto begin = get_iterator(buffer, atom_it->begin());
-                auto end = get_iterator(buffer, atom_it->end());
-                for (BufferIterator it = begin; it != end; )
+                auto end   = get_iterator(buffer, atom_it->end());
+                for (BufferIterator it = begin; it != end;)
                 {
-                    auto coord = it.coord();
+                    auto coord   = it.coord();
                     Codepoint cp = utf8::read_codepoint(it, end);
                     if (cp == '\t' or cp == ' ' or cp == '\n' or cp == 0xA0)
                     {
@@ -1016,10 +1128,15 @@ private:
 
                         if (cp == '\t')
                         {
-                            const ColumnCount column = get_column(buffer, tabstop, coord);
-                            const ColumnCount count = tabstop - (column % tabstop) -
-                                                      std::max(win_column - column, 0_col);
-                            atom_it->replace(m_tab + String(m_tabpad[(CharCount)0], count - m_tab.column_length()));
+                            const ColumnCount column
+                                = get_column(buffer, tabstop, coord);
+                            const ColumnCount count
+                                = tabstop - (column % tabstop)
+                                  - std::max(win_column - column, 0_col);
+                            atom_it->replace(
+                                m_tab
+                                + String(m_tabpad[(CharCount)0],
+                                         count - m_tab.column_length()));
                         }
                         else if (cp == ' ')
                             atom_it->replace(m_spc);
@@ -1027,7 +1144,8 @@ private:
                             atom_it->replace(m_lf);
                         else if (cp == 0xA0)
                             atom_it->replace(m_nbsp);
-                        atom_it->face = merge_faces(atom_it->face, whitespaceface);
+                        atom_it->face
+                            = merge_faces(atom_it->face, whitespaceface);
                         break;
                     }
                 }
@@ -1041,56 +1159,66 @@ private:
 struct LineNumbersHighlighter : Highlighter
 {
     LineNumbersHighlighter(bool relative, bool hl_cursor_line, String separator)
-      : Highlighter{HighlightPass::Move},
-        m_relative{relative},
-        m_hl_cursor_line{hl_cursor_line},
-        m_separator{std::move(separator)} {}
+        : Highlighter{HighlightPass::Move},
+          m_relative{relative},
+          m_hl_cursor_line{hl_cursor_line},
+          m_separator{std::move(separator)}
+    {}
 
-    static std::unique_ptr<Highlighter> create(HighlighterParameters params, Highlighter*)
+    static std::unique_ptr<Highlighter> create(HighlighterParameters params,
+                                               Highlighter*)
     {
-        static const ParameterDesc param_desc{
-            { { "relative", { false, "" } },
-              { "separator", { true, "" } },
-              { "hlcursor", { false, "" } } },
-            ParameterDesc::Flags::None, 0, 0
-        };
+        static const ParameterDesc param_desc{{{"relative", {false, ""}},
+                                               {"separator", {true, ""}},
+                                               {"hlcursor", {false, ""}}},
+                                              ParameterDesc::Flags::None,
+                                              0,
+                                              0};
         ParametersParser parser(params, param_desc);
 
         StringView separator = parser.get_switch("separator").value_or("│");
         if (separator.length() > 10)
             throw runtime_error("separator length is limited to 10 bytes");
 
-        return std::make_unique<LineNumbersHighlighter>((bool)parser.get_switch("relative"), (bool)parser.get_switch("hlcursor"), separator.str());
+        return std::make_unique<LineNumbersHighlighter>(
+            (bool)parser.get_switch("relative"),
+            (bool)parser.get_switch("hlcursor"), separator.str());
     }
 
 private:
     static constexpr StringView ms_id = "line-numbers";
 
-    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange) override
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                      BufferRange) override
     {
         if (contains(context.disabled_ids, ms_id))
             return;
 
-        auto& faces = context.context.faces();
-        const Face face = faces["LineNumbers"];
-        const Face face_wrapped = faces["LineNumbersWrapped"];
+        auto& faces              = context.context.faces();
+        const Face face          = faces["LineNumbers"];
+        const Face face_wrapped  = faces["LineNumbersWrapped"];
         const Face face_absolute = faces["LineNumberCursor"];
-        int digit_count = compute_digit_count(context.context);
+        int digit_count          = compute_digit_count(context.context);
 
         char format[16];
         format_to(format, "%{}d", digit_count);
-        const int main_line = (int)context.context.selections().main().cursor().line + 1;
+        const int main_line
+            = (int)context.context.selections().main().cursor().line + 1;
         int last_line = -1;
         for (auto& line : display_buffer.lines())
         {
-            const int current_line = (int)line.range().begin.line + 1;
+            const int current_line    = (int)line.range().begin.line + 1;
             const bool is_cursor_line = main_line == current_line;
-            const int line_to_format = (m_relative and not is_cursor_line) ?
-                                       current_line - main_line : current_line;
+            const int line_to_format  = (m_relative and not is_cursor_line)
+                                           ? current_line - main_line
+                                           : current_line;
             char buffer[16];
             snprintf(buffer, 16, format, std::abs(line_to_format));
-            const auto atom_face = last_line == current_line ? face_wrapped :
-                ((m_hl_cursor_line and is_cursor_line) ? face_absolute : face);
+            const auto atom_face
+                = last_line == current_line
+                      ? face_wrapped
+                      : ((m_hl_cursor_line and is_cursor_line) ? face_absolute
+                                                               : face);
             line.insert(line.begin(), {buffer, atom_face});
             line.insert(line.begin() + 1, {m_separator, face});
 
@@ -1098,12 +1226,14 @@ private:
         }
     }
 
-    void do_compute_display_setup(HighlightContext context, DisplaySetup& setup) const override
+    void do_compute_display_setup(HighlightContext context,
+                                  DisplaySetup& setup) const override
     {
         if (contains(context.disabled_ids, ms_id))
             return;
 
-        ColumnCount width = compute_digit_count(context.context) + m_separator.column_length();
+        ColumnCount width = compute_digit_count(context.context)
+                            + m_separator.column_length();
         setup.window_range.column -= std::min(width, setup.window_range.column);
     }
 
@@ -1114,26 +1244,28 @@ private:
 
     int compute_digit_count(const Context& context) const
     {
-        int digit_count = 0;
+        int digit_count     = 0;
         LineCount last_line = context.buffer().line_count();
         for (LineCount c = last_line; c > 0; c /= 10)
             ++digit_count;
         return digit_count;
     }
 
-   const bool m_relative;
-   const bool m_hl_cursor_line;
-   const String m_separator;
+    const bool m_relative;
+    const bool m_hl_cursor_line;
+    const String m_separator;
 };
 
 constexpr StringView LineNumbersHighlighter::ms_id;
 
-
-void show_matching_char(HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
+void show_matching_char(HighlightContext context, DisplayBuffer& display_buffer,
+                        BufferRange)
 {
     const Face face = context.context.faces()["MatchingChar"];
-    const auto& matching_pairs = context.context.options()["matching_pairs"].get<Vector<Codepoint, MemoryDomain::Options>>();
-    const auto range = display_buffer.range();
+    const auto& matching_pairs
+        = context.context.options()["matching_pairs"]
+              .get<Vector<Codepoint, MemoryDomain::Options>>();
+    const auto range   = display_buffer.range();
     const auto& buffer = context.context.buffer();
     for (auto& sel : context.context.selections())
     {
@@ -1151,15 +1283,16 @@ void show_matching_char(HighlightContext context, DisplayBuffer& display_buffer,
         if (((match - matching_pairs.begin()) % 2) == 0)
         {
             const Codepoint opening = *match;
-            const Codepoint closing = *(match+1);
+            const Codepoint closing = *(match + 1);
             while (it != buffer.end())
             {
                 if (*it == opening)
                     ++level;
                 else if (*it == closing and --level == 0)
                 {
-                    highlight_range(display_buffer, it.base().coord(), (it+1).base().coord(),
-                                    false, apply_face(face));
+                    highlight_range(display_buffer, it.base().coord(),
+                                    (it + 1).base().coord(), false,
+                                    apply_face(face));
                     break;
                 }
                 ++it;
@@ -1167,7 +1300,7 @@ void show_matching_char(HighlightContext context, DisplayBuffer& display_buffer,
         }
         else if (pos > range.begin)
         {
-            const Codepoint opening = *(match-1);
+            const Codepoint opening = *(match - 1);
             const Codepoint closing = *match;
             while (true)
             {
@@ -1175,8 +1308,9 @@ void show_matching_char(HighlightContext context, DisplayBuffer& display_buffer,
                     ++level;
                 else if (*it == opening and --level == 0)
                 {
-                    highlight_range(display_buffer, it.base().coord(), (it+1).base().coord(),
-                                    false, apply_face(face));
+                    highlight_range(display_buffer, it.base().coord(),
+                                    (it + 1).base().coord(), false,
+                                    apply_face(face));
                     break;
                 }
                 if (it == buffer.begin())
@@ -1187,28 +1321,32 @@ void show_matching_char(HighlightContext context, DisplayBuffer& display_buffer,
     }
 }
 
-std::unique_ptr<Highlighter> create_matching_char_highlighter(HighlighterParameters params, Highlighter*)
+std::unique_ptr<Highlighter> create_matching_char_highlighter(
+    HighlighterParameters params, Highlighter*)
 {
     return make_highlighter(show_matching_char);
 }
 
-void highlight_selections(HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
+void highlight_selections(HighlightContext context,
+                          DisplayBuffer& display_buffer, BufferRange)
 {
-    const auto& buffer = context.context.buffer();
-    const auto& faces = context.context.faces();
+    const auto& buffer      = context.context.buffer();
+    const auto& faces       = context.context.faces();
     const Face sel_faces[6] = {
-            faces["PrimarySelection"], faces["SecondarySelection"],
-            faces["PrimaryCursor"],    faces["SecondaryCursor"],
-            faces["PrimaryCursorEol"], faces["SecondaryCursorEol"],
+        faces["PrimarySelection"], faces["SecondarySelection"],
+        faces["PrimaryCursor"],    faces["SecondaryCursor"],
+        faces["PrimaryCursorEol"], faces["SecondaryCursorEol"],
     };
 
     const auto& selections = context.context.selections();
     for (size_t i = 0; i < selections.size(); ++i)
     {
-        auto& sel = selections[i];
+        auto& sel          = selections[i];
         const bool forward = sel.anchor() <= sel.cursor();
-        BufferCoord begin = forward ? sel.anchor() : buffer.char_next(sel.cursor());
-        BufferCoord end   = forward ? (BufferCoord)sel.cursor() : buffer.char_next(sel.anchor());
+        BufferCoord begin
+            = forward ? sel.anchor() : buffer.char_next(sel.cursor());
+        BufferCoord end = forward ? (BufferCoord)sel.cursor()
+                                  : buffer.char_next(sel.anchor());
 
         const bool primary = (i == selections.main_index());
         highlight_range(display_buffer, begin, end, false,
@@ -1216,19 +1354,21 @@ void highlight_selections(HighlightContext context, DisplayBuffer& display_buffe
     }
     for (size_t i = 0; i < selections.size(); ++i)
     {
-        auto& sel = selections[i];
+        auto& sel               = selections[i];
         const BufferCoord coord = sel.cursor();
-        const bool primary = (i == selections.main_index());
+        const bool primary      = (i == selections.main_index());
         const bool eol = buffer[coord.line].length() - 1 == coord.column;
-        highlight_range(display_buffer, coord, buffer.char_next(coord), false,
-                        apply_face(sel_faces[2 + (eol ? 2 : 0) + (primary ? 0 : 1)]));
+        highlight_range(
+            display_buffer, coord, buffer.char_next(coord), false,
+            apply_face(sel_faces[2 + (eol ? 2 : 0) + (primary ? 0 : 1)]));
     }
 }
 
-void expand_unprintable(HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
+void expand_unprintable(HighlightContext context, DisplayBuffer& display_buffer,
+                        BufferRange)
 {
     auto& buffer = context.context.buffer();
-    auto error = context.context.faces()["Error"];
+    auto error   = context.context.faces()["Error"];
     for (auto& line : display_buffer.lines())
     {
         for (auto atom_it = line.begin(); atom_it != line.end(); ++atom_it)
@@ -1236,9 +1376,10 @@ void expand_unprintable(HighlightContext context, DisplayBuffer& display_buffer,
             if (atom_it->type() == DisplayAtom::Range)
             {
                 for (auto it  = get_iterator(buffer, atom_it->begin()),
-                          end = get_iterator(buffer, atom_it->end()); it < end;)
+                          end = get_iterator(buffer, atom_it->end());
+                     it < end;)
                 {
-                    auto coord = it.coord();
+                    auto coord   = it.coord();
                     Codepoint cp = utf8::read_codepoint(it, end);
                     if (cp != '\n' and not iswprint((wchar_t)cp))
                     {
@@ -1257,25 +1398,29 @@ void expand_unprintable(HighlightContext context, DisplayBuffer& display_buffer,
     }
 }
 
-static void update_line_specs_ifn(const Buffer& buffer, LineAndSpecList& line_flags)
+static void update_line_specs_ifn(const Buffer& buffer,
+                                  LineAndSpecList& line_flags)
 {
     if (line_flags.prefix == buffer.timestamp())
         return;
 
     auto& lines = line_flags.list;
 
-    auto modifs = compute_line_modifications(buffer, line_flags.prefix);
+    auto modifs  = compute_line_modifications(buffer, line_flags.prefix);
     auto ins_pos = lines.begin();
     for (auto it = lines.begin(); it != lines.end(); ++it)
     {
-        auto& line = std::get<0>(*it); // that line is 1 based as it comes from user side
-        auto modif_it = std::upper_bound(modifs.begin(), modifs.end(), line-1,
-                                         [](const LineCount& l, const LineModification& c)
-                                         { return l < c.old_line; });
+        auto& line = std::get<0>(
+            *it); // that line is 1 based as it comes from user side
+        auto modif_it = std::upper_bound(
+            modifs.begin(), modifs.end(), line - 1,
+            [](const LineCount& l, const LineModification& c) {
+                return l < c.old_line;
+            });
         if (modif_it != modifs.begin())
         {
-            auto& prev = *(modif_it-1);
-            if (line-1 < prev.old_line + prev.num_removed)
+            auto& prev = *(modif_it - 1);
+            if (line - 1 < prev.old_line + prev.num_removed)
                 continue; // line removed
 
             line += prev.diff();
@@ -1296,9 +1441,9 @@ void option_update(LineAndSpecList& opt, const Context& context)
 
 void option_list_postprocess(Vector<LineAndSpec, MemoryDomain::Options>& opt)
 {
-    std::sort(opt.begin(), opt.end(),
-              [](auto& lhs, auto& rhs)
-              { return std::get<0>(lhs) < std::get<0>(rhs); });
+    std::sort(opt.begin(), opt.end(), [](auto& lhs, auto& rhs) {
+        return std::get<0>(lhs) < std::get<0>(rhs);
+    });
 }
 
 struct FlagLinesHighlighter : Highlighter
@@ -1306,26 +1451,31 @@ struct FlagLinesHighlighter : Highlighter
     FlagLinesHighlighter(String option_name, String default_face)
         : Highlighter{HighlightPass::Move},
           m_option_name{std::move(option_name)},
-          m_default_face{std::move(default_face)} {}
+          m_default_face{std::move(default_face)}
+    {}
 
-    static std::unique_ptr<Highlighter> create(HighlighterParameters params, Highlighter*)
+    static std::unique_ptr<Highlighter> create(HighlighterParameters params,
+                                               Highlighter*)
     {
         if (params.size() != 2)
             throw runtime_error("wrong parameter count");
 
-        const String& option_name = params[1];
+        const String& option_name  = params[1];
         const String& default_face = params[0];
 
         // throw if wrong option type
         GlobalScope::instance().options()[option_name].get<LineAndSpecList>();
 
-        return std::make_unique<FlagLinesHighlighter>(option_name, default_face);
+        return std::make_unique<FlagLinesHighlighter>(option_name,
+                                                      default_face);
     }
 
 private:
-    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange) override
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                      BufferRange) override
     {
-        auto& line_flags = context.context.options()[m_option_name].get_mutable<LineAndSpecList>();
+        auto& line_flags = context.context.options()[m_option_name]
+                               .get_mutable<LineAndSpecList>();
         auto& buffer = context.context.buffer();
         update_line_specs_ifn(buffer, line_flags);
 
@@ -1336,36 +1486,40 @@ private:
         {
             for (auto& line : lines)
             {
-                display_lines.push_back(parse_display_line(std::get<1>(line), context.context.faces()));
+                display_lines.push_back(parse_display_line(
+                    std::get<1>(line), context.context.faces()));
                 for (auto& atom : display_lines.back())
                     atom.face = merge_faces(def_face, atom.face);
             }
         }
         catch (runtime_error& err)
         {
-            write_to_debug_buffer(format("Error while evaluating line flag: {}", err.what()));
+            write_to_debug_buffer(
+                format("Error while evaluating line flag: {}", err.what()));
             return;
         }
 
         ColumnCount width = 0;
         for (auto& l : display_lines)
-             width = std::max(width, l.length());
+            width = std::max(width, l.length());
         const DisplayAtom empty{String{' ', width}, def_face};
         for (auto& line : display_buffer.lines())
         {
             int line_num = (int)line.range().begin.line + 1;
-            auto it = find_if(lines,
-                              [&](const LineAndSpec& l)
-                              { return std::get<0>(l) == line_num; });
+            auto it      = find_if(lines, [&](const LineAndSpec& l) {
+                return std::get<0>(l) == line_num;
+            });
             if (it == lines.end())
                 line.insert(line.begin(), empty);
             else
             {
                 DisplayLine& display_line = display_lines[it - lines.begin()];
-                DisplayAtom padding_atom{String(' ', width - display_line.length()), def_face};
-                auto it = std::copy(std::make_move_iterator(display_line.begin()),
-                                    std::make_move_iterator(display_line.end()),
-                                    std::inserter(line, line.begin()));
+                DisplayAtom padding_atom{
+                    String(' ', width - display_line.length()), def_face};
+                auto it
+                    = std::copy(std::make_move_iterator(display_line.begin()),
+                                std::make_move_iterator(display_line.end()),
+                                std::inserter(line, line.begin()));
 
                 if (padding_atom.length() != 0)
                     *it++ = std::move(padding_atom);
@@ -1373,9 +1527,11 @@ private:
         }
     }
 
-    void do_compute_display_setup(HighlightContext context, DisplaySetup& setup) const override
+    void do_compute_display_setup(HighlightContext context,
+                                  DisplaySetup& setup) const override
     {
-        auto& line_flags = context.context.options()[m_option_name].get_mutable<LineAndSpecList>();
+        auto& line_flags = context.context.options()[m_option_name]
+                               .get_mutable<LineAndSpecList>();
         auto& buffer = context.context.buffer();
         update_line_specs_ifn(buffer, line_flags);
 
@@ -1383,11 +1539,15 @@ private:
         try
         {
             for (auto& line : line_flags.list)
-                width = std::max(parse_display_line(std::get<1>(line), context.context.faces()).length(), width);
+                width = std::max(parse_display_line(std::get<1>(line),
+                                                    context.context.faces())
+                                     .length(),
+                                 width);
         }
         catch (runtime_error& err)
         {
-            write_to_debug_buffer(format("Error while evaluating line flag: {}", err.what()));
+            write_to_debug_buffer(
+                format("Error while evaluating line flag: {}", err.what()));
             return;
         }
 
@@ -1400,33 +1560,37 @@ private:
 
 String option_to_string(InclusiveBufferRange range)
 {
-    return format("{}.{},{}.{}",
-                  range.first.line+1, range.first.column+1,
-                  range.last.line+1, range.last.column+1);
+    return format("{}.{},{}.{}", range.first.line + 1, range.first.column + 1,
+                  range.last.line + 1, range.last.column + 1);
 }
 
-InclusiveBufferRange option_from_string(Meta::Type<InclusiveBufferRange>, StringView str)
+InclusiveBufferRange option_from_string(Meta::Type<InclusiveBufferRange>,
+                                        StringView str)
 {
-    auto sep = find_if(str, [](char c){ return c == ',' or c == '+'; });
+    auto sep     = find_if(str, [](char c) { return c == ',' or c == '+'; });
     auto dot_beg = find(StringView{str.begin(), sep}, '.');
     auto dot_end = find(StringView{sep, str.end()}, '.');
 
-    if (sep == str.end() or dot_beg == sep or
-        (*sep == ',' and dot_end == str.end()))
-        throw runtime_error(format("'{}' does not follow <line>.<column>,<line>.<column> or <line>.<column>+<len> format", str));
+    if (sep == str.end() or dot_beg == sep
+        or (*sep == ',' and dot_end == str.end()))
+        throw runtime_error(
+            format("'{}' does not follow <line>.<column>,<line>.<column> or "
+                   "<line>.<column>+<len> format",
+                   str));
 
     const BufferCoord first{str_to_int({str.begin(), dot_beg}) - 1,
-                            str_to_int({dot_beg+1, sep}) - 1};
+                            str_to_int({dot_beg + 1, sep}) - 1};
 
     const bool len = (*sep == '+');
-    const BufferCoord last{len ? first.line : str_to_int({sep+1, dot_end}) - 1,
-                           len ? first.column + str_to_int({sep+1, str.end()}) - 1
-                               : str_to_int({dot_end+1, str.end()}) - 1 };
+    const BufferCoord last{
+        len ? first.line : str_to_int({sep + 1, dot_end}) - 1,
+        len ? first.column + str_to_int({sep + 1, str.end()}) - 1
+            : str_to_int({dot_end + 1, str.end()}) - 1};
 
     if (first.line < 0 or first.column < 0 or last.line < 0 or last.column < 0)
         throw runtime_error("coordinates elements should be >= 1");
 
-    return { std::min(first, last), std::max(first, last) };
+    return {std::min(first, last), std::max(first, last)};
 }
 
 BufferCoord& get_first(RangeAndString& r) { return std::get<0>(r).first; }
@@ -1434,11 +1598,10 @@ BufferCoord& get_last(RangeAndString& r) { return std::get<0>(r).last; }
 
 void option_list_postprocess(Vector<RangeAndString, MemoryDomain::Options>& opt)
 {
-    std::sort(opt.begin(), opt.end(),
-              [](auto& lhs, auto& rhs) {
-        return std::get<0>(lhs).first == std::get<0>(rhs).first ?
-            std::get<0>(lhs).last < std::get<0>(rhs).last
-          : std::get<0>(lhs).first < std::get<0>(rhs).first;
+    std::sort(opt.begin(), opt.end(), [](auto& lhs, auto& rhs) {
+        return std::get<0>(lhs).first == std::get<0>(rhs).first
+                   ? std::get<0>(lhs).last < std::get<0>(rhs).last
+                   : std::get<0>(lhs).first < std::get<0>(rhs).first;
     });
 }
 
@@ -1450,26 +1613,32 @@ void option_update(RangeAndStringList& opt, const Context& context)
 struct RangesHighlighter : Highlighter
 {
     RangesHighlighter(String option_name)
-        : Highlighter{HighlightPass::Colorize}
-        , m_option_name{std::move(option_name)} {}
+        : Highlighter{HighlightPass::Colorize},
+          m_option_name{std::move(option_name)}
+    {}
 
-    static std::unique_ptr<Highlighter> create(HighlighterParameters params, Highlighter*)
+    static std::unique_ptr<Highlighter> create(HighlighterParameters params,
+                                               Highlighter*)
     {
         if (params.size() != 1)
             throw runtime_error("wrong parameter count");
 
         const String& option_name = params[0];
         // throw if wrong option type
-        GlobalScope::instance().options()[option_name].get<RangeAndStringList>();
+        GlobalScope::instance()
+            .options()[option_name]
+            .get<RangeAndStringList>();
 
         return std::make_unique<RangesHighlighter>(option_name);
     }
 
 private:
-    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange) override
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                      BufferRange) override
     {
-        auto& buffer = context.context.buffer();
-        auto& range_and_faces = context.context.options()[m_option_name].get_mutable<RangeAndStringList>();
+        auto& buffer          = context.context.buffer();
+        auto& range_and_faces = context.context.options()[m_option_name]
+                                    .get_mutable<RangeAndStringList>();
         update_ranges(buffer, range_and_faces.prefix, range_and_faces.list);
 
         for (auto& range : range_and_faces.list)
@@ -1477,9 +1646,13 @@ private:
             try
             {
                 auto& r = std::get<0>(range);
-                if (buffer.is_valid(r.first) and (buffer.is_valid(r.last) and not buffer.is_end(r.last)))
-                    highlight_range(display_buffer, r.first, buffer.char_next(r.last), false,
-                                    apply_face(context.context.faces()[std::get<1>(range)]));
+                if (buffer.is_valid(r.first)
+                    and (buffer.is_valid(r.last) and not buffer.is_end(r.last)))
+                    highlight_range(
+                        display_buffer, r.first, buffer.char_next(r.last),
+                        false,
+                        apply_face(
+                            context.context.faces()[std::get<1>(range)]));
             }
             catch (runtime_error&)
             {}
@@ -1492,26 +1665,32 @@ private:
 struct ReplaceRangesHighlighter : Highlighter
 {
     ReplaceRangesHighlighter(String option_name)
-        : Highlighter{HighlightPass::Colorize}
-        , m_option_name{std::move(option_name)} {}
+        : Highlighter{HighlightPass::Colorize},
+          m_option_name{std::move(option_name)}
+    {}
 
-    static std::unique_ptr<Highlighter> create(HighlighterParameters params, Highlighter*)
+    static std::unique_ptr<Highlighter> create(HighlighterParameters params,
+                                               Highlighter*)
     {
         if (params.size() != 1)
             throw runtime_error("wrong parameter count");
 
         const String& option_name = params[0];
         // throw if wrong option type
-        GlobalScope::instance().options()[option_name].get<RangeAndStringList>();
+        GlobalScope::instance()
+            .options()[option_name]
+            .get<RangeAndStringList>();
 
         return std::make_unique<ReplaceRangesHighlighter>(option_name);
     }
 
 private:
-    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange) override
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                      BufferRange) override
     {
-        auto& buffer = context.context.buffer();
-        auto& range_and_faces = context.context.options()[m_option_name].get_mutable<RangeAndStringList>();
+        auto& buffer          = context.context.buffer();
+        auto& range_and_faces = context.context.options()[m_option_name]
+                                    .get_mutable<RangeAndStringList>();
         update_ranges(buffer, range_and_faces.prefix, range_and_faces.list);
 
         for (auto& range : range_and_faces.list)
@@ -1521,13 +1700,16 @@ private:
                 auto& r = std::get<0>(range);
                 if (buffer.is_valid(r.first) and buffer.is_valid(r.last))
                 {
-                    auto replacement = parse_display_line(std::get<1>(range), context.context.faces());
-                    replace_range(display_buffer, r.first, buffer.char_next(r.last),
-                                  [&](DisplayLine& line, int beg_idx, int end_idx){
-                                      auto it = line.erase(line.begin() + beg_idx, line.begin() + end_idx);
-                                      for (auto& atom : replacement)
-                                          it = ++line.insert(it, std::move(atom));
-                                  });
+                    auto replacement = parse_display_line(
+                        std::get<1>(range), context.context.faces());
+                    replace_range(
+                        display_buffer, r.first, buffer.char_next(r.last),
+                        [&](DisplayLine& line, int beg_idx, int end_idx) {
+                            auto it = line.erase(line.begin() + beg_idx,
+                                                 line.begin() + end_idx);
+                            for (auto& atom : replacement)
+                                it = ++line.insert(it, std::move(atom));
+                        });
                 }
             }
             catch (runtime_error&)
@@ -1558,14 +1740,17 @@ HighlightPass parse_passes(StringView str)
     return passes;
 }
 
-std::unique_ptr<Highlighter> create_highlighter_group(HighlighterParameters params, Highlighter*)
+std::unique_ptr<Highlighter> create_highlighter_group(
+    HighlighterParameters params, Highlighter*)
 {
     static const ParameterDesc param_desc{
-        { { "passes", { true, "" } } },
-        ParameterDesc::Flags::SwitchesOnlyAtStart, 0, 0
-    };
+        {{"passes", {true, ""}}},
+        ParameterDesc::Flags::SwitchesOnlyAtStart,
+        0,
+        0};
     ParametersParser parser{params, param_desc};
-    HighlightPass passes = parse_passes(parser.get_switch("passes").value_or("colorize"));
+    HighlightPass passes
+        = parse_passes(parser.get_switch("passes").value_or("colorize"));
 
     return std::make_unique<HighlighterGroup>(passes);
 }
@@ -1573,43 +1758,53 @@ std::unique_ptr<Highlighter> create_highlighter_group(HighlighterParameters para
 struct ReferenceHighlighter : Highlighter
 {
     ReferenceHighlighter(HighlightPass passes, String name)
-        : Highlighter{passes}, m_name{std::move(name)} {}
+        : Highlighter{passes}, m_name{std::move(name)}
+    {}
 
-    static std::unique_ptr<Highlighter> create(HighlighterParameters params, Highlighter*)
+    static std::unique_ptr<Highlighter> create(HighlighterParameters params,
+                                               Highlighter*)
     {
         static const ParameterDesc param_desc{
-            { { "passes", { true, "" } } },
-            ParameterDesc::Flags::SwitchesOnlyAtStart, 1, 1
-        };
+            {{"passes", {true, ""}}},
+            ParameterDesc::Flags::SwitchesOnlyAtStart,
+            1,
+            1};
         ParametersParser parser{params, param_desc};
-        HighlightPass passes = parse_passes(parser.get_switch("passes").value_or("colorize"));
+        HighlightPass passes
+            = parse_passes(parser.get_switch("passes").value_or("colorize"));
         return std::make_unique<ReferenceHighlighter>(passes, parser[0]);
     }
 
 private:
-    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range) override
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                      BufferRange range) override
     {
         static Vector<std::pair<StringView, BufferRange>> running_refs;
         const std::pair<StringView, BufferRange> desc{m_name, range};
         if (contains(running_refs, desc))
-            return write_to_debug_buffer(format("highlighting recursion detected with ref to {}", m_name));
+            return write_to_debug_buffer(format(
+                "highlighting recursion detected with ref to {}", m_name));
 
         running_refs.push_back(desc);
         auto pop_desc = on_scope_end([] { running_refs.pop_back(); });
 
         try
         {
-            DefinedHighlighters::instance().get_child(m_name).highlight(context, display_buffer, range);
+            DefinedHighlighters::instance().get_child(m_name).highlight(
+                context, display_buffer, range);
         }
         catch (child_not_found&)
         {}
     }
 
-    void do_compute_display_setup(HighlightContext context, DisplaySetup& setup) const override
+    void do_compute_display_setup(HighlightContext context,
+                                  DisplaySetup& setup) const override
     {
         try
         {
-            DefinedHighlighters::instance().get_child(m_name).compute_display_setup(context, setup);
+            DefinedHighlighters::instance()
+                .get_child(m_name)
+                .compute_display_setup(context, setup);
         }
         catch (child_not_found&)
         {}
@@ -1626,8 +1821,8 @@ struct RegexMatch
     uint16_t capture_pos;
     uint16_t capture_len;
 
-    BufferCoord begin_coord() const { return { line, begin }; }
-    BufferCoord end_coord() const { return { line, end }; }
+    BufferCoord begin_coord() const { return {line, begin}; }
+    BufferCoord end_coord() const { return {line, end}; }
     bool empty() const { return begin == end; }
 
     StringView capture(const Buffer& buffer) const
@@ -1639,63 +1834,72 @@ struct RegexMatch
 };
 
 using RegexMatchList = Vector<RegexMatch, MemoryDomain::Regions>;
-void append_matches(const Buffer& buffer, LineCount line, RegexMatchList& matches, const Regex& regex, bool capture)
+void append_matches(const Buffer& buffer, LineCount line,
+                    RegexMatchList& matches, const Regex& regex, bool capture)
 {
     auto l = buffer[line];
-    for (RegexIterator<const char*> it{l.begin(), l.end(), regex}, end{}; it != end; ++it)
+    for (RegexIterator<const char*> it{l.begin(), l.end(), regex}, end{};
+         it != end; ++it)
     {
         auto& m = *it;
-        const bool with_capture = capture and m[1].matched and
-                                  m[0].second - m[0].first < std::numeric_limits<uint16_t>::max();
-        matches.push_back({
-            line,
-            (int)(m[0].first - l.begin()),
-            (int)(m[0].second - l.begin()),
-            (uint16_t)(with_capture ? m[1].first - m[0].first : 0),
-            (uint16_t)(with_capture ? m[1].second - m[1].first : 0)
-        });
+        const bool with_capture
+            = capture and m[1].matched
+              and m[0].second - m[0].first
+                      < std::numeric_limits<uint16_t>::max();
+        matches.push_back(
+            {line, (int)(m[0].first - l.begin()),
+             (int)(m[0].second - l.begin()),
+             (uint16_t)(with_capture ? m[1].first - m[0].first : 0),
+             (uint16_t)(with_capture ? m[1].second - m[1].first : 0)});
     }
 }
 
-void insert_matches(const Buffer& buffer, RegexMatchList& matches, const Regex& regex, bool capture, LineRange range)
+void insert_matches(const Buffer& buffer, RegexMatchList& matches,
+                    const Regex& regex, bool capture, LineRange range)
 {
     size_t pivot = matches.size();
-    capture = capture and regex.mark_count() > 0;
+    capture      = capture and regex.mark_count() > 0;
     for (auto line = range.begin; line < range.end; ++line)
         append_matches(buffer, line, matches, regex, capture);
 
-    auto pos = std::lower_bound(matches.begin(), matches.begin() + pivot, range.begin,
-                                [](const RegexMatch& m, LineCount l) { return m.line < l; });
-    kak_assert(pos == matches.begin() + pivot or pos->line >= range.end); // We should not have had matches for range
+    auto pos = std::lower_bound(
+        matches.begin(), matches.begin() + pivot, range.begin,
+        [](const RegexMatch& m, LineCount l) { return m.line < l; });
+    kak_assert(pos == matches.begin() + pivot
+               or pos->line
+                      >= range.end); // We should not have had matches for range
 
     // Move new matches into position.
     std::rotate(pos, matches.begin() + pivot, matches.end());
 }
 
-void update_matches(const Buffer& buffer, ConstArrayView<LineModification> modifs,
+void update_matches(const Buffer& buffer,
+                    ConstArrayView<LineModification> modifs,
                     RegexMatchList& matches)
 {
     // remove out of date matches and update line for others
     auto ins_pos = matches.begin();
     for (auto it = ins_pos; it != matches.end(); ++it)
     {
-        auto modif_it = std::upper_bound(modifs.begin(), modifs.end(), it->line,
-                                         [](const LineCount& l, const LineModification& c)
-                                         { return l < c.old_line; });
+        auto modif_it = std::upper_bound(
+            modifs.begin(), modifs.end(), it->line,
+            [](const LineCount& l, const LineModification& c) {
+                return l < c.old_line;
+            });
 
         if (modif_it != modifs.begin())
         {
-            auto& prev = *(modif_it-1);
+            auto& prev = *(modif_it - 1);
             if (it->line < prev.old_line + prev.num_removed)
                 continue; // match removed
 
             it->line += prev.diff();
         }
 
-        kak_assert(buffer.is_valid(it->begin_coord()) or
-                   buffer[it->line].length() == it->begin);
-        kak_assert(buffer.is_valid(it->end_coord()) or
-                   buffer[it->line].length() == it->end);
+        kak_assert(buffer.is_valid(it->begin_coord())
+                   or buffer[it->line].length() == it->begin);
+        kak_assert(buffer.is_valid(it->end_coord())
+                   or buffer[it->line].length() == it->end);
 
         if (ins_pos != it)
             *ins_pos = std::move(*it);
@@ -1717,14 +1921,16 @@ struct RegionMatches : UseMemoryDomain<MemoryDomain::Highlight>
 
     RegexMatchList::const_iterator find_next_begin(BufferCoord pos) const
     {
-        return std::lower_bound(begin_matches.begin(), begin_matches.end(),
-                                pos, compare_to_begin);
+        return std::lower_bound(begin_matches.begin(), begin_matches.end(), pos,
+                                compare_to_begin);
     }
 
-    RegexMatchList::const_iterator find_matching_end(const Buffer& buffer, BufferCoord beg_pos, Optional<StringView> capture) const
+    RegexMatchList::const_iterator find_matching_end(
+        const Buffer& buffer, BufferCoord beg_pos,
+        Optional<StringView> capture) const
     {
-        auto end_it = end_matches.begin();
-        auto rec_it = recurse_matches.begin();
+        auto end_it       = end_matches.begin();
+        auto rec_it       = recurse_matches.begin();
         int recurse_level = 0;
         while (true)
         {
@@ -1736,8 +1942,8 @@ struct RegionMatches : UseMemoryDomain<MemoryDomain::Highlight>
             if (end_it == end_matches.end())
                 return end_it;
 
-            while (rec_it != recurse_matches.end() and
-                   rec_it->end_coord() <= end_it->end_coord())
+            while (rec_it != recurse_matches.end()
+                   and rec_it->end_coord() <= end_it->end_coord())
             {
                 if (not capture or rec_it->capture(buffer) == *capture)
                     ++recurse_level;
@@ -1761,53 +1967,53 @@ struct RegionMatches : UseMemoryDomain<MemoryDomain::Highlight>
 struct RegionsHighlighter : public Highlighter
 {
 public:
-    RegionsHighlighter()
-        : Highlighter{HighlightPass::Colorize} {}
+    RegionsHighlighter() : Highlighter{HighlightPass::Colorize} {}
 
-    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range) override
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer,
+                      BufferRange range) override
     {
         if (m_regions.empty())
             return;
 
         auto display_range = display_buffer.range();
         const auto& buffer = context.context.buffer();
-        auto& regions = get_regions_for_range(buffer, range);
+        auto& regions      = get_regions_for_range(buffer, range);
 
-        auto begin = std::lower_bound(regions.begin(), regions.end(), display_range.begin,
-                                      [](const Region& r, BufferCoord c) { return r.end < c; });
-        auto end = std::lower_bound(begin, regions.end(), display_range.end,
-                                    [](const Region& r, BufferCoord c) { return r.begin < c; });
+        auto begin = std::lower_bound(
+            regions.begin(), regions.end(), display_range.begin,
+            [](const Region& r, BufferCoord c) { return r.end < c; });
+        auto end = std::lower_bound(
+            begin, regions.end(), display_range.end,
+            [](const Region& r, BufferCoord c) { return r.begin < c; });
         auto correct = [&](BufferCoord c) -> BufferCoord {
             if (not buffer.is_end(c) and buffer[c.line].length() == c.column)
-                return {c.line+1, 0};
+                return {c.line + 1, 0};
             return c;
         };
 
-        auto default_region_it = m_regions.find(m_default_region);
+        auto default_region_it   = m_regions.find(m_default_region);
         const bool apply_default = default_region_it != m_regions.end();
 
-        auto last_begin = (begin == regions.begin()) ?
-                             BufferCoord{0,0} : (begin-1)->end;
+        auto last_begin
+            = (begin == regions.begin()) ? BufferCoord{0, 0} : (begin - 1)->end;
         kak_assert(begin <= end);
         for (; begin != end; ++begin)
         {
             if (apply_default and last_begin < begin->begin)
-                apply_highlighter(context, display_buffer,
-                                  correct(last_begin), correct(begin->begin),
+                apply_highlighter(context, display_buffer, correct(last_begin),
+                                  correct(begin->begin),
                                   *default_region_it->value);
 
             auto it = m_regions.find(begin->region);
             if (it == m_regions.end())
                 continue;
-            apply_highlighter(context, display_buffer,
-                              correct(begin->begin), correct(begin->end),
-                              *it->value);
+            apply_highlighter(context, display_buffer, correct(begin->begin),
+                              correct(begin->end), *it->value);
             last_begin = begin->end;
         }
         if (apply_default and last_begin < display_range.end)
-            apply_highlighter(context, display_buffer,
-                              correct(last_begin), range.end,
-                              *default_region_it->value);
+            apply_highlighter(context, display_buffer, correct(last_begin),
+                              range.end, *default_region_it->value);
     }
 
     bool has_children() const override { return true; }
@@ -1822,17 +2028,20 @@ public:
         if (sep_it == path.end())
             return *it->value;
         else
-            return it->value->get_child({sep_it+1, path.end()});
+            return it->value->get_child({sep_it + 1, path.end()});
     }
 
     void add_child(String name, std::unique_ptr<Highlighter>&& hl) override
     {
         if (not dynamic_cast<RegionHighlighter*>(hl.get()))
-            throw runtime_error{"only region highlighter can be added as child of a regions highlighter"};
+            throw runtime_error{
+                "only region highlighter can be added as child of a regions "
+                "highlighter"};
         if (m_regions.contains(name))
             throw runtime_error{format("duplicate id: '{}'", name)};
 
-        std::unique_ptr<RegionHighlighter> region_hl{dynamic_cast<RegionHighlighter*>(hl.release())};
+        std::unique_ptr<RegionHighlighter> region_hl{
+            dynamic_cast<RegionHighlighter*>(hl.release())};
         if (region_hl->is_default())
         {
             if (not m_default_region.empty())
@@ -1853,21 +2062,26 @@ public:
         ++m_regions_timestamp;
     }
 
-    Completions complete_child(StringView path, ByteCount cursor_pos, bool group) const override
+    Completions complete_child(StringView path, ByteCount cursor_pos,
+                               bool group) const override
     {
         auto sep_it = find(path, '/');
         if (sep_it != path.end())
         {
-            ByteCount offset = sep_it+1 - path.begin();
-            Highlighter& hl = const_cast<RegionsHighlighter*>(this)->get_child({path.begin(), sep_it});
-            return offset_pos(hl.complete_child(path.substr(offset), cursor_pos - offset, group), offset);
+            ByteCount offset = sep_it + 1 - path.begin();
+            Highlighter& hl  = const_cast<RegionsHighlighter*>(this)->get_child(
+                {path.begin(), sep_it});
+            return offset_pos(hl.complete_child(path.substr(offset),
+                                                cursor_pos - offset, group),
+                              offset);
         }
 
         auto container = m_regions | transform(&decltype(m_regions)::Item::key);
-        return { 0, 0, complete(path, cursor_pos, container) };
+        return {0, 0, complete(path, cursor_pos, container)};
     }
 
-    static std::unique_ptr<Highlighter> create(HighlighterParameters params, Highlighter*)
+    static std::unique_ptr<Highlighter> create(HighlighterParameters params,
+                                               Highlighter*)
     {
         if (not params.empty())
             throw runtime_error{"unexpected parameters"};
@@ -1883,16 +2097,18 @@ public:
         return false;
     }
 
-    static std::unique_ptr<Highlighter> create_region(HighlighterParameters params, Highlighter* parent)
+    static std::unique_ptr<Highlighter> create_region(
+        HighlighterParameters params, Highlighter* parent)
     {
         if (not is_regions(parent))
-            throw runtime_error{"region highlighter can only be added to a regions parent"};
+            throw runtime_error{
+                "region highlighter can only be added to a regions parent"};
 
         static const ParameterDesc param_desc{
-            { { "match-capture", { false, "" } }, { "recurse", { true, "" } } },
-            ParameterDesc::Flags::SwitchesOnlyAtStart | ParameterDesc::Flags::IgnoreUnknownSwitches,
-            3
-        };
+            {{"match-capture", {false, ""}}, {"recurse", {true, ""}}},
+            ParameterDesc::Flags::SwitchesOnlyAtStart
+                | ParameterDesc::Flags::IgnoreUnknownSwitches,
+            3};
 
         ParametersParser parser{params, param_desc};
 
@@ -1900,12 +2116,14 @@ public:
         if (parser[0].empty() or parser[1].empty())
             throw runtime_error("begin and end must not be empty");
 
-        const RegexCompileFlags flags = match_capture ?
-            RegexCompileFlags::Optimize : RegexCompileFlags::NoSubs | RegexCompileFlags::Optimize;
+        const RegexCompileFlags flags
+            = match_capture
+                  ? RegexCompileFlags::Optimize
+                  : RegexCompileFlags::NoSubs | RegexCompileFlags::Optimize;
 
         const auto& type = parser[2];
-        auto& registry = HighlighterRegistry::instance();
-        auto it = registry.find(type);
+        auto& registry   = HighlighterRegistry::instance();
+        auto it          = registry.find(type);
         if (it == registry.end())
             throw runtime_error(format("no such highlighter type: '{}'", type));
 
@@ -1914,18 +2132,25 @@ public:
             recurse = Regex{*recurse_switch, flags};
 
         auto delegate = it->value.factory(parser.positionals_from(3), nullptr);
-        return std::make_unique<RegionHighlighter>(std::move(delegate), Regex{parser[0], flags}, Regex{parser[1], flags}, recurse, match_capture);
+        return std::make_unique<RegionHighlighter>(
+            std::move(delegate), Regex{parser[0], flags},
+            Regex{parser[1], flags}, recurse, match_capture);
     }
 
-    static std::unique_ptr<Highlighter> create_default_region(HighlighterParameters params, Highlighter* parent)
+    static std::unique_ptr<Highlighter> create_default_region(
+        HighlighterParameters params, Highlighter* parent)
     {
         if (not is_regions(parent))
-            throw runtime_error{"default-region highlighter can only be added to a regions parent"};
+            throw runtime_error{
+                "default-region highlighter can only be added to a regions "
+                "parent"};
 
-        static const ParameterDesc param_desc{ {}, ParameterDesc::Flags::SwitchesOnlyAtStart, 1 };
+        static const ParameterDesc param_desc{
+            {}, ParameterDesc::Flags::SwitchesOnlyAtStart, 1};
         ParametersParser parser{params, param_desc};
 
-        auto delegate = HighlighterRegistry::instance()[parser[0]].factory(parser.positionals_from(1), nullptr);
+        auto delegate = HighlighterRegistry::instance()[parser[0]].factory(
+            parser.positionals_from(1), nullptr);
         return std::make_unique<RegionHighlighter>(std::move(delegate));
     }
 
@@ -1940,7 +2165,7 @@ private:
 
     struct Cache
     {
-        size_t buffer_timestamp = 0;
+        size_t buffer_timestamp  = 0;
         size_t regions_timestamp = 0;
         LineRangeSet ranges;
         std::unique_ptr<RegionMatches[]> matches;
@@ -1956,10 +2181,10 @@ private:
         for (size_t i = 1; i < m_regions.size(); ++i)
         {
             const auto& matches = cache.matches[i];
-            auto it = matches.find_next_begin(pos);
-            if (it != matches.begin_matches.end() and
-                (res.second == cache.matches[res.first].begin_matches.end() or
-                 it->begin_coord() < res.second->begin_coord()))
+            auto it             = matches.find_next_begin(pos);
+            if (it != matches.begin_matches.end()
+                and (res.second == cache.matches[res.first].begin_matches.end()
+                     or it->begin_coord() < res.second->begin_coord()))
                 res = RegionAndMatch{i, it};
         }
         return res;
@@ -1968,17 +2193,18 @@ private:
     bool update_matches(Cache& cache, const Buffer& buffer, LineRange range)
     {
         const size_t buffer_timestamp = buffer.timestamp();
-        if (cache.buffer_timestamp == 0 or
-            cache.regions_timestamp != m_regions_timestamp)
+        if (cache.buffer_timestamp == 0
+            or cache.regions_timestamp != m_regions_timestamp)
         {
             cache.matches.reset(new RegionMatches[m_regions.size()]);
             for (size_t i = 0; i < m_regions.size(); ++i)
             {
                 cache.matches[i] = RegionMatches{};
-                m_regions.item(i).value->add_matches(buffer, range, cache.matches[i]);
+                m_regions.item(i).value->add_matches(buffer, range,
+                                                     cache.matches[i]);
             }
             cache.ranges.reset(range);
-            cache.buffer_timestamp = buffer_timestamp;
+            cache.buffer_timestamp  = buffer_timestamp;
             cache.regions_timestamp = m_regions_timestamp;
             return true;
         }
@@ -1987,34 +2213,42 @@ private:
             bool modified = false;
             if (cache.buffer_timestamp != buffer_timestamp)
             {
-                auto modifs = compute_line_modifications(buffer, cache.buffer_timestamp);
+                auto modifs = compute_line_modifications(
+                    buffer, cache.buffer_timestamp);
                 for (size_t i = 0; i < m_regions.size(); ++i)
                 {
-                    Kakoune::update_matches(buffer, modifs, cache.matches[i].begin_matches);
-                    Kakoune::update_matches(buffer, modifs, cache.matches[i].end_matches);
-                    Kakoune::update_matches(buffer, modifs, cache.matches[i].recurse_matches);
+                    Kakoune::update_matches(buffer, modifs,
+                                            cache.matches[i].begin_matches);
+                    Kakoune::update_matches(buffer, modifs,
+                                            cache.matches[i].end_matches);
+                    Kakoune::update_matches(buffer, modifs,
+                                            cache.matches[i].recurse_matches);
                 }
 
                 cache.ranges.update(modifs);
                 cache.buffer_timestamp = buffer_timestamp;
-                modified = true;
+                modified               = true;
             }
 
             cache.ranges.add_range(range, [&, this](const LineRange& range) {
                 if (range.begin == range.end)
                     return;
                 for (size_t i = 0; i < m_regions.size(); ++i)
-                    m_regions.item(i).value->add_matches(buffer, range, cache.matches[i]);
+                    m_regions.item(i).value->add_matches(buffer, range,
+                                                         cache.matches[i]);
                 modified = true;
             });
             return modified;
         }
     }
 
-    const RegionList& get_regions_for_range(const Buffer& buffer, BufferRange range)
+    const RegionList& get_regions_for_range(const Buffer& buffer,
+                                            BufferRange range)
     {
         Cache& cache = m_cache.get(buffer);
-        if (update_matches(cache, buffer, {range.begin.line, std::min(buffer.line_count(), range.end.line + 1)}))
+        if (update_matches(cache, buffer,
+                           {range.begin.line,
+                            std::min(buffer.line_count(), range.end.line + 1)}))
             cache.regions.clear();
 
         auto it = cache.regions.find(range);
@@ -2024,25 +2258,27 @@ private:
         RegionList& regions = cache.regions[range];
 
         for (auto begin = find_next_begin(cache, range.begin),
-                  end = RegionAndMatch{ 0, cache.matches[0].begin_matches.end() };
-             begin != end; )
+                  end = RegionAndMatch{0, cache.matches[0].begin_matches.end()};
+             begin != end;)
         {
             const RegionMatches& matches = cache.matches[begin.first];
-            auto& region = m_regions.item(begin.first);
-            auto beg_it = begin.second;
-            auto end_it = matches.find_matching_end(buffer, beg_it->end_coord(),
-                                                    region.value->match_capture() ? beg_it->capture(buffer) : Optional<StringView>{});
+            auto& region                 = m_regions.item(begin.first);
+            auto beg_it                  = begin.second;
+            auto end_it                  = matches.find_matching_end(
+                buffer, beg_it->end_coord(),
+                region.value->match_capture() ? beg_it->capture(buffer)
+                                              : Optional<StringView>{});
 
-            if (end_it == matches.end_matches.end() or end_it->end_coord() >= range.end)
+            if (end_it == matches.end_matches.end()
+                or end_it->end_coord() >= range.end)
             {
-                regions.push_back({ {beg_it->line, beg_it->begin},
-                                    range.end,
-                                    region.key });
+                regions.push_back(
+                    {{beg_it->line, beg_it->begin}, range.end, region.key});
                 break;
             }
 
             auto end_coord = end_it->end_coord();
-            regions.push_back({ beg_it->begin_coord(), end_coord, region.key });
+            regions.push_back({beg_it->begin_coord(), end_coord, region.key});
 
             // With empty begin and end matches (for example if the regexes
             // are /"\K/ and /(?=")/), that case can happen, and would
@@ -2059,20 +2295,21 @@ private:
 
     struct RegionHighlighter : public Highlighter
     {
-        RegionHighlighter(std::unique_ptr<Highlighter>&& delegate,
-                          Regex begin, Regex end, Regex recurse,
-                          bool match_capture)
+        RegionHighlighter(std::unique_ptr<Highlighter>&& delegate, Regex begin,
+                          Regex end, Regex recurse, bool match_capture)
             : Highlighter{delegate->passes()},
               m_delegate{std::move(delegate)},
-              m_begin{std::move(begin)}, m_end{std::move(end)}, m_recurse{std::move(recurse)},
+              m_begin{std::move(begin)},
+              m_end{std::move(end)},
+              m_recurse{std::move(recurse)},
               m_match_capture{match_capture}
-       {
-       }
+        {}
 
         RegionHighlighter(std::unique_ptr<Highlighter>&& delegate)
-            : Highlighter{delegate->passes()}, m_delegate{std::move(delegate)}, m_default{true}
-       {
-       }
+            : Highlighter{delegate->passes()},
+              m_delegate{std::move(delegate)},
+              m_default{true}
+        {}
 
         bool has_children() const override
         {
@@ -2094,7 +2331,8 @@ private:
             return m_delegate->remove_child(id);
         }
 
-        Completions complete_child(StringView path, ByteCount cursor_pos, bool group) const override
+        Completions complete_child(StringView path, ByteCount cursor_pos,
+                                   bool group) const override
         {
             return m_delegate->complete_child(path, cursor_pos, group);
         }
@@ -2104,20 +2342,26 @@ private:
             return m_delegate->fill_unique_ids(unique_ids);
         }
 
-        void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range) override
+        void do_highlight(HighlightContext context,
+                          DisplayBuffer& display_buffer,
+                          BufferRange range) override
         {
             return m_delegate->highlight(context, display_buffer, range);
         }
 
-        void add_matches(const Buffer& buffer, LineRange range, RegionMatches& matches) const
+        void add_matches(const Buffer& buffer, LineRange range,
+                         RegionMatches& matches) const
         {
             if (m_default)
                 return;
 
-            Kakoune::insert_matches(buffer, matches.begin_matches, m_begin, m_match_capture, range);
-            Kakoune::insert_matches(buffer, matches.end_matches, m_end, m_match_capture, range);
+            Kakoune::insert_matches(buffer, matches.begin_matches, m_begin,
+                                    m_match_capture, range);
+            Kakoune::insert_matches(buffer, matches.end_matches, m_end,
+                                    m_match_capture, range);
             if (not m_recurse.empty())
-                Kakoune::insert_matches(buffer, matches.recurse_matches, m_recurse, m_match_capture, range);
+                Kakoune::insert_matches(buffer, matches.recurse_matches,
+                                        m_recurse, m_match_capture, range);
         }
 
         bool match_capture() const { return m_match_capture; }
@@ -2131,11 +2375,12 @@ private:
         Regex m_begin;
         Regex m_end;
         Regex m_recurse;
-        bool  m_match_capture = false;
-        bool  m_default = false;
+        bool m_match_capture = false;
+        bool m_default       = false;
     };
 
-    HashMap<String, std::unique_ptr<RegionHighlighter>, MemoryDomain::Highlight> m_regions;
+    HashMap<String, std::unique_ptr<RegionHighlighter>, MemoryDomain::Highlight>
+        m_regions;
     String m_default_region;
 
     size_t m_regions_timestamp = 0;
@@ -2144,116 +2389,127 @@ private:
 
 void setup_builtin_highlighters(HighlighterGroup& group)
 {
-    group.add_child("tabulations"_str, std::make_unique<TabulationHighlighter>());
+    group.add_child("tabulations"_str,
+                    std::make_unique<TabulationHighlighter>());
     group.add_child("unprintable"_str, make_highlighter(expand_unprintable));
-    group.add_child("selections"_str,  make_highlighter(highlight_selections));
+    group.add_child("selections"_str, make_highlighter(highlight_selections));
 }
 
 void register_highlighters()
 {
     HighlighterRegistry& registry = HighlighterRegistry::instance();
 
-    registry.insert({
-        "number-lines",
-        { LineNumbersHighlighter::create,
+    registry.insert(
+        {"number-lines",
+         {LineNumbersHighlighter::create,
           "Display line numbers \n"
-          "Parameters: -relative, -hlcursor, -separator <separator text>\n" } });
-    registry.insert({
-        "show-matching",
-        { create_matching_char_highlighter,
-          "Apply the MatchingChar face to the char matching the one under the cursor" } });
-    registry.insert({
-        "show-whitespaces",
-        { ShowWhitespacesHighlighter::create,
-          "Display whitespaces using symbols \n"
-          "Parameters: -tab <separator> -tabpad <separator> -lf <separator> -spc <separator> -nbsp <separator>\n" } });
-    registry.insert({
-        "fill",
-        { create_fill_highlighter,
-          "Fill the whole highlighted range with the given face" } });
-    registry.insert({
-        "regex",
-        { RegexHighlighter::create,
+          "Parameters: -relative, -hlcursor, -separator <separator text>\n"}});
+    registry.insert({"show-matching",
+                     {create_matching_char_highlighter,
+                      "Apply the MatchingChar face to the char matching the "
+                      "one under the cursor"}});
+    registry.insert({"show-whitespaces",
+                     {ShowWhitespacesHighlighter::create,
+                      "Display whitespaces using symbols \n"
+                      "Parameters: -tab <separator> -tabpad <separator> -lf "
+                      "<separator> -spc <separator> -nbsp <separator>\n"}});
+    registry.insert({"fill",
+                     {create_fill_highlighter,
+                      "Fill the whole highlighted range with the given face"}});
+    registry.insert(
+        {"regex",
+         {RegexHighlighter::create,
           "Parameters: <regex> <capture num>:<face> <capture num>:<face>...\n"
-          "Highlights the matches for captures from the regex with the given faces" } });
-    registry.insert({
-        "dynregex",
-        { create_dynamic_regex_highlighter,
+          "Highlights the matches for captures from the regex with the given "
+          "faces"}});
+    registry.insert(
+        {"dynregex",
+         {create_dynamic_regex_highlighter,
           "Parameters: <expr> <capture num>:<face> <capture num>:<face>...\n"
-          "Evaluate expression at every redraw to gather a regex" } });
-    registry.insert({
-        "group",
-        { create_highlighter_group,
+          "Evaluate expression at every redraw to gather a regex"}});
+    registry.insert(
+        {"group",
+         {create_highlighter_group,
           "Parameters: [-passes <passes>]\n"
           "Creates a group that can contain other highlighters,\n"
           "<passes> is a flags(colorize|move|wrap) defaulting to colorize\n"
-          "which specify what kind of highlighters can be put in the group" } });
-    registry.insert({
-        "flag-lines",
-        { FlagLinesHighlighter::create,
-          "Parameters: <face> <option name>\n"
-          "Display flags specified in the line-spec option <option name> with <face>"} });
-    registry.insert({
-        "ranges",
-        { RangesHighlighter::create,
+          "which specify what kind of highlighters can be put in the group"}});
+    registry.insert({"flag-lines",
+                     {FlagLinesHighlighter::create,
+                      "Parameters: <face> <option name>\n"
+                      "Display flags specified in the line-spec option <option "
+                      "name> with <face>"}});
+    registry.insert(
+        {"ranges",
+         {RangesHighlighter::create,
           "Parameters: <option name>\n"
           "Use the range-specs option given as parameter to highlight buffer\n"
-          "each spec is interpreted as a face to apply to the range\n" } });
-    registry.insert({
-        "replace-ranges",
-        { ReplaceRangesHighlighter::create,
+          "each spec is interpreted as a face to apply to the range\n"}});
+    registry.insert(
+        {"replace-ranges",
+         {ReplaceRangesHighlighter::create,
           "Parameters: <option name>\n"
           "Use the range-specs option given as parameter to highlight buffer\n"
-          "each spec is interpreted as a display line to display in place of the range\n" } });
-    registry.insert({
-        "line",
-        { create_line_highlighter,
-          "Parameters: <value string> <face>\n"
-          "Highlight the line given by evaluating <value string> with <face>" } });
-    registry.insert({
-        "column",
-        { create_column_highlighter,
-          "Parameters: <value string> <face>\n"
-          "Highlight the column given by evaluating <value string> with <face>" } });
-    registry.insert({
-        "wrap",
-        { WrapHighlighter::create,
-          "Parameters: [-word] [-indent] [-width <max_width>] [-marker <marker_text>]\n"
-          "Wrap lines to window width, or max_width if given and window is wider,\n"
-          "wrap at word boundaries instead of codepoint boundaries if -word is given\n"
+          "each spec is interpreted as a display line to display in place of "
+          "the range\n"}});
+    registry.insert({"line",
+                     {create_line_highlighter,
+                      "Parameters: <value string> <face>\n"
+                      "Highlight the line given by evaluating <value string> "
+                      "with <face>"}});
+    registry.insert({"column",
+                     {create_column_highlighter,
+                      "Parameters: <value string> <face>\n"
+                      "Highlight the column given by evaluating <value string> "
+                      "with <face>"}});
+    registry.insert(
+        {"wrap",
+         {WrapHighlighter::create,
+          "Parameters: [-word] [-indent] [-width <max_width>] [-marker "
+          "<marker_text>]\n"
+          "Wrap lines to window width, or max_width if given and window is "
+          "wider,\n"
+          "wrap at word boundaries instead of codepoint boundaries if -word is "
+          "given\n"
           "insert marker_text at start of wrapped lines if given\n"
-          "preserve line indent in wrapped parts if -indent is given\n"} });
-    registry.insert({
-        "ref",
-        { ReferenceHighlighter::create,
+          "preserve line indent in wrapped parts if -indent is given\n"}});
+    registry.insert(
+        {"ref",
+         {ReferenceHighlighter::create,
           "Parameters: [-passes <passes>] <path>\n"
           "Reference the highlighter at <path> in shared highlighters\n"
           "<passes> is a flags(colorize|move|wrap) defaulting to colorize\n"
-          "which specify what kind of highlighters can be referenced" } });
-    registry.insert({
-        "regions",
-        { RegionsHighlighter::create,
-          "Parameters: None\n"
-          "Holds child region highlighters and segments the buffer in ranges based on those regions\n"
-          "definitions. The regions highlighter finds the next region to start by finding which\n"
-          "of its child region has the leftmost starting point from current position. In between\n"
-          "regions, the default-region child highlighter is applied (if such a child exists)" } });
-    registry.insert({
-        "region",
-        { RegionsHighlighter::create_region,
-          "Parameters:  [-match-capture] [-recurse <recurse>] <opening> <closing> <type> <params>...\n"
-          "Define a region for a regions highlighter, and apply the given delegate\n"
+          "which specify what kind of highlighters can be referenced"}});
+    registry.insert({"regions",
+                     {RegionsHighlighter::create,
+                      "Parameters: None\n"
+                      "Holds child region highlighters and segments the buffer "
+                      "in ranges based on those regions\n"
+                      "definitions. The regions highlighter finds the next "
+                      "region to start by finding which\n"
+                      "of its child region has the leftmost starting point "
+                      "from current position. In between\n"
+                      "regions, the default-region child highlighter is "
+                      "applied (if such a child exists)"}});
+    registry.insert(
+        {"region",
+         {RegionsHighlighter::create_region,
+          "Parameters:  [-match-capture] [-recurse <recurse>] <opening> "
+          "<closing> <type> <params>...\n"
+          "Define a region for a regions highlighter, and apply the given "
+          "delegate\n"
           "highlighter as defined by <type> and eventual <params>...\n"
           "The region starts at <begin> match and ends at the first <end>\n"
-          "If -recurse is specified, then the region ends at the first <end> that\n"
+          "If -recurse is specified, then the region ends at the first <end> "
+          "that\n"
           "does not close a <recurse> match.\n"
-          "If -match-capture is specified, then regions end/recurse matches must have\n"
-          "the same \\1 capture content as the begin match to be considered"} });
-    registry.insert({
-        "default-region",
-        { RegionsHighlighter::create_default_region,
-          "Parameters: <delegate_type> <delegate_params>...\n"
-          "Define the default region of a regions highlighter" } });
+          "If -match-capture is specified, then regions end/recurse matches "
+          "must have\n"
+          "the same \\1 capture content as the begin match to be considered"}});
+    registry.insert({"default-region",
+                     {RegionsHighlighter::create_default_region,
+                      "Parameters: <delegate_type> <delegate_params>...\n"
+                      "Define the default region of a regions highlighter"}});
 }
 
 }

--- a/src/highlighters.hh
+++ b/src/highlighters.hh
@@ -10,16 +10,21 @@ namespace Kakoune
 
 void register_highlighters();
 
-struct InclusiveBufferRange{ BufferCoord first, last; };
+struct InclusiveBufferRange
+{
+    BufferCoord first, last;
+};
 
-inline bool operator==(const InclusiveBufferRange& lhs, const InclusiveBufferRange& rhs)
+inline bool operator==(const InclusiveBufferRange& lhs,
+                       const InclusiveBufferRange& rhs)
 {
     return lhs.first == rhs.first and lhs.last == rhs.last;
 }
 String option_to_string(InclusiveBufferRange range);
-InclusiveBufferRange option_from_string(Meta::Type<InclusiveBufferRange>, StringView str);
+InclusiveBufferRange option_from_string(Meta::Type<InclusiveBufferRange>,
+                                        StringView str);
 
-using LineAndSpec = std::tuple<LineCount, String>;
+using LineAndSpec     = std::tuple<LineCount, String>;
 using LineAndSpecList = TimestampedList<LineAndSpec>;
 
 constexpr StringView option_type_name(Meta::Type<LineAndSpecList>)
@@ -29,7 +34,7 @@ constexpr StringView option_type_name(Meta::Type<LineAndSpecList>)
 void option_update(LineAndSpecList& opt, const Context& context);
 void option_list_postprocess(Vector<LineAndSpec, MemoryDomain::Options>& opt);
 
-using RangeAndString = std::tuple<InclusiveBufferRange, String>;
+using RangeAndString     = std::tuple<InclusiveBufferRange, String>;
 using RangeAndStringList = TimestampedList<RangeAndString>;
 
 constexpr StringView option_type_name(Meta::Type<RangeAndStringList>)
@@ -37,7 +42,8 @@ constexpr StringView option_type_name(Meta::Type<RangeAndStringList>)
     return "range-specs";
 }
 void option_update(RangeAndStringList& opt, const Context& context);
-void option_list_postprocess(Vector<RangeAndString, MemoryDomain::Options>& opt);
+void option_list_postprocess(
+    Vector<RangeAndString, MemoryDomain::Options>& opt);
 
 }
 

--- a/src/hook_manager.cc
+++ b/src/hook_manager.cc
@@ -23,35 +23,45 @@ struct HookManager::HookData
 };
 
 HookManager::HookManager() : m_parent(nullptr) {}
-HookManager::HookManager(HookManager& parent) : SafeCountable{}, m_parent(&parent) {}
+HookManager::HookManager(HookManager& parent)
+    : SafeCountable{}, m_parent(&parent)
+{}
 HookManager::~HookManager() = default;
 
-void HookManager::add_hook(Hook hook, String group, HookFlags flags, Regex filter, String commands)
+void HookManager::add_hook(Hook hook, String group, HookFlags flags,
+                           Regex filter, String commands)
 {
     auto& hooks = m_hooks[to_underlying(hook)];
-    hooks.emplace_back(new HookData{std::move(group), flags, std::move(filter), std::move(commands)});
+    hooks.emplace_back(new HookData{std::move(group), flags, std::move(filter),
+                                    std::move(commands)});
 }
 
 void HookManager::remove_hooks(const Regex& regex)
 {
     for (auto& list : m_hooks)
     {
-        auto it = std::remove_if(list.begin(), list.end(),
-                                 [&](const std::unique_ptr<HookData>& h)
-                                 { return regex_match(h->group.begin(), h->group.end(), regex); });
-        if (not m_running_hooks.empty()) // we are running some hooks, defer deletion
-            m_hooks_trash.insert(m_hooks_trash.end(), std::make_move_iterator(it),
+        auto it = std::remove_if(
+            list.begin(), list.end(), [&](const std::unique_ptr<HookData>& h) {
+                return regex_match(h->group.begin(), h->group.end(), regex);
+            });
+        if (not m_running_hooks
+                    .empty()) // we are running some hooks, defer deletion
+            m_hooks_trash.insert(m_hooks_trash.end(),
+                                 std::make_move_iterator(it),
                                  std::make_move_iterator(list.end()));
         list.erase(it, list.end());
     }
 }
 
-CandidateList HookManager::complete_hook_group(StringView prefix, ByteCount pos_in_token)
+CandidateList HookManager::complete_hook_group(StringView prefix,
+                                               ByteCount pos_in_token)
 {
     CandidateList res;
     for (auto& list : m_hooks)
     {
-        auto container = list | transform([](const std::unique_ptr<HookData>& h) -> const String& { return h->group; });
+        auto container = list
+                         | transform([](const std::unique_ptr<HookData>& h)
+                                         -> const String& { return h->group; });
         for (auto& c : complete(prefix, pos_in_token, container))
         {
             if (!contains(res, c))
@@ -69,37 +79,44 @@ void HookManager::run_hook(Hook hook, StringView param, Context& context)
         m_parent->run_hook(hook, param, context);
 
     auto& hook_list = m_hooks[to_underlying(hook)];
-    auto hook_name = enum_desc(Meta::Type<Hook>{})[to_underlying(hook)].name;
+    auto hook_name  = enum_desc(Meta::Type<Hook>{})[to_underlying(hook)].name;
     if (contains(m_running_hooks, std::make_pair(hook, param)))
     {
-        auto error = format("recursive call of hook {}/{}, not executing", hook_name, param);
+        auto error = format("recursive call of hook {}/{}, not executing",
+                            hook_name, param);
         write_to_debug_buffer(error);
         return;
     }
 
     m_running_hooks.emplace_back(hook, param);
-    auto pop_running_hook = on_scope_end([this]{
+    auto pop_running_hook = on_scope_end([this] {
         m_running_hooks.pop_back();
         if (m_running_hooks.empty())
             m_hooks_trash.clear();
     });
 
     const DebugFlags debug_flags = context.options()["debug"].get<DebugFlags>();
-    const bool profile = debug_flags & DebugFlags::Profile;
-    auto start_time = profile ? Clock::now() : TimePoint{};
+    const bool profile           = debug_flags & DebugFlags::Profile;
+    auto start_time              = profile ? Clock::now() : TimePoint{};
 
     auto& disabled_hooks = context.options()["disabled_hooks"].get<Regex>();
 
-    struct ToRun { HookData* hook; MatchResults<const char*> captures; };
-    Vector<ToRun> hooks_to_run; // The m_hooks_trash vector ensure hooks wont die during this method
+    struct ToRun
+    {
+        HookData* hook;
+        MatchResults<const char*> captures;
+    };
+    Vector<ToRun> hooks_to_run; // The m_hooks_trash vector ensure hooks wont
+                                // die during this method
     for (auto& hook : hook_list)
     {
         MatchResults<const char*> captures;
-        if ((not only_always or (hook->flags & HookFlags::Always)) and
-            (hook->group.empty() or disabled_hooks.empty() or
-             not regex_match(hook->group.begin(), hook->group.end(), disabled_hooks))
+        if ((not only_always or (hook->flags & HookFlags::Always))
+            and (hook->group.empty() or disabled_hooks.empty()
+                 or not regex_match(hook->group.begin(), hook->group.end(),
+                                    disabled_hooks))
             and regex_match(param.begin(), param.end(), captures, hook->filter))
-            hooks_to_run.push_back({ hook.get(), std::move(captures) });
+            hooks_to_run.push_back({hook.get(), std::move(captures)});
     }
 
     bool hook_error = false;
@@ -108,17 +125,19 @@ void HookManager::run_hook(Hook hook, StringView param, Context& context)
         try
         {
             if (debug_flags & DebugFlags::Hooks)
-                write_to_debug_buffer(format("hook {}({})/{}", hook_name, param, to_run.hook->group));
+                write_to_debug_buffer(format("hook {}({})/{}", hook_name, param,
+                                             to_run.hook->group));
 
             ScopedSetBool disable_history{context.history_disabled()};
 
-            EnvVarMap env_vars{ {"hook_param", param.str()} };
+            EnvVarMap env_vars{{"hook_param", param.str()}};
             for (size_t i = 0; i < to_run.captures.size(); ++i)
-                env_vars.insert({format("hook_param_capture_{}", i),
-                                 {to_run.captures[i].first, to_run.captures[i].second}});
+                env_vars.insert(
+                    {format("hook_param_capture_{}", i),
+                     {to_run.captures[i].first, to_run.captures[i].second}});
 
             CommandManager::instance().execute(to_run.hook->commands, context,
-                                               { {}, std::move(env_vars) });
+                                               {{}, std::move(env_vars)});
 
             if (to_run.hook->flags & HookFlags::Once)
             {
@@ -134,20 +153,24 @@ void HookManager::run_hook(Hook hook, StringView param, Context& context)
         {
             hook_error = true;
             write_to_debug_buffer(format("error running hook {}({})/{}: {}",
-                                         hook_name, param, to_run.hook->group, err.what()));
+                                         hook_name, param, to_run.hook->group,
+                                         err.what()));
         }
     }
 
     if (hook_error)
-        context.print_status({
-            format("Error running hooks for '{}' '{}', see *debug* buffer",
-                   hook_name, param), context.faces()["Error"] });
+        context.print_status(
+            {format("Error running hooks for '{}' '{}', see *debug* buffer",
+                    hook_name, param),
+             context.faces()["Error"]});
 
     if (profile)
     {
         auto end_time = Clock::now();
-        auto full = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
-        write_to_debug_buffer(format("hook '{}({})' took {} us", hook_name, param, (size_t)full.count()));
+        auto full     = std::chrono::duration_cast<std::chrono::microseconds>(
+            end_time - start_time);
+        write_to_debug_buffer(format("hook '{}({})' took {} us", hook_name,
+                                     param, (size_t)full.count()));
     }
 }
 

--- a/src/hook_manager.hh
+++ b/src/hook_manager.hh
@@ -103,9 +103,9 @@ constexpr auto enum_desc(Meta::Type<Hook>)
 
 enum class HookFlags
 {
-    None = 0,
+    None   = 0,
     Always = 1 << 0,
-    Once = 1 << 1
+    Once   = 1 << 1
 };
 constexpr bool with_bit_ops(Meta::Type<HookFlags>) { return true; }
 
@@ -115,10 +115,11 @@ public:
     HookManager(HookManager& parent);
     ~HookManager();
 
-    void add_hook(Hook hook, String group, HookFlags flags,
-                  Regex filter, String commands);
+    void add_hook(Hook hook, String group, HookFlags flags, Regex filter,
+                  String commands);
     void remove_hooks(const Regex& regex);
-    CandidateList complete_hook_group(StringView prefix, ByteCount pos_in_token);
+    CandidateList complete_hook_group(StringView prefix,
+                                      ByteCount pos_in_token);
     void run_hook(Hook hook, StringView param, Context& context);
 
 private:
@@ -129,10 +130,14 @@ private:
     struct HookData;
 
     SafePtr<HookManager> m_parent;
-    Array<Vector<std::unique_ptr<HookData>, MemoryDomain::Hooks>, enum_desc(Meta::Type<Hook>{}).size()> m_hooks;
+    Array<Vector<std::unique_ptr<HookData>, MemoryDomain::Hooks>,
+          enum_desc(Meta::Type<Hook>{}).size()>
+        m_hooks;
 
-    mutable Vector<std::pair<Hook, StringView>, MemoryDomain::Hooks> m_running_hooks;
-    mutable Vector<std::unique_ptr<HookData>, MemoryDomain::Hooks> m_hooks_trash;
+    mutable Vector<std::pair<Hook, StringView>, MemoryDomain::Hooks>
+        m_running_hooks;
+    mutable Vector<std::unique_ptr<HookData>, MemoryDomain::Hooks>
+        m_hooks_trash;
 };
 
 }

--- a/src/input_handler.hh
+++ b/src/input_handler.hh
@@ -21,7 +21,7 @@ enum class MenuEvent
     Abort,
     Validate
 };
-using MenuCallback = std::function<void (int, MenuEvent, Context&)>;
+using MenuCallback = std::function<void(int, MenuEvent, Context&)>;
 
 enum class PromptEvent
 {
@@ -29,18 +29,17 @@ enum class PromptEvent
     Abort,
     Validate
 };
-using PromptCallback = std::function<void (StringView, PromptEvent, Context&)>;
+using PromptCallback = std::function<void(StringView, PromptEvent, Context&)>;
 enum class PromptFlags
 {
-    None = 0,
-    Password = 1 << 0,
+    None                              = 0,
+    Password                          = 1 << 0,
     DropHistoryEntriesWithBlankPrefix = 1 << 1,
-    Search = 1 << 2,
+    Search                            = 1 << 2,
 };
 constexpr bool with_bit_ops(Meta::Type<PromptFlags>) { return true; }
 
-
-using KeyCallback = std::function<void (Key, Context&)>;
+using KeyCallback = std::function<void(Key, Context&)>;
 
 class InputMode;
 enum class InsertMode : unsigned;
@@ -51,8 +50,7 @@ class InputHandler : public SafeCountable
 {
 public:
     InputHandler(SelectionList selections,
-                 Context::Flags flags = Context::Flags::None,
-                 String name = "");
+                 Context::Flags flags = Context::Flags::None, String name = "");
     ~InputHandler();
 
     // switch to insert mode
@@ -65,8 +63,8 @@ public:
     // returns to normal mode after validation if callback does
     // not change the mode itself
     void prompt(StringView prompt, String initstr, String emptystr,
-                Face prompt_face, PromptFlags flags,
-                Completer completer, PromptCallback callback);
+                Face prompt_face, PromptFlags flags, Completer completer,
+                PromptCallback callback);
     void set_prompt_face(Face prompt_face);
 
     // enter menu mode, callback is called on each selection change,
@@ -118,24 +116,25 @@ private:
     void push_mode(InputMode* new_mode);
     void pop_mode(InputMode* current_mode);
 
-    struct Insertion{
+    struct Insertion
+    {
         NestedBool recording;
         InsertMode mode;
         Vector<Key> keys;
         bool disable_hooks;
         int count;
-    } m_last_insert = { {}, InsertMode::Insert, {}, false, 1 };
+    } m_last_insert = {{}, InsertMode::Insert, {}, false, 1};
 
-    char   m_recording_reg = 0;
+    char m_recording_reg = 0;
     String m_recorded_keys;
-    int    m_recording_level = -1;
+    int m_recording_level = -1;
 
-    int    m_handle_key_level = 0;
+    int m_handle_key_level = 0;
 };
 
 enum class AutoInfo
 {
-    None = 0,
+    None    = 0,
     Command = 1 << 0,
     OnKey   = 1 << 1,
     Normal  = 1 << 2
@@ -145,16 +144,14 @@ constexpr bool with_bit_ops(Meta::Type<AutoInfo>) { return true; }
 
 constexpr auto enum_desc(Meta::Type<AutoInfo>)
 {
-    return make_array<EnumDesc<AutoInfo>, 3>({
-        { AutoInfo::Command, "command"},
-        { AutoInfo::OnKey, "onkey"},
-        { AutoInfo::Normal, "normal" }
-    });
+    return make_array<EnumDesc<AutoInfo>, 3>({{AutoInfo::Command, "command"},
+                                              {AutoInfo::OnKey, "onkey"},
+                                              {AutoInfo::Normal, "normal"}});
 }
 
 enum class AutoComplete
 {
-    None = 0,
+    None   = 0,
     Insert = 0b01,
     Prompt = 0b10
 };
@@ -162,25 +159,24 @@ constexpr bool with_bit_ops(Meta::Type<AutoComplete>) { return true; }
 
 constexpr auto enum_desc(Meta::Type<AutoComplete>)
 {
-    return make_array<EnumDesc<AutoComplete>, 3>({
-        { AutoComplete::Insert, "insert"},
-        { AutoComplete::Prompt, "prompt" }
-    });
+    return make_array<EnumDesc<AutoComplete>, 3>(
+        {{AutoComplete::Insert, "insert"}, {AutoComplete::Prompt, "prompt"}});
 }
 
-bool show_auto_info_ifn(StringView title, StringView info, AutoInfo mask, const Context& context);
+bool show_auto_info_ifn(StringView title, StringView info, AutoInfo mask,
+                        const Context& context);
 void hide_auto_info_ifn(const Context& context, bool hide);
 
 template<typename Cmd>
-void on_next_key_with_autoinfo(const Context& context, KeymapMode keymap_mode, Cmd cmd,
-                               StringView title, StringView info)
+void on_next_key_with_autoinfo(const Context& context, KeymapMode keymap_mode,
+                               Cmd cmd, StringView title, StringView info)
 {
     const bool hide = show_auto_info_ifn(title, info, AutoInfo::OnKey, context);
     context.input_handler().on_next_key(
-        keymap_mode, [hide,cmd](Key key, Context& context) mutable {
+        keymap_mode, [hide, cmd](Key key, Context& context) mutable {
             hide_auto_info_ifn(context, hide);
             cmd(key, context);
-    });
+        });
 }
 
 void scroll_window(Context& context, LineCount offset);

--- a/src/insert_completer.cc
+++ b/src/insert_completer.cc
@@ -40,7 +40,8 @@ String option_to_string(const InsertCompleterDesc& opt)
     return "";
 }
 
-InsertCompleterDesc option_from_string(Meta::Type<InsertCompleterDesc>, StringView str)
+InsertCompleterDesc option_from_string(Meta::Type<InsertCompleterDesc>,
+                                       StringView str)
 {
     if (str.substr(0_byte, 7_byte) == "option=")
         return {InsertCompleterDesc::Option, str.substr(7_byte).str()};
@@ -69,15 +70,19 @@ InsertCompletion complete_word(const SelectionList& sels,
                                const OptionManager& options,
                                const FaceRegistry& faces)
 {
-    ConstArrayView<Codepoint> extra_word_chars = options["extra_word_chars"].get<Vector<Codepoint, MemoryDomain::Options>>();
-    auto is_word_pred = [extra_word_chars](Codepoint c) { return is_word(c, extra_word_chars); };
+    ConstArrayView<Codepoint> extra_word_chars
+        = options["extra_word_chars"]
+              .get<Vector<Codepoint, MemoryDomain::Options>>();
+    auto is_word_pred = [extra_word_chars](Codepoint c) {
+        return is_word(c, extra_word_chars);
+    };
 
-    const Buffer& buffer = sels.buffer();
+    const Buffer& buffer   = sels.buffer();
     BufferCoord cursor_pos = sels.main().cursor();
 
     using Utf8It = utf8::iterator<BufferIterator>;
     Utf8It pos{buffer.iterator_at(cursor_pos), buffer};
-    if (pos == buffer.begin() or not is_word_pred(*(pos-1)))
+    if (pos == buffer.begin() or not is_word_pred(*(pos - 1)))
         return {};
 
     BufferCoord word_begin;
@@ -86,27 +91,29 @@ InsertCompletion complete_word(const SelectionList& sels,
     for (int i = 0; i < sels.size(); ++i)
     {
         Utf8It end{buffer.iterator_at(sels[i].cursor()), buffer};
-        Utf8It begin = end-1;
-        if (not skip_while_reverse(begin, buffer.begin(), is_word_pred) and
-            begin < end) // (begin might == end if end == buffer.begin())
+        Utf8It begin = end - 1;
+        if (not skip_while_reverse(begin, buffer.begin(), is_word_pred)
+            and begin < end) // (begin might == end if end == buffer.begin())
             ++begin;
 
         if (i == sels.main_index())
         {
             word_begin = begin.base().coord();
-            prefix = buffer.substr(word_begin, end.base().coord());
+            prefix     = buffer.substr(word_begin, end.base().coord());
         }
 
         skip_while(end, buffer.end(), is_word_pred);
 
-        StringView word = buffer.substr(begin.base().coord(), end.base().coord());
+        StringView word
+            = buffer.substr(begin.base().coord(), end.base().coord());
         ++sel_word_counts[word];
     }
 
     struct RankedMatchAndBuffer : RankedMatch
     {
-        RankedMatchAndBuffer(RankedMatch  m, const Buffer* b)
-            : RankedMatch{std::move(m)}, buffer{b} {}
+        RankedMatchAndBuffer(RankedMatch m, const Buffer* b)
+            : RankedMatch{std::move(m)}, buffer{b}
+        {}
 
         using RankedMatch::operator==;
         using RankedMatch::operator<;
@@ -118,7 +125,7 @@ InsertCompletion complete_word(const SelectionList& sels,
 
     auto& word_db = get_word_db(buffer);
     for (auto& m : word_db.find_matching(prefix))
-        matches.push_back({ m, &buffer });
+        matches.push_back({m, &buffer});
 
     // Remove words that are being edited
     for (auto& word_count : sel_word_counts)
@@ -134,10 +141,14 @@ InsertCompletion complete_word(const SelectionList& sels,
             if (buf.get() == &buffer or buf->flags() & Buffer::Flags::Debug)
                 continue;
             for (auto& m : get_word_db(*buf).find_matching(prefix) |
-                           // filter out words that are not considered words for the current buffer
-                           filter([&](auto& rm) { return std::all_of(rm.candidate().begin(), rm.candidate().end(),
-                                                                     is_word_pred); }))
-                matches.push_back({ m, buf.get() });
+                               // filter out words that are not considered words
+                               // for the current buffer
+                               filter([&](auto& rm) {
+                                   return std::all_of(rm.candidate().begin(),
+                                                      rm.candidate().end(),
+                                                      is_word_pred);
+                               }))
+                matches.push_back({m, buf.get()});
         }
     }
 
@@ -147,35 +158,41 @@ InsertCompletion complete_word(const SelectionList& sels,
             matches.emplace_back(match, nullptr);
 
     unordered_erase(matches, prefix);
-    const auto longest = accumulate(matches, 0_char,
-                                    [](const CharCount& lhs, const RankedMatchAndBuffer& rhs)
-                                    { return std::max(lhs, rhs.candidate().char_length()); });
+    const auto longest
+        = accumulate(matches, 0_char,
+                     [](const CharCount& lhs, const RankedMatchAndBuffer& rhs) {
+                         return std::max(lhs, rhs.candidate().char_length());
+                     });
 
     constexpr size_t max_count = 100;
     // Gather best max_count matches
     InsertCompletion::CandidateList candidates;
     candidates.reserve(std::min(matches.size(), max_count));
 
-    for_n_best(matches, max_count, [](auto& lhs, auto& rhs) { return rhs < lhs; },
-               [&](RankedMatchAndBuffer& m) {
-        if (not candidates.empty() and candidates.back().completion == m.candidate())
-            return false;
-        DisplayLine menu_entry;
-        if (other_buffers && m.buffer)
-        {
-            const auto pad_len = longest + 1 - m.candidate().char_length();
-            menu_entry.push_back({ m.candidate().str(), {} });
-            menu_entry.push_back({ String{' ', pad_len}, {} });
-            menu_entry.push_back({ m.buffer->display_name(), faces["MenuInfo"] });
-        }
-        else
-            menu_entry.push_back({ m.candidate().str(), {} });
+    for_n_best(
+        matches, max_count, [](auto& lhs, auto& rhs) { return rhs < lhs; },
+        [&](RankedMatchAndBuffer& m) {
+            if (not candidates.empty()
+                and candidates.back().completion == m.candidate())
+                return false;
+            DisplayLine menu_entry;
+            if (other_buffers && m.buffer)
+            {
+                const auto pad_len = longest + 1 - m.candidate().char_length();
+                menu_entry.push_back({m.candidate().str(), {}});
+                menu_entry.push_back({String{' ', pad_len}, {}});
+                menu_entry.push_back(
+                    {m.buffer->display_name(), faces["MenuInfo"]});
+            }
+            else
+                menu_entry.push_back({m.candidate().str(), {}});
 
-        candidates.push_back({m.candidate().str(), "", std::move(menu_entry)});
-        return true;
-    });
+            candidates.push_back(
+                {m.candidate().str(), "", std::move(menu_entry)});
+            return true;
+        });
 
-    return { std::move(candidates), word_begin, cursor_pos, buffer.timestamp() };
+    return {std::move(candidates), word_begin, cursor_pos, buffer.timestamp()};
 }
 
 template<bool require_slash>
@@ -184,17 +201,16 @@ InsertCompletion complete_filename(const SelectionList& sels,
                                    const FaceRegistry&)
 {
     const Buffer& buffer = sels.buffer();
-    auto pos = buffer.iterator_at(sels.main().cursor());
-    auto begin = pos;
+    auto pos             = buffer.iterator_at(sels.main().cursor());
+    auto begin           = pos;
 
-    auto is_filename = [](char c)
-    {
+    auto is_filename = [](char c) {
         return isalnum(c) or c == '/' or c == '.' or c == '_' or c == '-';
     };
-    while (begin != buffer.begin() and is_filename(*(begin-1)))
+    while (begin != buffer.begin() and is_filename(*(begin - 1)))
         --begin;
 
-    if (begin != buffer.begin() and *begin == '/' and *(begin-1) == '~')
+    if (begin != buffer.begin() and *begin == '/' and *(begin - 1) == '~')
         --begin;
 
     StringView prefix = buffer.substr(begin.coord(), pos.coord());
@@ -209,17 +225,19 @@ InsertCompletion complete_filename(const SelectionList& sels,
     InsertCompletion::CandidateList candidates;
     if (prefix.front() == '/' or prefix.front() == '~')
     {
-        for (auto& filename : Kakoune::complete_filename(prefix,
-                                                         options["ignored_files"].get<Regex>()))
-            candidates.push_back({ filename, "", {filename, {}} });
+        for (auto& filename : Kakoune::complete_filename(
+                 prefix, options["ignored_files"].get<Regex>()))
+            candidates.push_back({filename, "", {filename, {}}});
     }
     else
     {
         Vector<String> visited_dirs;
         for (auto dir : options["path"].get<StringList>())
         {
-            dir = real_path(parse_filename(dir, (buffer.flags() & Buffer::Flags::File) ?
-                                           split_path(buffer.name()).first : StringView{}));
+            dir = real_path(
+                parse_filename(dir, (buffer.flags() & Buffer::Flags::File)
+                                        ? split_path(buffer.name()).first
+                                        : StringView{}));
 
             if (not dir.empty() and dir.back() != '/')
                 dir += '/';
@@ -227,11 +245,12 @@ InsertCompletion complete_filename(const SelectionList& sels,
             if (contains(visited_dirs, dir))
                 continue;
 
-            for (auto& filename : Kakoune::complete_filename(dir + prefix,
-                                                             options["ignored_files"].get<Regex>()))
+            for (auto& filename : Kakoune::complete_filename(
+                     dir + prefix, options["ignored_files"].get<Regex>()))
             {
                 StringView candidate = filename.substr(dir.length());
-                candidates.push_back({ candidate.str(), "", {candidate.str(), {}} });
+                candidates.push_back(
+                    {candidate.str(), "", {candidate.str(), {}}});
             }
 
             visited_dirs.push_back(std::move(dir));
@@ -239,7 +258,8 @@ InsertCompletion complete_filename(const SelectionList& sels,
     }
     if (candidates.empty())
         return {};
-    return { std::move(candidates), begin.coord(), pos.coord(), buffer.timestamp() };
+    return {std::move(candidates), begin.coord(), pos.coord(),
+            buffer.timestamp()};
 }
 
 InsertCompletion complete_option(const SelectionList& sels,
@@ -247,7 +267,7 @@ InsertCompletion complete_option(const SelectionList& sels,
                                  const FaceRegistry& faces,
                                  StringView option_name)
 {
-    const Buffer& buffer = sels.buffer();
+    const Buffer& buffer   = sels.buffer();
     BufferCoord cursor_pos = sels.main().cursor();
 
     const CompletionList& opt = options[option_name].get<CompletionList>();
@@ -259,19 +279,21 @@ InsertCompletion complete_option(const SelectionList& sels,
     MatchResults<String::const_iterator> match;
     if (regex_match(desc.begin(), desc.end(), match, re))
     {
-        BufferCoord coord{ str_to_int({match[1].first, match[1].second}) - 1,
-                         str_to_int({match[2].first, match[2].second}) - 1 };
+        BufferCoord coord{str_to_int({match[1].first, match[1].second}) - 1,
+                          str_to_int({match[2].first, match[2].second}) - 1};
         if (not buffer.is_valid(coord))
             return {};
         auto end = cursor_pos;
         if (match[3].matched)
         {
             ByteCount len = str_to_int({match[3].first, match[3].second});
-            end = buffer.advance(coord, len);
+            end           = buffer.advance(coord, len);
         }
-        size_t timestamp = (size_t)str_to_int({match[4].first, match[4].second});
+        size_t timestamp
+            = (size_t)str_to_int({match[4].first, match[4].second});
         auto changes = buffer.changes_since(timestamp);
-        if (any_of(changes, [&](auto&& change) { return change.begin < coord; }))
+        if (any_of(changes,
+                   [&](auto&& change) { return change.begin < coord; }))
             return {};
 
         if (cursor_pos.line == coord.line and cursor_pos.column >= coord.column)
@@ -279,7 +301,7 @@ InsertCompletion complete_option(const SelectionList& sels,
             StringView query = buffer.substr(coord, cursor_pos);
 
             const ColumnCount tabstop = options["tabstop"].get<int>();
-            const ColumnCount column = get_column(buffer, tabstop, cursor_pos);
+            const ColumnCount column  = get_column(buffer, tabstop, cursor_pos);
 
             struct RankedMatchAndInfo : RankedMatch
             {
@@ -298,10 +320,13 @@ InsertCompletion complete_option(const SelectionList& sels,
                 if (RankedMatchAndInfo match{std::get<0>(candidate), query})
                 {
                     match.docstring = std::get<1>(candidate);
-                    auto& menu = std::get<2>(candidate);
-                    match.menu_entry = not menu.empty() ?
-                        parse_display_line(expand_tabs(menu, tabstop, column), faces)
-                      : DisplayLine{ expand_tabs(menu, tabstop, column), {} };
+                    auto& menu      = std::get<2>(candidate);
+                    match.menu_entry
+                        = not menu.empty()
+                              ? parse_display_line(
+                                    expand_tabs(menu, tabstop, column), faces)
+                              : DisplayLine{expand_tabs(menu, tabstop, column),
+                                            {}};
 
                     matches.push_back(std::move(match));
                 }
@@ -317,13 +342,15 @@ InsertCompletion complete_option(const SelectionList& sels,
             candidates.reserve(matches.size());
             while (candidates.size() < max_count and first != last)
             {
-                if (candidates.empty() or candidates.back().completion != first->candidate())
-                    candidates.push_back({ first->candidate().str(), first->docstring.str(),
-                                           std::move(first->menu_entry) });
+                if (candidates.empty()
+                    or candidates.back().completion != first->candidate())
+                    candidates.push_back({first->candidate().str(),
+                                          first->docstring.str(),
+                                          std::move(first->menu_entry)});
                 std::pop_heap(first, last--, greater);
             }
 
-            return { std::move(candidates), coord, end, timestamp };
+            return {std::move(candidates), coord, end, timestamp};
         }
     }
     return {};
@@ -334,13 +361,14 @@ InsertCompletion complete_line(const SelectionList& sels,
                                const OptionManager& options,
                                const FaceRegistry&)
 {
-    const Buffer& buffer = sels.buffer();
+    const Buffer& buffer   = sels.buffer();
     BufferCoord cursor_pos = sels.main().cursor();
 
     const ColumnCount tabstop = options["tabstop"].get<int>();
-    const ColumnCount column = get_column(buffer, tabstop, cursor_pos);
+    const ColumnCount column  = get_column(buffer, tabstop, cursor_pos);
 
-    StringView prefix = buffer[cursor_pos.line].substr(0_byte, cursor_pos.column);
+    StringView prefix
+        = buffer[cursor_pos.line].substr(0_byte, cursor_pos.column);
     InsertCompletion::CandidateList candidates;
 
     auto add_candidates = [&](const Buffer& buf) {
@@ -351,10 +379,13 @@ InsertCompletion complete_line(const SelectionList& sels,
             const StringView line = buf[l];
             if (prefix == line.substr(0_byte, prefix.length()))
             {
-                StringView candidate = line.substr(0_byte, line.length()-1);
-                candidates.push_back({candidate.str(), "",
-                                      {expand_tabs(candidate, tabstop, column), {}}});
-                // perf: it's unlikely the user intends to search among >10 candidates anyway
+                StringView candidate = line.substr(0_byte, line.length() - 1);
+                candidates.push_back(
+                    {candidate.str(),
+                     "",
+                     {expand_tabs(candidate, tabstop, column), {}}});
+                // perf: it's unlikely the user intends to search among >10
+                // candidates anyway
                 if (candidates.size() == 100)
                     break;
             }
@@ -367,7 +398,8 @@ InsertCompletion complete_line(const SelectionList& sels,
     {
         for (const auto& buf : BufferManager::instance())
         {
-            if (buf.get() != &buffer and not (buf->flags() & Buffer::Flags::Debug))
+            if (buf.get() != &buffer
+                and not(buf->flags() & Buffer::Flags::Debug))
                 add_candidates(*buf);
         }
     }
@@ -375,8 +407,10 @@ InsertCompletion complete_line(const SelectionList& sels,
     if (candidates.empty())
         return {};
     std::sort(candidates.begin(), candidates.end());
-    candidates.erase(std::unique(candidates.begin(), candidates.end()), candidates.end());
-    return { std::move(candidates), cursor_pos.line, cursor_pos, buffer.timestamp() };
+    candidates.erase(std::unique(candidates.begin(), candidates.end()),
+                     candidates.end());
+    return {std::move(candidates), cursor_pos.line, cursor_pos,
+            buffer.timestamp()};
 }
 
 }
@@ -387,25 +421,25 @@ InsertCompleter::InsertCompleter(Context& context)
     m_options.register_watcher(*this);
 }
 
-InsertCompleter::~InsertCompleter()
-{
-    m_options.unregister_watcher(*this);
-}
+InsertCompleter::~InsertCompleter() { m_options.unregister_watcher(*this); }
 
 void InsertCompleter::select(int index, bool relative, Vector<Key>& keystrokes)
 {
     if (not setup_ifn())
         return;
 
-    auto& buffer = m_context.buffer();
-    m_current_candidate = (relative ? m_current_candidate + index : index) % (int)m_completions.candidates.size();
+    auto& buffer        = m_context.buffer();
+    m_current_candidate = (relative ? m_current_candidate + index : index)
+                          % (int)m_completions.candidates.size();
     if (m_current_candidate < 0)
         m_current_candidate += m_completions.candidates.size();
-    const InsertCompletion::Candidate& candidate = m_completions.candidates[m_current_candidate];
-    auto& selections = m_context.selections();
+    const InsertCompletion::Candidate& candidate
+        = m_completions.candidates[m_current_candidate];
+    auto& selections       = m_context.selections();
     const auto& cursor_pos = selections.main().cursor();
-    const auto prefix_len = buffer.distance(m_completions.begin, cursor_pos);
-    const auto suffix_len = std::max(0_byte, buffer.distance(cursor_pos, m_completions.end));
+    const auto prefix_len  = buffer.distance(m_completions.begin, cursor_pos);
+    const auto suffix_len
+        = std::max(0_byte, buffer.distance(cursor_pos, m_completions.end));
 
     auto ref = buffer.string(m_completions.begin, m_completions.end);
     ForwardChangesTracker changes_tracker;
@@ -413,9 +447,11 @@ void InsertCompleter::select(int index, bool relative, Vector<Key>& keystrokes)
     Vector<BufferCoord> positions;
     for (auto& sel : selections)
     {
-        auto pos = buffer.iterator_at(changes_tracker.get_new_coord_tolerant(sel.cursor()));
-        if (pos.coord().column >= prefix_len and (pos + suffix_len) != buffer.end() and
-            std::equal(ref.begin(), ref.end(), pos - prefix_len))
+        auto pos = buffer.iterator_at(
+            changes_tracker.get_new_coord_tolerant(sel.cursor()));
+        if (pos.coord().column >= prefix_len
+            and (pos + suffix_len) != buffer.end()
+            and std::equal(ref.begin(), ref.end(), pos - prefix_len))
         {
             positions.push_back(buffer.erase((pos - prefix_len).coord(),
                                              (pos + suffix_len).coord()));
@@ -426,20 +462,23 @@ void InsertCompleter::select(int index, bool relative, Vector<Key>& keystrokes)
     changes_tracker = ForwardChangesTracker{};
     for (auto pos : positions)
     {
-        buffer.insert(changes_tracker.get_new_coord_tolerant(pos), candidate.completion);
+        buffer.insert(changes_tracker.get_new_coord_tolerant(pos),
+                      candidate.completion);
         changes_tracker.update(buffer, timestamp);
     }
 
     selections.update();
     m_completions.end = cursor_pos;
-    m_completions.begin = buffer.advance(cursor_pos, -candidate.completion.length());
+    m_completions.begin
+        = buffer.advance(cursor_pos, -candidate.completion.length());
     m_completions.timestamp = buffer.timestamp();
     if (m_context.has_client())
     {
         m_context.client().menu_select(m_current_candidate);
         if (not candidate.docstring.empty())
-            m_context.client().info_show(candidate.completion, candidate.docstring,
-                                         {}, InfoStyle::MenuDoc);
+            m_context.client().info_show(candidate.completion,
+                                         candidate.docstring, {},
+                                         InfoStyle::MenuDoc);
         else
             m_context.client().info_hide();
     }
@@ -453,9 +492,12 @@ void InsertCompleter::select(int index, bool relative, Vector<Key>& keystrokes)
 
     if (m_context.has_client())
     {
-        const auto param = (m_current_candidate == m_completions.candidates.size() - 1) ?
-            StringView{} : candidate.completion;
-        m_context.hooks().run_hook(Hook::InsertCompletionSelect, param, m_context);
+        const auto param
+            = (m_current_candidate == m_completions.candidates.size() - 1)
+                  ? StringView{}
+                  : candidate.completion;
+        m_context.hooks().run_hook(Hook::InsertCompletionSelect, param,
+                                   m_context);
     }
 }
 
@@ -474,12 +516,13 @@ void InsertCompleter::reset()
     if (m_explicit_completer or m_completions.is_valid())
     {
         m_explicit_completer = nullptr;
-        m_completions = InsertCompletion{};
+        m_completions        = InsertCompletion{};
         if (m_context.has_client())
         {
             m_context.client().menu_hide();
             m_context.client().info_hide();
-            m_context.hooks().run_hook(Hook::InsertCompletionHide, "", m_context);
+            m_context.hooks().run_hook(Hook::InsertCompletionHide, "",
+                                       m_context);
         }
     }
 }
@@ -489,34 +532,36 @@ bool InsertCompleter::setup_ifn()
     using namespace std::placeholders;
     if (not m_completions.is_valid())
     {
-        auto& completers = m_options["completers"].get<InsertCompleterDescList>();
+        auto& completers
+            = m_options["completers"].get<InsertCompleterDescList>();
         for (auto& completer : completers)
         {
-            if (completer.mode == InsertCompleterDesc::Filename and
-                try_complete(complete_filename<true>))
+            if (completer.mode == InsertCompleterDesc::Filename
+                and try_complete(complete_filename<true>))
                 return true;
-            if (completer.mode == InsertCompleterDesc::Option and
-                try_complete([&](const SelectionList& sels,
-                                 const OptionManager& options,
-                                 const FaceRegistry& faces) {
-                   return complete_option(sels, options, faces, *completer.param);
-                }))
+            if (completer.mode == InsertCompleterDesc::Option
+                and try_complete([&](const SelectionList& sels,
+                                     const OptionManager& options,
+                                     const FaceRegistry& faces) {
+                        return complete_option(sels, options, faces,
+                                               *completer.param);
+                    }))
                 return true;
-            if (completer.mode == InsertCompleterDesc::Word and
-                *completer.param == "buffer" and
-                try_complete(complete_word<false>))
+            if (completer.mode == InsertCompleterDesc::Word
+                and *completer.param == "buffer"
+                and try_complete(complete_word<false>))
                 return true;
-            if (completer.mode == InsertCompleterDesc::Word and
-                *completer.param == "all" and
-                try_complete(complete_word<true>))
+            if (completer.mode == InsertCompleterDesc::Word
+                and *completer.param == "all"
+                and try_complete(complete_word<true>))
                 return true;
-            if (completer.mode == InsertCompleterDesc::Line and
-                *completer.param == "buffer" and
-                try_complete(complete_line<false>))
+            if (completer.mode == InsertCompleterDesc::Line
+                and *completer.param == "buffer"
+                and try_complete(complete_line<false>))
                 return true;
-            if (completer.mode == InsertCompleterDesc::Line and
-                *completer.param == "all" and
-                try_complete(complete_line<true>))
+            if (completer.mode == InsertCompleterDesc::Line
+                and *completer.param == "all"
+                and try_complete(complete_line<true>))
                 return true;
         }
         return false;
@@ -542,15 +587,15 @@ void InsertCompleter::menu_show()
 void InsertCompleter::on_option_changed(const Option& opt)
 {
     // Do not reset the menu if the user has selected an entry
-    if (not m_completions.candidates.empty() and
-        m_current_candidate != m_completions.candidates.size() - 1)
+    if (not m_completions.candidates.empty()
+        and m_current_candidate != m_completions.candidates.size() - 1)
         return;
 
     auto& completers = m_options["completers"].get<InsertCompleterDescList>();
     for (auto& completer : completers)
     {
-        if (completer.mode == InsertCompleterDesc::Option and
-            *completer.param == opt.name())
+        if (completer.mode == InsertCompleterDesc::Option
+            and *completer.param == opt.name())
         {
             reset();
             setup_ifn();
@@ -569,7 +614,8 @@ bool InsertCompleter::try_complete(Func complete_func)
     }
     catch (runtime_error& e)
     {
-        write_to_debug_buffer(format("error while trying to run completer: {}", e.what()));
+        write_to_debug_buffer(
+            format("error while trying to run completer: {}", e.what()));
         return false;
     }
     if (not m_completions.is_valid())
@@ -578,7 +624,8 @@ bool InsertCompleter::try_complete(Func complete_func)
     kak_assert(m_completions.begin <= sels.main().cursor());
     m_current_candidate = m_completions.candidates.size();
     menu_show();
-    m_completions.candidates.push_back({sels.buffer().string(m_completions.begin, m_completions.end), "", {}});
+    m_completions.candidates.push_back(
+        {sels.buffer().string(m_completions.begin, m_completions.end), "", {}});
     return true;
 }
 

--- a/src/insert_completer.hh
+++ b/src/insert_completer.hh
@@ -26,19 +26,25 @@ struct InsertCompleterDesc
     };
 
     bool operator==(const InsertCompleterDesc& other) const
-    { return mode == other.mode and param == other.param; }
+    {
+        return mode == other.mode and param == other.param;
+    }
 
     bool operator!=(const InsertCompleterDesc& other) const
-    { return not (*this == other); }
+    {
+        return not(*this == other);
+    }
 
     Mode mode;
     Optional<String> param;
 };
 
-using InsertCompleterDescList = Vector<InsertCompleterDesc, MemoryDomain::Options>;
+using InsertCompleterDescList
+    = Vector<InsertCompleterDesc, MemoryDomain::Options>;
 
 String option_to_string(const InsertCompleterDesc& opt);
-InsertCompleterDesc option_from_string(Meta::Type<InsertCompleterDesc>, StringView str);
+InsertCompleterDesc option_from_string(Meta::Type<InsertCompleterDesc>,
+                                       StringView str);
 
 inline StringView option_type_name(Meta::Type<InsertCompleterDesc>)
 {
@@ -46,7 +52,7 @@ inline StringView option_type_name(Meta::Type<InsertCompleterDesc>)
 }
 
 using CompletionCandidate = std::tuple<String, String, String>;
-using CompletionList = PrefixedList<String, CompletionCandidate>;
+using CompletionList      = PrefixedList<String, CompletionCandidate>;
 
 inline StringView option_type_name(Meta::Type<CompletionList>)
 {
@@ -61,8 +67,14 @@ struct InsertCompletion
         String docstring;
         DisplayLine menu_entry;
 
-        bool operator==(const Candidate& other) const { return completion == other.completion; }
-        bool operator<(const Candidate& other) const { return completion < other.completion; }
+        bool operator==(const Candidate& other) const
+        {
+            return completion == other.completion;
+        }
+        bool operator<(const Candidate& other) const
+        {
+            return completion < other.completion;
+        }
     };
     using CandidateList = Vector<Candidate, MemoryDomain::Completion>;
 
@@ -101,15 +113,15 @@ private:
 
     void menu_show();
 
-    Context&            m_context;
-    OptionManager&      m_options;
+    Context& m_context;
+    OptionManager& m_options;
     const FaceRegistry& m_faces;
-    InsertCompletion    m_completions;
-    int                 m_current_candidate = -1;
+    InsertCompletion m_completions;
+    int m_current_candidate = -1;
 
-    using CompleteFunc = InsertCompletion (const SelectionList& sels,
-                                           const OptionManager& options,
-                                           const FaceRegistry& faces);
+    using CompleteFunc = InsertCompletion(const SelectionList& sels,
+                                          const OptionManager& options,
+                                          const FaceRegistry& faces);
     CompleteFunc* m_explicit_completer = nullptr;
 };
 

--- a/src/json_ui.cc
+++ b/src/json_ui.cc
@@ -17,25 +17,37 @@
 namespace Kakoune
 {
 
-struct invalid_rpc_request : runtime_error {
+struct invalid_rpc_request : runtime_error
+{
     invalid_rpc_request(String message)
-        : runtime_error(format("invalid json rpc request ({})", message)) {}
+        : runtime_error(format("invalid json rpc request ({})", message))
+    {}
 };
 
 template<typename T>
 String to_json(ArrayView<const T> array)
 {
-    return "[" + join(array | transform([](auto&& elem) { return to_json(elem); }), ", ") + "]";
+    return "["
+           + join(array | transform([](auto&& elem) { return to_json(elem); }),
+                  ", ")
+           + "]";
 }
 
 template<typename T, MemoryDomain D>
-String to_json(const Vector<T, D>& vec) { return to_json(ArrayView<const T>{vec}); }
+String to_json(const Vector<T, D>& vec)
+{
+    return to_json(ArrayView<const T>{vec});
+}
 
 template<typename K, typename V, MemoryDomain D>
 String to_json(const HashMap<K, V, D>& map)
 {
-    return "{" + join(map | transform([](auto&& i) { return format("{}: {}", to_json(i.key), to_json(i.value)); }),
-                      ',', false) + "}";
+    return "{"
+           + join(map | transform([](auto&& i) {
+                      return format("{}: {}", to_json(i.key), to_json(i.value));
+                  }),
+                  ',', false)
+           + "}";
 }
 
 String to_json(int i) { return to_string(i); }
@@ -45,7 +57,7 @@ String to_json(StringView str)
     String res;
     res.reserve(str.length() + 4);
     res += '"';
-    for (auto it = str.begin(), end = str.end(); it != end; )
+    for (auto it = str.begin(), end = str.end(); it != end;)
     {
         auto next = std::find_if(it, end, [](char c) {
             return c == '\\' or c == '"' or (c >= 0 and c <= 0x1F);
@@ -60,7 +72,7 @@ String to_json(StringView str)
             sprintf(buf, "\\u%04x", *next);
 
         res += buf;
-        it = next+1;
+        it = next + 1;
     }
     res += '"';
     return res;
@@ -79,23 +91,28 @@ String to_json(Color color)
 
 String to_json(Attribute attributes)
 {
-    struct Attr { Attribute attr; StringView name; }
-    attrs[] {
-        { Attribute::Underline, "underline" },
-        { Attribute::Reverse, "reverse" },
-        { Attribute::Blink, "blink" },
-        { Attribute::Bold, "bold" },
-        { Attribute::Dim, "dim" },
-        { Attribute::Italic, "italic" },
-        { Attribute::FinalFg, "final_fg" },
-        { Attribute::FinalBg, "final_bg" },
-        { Attribute::FinalAttr, "final_attr" },
+    struct Attr
+    {
+        Attribute attr;
+        StringView name;
+    } attrs[]{
+        {Attribute::Underline, "underline"},
+        {Attribute::Reverse, "reverse"},
+        {Attribute::Blink, "blink"},
+        {Attribute::Bold, "bold"},
+        {Attribute::Dim, "dim"},
+        {Attribute::Italic, "italic"},
+        {Attribute::FinalFg, "final_fg"},
+        {Attribute::FinalBg, "final_bg"},
+        {Attribute::FinalAttr, "final_attr"},
     };
 
-    return "[" + join(attrs |
-                      filter([=](const Attr& a) { return attributes & a.attr; }) |
-                      transform([](const Attr& a) { return to_json(a.name); }),
-                      ',', false) + "]";
+    return "["
+           + join(attrs | filter([=](const Attr& a) {
+                      return attributes & a.attr;
+                  }) | transform([](const Attr& a) { return to_json(a.name); }),
+                  ',', false)
+           + "]";
 }
 
 String to_json(Face face)
@@ -106,13 +123,11 @@ String to_json(Face face)
 
 String to_json(const DisplayAtom& atom)
 {
-    return format(R"(\{ "face": {}, "contents": {} })", to_json(atom.face), to_json(atom.content()));
+    return format(R"(\{ "face": {}, "contents": {} })", to_json(atom.face),
+                  to_json(atom.content()));
 }
 
-String to_json(const DisplayLine& line)
-{
-    return to_json(line.atoms());
-}
+String to_json(const DisplayLine& line) { return to_json(line.atoms()); }
 
 String to_json(DisplayCoord coord)
 {
@@ -123,9 +138,12 @@ String to_json(MenuStyle style)
 {
     switch (style)
     {
-        case MenuStyle::Prompt: return R"("prompt")";
-        case MenuStyle::Search: return R"("search")";
-        case MenuStyle::Inline: return R"("inline")";
+        case MenuStyle::Prompt:
+            return R"("prompt")";
+        case MenuStyle::Search:
+            return R"("search")";
+        case MenuStyle::Inline:
+            return R"("inline")";
     }
     return "";
 }
@@ -134,12 +152,18 @@ String to_json(InfoStyle style)
 {
     switch (style)
     {
-        case InfoStyle::Prompt: return R"("prompt")";
-        case InfoStyle::Inline: return R"("inline")";
-        case InfoStyle::InlineAbove: return R"("inlineAbove")";
-        case InfoStyle::InlineBelow: return R"("inlineBelow")";
-        case InfoStyle::MenuDoc: return R"("menuDoc")";
-        case InfoStyle::Modal: return R"("modal")";
+        case InfoStyle::Prompt:
+            return R"("prompt")";
+        case InfoStyle::Inline:
+            return R"("inline")";
+        case InfoStyle::InlineAbove:
+            return R"("inlineAbove")";
+        case InfoStyle::InlineBelow:
+            return R"("inlineBelow")";
+        case InfoStyle::MenuDoc:
+            return R"("menuDoc")";
+        case InfoStyle::Modal:
+            return R"("modal")";
     }
     return "";
 }
@@ -148,16 +172,15 @@ String to_json(CursorMode mode)
 {
     switch (mode)
     {
-        case CursorMode::Prompt: return R"("prompt")";
-        case CursorMode::Buffer: return R"("buffer")";
+        case CursorMode::Prompt:
+            return R"("prompt")";
+        case CursorMode::Buffer:
+            return R"("buffer")";
     }
     return "";
 }
 
-String concat()
-{
-    return "";
-}
+String concat() { return ""; }
 
 template<typename First, typename... Args>
 String concat(First&& first, Args&&... args)
@@ -170,8 +193,9 @@ String concat(First&& first, Args&&... args)
 template<typename... Args>
 void rpc_call(StringView method, Args&&... args)
 {
-    auto q = format(R"(\{ "jsonrpc": "2.0", "method": "{}", "params": [{}] }{})",
-                    method, concat(std::forward<Args>(args)...), "\n");
+    auto q
+        = format(R"(\{ "jsonrpc": "2.0", "method": "{}", "params": [{}] }{})",
+                 method, concat(std::forward<Args>(args)...), "\n");
 
     write(1, q);
 }
@@ -179,87 +203,68 @@ void rpc_call(StringView method, Args&&... args)
 JsonUI::JsonUI()
     : m_stdin_watcher{0, FdEvents::Read,
                       [this](FDWatcher&, FdEvents, EventMode mode) {
-        parse_requests(mode);
-      }}, m_dimensions{24, 80}
+                          parse_requests(mode);
+                      }},
+      m_dimensions{24, 80}
 {
     set_signal_handler(SIGINT, SIG_DFL);
 }
 
-void JsonUI::draw(const DisplayBuffer& display_buffer,
-                  const Face& default_face, const Face& padding_face)
+void JsonUI::draw(const DisplayBuffer& display_buffer, const Face& default_face,
+                  const Face& padding_face)
 {
     rpc_call("draw", display_buffer.lines(), default_face, padding_face);
 }
 
 void JsonUI::draw_status(const DisplayLine& status_line,
-                         const DisplayLine& mode_line,
-                         const Face& default_face)
+                         const DisplayLine& mode_line, const Face& default_face)
 {
     rpc_call("draw_status", status_line, mode_line, default_face);
 }
 
-
-void JsonUI::menu_show(ConstArrayView<DisplayLine> items,
-                       DisplayCoord anchor, Face fg, Face bg,
-                       MenuStyle style)
+void JsonUI::menu_show(ConstArrayView<DisplayLine> items, DisplayCoord anchor,
+                       Face fg, Face bg, MenuStyle style)
 {
     rpc_call("menu_show", items, anchor, fg, bg, style);
 }
 
-void JsonUI::menu_select(int selected)
-{
-    rpc_call("menu_select", selected);
-}
+void JsonUI::menu_select(int selected) { rpc_call("menu_select", selected); }
 
-void JsonUI::menu_hide()
-{
-    rpc_call("menu_hide");
-}
+void JsonUI::menu_hide() { rpc_call("menu_hide"); }
 
 void JsonUI::info_show(StringView title, StringView content,
-                       DisplayCoord anchor, Face face,
-                       InfoStyle style)
+                       DisplayCoord anchor, Face face, InfoStyle style)
 {
     rpc_call("info_show", title, content, anchor, face, style);
 }
 
-void JsonUI::info_hide()
-{
-    rpc_call("info_hide");
-}
+void JsonUI::info_hide() { rpc_call("info_hide"); }
 
 void JsonUI::set_cursor(CursorMode mode, DisplayCoord coord)
 {
     rpc_call("set_cursor", mode, coord);
 }
 
-void JsonUI::refresh(bool force)
-{
-    rpc_call("refresh", force);
-}
+void JsonUI::refresh(bool force) { rpc_call("refresh", force); }
 
 void JsonUI::set_ui_options(const Options& options)
 {
     rpc_call("set_ui_options", options);
 }
 
-DisplayCoord JsonUI::dimensions()
-{
-    return m_dimensions;
-}
+DisplayCoord JsonUI::dimensions() { return m_dimensions; }
 
 void JsonUI::set_on_key(OnKeyCallback callback)
 {
     m_on_key = std::move(callback);
 }
 
-using JsonArray = Vector<Value>;
+using JsonArray  = Vector<Value>;
 using JsonObject = HashMap<String, Value>;
 
 static bool is_digit(char c) { return c >= '0' and c <= '9'; }
 
-std::tuple<Value, const char*>
-parse_json(const char* pos, const char* end)
+std::tuple<Value, const char*> parse_json(const char* pos, const char* end)
 {
     using Result = std::tuple<Value, const char*>;
 
@@ -270,12 +275,12 @@ parse_json(const char* pos, const char* end)
     {
         auto digit_end = pos;
         skip_while(digit_end, end, is_digit);
-        return Result{ Value{str_to_int({pos, digit_end})}, digit_end };
+        return Result{Value{str_to_int({pos, digit_end})}, digit_end};
     }
-    if (end - pos > 4 and StringView{pos, pos+4} == "true")
-        return Result{ Value{true}, pos+4 };
-    if (end - pos > 5 and StringView{pos, pos+5} == "false")
-        return Result{ Value{false}, pos+5 };
+    if (end - pos > 4 and StringView{pos, pos + 4} == "true")
+        return Result{Value{true}, pos + 4};
+    if (end - pos > 5 and StringView{pos, pos + 5} == "false")
+        return Result{Value{false}, pos + 5};
     if (*pos == '"')
     {
         String value;
@@ -288,7 +293,7 @@ parse_json(const char* pos, const char* end)
                 escaped = false;
                 value += StringView{pos, string_end};
                 value.back() = *string_end;
-                pos = string_end+1;
+                pos          = string_end + 1;
                 continue;
             }
             if (*string_end == '\\')
@@ -296,7 +301,7 @@ parse_json(const char* pos, const char* end)
             if (*string_end == '"')
             {
                 value += StringView{pos, string_end};
-                return Result{std::move(value), string_end+1};
+                return Result{std::move(value), string_end + 1};
             }
         }
         return {};
@@ -307,7 +312,7 @@ parse_json(const char* pos, const char* end)
         if (++pos == end)
             throw runtime_error("unable to parse array");
         if (*pos == ']')
-            return Result{std::move(array), pos+1};
+            return Result{std::move(array), pos + 1};
 
         while (true)
         {
@@ -322,9 +327,10 @@ parse_json(const char* pos, const char* end)
             if (*pos == ',')
                 ++pos;
             else if (*pos == ']')
-                return Result{std::move(array), pos+1};
+                return Result{std::move(array), pos + 1};
             else
-                throw runtime_error("unable to parse array, expected ',' or ']'");
+                throw runtime_error(
+                    "unable to parse array, expected ',' or ']'");
         }
     }
     if (*pos == '{')
@@ -333,7 +339,7 @@ parse_json(const char* pos, const char* end)
             throw runtime_error("unable to parse object");
         JsonObject object;
         if (*pos == '}')
-            return Result{std::move(object), pos+1};
+            return Result{std::move(object), pos + 1};
 
         while (true)
         {
@@ -352,23 +358,26 @@ parse_json(const char* pos, const char* end)
             std::tie(element, pos) = parse_json(pos, end);
             if (not element)
                 return {};
-            object.insert({ std::move(name), std::move(element) });
+            object.insert({std::move(name), std::move(element)});
             if (not skip_while(pos, end, is_blank))
                 return {};
 
             if (*pos == ',')
                 ++pos;
             else if (*pos == '}')
-                return Result{std::move(object), pos+1};
+                return Result{std::move(object), pos + 1};
             else
-                throw runtime_error("unable to parse object, expected ',' or '}'");
+                throw runtime_error(
+                    "unable to parse object, expected ',' or '}'");
         }
     }
     throw runtime_error("unable to parse json");
 }
 
-std::tuple<Value, const char*>
-parse_json(StringView json) { return parse_json(json.begin(), json.end()); }
+std::tuple<Value, const char*> parse_json(StringView json)
+{
+    return parse_json(json.begin(), json.end());
+}
 
 void JsonUI::eval_json(const Value& json)
 {
@@ -376,10 +385,9 @@ void JsonUI::eval_json(const Value& json)
         throw invalid_rpc_request("request is not an object");
 
     const JsonObject& object = json.as<JsonObject>();
-    auto json_it = object.find("jsonrpc"_sv);
-    if (json_it == object.end() or
-        not json_it->value.is_a<String>() or
-        json_it->value.as<String>() != "2.0")
+    auto json_it             = object.find("jsonrpc"_sv);
+    if (json_it == object.end() or not json_it->value.is_a<String>()
+        or json_it->value.as<String>() != "2.0")
         throw invalid_rpc_request("only protocol '2.0' is supported");
     else if (not json_it->value.is_a<String>())
         throw invalid_rpc_request("'jsonrpc' is not a string");
@@ -416,12 +424,12 @@ void JsonUI::eval_json(const Value& json)
 
         if (not params[0].is_a<String>())
             throw invalid_rpc_request("mouse type is not a string");
-        else if (not params[1].is_a<int>() or
-                 not params[2].is_a<int>())
+        else if (not params[1].is_a<int>() or not params[2].is_a<int>())
             throw invalid_rpc_request("mouse coordinates are not integers");
 
         const StringView type = params[0].as<String>();
-        const Codepoint coord = encode_coord({params[1].as<int>(), params[2].as<int>()});
+        const Codepoint coord
+            = encode_coord({params[1].as<int>(), params[2].as<int>()});
         if (type == "move")
             m_on_key({Key::Modifiers::MousePos, coord});
         else if (type == "press")
@@ -433,7 +441,8 @@ void JsonUI::eval_json(const Value& json)
         else if (type == "wheel_down")
             m_on_key({Key::Modifiers::MouseWheelDown, coord});
         else
-            throw invalid_rpc_request(format("invalid mouse event type: {}", type));
+            throw invalid_rpc_request(
+                format("invalid mouse event type: {}", type));
     }
     else if (method == "menu_select")
     {
@@ -448,8 +457,7 @@ void JsonUI::eval_json(const Value& json)
     {
         if (params.size() != 2)
             throw runtime_error("resize expects 2 parameters");
-        else if (not params[0].is_a<int>() or
-                 not params[1].is_a<int>())
+        else if (not params[0].is_a<int>() or not params[1].is_a<int>())
             throw invalid_rpc_request("width and height are not integers");
 
         DisplayCoord dim{params[0].as<int>(), params[1].as<int>()};
@@ -494,7 +502,7 @@ void JsonUI::parse_requests(EventMode mode)
             write(2, format("error while handling requests '{}': '{}'\n",
                             m_requests, error.what()));
             // try to salvage request by dropping its first line
-            pos = std::min(m_requests.end(), find(m_requests, '\n')+1);
+            pos = std::min(m_requests.end(), find(m_requests, '\n') + 1);
         }
         if (not pos)
             break; // unterminated request ?
@@ -503,10 +511,10 @@ void JsonUI::parse_requests(EventMode mode)
     }
 }
 
-UnitTest test_json_parser{[]()
-{
+UnitTest test_json_parser{[]() {
     {
-        auto value = std::get<0>(parse_json(R"({ "jsonrpc": "2.0", "method": "keys", "params": [ "b", "l", "a", "h" ] })"));
+        auto value = std::get<0>(parse_json(
+            R"({ "jsonrpc": "2.0", "method": "keys", "params": [ "b", "l", "a", "h" ] })"));
         kak_assert(value);
     }
 

--- a/src/json_ui.hh
+++ b/src/json_ui.hh
@@ -21,23 +21,20 @@ public:
 
     bool is_ok() const override { return m_stdin_watcher.fd() != -1; }
 
-    void draw(const DisplayBuffer& display_buffer,
-              const Face& default_face,
+    void draw(const DisplayBuffer& display_buffer, const Face& default_face,
               const Face& buffer_padding) override;
 
     void draw_status(const DisplayLine& status_line,
                      const DisplayLine& mode_line,
                      const Face& default_face) override;
 
-    void menu_show(ConstArrayView<DisplayLine> items,
-                   DisplayCoord anchor, Face fg, Face bg,
-                   MenuStyle style) override;
+    void menu_show(ConstArrayView<DisplayLine> items, DisplayCoord anchor,
+                   Face fg, Face bg, MenuStyle style) override;
     void menu_select(int selected) override;
     void menu_hide() override;
 
-    void info_show(StringView title, StringView content,
-                   DisplayCoord anchor, Face face,
-                   InfoStyle style) override;
+    void info_show(StringView title, StringView content, DisplayCoord anchor,
+                   Face face, InfoStyle style) override;
     void info_hide() override;
 
     void set_cursor(CursorMode mode, DisplayCoord coord) override;

--- a/src/keymap_manager.cc
+++ b/src/keymap_manager.cc
@@ -10,10 +10,11 @@
 namespace Kakoune
 {
 
-void KeymapManager::map_key(Key key, KeymapMode mode,
-                            KeyList mapping, String docstring)
+void KeymapManager::map_key(Key key, KeymapMode mode, KeyList mapping,
+                            String docstring)
 {
-    m_mapping[KeyAndMode{key, mode}] = {std::move(mapping), std::move(docstring)};
+    m_mapping[KeyAndMode{key, mode}]
+        = {std::move(mapping), std::move(docstring)};
 }
 
 void KeymapManager::unmap_key(Key key, KeymapMode mode)
@@ -36,12 +37,12 @@ void KeymapManager::unmap_keys(KeymapMode mode)
 
 bool KeymapManager::is_mapped(Key key, KeymapMode mode) const
 {
-    return m_mapping.find(KeyAndMode{key, mode}) != m_mapping.end() or
-           (m_parent and m_parent->is_mapped(key, mode));
+    return m_mapping.find(KeyAndMode{key, mode}) != m_mapping.end()
+           or (m_parent and m_parent->is_mapped(key, mode));
 }
 
-const KeymapManager::KeymapInfo&
-KeymapManager::get_mapping(Key key, KeymapMode mode) const
+const KeymapManager::KeymapInfo& KeymapManager::get_mapping(
+    Key key, KeymapMode mode) const
 {
     auto it = m_mapping.find(KeyAndMode{key, mode});
     if (it != m_mapping.end())
@@ -65,13 +66,16 @@ KeymapManager::KeyList KeymapManager::get_mapped_keys(KeymapMode mode) const
 
 void KeymapManager::add_user_mode(String user_mode_name)
 {
-    auto modes = {"normal", "insert", "prompt", "menu", "goto", "view", "user", "object"};
+    auto modes = {"normal", "insert", "prompt", "menu",
+                  "goto",   "view",   "user",   "object"};
 
     if (contains(modes, user_mode_name))
-        throw runtime_error(format("'{}' is already a regular mode", user_mode_name));
+        throw runtime_error(
+            format("'{}' is already a regular mode", user_mode_name));
 
     if (contains(user_modes(), user_mode_name))
-        throw runtime_error(format("user mode '{}' already defined", user_mode_name));
+        throw runtime_error(
+            format("user mode '{}' already defined", user_mode_name));
 
     if (not all_of(user_mode_name, is_identifier))
         throw runtime_error(format("invalid mode name: '{}'", user_mode_name));

--- a/src/keymap_manager.hh
+++ b/src/keymap_manager.hh
@@ -46,7 +46,8 @@ public:
     const KeymapInfo& get_mapping(Key key, KeymapMode mode) const;
 
     using UserModeList = Vector<String>;
-    UserModeList& user_modes() {
+    UserModeList& user_modes()
+    {
         if (m_parent)
             return m_parent->user_modes();
         return m_user_modes;
@@ -54,8 +55,7 @@ public:
     void add_user_mode(const String user_mode_name);
 
 private:
-    KeymapManager()
-        : m_parent(nullptr) {}
+    KeymapManager() : m_parent(nullptr) {}
     // the only one allowed to construct a root map manager
     friend class Scope;
 

--- a/src/keys.cc
+++ b/src/keys.cc
@@ -22,7 +22,7 @@ static Key canonicalize_ifn(Key key)
     {
         kak_assert(key.modifiers == Key::Modifiers::None);
         key.modifiers = Key::Modifiers::Control;
-        key.key = key.key - 1 + 'a';
+        key.key       = key.key - 1 + 'a';
     }
 
     if (key.modifiers & Key::Modifiers::Shift)
@@ -36,7 +36,10 @@ static Key canonicalize_ifn(Key key)
         else if (key.key < 0xD800 || key.key > 0xDFFF)
         {
             // Shift + any other printable character is not allowed.
-            throw key_parse_error(format("Shift modifier only works on special keys and lowercase ASCII, not '{}'", key.key));
+            throw key_parse_error(
+                format("Shift modifier only works on special keys and "
+                       "lowercase ASCII, not '{}'",
+                       key.key));
         }
     }
 
@@ -51,39 +54,44 @@ Optional<Codepoint> Key::codepoint() const
         return '\t';
     if (*this == Key::Escape)
         return 0x1B;
-    if (modifiers == Modifiers::None and key > 27 and
-        (key < 0xD800 or key > 0xDFFF)) // avoid surrogates
+    if (modifiers == Modifiers::None and key > 27
+        and (key < 0xD800 or key > 0xDFFF)) // avoid surrogates
         return key;
     return {};
 }
 
-struct KeyAndName { const char* name; Codepoint key; };
+struct KeyAndName
+{
+    const char* name;
+    Codepoint key;
+};
 static constexpr KeyAndName keynamemap[] = {
-    { "ret", Key::Return },
-    { "space", ' ' },
-    { "tab", Key::Tab },
-    { "lt", '<' },
-    { "gt", '>' },
-    { "backspace", Key::Backspace},
-    { "esc", Key::Escape },
-    { "up", Key::Up },
-    { "down", Key::Down},
-    { "left", Key::Left },
-    { "right", Key::Right },
-    { "pageup", Key::PageUp },
-    { "pagedown", Key::PageDown },
-    { "home", Key::Home },
-    { "end", Key::End },
-    { "del", Key::Delete },
-    { "plus", '+' },
-    { "minus", '-' },
+    {"ret", Key::Return},
+    {"space", ' '},
+    {"tab", Key::Tab},
+    {"lt", '<'},
+    {"gt", '>'},
+    {"backspace", Key::Backspace},
+    {"esc", Key::Escape},
+    {"up", Key::Up},
+    {"down", Key::Down},
+    {"left", Key::Left},
+    {"right", Key::Right},
+    {"pageup", Key::PageUp},
+    {"pagedown", Key::PageDown},
+    {"home", Key::Home},
+    {"end", Key::End},
+    {"del", Key::Delete},
+    {"plus", '+'},
+    {"minus", '-'},
 };
 
 KeyList parse_keys(StringView str)
 {
     KeyList result;
     using Utf8It = utf8::iterator<const char*>;
-    for (Utf8It it{str.begin(), str}, str_end{str.end(), str}; it < str_end; ++it)
+    for (Utf8It it{str.begin(), str}, str_end{str.end(), str}; it < str_end;
+         ++it)
     {
         if (*it != '<')
         {
@@ -100,43 +108,52 @@ KeyList parse_keys(StringView str)
 
         Key::Modifiers modifier = Key::Modifiers::None;
 
-        StringView full_desc{it.base(), end_it.base()+1};
-        StringView desc{it.base()+1, end_it.base()};
-        for (auto dash = find(desc, '-'); dash != desc.end(); dash = find(desc, '-'))
+        StringView full_desc{it.base(), end_it.base() + 1};
+        StringView desc{it.base() + 1, end_it.base()};
+        for (auto dash = find(desc, '-'); dash != desc.end();
+             dash      = find(desc, '-'))
         {
             if (dash != desc.begin() + 1)
-                throw key_parse_error(format("unable to parse modifier in '{}'",
-                                                    full_desc));
+                throw key_parse_error(
+                    format("unable to parse modifier in '{}'", full_desc));
 
-            switch(to_lower(desc[0_byte]))
+            switch (to_lower(desc[0_byte]))
             {
-                case 'c': modifier |= Key::Modifiers::Control; break;
-                case 'a': modifier |= Key::Modifiers::Alt; break;
-                case 's': modifier |= Key::Modifiers::Shift; break;
+                case 'c':
+                    modifier |= Key::Modifiers::Control;
+                    break;
+                case 'a':
+                    modifier |= Key::Modifiers::Alt;
+                    break;
+                case 's':
+                    modifier |= Key::Modifiers::Shift;
+                    break;
                 default:
-                    throw key_parse_error(format("unable to parse modifier in '{}'",
-                                                        full_desc));
+                    throw key_parse_error(
+                        format("unable to parse modifier in '{}'", full_desc));
             }
-            desc = StringView{dash+1, desc.end()};
+            desc = StringView{dash + 1, desc.end()};
         }
 
-        auto name_it = find_if(keynamemap, [&desc](const KeyAndName& item)
-                                           { return item.name == desc; });
+        auto name_it = find_if(keynamemap, [&desc](const KeyAndName& item) {
+            return item.name == desc;
+        });
         if (name_it != std::end(keynamemap))
-            result.push_back(canonicalize_ifn({ modifier, name_it->key }));
+            result.push_back(canonicalize_ifn({modifier, name_it->key}));
         else if (desc.char_length() == 1)
-            result.push_back(canonicalize_ifn({ modifier, desc[0_char] }));
+            result.push_back(canonicalize_ifn({modifier, desc[0_char]}));
         else if (to_lower(desc[0_byte]) == 'f' and desc.length() <= 3)
         {
             int val = str_to_int(desc.substr(1_byte));
             if (val >= 1 and val <= 12)
                 result.emplace_back(modifier, Key::F1 + (val - 1));
             else
-                throw key_parse_error(format("only F1 through F12 are supported, not '{}'", desc));
+                throw key_parse_error(format(
+                    "only F1 through F12 are supported, not '{}'", desc));
         }
         else
-            throw key_parse_error("unable to parse " +
-                                 StringView{it.base(), end_it.base()+1});
+            throw key_parse_error("unable to parse "
+                                  + StringView{it.base(), end_it.base() + 1});
 
         it = end_it;
     }
@@ -147,7 +164,7 @@ String key_to_str(Key key)
 {
     if (auto mouse_event = (key.modifiers & Key::Modifiers::MouseEvent))
     {
-        const auto coord = key.coord() + DisplayCoord{1,1};
+        const auto coord = key.coord() + DisplayCoord{1, 1};
         switch ((Key::Modifiers)mouse_event)
         {
             case Key::Modifiers::MousePos:
@@ -155,72 +172,81 @@ String key_to_str(Key key)
             case Key::Modifiers::MousePress:
                 return format("<mouse:press:{}.{}>", coord.line, coord.column);
             case Key::Modifiers::MouseRelease:
-                return format("<mouse:release:{}.{}>", coord.line, coord.column);
+                return format("<mouse:release:{}.{}>", coord.line,
+                              coord.column);
             case Key::Modifiers::MouseWheelDown:
                 return "<mouse:wheel_down>";
             case Key::Modifiers::MouseWheelUp:
                 return "<mouse:wheel_up>";
-            default: kak_assert(false);
+            default:
+                kak_assert(false);
         }
     }
     else if (key.modifiers == Key::Modifiers::Resize)
     {
-        auto size = key.coord() + DisplayCoord{1,1};
+        auto size = key.coord() + DisplayCoord{1, 1};
         return format("<resize:{}.{}>", size.line, size.column);
     }
 
     bool named = false;
     String res;
-    auto it = find_if(keynamemap, [&key](const KeyAndName& item)
-                                  { return item.key == key.key; });
+    auto it = find_if(keynamemap, [&key](const KeyAndName& item) {
+        return item.key == key.key;
+    });
     if (it != std::end(keynamemap))
     {
         named = true;
-        res = it->name;
+        res   = it->name;
     }
     else if (key.key >= Key::F1 and key.key < Key::F12)
     {
         named = true;
-        res = "F" + to_string((int)(key.key - Key::F1 + 1));
+        res   = "F" + to_string((int)(key.key - Key::F1 + 1));
     }
     else
         res = String{key.key};
 
-    if (key.modifiers & Key::Modifiers::Shift)   { res = "s-" + res; named = true; }
-    if (key.modifiers & Key::Modifiers::Alt)     { res = "a-" + res; named = true; }
-    if (key.modifiers & Key::Modifiers::Control) { res = "c-" + res; named = true; }
+    if (key.modifiers & Key::Modifiers::Shift)
+    {
+        res   = "s-" + res;
+        named = true;
+    }
+    if (key.modifiers & Key::Modifiers::Alt)
+    {
+        res   = "a-" + res;
+        named = true;
+    }
+    if (key.modifiers & Key::Modifiers::Control)
+    {
+        res   = "c-" + res;
+        named = true;
+    }
 
     if (named)
         res = StringView{'<'} + res + StringView{'>'};
     return res;
 }
 
-UnitTest test_keys{[]()
-{
+UnitTest test_keys{[]() {
     KeyList keys{
-         { ' ' },
-         { 'c' },
-         { Key::Up },
-         alt('j'),
-         ctrl('r'),
-         shift(Key::Up),
+        {' '}, {'c'}, {Key::Up}, alt('j'), ctrl('r'), shift(Key::Up),
     };
     String keys_as_str;
     for (auto& key : keys)
         keys_as_str += key_to_str(key);
     auto parsed_keys = parse_keys(keys_as_str);
     kak_assert(keys == parsed_keys);
-    kak_assert(ConstArrayView<Key>{parse_keys("a<c-a-b>c")} ==
-               ConstArrayView<Key>{'a', ctrl(alt({'b'})), 'c'});
+    kak_assert(ConstArrayView<Key>{parse_keys("a<c-a-b>c")}
+               == ConstArrayView<Key>{'a', ctrl(alt({'b'})), 'c'});
 
-    kak_assert(parse_keys("x") == KeyList{ {'x'} });
-    kak_assert(parse_keys("<x>") == KeyList{ {'x'} });
-    kak_assert(parse_keys("<s-x>") == KeyList{ {'X'} });
-    kak_assert(parse_keys("<s-X>") == KeyList{ {'X'} });
-    kak_assert(parse_keys("<X>") == KeyList{ {'X'} });
-    kak_assert(parse_keys("X") == KeyList{ {'X'} });
-    kak_assert(parse_keys("<s-up>") == KeyList{ shift({Key::Up}) });
-    kak_assert(parse_keys("<s-tab>") == KeyList{ shift({Key::Tab}) });
+    kak_assert(parse_keys("x") == KeyList{{'x'}});
+    kak_assert(parse_keys("<x>") == KeyList{{'x'}});
+    kak_assert(parse_keys("<s-x>") == KeyList{{'X'}});
+    kak_assert(parse_keys("<s-X>") == KeyList{{'X'}});
+    kak_assert(parse_keys("<X>") == KeyList{{'X'}});
+    kak_assert(parse_keys("X") == KeyList{{'X'}});
+    kak_assert(parse_keys("<s-up>") == KeyList{shift({Key::Up})});
+    kak_assert(parse_keys("<s-tab>") == KeyList{shift({Key::Tab})});
 
     kak_assert(key_to_str(shift({Key::Tab})) == "<s-tab>");
 

--- a/src/keys.hh
+++ b/src/keys.hh
@@ -21,15 +21,15 @@ struct Key
         Alt     = 1 << 1,
         Shift   = 1 << 2,
 
-        MousePress   = 1 << 3,
-        MouseRelease = 1 << 4,
-        MousePos     = 1 << 5,
+        MousePress     = 1 << 3,
+        MouseRelease   = 1 << 4,
+        MousePos       = 1 << 5,
         MouseWheelDown = 1 << 6,
-        MouseWheelUp = 1 << 7,
-        MouseEvent = MousePress | MouseRelease | MousePos |
-                     MouseWheelDown | MouseWheelUp,
+        MouseWheelUp   = 1 << 7,
+        MouseEvent
+        = MousePress | MouseRelease | MousePos | MouseWheelDown | MouseWheelUp,
 
-        Resize = 1 << 8,
+        Resize     = 1 << 8,
         MenuSelect = 1 << 10,
     };
     enum NamedKey : Codepoint
@@ -66,13 +66,13 @@ struct Key
     };
 
     Modifiers modifiers = {};
-    Codepoint key = {};
+    Codepoint key       = {};
 
     constexpr Key(Modifiers modifiers, Codepoint key)
-        : modifiers(modifiers), key(key) {}
+        : modifiers(modifiers), key(key)
+    {}
 
-    constexpr Key(Codepoint key)
-        : modifiers(Modifiers::None), key(key) {}
+    constexpr Key(Codepoint key) : modifiers(Modifiers::None), key(key) {}
 
     constexpr Key() = default;
 
@@ -82,7 +82,10 @@ struct Key
     constexpr bool operator!=(Key other) const { return val() != other.val(); }
     constexpr bool operator<(Key other) const { return val() < other.val(); }
 
-    constexpr DisplayCoord coord() const { return {(int)((key & 0xFFFF0000) >> 16), (int)(key & 0x0000FFFF)}; }
+    constexpr DisplayCoord coord() const
+    {
+        return {(int)((key & 0xFFFF0000) >> 16), (int)(key & 0x0000FFFF)};
+    }
 
     Optional<Codepoint> codepoint() const;
 };
@@ -95,26 +98,36 @@ class String;
 class StringView;
 
 KeyList parse_keys(StringView str);
-String  key_to_str(Key key);
+String key_to_str(Key key);
 
 constexpr Key shift(Key key)
 {
-    return { key.modifiers | Key::Modifiers::Shift, key.key };
+    return {key.modifiers | Key::Modifiers::Shift, key.key};
 }
 constexpr Key alt(Key key)
 {
-    return { key.modifiers | Key::Modifiers::Alt, key.key };
+    return {key.modifiers | Key::Modifiers::Alt, key.key};
 }
 constexpr Key ctrl(Key key)
 {
-    return { key.modifiers | Key::Modifiers::Control, key.key };
+    return {key.modifiers | Key::Modifiers::Control, key.key};
 }
 
-constexpr Codepoint encode_coord(DisplayCoord coord) { return (Codepoint)(((int)coord.line << 16) | ((int)coord.column & 0x0000FFFF)); }
+constexpr Codepoint encode_coord(DisplayCoord coord)
+{
+    return (Codepoint)(((int)coord.line << 16)
+                       | ((int)coord.column & 0x0000FFFF));
+}
 
-constexpr Key resize(DisplayCoord dim) { return { Key::Modifiers::Resize, encode_coord(dim) }; }
+constexpr Key resize(DisplayCoord dim)
+{
+    return {Key::Modifiers::Resize, encode_coord(dim)};
+}
 
-constexpr size_t hash_value(const Key& key) { return hash_values(key.modifiers, key.key); }
+constexpr size_t hash_value(const Key& key)
+{
+    return hash_values(key.modifiers, key.key);
+}
 
 }
 

--- a/src/line_modification.hh
+++ b/src/line_modification.hh
@@ -14,15 +14,19 @@ class Buffer;
 
 struct LineModification
 {
-    LineCount old_line; // line position in the old buffer
-    LineCount new_line; // new line position
+    LineCount old_line;    // line position in the old buffer
+    LineCount new_line;    // new line position
     LineCount num_removed; // number of lines removed (including this one)
-    LineCount num_added; // number of lines added (including this one)
+    LineCount num_added;   // number of lines added (including this one)
 
-    LineCount diff() const { return new_line - old_line + num_added - num_removed; }
+    LineCount diff() const
+    {
+        return new_line - old_line + num_added - num_removed;
+    }
 };
 
-Vector<LineModification> compute_line_modifications(const Buffer& buffer, size_t timestamp);
+Vector<LineModification> compute_line_modifications(const Buffer& buffer,
+                                                    size_t timestamp);
 
 using LineRange = Range<LineCount>;
 
@@ -38,10 +42,10 @@ struct LineRangeSet : private Vector<LineRange, MemoryDomain::Highlight>
     void reset(LineRange range) { Base::operator=({range}); }
 
     void update(ConstArrayView<LineModification> modifs);
-    void add_range(LineRange range, std::function<void (LineRange)> on_new_range);
+    void add_range(LineRange range,
+                   std::function<void(LineRange)> on_new_range);
     void remove_range(LineRange range);
 };
-
 
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -39,33 +39,37 @@ namespace Kakoune
 
 extern const char* version;
 
-struct {
+struct
+{
     unsigned int version;
     const char* notes;
-} constexpr version_notes[] = { {
-        20181027,
-        "» define-commands -shell-completion and -shell-candidates has been renamed\n"
-        "» exclusive face attributes is replaced with final (fg/bg/attr)\n"
-        "» <a-M> (merge consecutive) moved to <a-_> to make <a-M> backward <a-m>\n"
-        "» remove-hooks now takes a regex parameter\n"
-    }, {
-        20180904,
-        "» Big breaking refactoring of various Kakoune features,\n"
-        "  configuration might need to be updated see `:doc changelog` for details\n"
-        "» define-command -allow-override switch has been renamed -override\n"
-    }, {
-        20180413,
-        "» ModeChange hook has been introduced and is expected to replace\n"
-        "  the various ${MODE}Begin/${MODE}End hooks, consider those deprecated.\n"
-        "» '*' Does not strip whitespaces anymore, use built-in '_' to strip them\n"
-        "» 'l' on eol will go to next line, 'h' on first char will go to previous\n"
-        "» selections merging behaviour is now a bit more complex again\n"
-        "» 'x' will only jump to next line if full line is already selected\n"
-        "» WORD text object moved to <a-w> instead of W for consistency\n"
-        "» rotate main selection moved to ), rotate content to <a-)>, ( for backward\n"
-        "» faces are now scoped, set-face command takes an additional scope parameter\n"
-        "» <backtab> key is gone, use <s-tab> instead\n"
-} };
+} constexpr version_notes[] = {
+    {20181027,
+     "» define-commands -shell-completion and -shell-candidates has been "
+     "renamed\n"
+     "» exclusive face attributes is replaced with final (fg/bg/attr)\n"
+     "» <a-M> (merge consecutive) moved to <a-_> to make <a-M> backward <a-m>\n"
+     "» remove-hooks now takes a regex parameter\n"},
+    {20180904,
+     "» Big breaking refactoring of various Kakoune features,\n"
+     "  configuration might need to be updated see `:doc changelog` for "
+     "details\n"
+     "» define-command -allow-override switch has been renamed -override\n"},
+    {20180413,
+     "» ModeChange hook has been introduced and is expected to replace\n"
+     "  the various ${MODE}Begin/${MODE}End hooks, consider those deprecated.\n"
+     "» '*' Does not strip whitespaces anymore, use built-in '_' to strip "
+     "them\n"
+     "» 'l' on eol will go to next line, 'h' on first char will go to "
+     "previous\n"
+     "» selections merging behaviour is now a bit more complex again\n"
+     "» 'x' will only jump to next line if full line is already selected\n"
+     "» WORD text object moved to <a-w> instead of W for consistency\n"
+     "» rotate main selection moved to ), rotate content to <a-)>, ( for "
+     "backward\n"
+     "» faces are now scoped, set-face command takes an additional scope "
+     "parameter\n"
+     "» <backtab> key is gone, use <s-tab> instead\n"}};
 
 void show_startup_info(Client* local_client, int last_version)
 {
@@ -76,17 +80,19 @@ void show_startup_info(Client* local_client, int last_version)
             info += format("• Development version\n{}\n", note.notes);
         else if (note.version > last_version)
         {
-            const auto year = note.version / 10000;
+            const auto year  = note.version / 10000;
             const auto month = (note.version / 100) % 100;
-            const auto day = note.version % 100;
-            info += format("• Kakoune v{}.{}{}.{}{}\n{}\n",
-                           year, month < 10 ? "0" : "", month, day < 10 ? "0" : "", day, note.notes);
+            const auto day   = note.version % 100;
+            info += format("• Kakoune v{}.{}{}.{}{}\n{}\n", year,
+                           month < 10 ? "0" : "", month, day < 10 ? "0" : "",
+                           day, note.notes);
         }
     }
     if (not info.empty())
     {
         info += "See the `:doc options startup-info` to control this message\n";
-        local_client->info_show(format("Kakoune {}", version), info, {}, InfoStyle::Prompt);
+        local_client->info_show(format("Kakoune {}", version), info, {},
+                                InfoStyle::Prompt);
     }
 }
 
@@ -95,13 +101,30 @@ struct startup_error : runtime_error
     using runtime_error::runtime_error;
 };
 
-inline void write_stdout(StringView str) { try { write(1, str); } catch (runtime_error&) {} }
-inline void write_stderr(StringView str) { try { write(2, str); } catch (runtime_error&) {} }
+inline void write_stdout(StringView str)
+{
+    try
+    {
+        write(1, str);
+    }
+    catch (runtime_error&)
+    {}
+}
+inline void write_stderr(StringView str)
+{
+    try
+    {
+        write(2, str);
+    }
+    catch (runtime_error&)
+    {}
+}
 
 String runtime_directory()
 {
-    char relpath[PATH_MAX+1];
-    format_to(relpath, "{}../share/kak", split_path(get_kak_binary_path()).first);
+    char relpath[PATH_MAX + 1];
+    format_to(relpath, "{}../share/kak",
+              split_path(get_kak_binary_path()).first);
     struct stat st;
     if (stat(relpath, &st) == 0 and S_ISDIR(st.st_mode))
         return real_path(relpath);
@@ -117,147 +140,159 @@ String config_directory()
     return format("{}/kak", config_home);
 }
 
-static const EnvVarDesc builtin_env_vars[] = { {
-        "bufname", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return context.buffer().display_name(); }
-    }, {
-        "buffile", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return context.buffer().name(); }
-    }, {
-        "buflist", false,
-        [](StringView name, const Context& context, Quoting quoting)
-        { return join(BufferManager::instance() |
-                      transform(&Buffer::display_name) | transform(quoter(quoting)), ' ', false); }
-    }, {
-        "buf_line_count", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return to_string(context.buffer().line_count()); }
-    }, {
-        "timestamp", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return to_string(context.buffer().timestamp()); }
-    }, {
-        "history_id", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return to_string((size_t)context.buffer().current_history_id()); }
-    }, {
-        "selection", false,
-        [](StringView name, const Context& context, Quoting quoting)
-        { const Selection& sel = context.selections().main();
-          return content(context.buffer(), sel); }
-    }, {
-        "selections", false,
-        [](StringView name, const Context& context, Quoting quoting)
-        { return join(context.selections_content() | transform(quoter(quoting)), ' ', false); }
-    }, {
-        "runtime", false,
-        [](StringView name, const Context& context, Quoting quoting)
-        { return runtime_directory(); }
-    }, {
-        "config", false,
-        [](StringView name, const Context& context, Quoting quoting)
-        { return config_directory(); }
-    }, {
-        "version", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return version; }
-    }, {
-        "opt_", true,
-        [](StringView name, const Context& context, Quoting quoting)
-        { return context.options()[name.substr(4_byte)].get_as_string(quoting); }
-    }, {
-        "main_reg_", true,
-        [](StringView name, const Context& context, Quoting quoting)
-        { return context.main_sel_register_value(name.substr(9_byte)).str(); }
-    }, {
-        "reg_", true,
-        [](StringView name, const Context& context, Quoting quoting)
-        { return join(RegisterManager::instance()[name.substr(4_byte)].get(context) |
-                      transform(quoter(quoting)), ' ', false); }
-    }, {
-        "client_env_", true,
-        [](StringView name, const Context& context, Quoting quoting)
-        { return context.client().get_env_var(name.substr(11_byte)).str(); }
-    }, {
-        "session", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return Server::instance().session(); }
-    }, {
-        "client", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return context.name(); }
-    }, {
-        "client_pid", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return to_string(context.client().pid()); }
-    }, {
-        "client_list", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return join(ClientManager::instance() |
-                      transform([](const std::unique_ptr<Client>& c) -> const String&
-                               { return c->context().name(); }), ' ', false); }
-    }, {
-        "modified", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return context.buffer().is_modified() ? "true" : "false"; }
-    }, {
-        "cursor_line", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return to_string(context.selections().main().cursor().line + 1); }
-    }, {
-        "cursor_column", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return to_string(context.selections().main().cursor().column + 1); }
-    }, {
-        "cursor_char_value", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { auto coord = context.selections().main().cursor();
-          auto& buffer = context.buffer();
-          return to_string((size_t)utf8::codepoint(buffer.iterator_at(coord), buffer.end())); }
-    }, {
-        "cursor_char_column", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { auto coord = context.selections().main().cursor();
-          return to_string(context.buffer()[coord.line].char_count_to(coord.column) + 1); }
-    }, {
-        "cursor_byte_offset", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { auto cursor = context.selections().main().cursor();
-          return to_string(context.buffer().distance({0,0}, cursor)); }
-    }, {
-        "selection_desc", false,
-        [](StringView name, const Context& context, Quoting quoting)
-        { return selection_to_string(context.selections().main()); }
-    }, {
-        "selections_desc", false,
-        [](StringView name, const Context& context, Quoting quoting)
-        { return selection_list_to_string(context.selections()); }
-    }, {
-        "selection_length", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return to_string(char_length(context.buffer(), context.selections().main())); }
-    }, {
-        "selections_length", false,
-        [](StringView name, const Context& context, Quoting quoting)
-        { return join(context.selections() |
-                      transform([&](const Selection& s)
-                               { return to_string(char_length(context.buffer(), s)); }), ' ', false); }
-    }, {
-        "window_width", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return to_string(context.window().dimensions().column); }
-    }, {
-        "window_height", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return to_string(context.window().dimensions().line); }
-    }, {
-        "user_modes", false,
-        [](StringView name, const Context& context, Quoting quoting) -> String
-        { return join(context.keymaps().user_modes(), ' ', false); }
-    }
-};
+static const EnvVarDesc builtin_env_vars[] = {
+    {"bufname", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return context.buffer().display_name();
+     }},
+    {"buffile", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return context.buffer().name();
+     }},
+    {"buflist", false,
+     [](StringView name, const Context& context, Quoting quoting) {
+         return join(BufferManager::instance()
+                         | transform(&Buffer::display_name)
+                         | transform(quoter(quoting)),
+                     ' ', false);
+     }},
+    {"buf_line_count", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return to_string(context.buffer().line_count());
+     }},
+    {"timestamp", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return to_string(context.buffer().timestamp());
+     }},
+    {"history_id", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return to_string((size_t)context.buffer().current_history_id());
+     }},
+    {"selection", false,
+     [](StringView name, const Context& context, Quoting quoting) {
+         const Selection& sel = context.selections().main();
+         return content(context.buffer(), sel);
+     }},
+    {"selections", false,
+     [](StringView name, const Context& context, Quoting quoting) {
+         return join(context.selections_content() | transform(quoter(quoting)),
+                     ' ', false);
+     }},
+    {"runtime", false,
+     [](StringView name, const Context& context, Quoting quoting) {
+         return runtime_directory();
+     }},
+    {"config", false,
+     [](StringView name, const Context& context, Quoting quoting) {
+         return config_directory();
+     }},
+    {"version", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return version;
+     }},
+    {"opt_", true,
+     [](StringView name, const Context& context, Quoting quoting) {
+         return context.options()[name.substr(4_byte)].get_as_string(quoting);
+     }},
+    {"main_reg_", true,
+     [](StringView name, const Context& context, Quoting quoting) {
+         return context.main_sel_register_value(name.substr(9_byte)).str();
+     }},
+    {"reg_", true,
+     [](StringView name, const Context& context, Quoting quoting) {
+         return join(
+             RegisterManager::instance()[name.substr(4_byte)].get(context)
+                 | transform(quoter(quoting)),
+             ' ', false);
+     }},
+    {"client_env_", true,
+     [](StringView name, const Context& context, Quoting quoting) {
+         return context.client().get_env_var(name.substr(11_byte)).str();
+     }},
+    {"session", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return Server::instance().session();
+     }},
+    {"client", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return context.name();
+     }},
+    {"client_pid", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return to_string(context.client().pid());
+     }},
+    {"client_list", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return join(
+             ClientManager::instance()
+                 | transform(
+                       [](const std::unique_ptr<Client>& c) -> const String& {
+                           return c->context().name();
+                       }),
+             ' ', false);
+     }},
+    {"modified", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return context.buffer().is_modified() ? "true" : "false";
+     }},
+    {"cursor_line", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return to_string(context.selections().main().cursor().line + 1);
+     }},
+    {"cursor_column", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return to_string(context.selections().main().cursor().column + 1);
+     }},
+    {"cursor_char_value", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         auto coord   = context.selections().main().cursor();
+         auto& buffer = context.buffer();
+         return to_string(
+             (size_t)utf8::codepoint(buffer.iterator_at(coord), buffer.end()));
+     }},
+    {"cursor_char_column", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         auto coord = context.selections().main().cursor();
+         return to_string(
+             context.buffer()[coord.line].char_count_to(coord.column) + 1);
+     }},
+    {"cursor_byte_offset", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         auto cursor = context.selections().main().cursor();
+         return to_string(context.buffer().distance({0, 0}, cursor));
+     }},
+    {"selection_desc", false,
+     [](StringView name, const Context& context, Quoting quoting) {
+         return selection_to_string(context.selections().main());
+     }},
+    {"selections_desc", false,
+     [](StringView name, const Context& context, Quoting quoting) {
+         return selection_list_to_string(context.selections());
+     }},
+    {"selection_length", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return to_string(
+             char_length(context.buffer(), context.selections().main()));
+     }},
+    {"selections_length", false,
+     [](StringView name, const Context& context, Quoting quoting) {
+         return join(context.selections() | transform([&](const Selection& s) {
+                         return to_string(char_length(context.buffer(), s));
+                     }),
+                     ' ', false);
+     }},
+    {"window_width", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return to_string(context.window().dimensions().column);
+     }},
+    {"window_height", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return to_string(context.window().dimensions().line);
+     }},
+    {"user_modes", false,
+     [](StringView name, const Context& context, Quoting quoting) -> String {
+         return join(context.keymaps().user_modes(), ' ', false);
+     }}};
 
 void register_registers()
 {
@@ -268,48 +303,54 @@ void register_registers()
 
     using StringList = Vector<String, MemoryDomain::Registers>;
 
-    register_manager.add_register('%', make_dyn_reg(
-        [](const Context& context)
-        { return StringList{{context.buffer().display_name()}}; }));
+    register_manager.add_register(
+        '%', make_dyn_reg([](const Context& context) {
+            return StringList{{context.buffer().display_name()}};
+        }));
 
-    register_manager.add_register('.', make_dyn_reg(
-        [](const Context& context) {
+    register_manager.add_register(
+        '.', make_dyn_reg([](const Context& context) {
             auto content = context.selections_content();
             return StringList{content.begin(), content.end()};
-         }));
-
-    register_manager.add_register('#', make_dyn_reg(
-        [](const Context& context) {
-            const size_t count = context.selections().size();
-            StringList res;
-            res.reserve(count);
-            for (size_t i = 1; i < count+1; ++i)
-                res.push_back(to_string((int)i));
-            return res;
         }));
+
+    register_manager.add_register('#', make_dyn_reg([](const Context& context) {
+                                      const size_t count
+                                          = context.selections().size();
+                                      StringList res;
+                                      res.reserve(count);
+                                      for (size_t i = 1; i < count + 1; ++i)
+                                          res.push_back(to_string((int)i));
+                                      return res;
+                                  }));
 
     for (size_t i = 0; i < 10; ++i)
     {
-        register_manager.add_register('0'+i, make_dyn_reg(
-            [i](const Context& context) {
-                StringList result;
-                for (auto& sel : context.selections())
-                    result.emplace_back(i < sel.captures().size() ? sel.captures()[i] : "");
-                return result;
-            },
-            [i](Context& context, ConstArrayView<String> values) {
-                if (values.empty())
-                    return;
+        register_manager.add_register(
+            '0' + i,
+            make_dyn_reg(
+                [i](const Context& context) {
+                    StringList result;
+                    for (auto& sel : context.selections())
+                        result.emplace_back(
+                            i < sel.captures().size() ? sel.captures()[i] : "");
+                    return result;
+                },
+                [i](Context& context, ConstArrayView<String> values) {
+                    if (values.empty())
+                        return;
 
-                auto& sels = context.selections();
-                for (size_t sel_index = 0; sel_index < sels.size(); ++sel_index)
-                {
-                    auto& sel = sels[sel_index];
-                    if (sel.captures().size() < i+1)
-                        sel.captures().resize(i+1);
-                    sel.captures()[i] = values[std::min(sel_index, values.size()-1)];
-                }
-            }));
+                    auto& sels = context.selections();
+                    for (size_t sel_index = 0; sel_index < sels.size();
+                         ++sel_index)
+                    {
+                        auto& sel = sels[sel_index];
+                        if (sel.captures().size() < i + 1)
+                            sel.captures().resize(i + 1);
+                        sel.captures()[i]
+                            = values[std::min(sel_index, values.size() - 1)];
+                    }
+                }));
     }
 
     register_manager.add_register('_', std::make_unique<NullRegister>());
@@ -317,12 +358,14 @@ void register_registers()
 
 static void check_tabstop(const int& val)
 {
-    if (val < 1) throw runtime_error{"tabstop should be strictly positive"};
+    if (val < 1)
+        throw runtime_error{"tabstop should be strictly positive"};
 }
 
 static void check_indentwidth(const int& val)
 {
-    if (val < 0) throw runtime_error{"indentwidth should be positive or zero"};
+    if (val < 0)
+        throw runtime_error{"indentwidth should be positive or zero"};
 }
 
 static void check_scrolloff(const DisplayCoord& so)
@@ -334,19 +377,24 @@ static void check_scrolloff(const DisplayCoord& so)
 static void check_timeout(const int& timeout)
 {
     if (timeout < 50)
-        throw runtime_error{"the minimum acceptable timeout is 50 milliseconds"};
+        throw runtime_error{
+            "the minimum acceptable timeout is 50 milliseconds"};
 }
 
-static void check_extra_word_chars(const Vector<Codepoint, MemoryDomain::Options>& extra_chars)
+static void check_extra_word_chars(
+    const Vector<Codepoint, MemoryDomain::Options>& extra_chars)
 {
     if (any_of(extra_chars, is_blank))
-        throw runtime_error{"blanks are not accepted for extra completion characters"};
+        throw runtime_error{
+            "blanks are not accepted for extra completion characters"};
 }
 
-static void check_matching_pairs(const Vector<Codepoint, MemoryDomain::Options>& pairs)
+static void check_matching_pairs(
+    const Vector<Codepoint, MemoryDomain::Options>& pairs)
 {
     if ((pairs.size() % 2) != 0)
-        throw runtime_error{"matching pairs should have a pair number of element"};
+        throw runtime_error{
+            "matching pairs should have a pair number of element"};
     if (not all_of(pairs, [](Codepoint cp) { return is_punctuation(cp); }))
         throw runtime_error{"matching pairs can only be punctuation"};
 }
@@ -355,84 +403,100 @@ void register_options()
 {
     OptionsRegistry& reg = GlobalScope::instance().option_registry();
 
-    reg.declare_option<int, check_tabstop>("tabstop", "size of a tab character", 8);
-    reg.declare_option<int, check_indentwidth>("indentwidth", "indentation width", 4);
+    reg.declare_option<int, check_tabstop>("tabstop", "size of a tab character",
+                                           8);
+    reg.declare_option<int, check_indentwidth>("indentwidth",
+                                               "indentation width", 4);
     reg.declare_option<DisplayCoord, check_scrolloff>(
-        "scrolloff", "number of lines and columns to keep visible main cursor when scrolling",
-        {0,0});
+        "scrolloff",
+        "number of lines and columns to keep visible main cursor when "
+        "scrolling",
+        {0, 0});
     reg.declare_option("eolformat", "end of line format", EolFormat::Lf);
     reg.declare_option("BOM", "byte order mark to use when writing buffer",
                        ByteOrderMark::None);
     reg.declare_option("incsearch",
-                       "incrementally apply search/select/split regex",
-                       true);
-    reg.declare_option("autoinfo",
-                       "automatically display contextual help",
+                       "incrementally apply search/select/split regex", true);
+    reg.declare_option("autoinfo", "automatically display contextual help",
                        AutoInfo::Command | AutoInfo::OnKey);
     reg.declare_option("autocomplete",
                        "automatically display possible completions",
                        AutoComplete::Insert | AutoComplete::Prompt);
     reg.declare_option("aligntab",
-                       "use tab characters when possible for alignment",
-                       false);
+                       "use tab characters when possible for alignment", false);
     reg.declare_option("ignored_files",
                        "patterns to ignore when completing filenames",
                        Regex{R"(^(\..*|.*\.(o|so|a))$)"});
     reg.declare_option("disabled_hooks",
-                      "patterns to disable hooks whose group is matched",
-                      Regex{});
+                       "patterns to disable hooks whose group is matched",
+                       Regex{});
     reg.declare_option("filetype", "buffer filetype", ""_str);
-    reg.declare_option("path", "path to consider when trying to find a file",
-                   Vector<String, MemoryDomain::Options>({ "./", "%/", "/usr/include" }));
-    reg.declare_option("completers", "insert mode completers to execute.",
-                       InsertCompleterDescList({
-                           InsertCompleterDesc{ InsertCompleterDesc::Filename, {} },
-                           InsertCompleterDesc{ InsertCompleterDesc::Word, "all"_str }
-                       }), OptionFlags::None);
-    reg.declare_option("static_words", "list of words to always consider for insert word completion",
-                   Vector<String, MemoryDomain::Options>{});
-    reg.declare_option("autoreload",
-                       "autoreload buffer when a filesystem modification is detected",
-                       Autoreload::Ask);
+    reg.declare_option(
+        "path", "path to consider when trying to find a file",
+        Vector<String, MemoryDomain::Options>({"./", "%/", "/usr/include"}));
+    reg.declare_option(
+        "completers", "insert mode completers to execute.",
+        InsertCompleterDescList(
+            {InsertCompleterDesc{InsertCompleterDesc::Filename, {}},
+             InsertCompleterDesc{InsertCompleterDesc::Word, "all"_str}}),
+        OptionFlags::None);
+    reg.declare_option(
+        "static_words",
+        "list of words to always consider for insert word completion",
+        Vector<String, MemoryDomain::Options>{});
+    reg.declare_option(
+        "autoreload",
+        "autoreload buffer when a filesystem modification is detected",
+        Autoreload::Ask);
     reg.declare_option<int, check_timeout>(
-        "idle_timeout", "timeout, in milliseconds, before idle hooks are triggered", 50);
+        "idle_timeout",
+        "timeout, in milliseconds, before idle hooks are triggered", 50);
     reg.declare_option<int, check_timeout>(
-        "fs_check_timeout", "timeout, in milliseconds, between file system buffer modification checks",
+        "fs_check_timeout",
+        "timeout, in milliseconds, between file system buffer modification "
+        "checks",
         500);
-    reg.declare_option("ui_options",
-                       "space separated list of <key>=<value> options that are "
-                       "passed to and interpreted by the user interface\n"
-                       "\n"
-                       "The ncurses ui supports the following options:\n"
-                       "    <key>:                        <value>:\n"
-                       "    ncurses_assistant             clippy|cat|dilbert|none|off\n"
-                       "    ncurses_status_on_top         bool\n"
-                       "    ncurses_set_title             bool\n"
-                       "    ncurses_enable_mouse          bool\n"
-                       "    ncurses_change_colors         bool\n"
-                       "    ncurses_wheel_up_button       int\n"
-                       "    ncurses_wheel_down_button     int\n"
-                       "    ncurses_shift_function_key    int\n",
-                       UserInterface::Options{});
-    reg.declare_option("modelinefmt", "format string used to generate the modeline",
-                       "%val{bufname} %val{cursor_line}:%val{cursor_char_column} {{context_info}} {{mode_info}} - %val{client}@[%val{session}]"_str);
+    reg.declare_option(
+        "ui_options",
+        "space separated list of <key>=<value> options that are "
+        "passed to and interpreted by the user interface\n"
+        "\n"
+        "The ncurses ui supports the following options:\n"
+        "    <key>:                        <value>:\n"
+        "    ncurses_assistant             clippy|cat|dilbert|none|off\n"
+        "    ncurses_status_on_top         bool\n"
+        "    ncurses_set_title             bool\n"
+        "    ncurses_enable_mouse          bool\n"
+        "    ncurses_change_colors         bool\n"
+        "    ncurses_wheel_up_button       int\n"
+        "    ncurses_wheel_down_button     int\n"
+        "    ncurses_shift_function_key    int\n",
+        UserInterface::Options{});
+    reg.declare_option(
+        "modelinefmt", "format string used to generate the modeline",
+        "%val{bufname} %val{cursor_line}:%val{cursor_char_column} {{context_info}} {{mode_info}} - %val{client}@[%val{session}]"_str);
 
     reg.declare_option("debug", "various debug flags", DebugFlags::None);
-    reg.declare_option("readonly", "prevent buffers from being modified", false);
-    reg.declare_option<Vector<Codepoint, MemoryDomain::Options>, check_extra_word_chars>(
+    reg.declare_option("readonly", "prevent buffers from being modified",
+                       false);
+    reg.declare_option<Vector<Codepoint, MemoryDomain::Options>,
+                       check_extra_word_chars>(
         "extra_word_chars",
         "Additional characters to be considered as words for insert completion",
-        { '_' });
-    reg.declare_option<Vector<Codepoint, MemoryDomain::Options>, check_matching_pairs>(
+        {'_'});
+    reg.declare_option<Vector<Codepoint, MemoryDomain::Options>,
+                       check_matching_pairs>(
         "matching_pairs",
         "set of pair of characters to be considered as matching pairs",
-        { '(', ')', '{', '}', '[', ']', '<', '>' });
-    reg.declare_option<int>("startup_info_version", "version up to which startup info changes should be hidden", 0);
+        {'(', ')', '{', '}', '[', ']', '<', '>'});
+    reg.declare_option<int>(
+        "startup_info_version",
+        "version up to which startup info changes should be hidden", 0);
 }
 
-static Client* local_client = nullptr;
-static int local_client_exit = 0;
-static UserInterface* local_ui = nullptr;
+static Client* local_client           = nullptr;
+static int local_client_exit          = 0;
+static UserInterface* local_ui        = nullptr;
 static bool convert_to_client_pending = false;
 
 enum class UIType
@@ -444,9 +508,12 @@ enum class UIType
 
 UIType parse_ui_type(StringView ui_name)
 {
-    if (ui_name == "ncurses") return UIType::NCurses;
-    if (ui_name == "json") return UIType::Json;
-    if (ui_name == "dummy") return UIType::Dummy;
+    if (ui_name == "ncurses")
+        return UIType::NCurses;
+    if (ui_name == "json")
+        return UIType::Json;
+    if (ui_name == "dummy")
+        return UIType::Dummy;
 
     throw parameter_error(format("error: unknown ui type: '{}'", ui_name));
 }
@@ -457,17 +524,22 @@ std::unique_ptr<UserInterface> make_ui(UIType ui_type)
     {
         DummyUI() { set_signal_handler(SIGINT, SIG_DFL); }
         bool is_ok() const override { return true; }
-        void menu_show(ConstArrayView<DisplayLine>, DisplayCoord,
-                       Face, Face, MenuStyle) override {}
+        void menu_show(ConstArrayView<DisplayLine>, DisplayCoord, Face, Face,
+                       MenuStyle) override
+        {}
         void menu_select(int) override {}
         void menu_hide() override {}
 
-        void info_show(StringView, StringView, DisplayCoord, Face, InfoStyle) override {}
+        void info_show(StringView, StringView, DisplayCoord, Face,
+                       InfoStyle) override
+        {}
         void info_hide() override {}
 
         void draw(const DisplayBuffer&, const Face&, const Face&) override {}
-        void draw_status(const DisplayLine&, const DisplayLine&, const Face&) override {}
-        DisplayCoord dimensions() override { return {24,80}; }
+        void draw_status(const DisplayLine&, const DisplayLine&,
+                         const Face&) override
+        {}
+        DisplayCoord dimensions() override { return {24, 80}; }
         void set_cursor(CursorMode, DisplayCoord) override {}
         void refresh(bool) override {}
         void set_on_key(OnKeyCallback) override {}
@@ -476,9 +548,12 @@ std::unique_ptr<UserInterface> make_ui(UIType ui_type)
 
     switch (ui_type)
     {
-        case UIType::NCurses: return std::make_unique<NCursesUI>();
-        case UIType::Json: return std::make_unique<JsonUI>();
-        case UIType::Dummy: return std::make_unique<DummyUI>();
+        case UIType::NCurses:
+            return std::make_unique<NCursesUI>();
+        case UIType::Json:
+            return std::make_unique<JsonUI>();
+        case UIType::Dummy:
+            return std::make_unique<DummyUI>();
     }
     throw logic_error{};
 }
@@ -491,8 +566,9 @@ pid_t fork_server_to_background()
     if (fork()) // double fork to orphan the server
         exit(0);
 
-    write_stderr(format("Kakoune forked server to background ({}), for session '{}'\n",
-                        getpid(), Server::instance().session()));
+    write_stderr(
+        format("Kakoune forked server to background ({}), for session '{}'\n",
+               getpid(), Server::instance().session()));
     return 0;
 }
 
@@ -509,11 +585,13 @@ std::unique_ptr<UserInterface> create_local_ui(UIType ui_type)
             local_ui = this;
 
             m_old_sigtstp = set_signal_handler(SIGTSTP, [](int) {
-                if (ClientManager::instance().count() == 1 and
-                    *ClientManager::instance().begin() == local_client)
+                if (ClientManager::instance().count() == 1
+                    and *ClientManager::instance().begin() == local_client)
                 {
                     // Suspend normally if we are the only client
-                    auto current = set_signal_handler(SIGTSTP, static_cast<LocalUI*>(local_ui)->m_old_sigtstp);
+                    auto current = set_signal_handler(
+                        SIGTSTP,
+                        static_cast<LocalUI*>(local_ui)->m_old_sigtstp);
 
                     sigset_t unblock_sigtstp, old_mask;
                     sigemptyset(&unblock_sigtstp);
@@ -527,16 +605,16 @@ std::unique_ptr<UserInterface> create_local_ui(UIType ui_type)
                 }
                 else
                     convert_to_client_pending = true;
-           });
+            });
         }
 
         ~LocalUI() override
         {
             set_signal_handler(SIGTSTP, m_old_sigtstp);
             local_client = nullptr;
-            local_ui = nullptr;
-            if (not convert_to_client_pending and
-                not ClientManager::instance().empty())
+            local_ui     = nullptr;
+            if (not convert_to_client_pending
+                and not ClientManager::instance().empty())
             {
                 if (fork_server_to_background())
                 {
@@ -557,7 +635,7 @@ std::unique_ptr<UserInterface> create_local_ui(UIType ui_type)
     if (not isatty(0))
     {
         // move stdin to another fd, and restore tty as stdin
-        int fd = dup(0);
+        int fd  = dup(0);
         int tty = open("/dev/tty", O_RDONLY);
         dup2(tty, 0);
         close(tty);
@@ -568,14 +646,14 @@ std::unique_ptr<UserInterface> create_local_ui(UIType ui_type)
 }
 
 int run_client(StringView session, StringView name, StringView client_init,
-               Optional<BufferCoord> init_coord, UIType ui_type,
-               bool suspend)
+               Optional<BufferCoord> init_coord, UIType ui_type, bool suspend)
 {
     try
     {
         EventManager event_manager;
-        RemoteClient client{session, name, make_ui(ui_type), getpid(), get_env_vars(),
-                            client_init, std::move(init_coord)};
+        RemoteClient client{
+            session,        name,        make_ui(ui_type),     getpid(),
+            get_env_vars(), client_init, std::move(init_coord)};
         if (suspend)
             raise(SIGTSTP);
         while (not client.exit_status() and client.is_ui_ok())
@@ -622,26 +700,27 @@ int run_server(StringView session, StringView server_init,
         }
         if (pid_t child = fork())
         {
-            write_stderr(format("Kakoune forked to background, for session '{}'\n"
-                                "send SIGTERM to process {} for closing the session\n",
-                                session, child));
+            write_stderr(
+                format("Kakoune forked to background, for session '{}'\n"
+                       "send SIGTERM to process {} for closing the session\n",
+                       session, child));
             exit(0);
         }
         set_signal_handler(SIGTERM, [](int) { terminate = true; });
     }
 
-    EventManager        event_manager;
-    Server              server{session.empty() ? to_string(getpid()) : session.str()};
+    EventManager event_manager;
+    Server server{session.empty() ? to_string(getpid()) : session.str()};
 
-    StringRegistry      string_registry;
-    GlobalScope         global_scope;
-    ShellManager        shell_manager{builtin_env_vars};
-    CommandManager      command_manager;
-    RegisterManager     register_manager;
+    StringRegistry string_registry;
+    GlobalScope global_scope;
+    ShellManager shell_manager{builtin_env_vars};
+    CommandManager command_manager;
+    RegisterManager register_manager;
     HighlighterRegistry highlighter_registry;
     DefinedHighlighters defined_highlighters;
-    ClientManager       client_manager;
-    BufferManager       buffer_manager;
+    ClientManager client_manager;
+    BufferManager buffer_manager;
 
     register_options();
     register_registers();
@@ -652,94 +731,111 @@ int run_server(StringView session, StringView server_init,
 
     UnitTest::run_all_tests();
 
-    write_to_debug_buffer("*** This is the debug buffer, where debug info will be written ***");
+    write_to_debug_buffer(
+        "*** This is the debug buffer, where debug info will be written ***");
 
-    GlobalScope::instance().options().get_local_option("readonly").set<bool>(flags & ServerFlags::ReadOnly);
+    GlobalScope::instance()
+        .options()
+        .get_local_option("readonly")
+        .set<bool>(flags & ServerFlags::ReadOnly);
 
     bool startup_error = false;
-    if (not (flags & ServerFlags::IgnoreKakrc)) try
-    {
-        Context init_context{Context::EmptyContextFlag{}};
-        command_manager.execute(format("source {}/kakrc", runtime_directory()),
-                                init_context);
-    }
-    catch (runtime_error& error)
-    {
-        startup_error = true;
-        write_to_debug_buffer(format("error while parsing kakrc:\n"
-                                     "    {}", error.what()));
-    }
+    if (not(flags & ServerFlags::IgnoreKakrc))
+        try
+        {
+            Context init_context{Context::EmptyContextFlag{}};
+            command_manager.execute(
+                format("source {}/kakrc", runtime_directory()), init_context);
+        }
+        catch (runtime_error& error)
+        {
+            startup_error = true;
+            write_to_debug_buffer(
+                format("error while parsing kakrc:\n"
+                       "    {}",
+                       error.what()));
+        }
 
-    if (not server_init.empty()) try
-    {
-        Context init_context{Context::EmptyContextFlag{}};
-        command_manager.execute(server_init, init_context);
-    }
-    catch (runtime_error& error)
-    {
-        startup_error = true;
-        write_to_debug_buffer(format("error while running server init commands:\n"
-                                     "    {}", error.what()));
-    }
+    if (not server_init.empty())
+        try
+        {
+            Context init_context{Context::EmptyContextFlag{}};
+            command_manager.execute(server_init, init_context);
+        }
+        catch (runtime_error& error)
+        {
+            startup_error = true;
+            write_to_debug_buffer(
+                format("error while running server init commands:\n"
+                       "    {}",
+                       error.what()));
+        }
 
     {
         Context empty_context{Context::EmptyContextFlag{}};
         global_scope.hooks().run_hook(Hook::KakBegin, session, empty_context);
     }
 
-    if (not files.empty()) try
-    {
-        // create buffers in reverse order so that the first given buffer
-        // is the most recently created one.
-        for (auto& file : files | reverse())
+    if (not files.empty())
+        try
         {
-            try
+            // create buffers in reverse order so that the first given buffer
+            // is the most recently created one.
+            for (auto& file : files | reverse())
             {
-                Buffer *buffer = open_or_create_file_buffer(file);
-                if (flags & ServerFlags::ReadOnly)
-                    buffer->flags() |= Buffer::Flags::ReadOnly;
-            }
-            catch (runtime_error& error)
-            {
-                startup_error = true;
-                write_to_debug_buffer(format("error while opening file '{}':\n"
-                                             "    {}", file, error.what()));
+                try
+                {
+                    Buffer* buffer = open_or_create_file_buffer(file);
+                    if (flags & ServerFlags::ReadOnly)
+                        buffer->flags() |= Buffer::Flags::ReadOnly;
+                }
+                catch (runtime_error& error)
+                {
+                    startup_error = true;
+                    write_to_debug_buffer(
+                        format("error while opening file '{}':\n"
+                               "    {}",
+                               file, error.what()));
+                }
             }
         }
-    }
-    catch (runtime_error& error)
-    {
-         write_to_debug_buffer(format("error while opening command line files: {}", error.what()));
-    }
+        catch (runtime_error& error)
+        {
+            write_to_debug_buffer(format(
+                "error while opening command line files: {}", error.what()));
+        }
 
     try
     {
-        if (not (flags & ServerFlags::Daemon))
+        if (not(flags & ServerFlags::Daemon))
         {
             local_client = client_manager.create_client(
-                 create_local_ui(ui_type), getpid(), {}, get_env_vars(), client_init, std::move(init_coord),
-                 [](int status) { local_client_exit = status; });
+                create_local_ui(ui_type), getpid(), {}, get_env_vars(),
+                client_init, std::move(init_coord),
+                [](int status) { local_client_exit = status; });
 
             if (startup_error and local_client)
-                local_client->print_status({
-                    "error during startup, see *debug* buffer for details",
-                    local_client->context().faces()["Error"]
-                });
+                local_client->print_status(
+                    {"error during startup, see *debug* buffer for details",
+                     local_client->context().faces()["Error"]});
 
             if (flags & ServerFlags::StartupInfo and local_client)
-                show_startup_info(local_client, global_scope.options()["startup_info_version"].get<int>());
+                show_startup_info(
+                    local_client,
+                    global_scope.options()["startup_info_version"].get<int>());
         }
 
-        while (not terminate and
-               (not client_manager.empty() or server.negotiating() or
-                (flags & ServerFlags::Daemon)))
+        while (not terminate
+               and (not client_manager.empty() or server.negotiating()
+                    or (flags & ServerFlags::Daemon)))
         {
             client_manager.redraw_clients();
 
-            // Loop so that eventual inputs happening during the processing are handled as
-            // well, avoiding unneeded redraws.
+            // Loop so that eventual inputs happening during the processing are
+            // handled as well, avoiding unneeded redraws.
             bool allow_blocking = not client_manager.has_pending_inputs();
-            while (event_manager.handle_next_events(EventMode::Normal, nullptr, allow_blocking))
+            while (event_manager.handle_next_events(EventMode::Normal, nullptr,
+                                                    allow_blocking))
             {
                 client_manager.process_pending_inputs();
                 allow_blocking = false;
@@ -754,7 +850,8 @@ int run_server(StringView session, StringView server_init,
                 local_client = nullptr;
             else if (local_client and not local_client->is_ui_ok())
             {
-                ClientManager::instance().remove_client(*local_client, false, -1);
+                ClientManager::instance().remove_client(*local_client, false,
+                                                        -1);
                 local_client = nullptr;
                 if (not client_manager.empty() and fork_server_to_background())
                     return 0;
@@ -763,8 +860,10 @@ int run_server(StringView session, StringView server_init,
             {
                 kak_assert(local_client);
                 const String client_name = local_client->context().name();
-                const String buffer_name = local_client->context().buffer().name();
-                const String selections = selection_list_to_string(local_client->context().selections());
+                const String buffer_name
+                    = local_client->context().buffer().name();
+                const String selections = selection_list_to_string(
+                    local_client->context().selections());
 
                 ClientManager::instance().remove_client(*local_client, true, 0);
                 client_manager.clear_client_trash();
@@ -774,7 +873,9 @@ int run_server(StringView session, StringView server_init,
                 {
                     String session = server.session();
                     server.close_session(false);
-                    throw convert_to_client_mode{ std::move(session), std::move(client_name), std::move(buffer_name), std::move(selections) };
+                    throw convert_to_client_mode{
+                        std::move(session), std::move(client_name),
+                        std::move(buffer_name), std::move(selections)};
                 }
             }
         }
@@ -792,14 +893,15 @@ int run_server(StringView session, StringView server_init,
     return local_client_exit;
 }
 
-int run_filter(StringView keystr, ConstArrayView<StringView> files, bool quiet, StringView suffix_backup)
+int run_filter(StringView keystr, ConstArrayView<StringView> files, bool quiet,
+               StringView suffix_backup)
 {
-    StringRegistry  string_registry;
-    GlobalScope     global_scope;
-    EventManager    event_manager;
-    ShellManager    shell_manager{builtin_env_vars};
+    StringRegistry string_registry;
+    GlobalScope global_scope;
+    EventManager event_manager;
+    ShellManager shell_manager{builtin_env_vars};
     RegisterManager register_manager;
-    BufferManager   buffer_manager;
+    BufferManager buffer_manager;
 
     register_options();
     register_registers();
@@ -808,14 +910,12 @@ int run_filter(StringView keystr, ConstArrayView<StringView> files, bool quiet, 
     {
         auto keys = parse_keys(keystr);
 
-        auto apply_to_buffer = [&](Buffer& buffer)
-        {
+        auto apply_to_buffer = [&](Buffer& buffer) {
             try
             {
                 InputHandler input_handler{
-                    { buffer, Selection{{0,0}, buffer.back_coord()} },
-                    Context::Flags::Draft
-                };
+                    {buffer, Selection{{0, 0}, buffer.back_coord()}},
+                    Context::Flags::Draft};
 
                 for (auto& key : keys)
                     input_handler.handle_key(key);
@@ -823,8 +923,9 @@ int run_filter(StringView keystr, ConstArrayView<StringView> files, bool quiet, 
             catch (runtime_error& err)
             {
                 if (not quiet)
-                    write_stderr(format("error while applying keys to buffer '{}': {}\n",
-                                        buffer.display_name(), err.what()));
+                    write_stderr(
+                        format("error while applying keys to buffer '{}': {}\n",
+                               buffer.display_name(), err.what()));
             }
         };
 
@@ -875,11 +976,21 @@ void signal_handler(int signal)
     const char* text = nullptr;
     switch (signal)
     {
-        case SIGSEGV: text = "SIGSEGV"; break;
-        case SIGFPE:  text = "SIGFPE";  break;
-        case SIGQUIT: text = "SIGQUIT"; break;
-        case SIGTERM: text = "SIGTERM"; break;
-        case SIGPIPE: text = "SIGPIPE"; break;
+        case SIGSEGV:
+            text = "SIGSEGV";
+            break;
+        case SIGFPE:
+            text = "SIGFPE";
+            break;
+        case SIGQUIT:
+            text = "SIGQUIT";
+            break;
+        case SIGTERM:
+            text = "SIGTERM";
+            break;
+        case SIGPIPE:
+            text = "SIGPIPE";
+            break;
     }
     if (signal != SIGTERM)
     {
@@ -909,50 +1020,59 @@ int main(int argc, char* argv[])
     setlocale(LC_ALL, "");
 
     set_signal_handler(SIGSEGV, signal_handler);
-    set_signal_handler(SIGFPE,  signal_handler);
+    set_signal_handler(SIGFPE, signal_handler);
     set_signal_handler(SIGQUIT, signal_handler);
     set_signal_handler(SIGTERM, signal_handler);
     set_signal_handler(SIGPIPE, SIG_IGN);
-    set_signal_handler(SIGINT, [](int){});
-    set_signal_handler(SIGCHLD, [](int){});
+    set_signal_handler(SIGINT, [](int) {});
+    set_signal_handler(SIGCHLD, [](int) {});
 
-    const ParameterDesc param_desc{
-        SwitchMap{ { "c", { true,  "connect to given session" } },
-                   { "e", { true,  "execute argument on client initialisation" } },
-                   { "E", { true,  "execute argument on server initialisation" } },
-                   { "n", { false, "do not source kakrc files on startup" } },
-                   { "s", { true,  "set session name" } },
-                   { "d", { false, "run as a headless session (requires -s)" } },
-                   { "p", { true,  "just send stdin as commands to the given session" } },
-                   { "f", { true,  "filter: for each file, select the entire buffer and execute the given keys" } },
-                   { "i", { true, "backup the files on which a filter is applied using the given suffix" } },
-                   { "q", { false, "in filter mode, be quiet about errors applying keys" } },
-                   { "ui", { true, "set the type of user interface to use (ncurses, dummy, or json)" } },
-                   { "l", { false, "list existing sessions" } },
-                   { "clear", { false, "clear dead sessions" } },
-                   { "debug", { true, "initial debug option value" } },
-                   { "version", { false, "display kakoune version and exit" } },
-                   { "ro", { false, "readonly mode" } },
-                   { "help", { false, "display a help message and quit" } } }
-    };
+    const ParameterDesc param_desc{SwitchMap{
+        {"c", {true, "connect to given session"}},
+        {"e", {true, "execute argument on client initialisation"}},
+        {"E", {true, "execute argument on server initialisation"}},
+        {"n", {false, "do not source kakrc files on startup"}},
+        {"s", {true, "set session name"}},
+        {"d", {false, "run as a headless session (requires -s)"}},
+        {"p", {true, "just send stdin as commands to the given session"}},
+        {"f",
+         {true,
+          "filter: for each file, select the entire buffer and execute the "
+          "given keys"}},
+        {"i",
+         {true,
+          "backup the files on which a filter is applied using the given "
+          "suffix"}},
+        {"q", {false, "in filter mode, be quiet about errors applying keys"}},
+        {"ui",
+         {true,
+          "set the type of user interface to use (ncurses, dummy, or json)"}},
+        {"l", {false, "list existing sessions"}},
+        {"clear", {false, "clear dead sessions"}},
+        {"debug", {true, "initial debug option value"}},
+        {"version", {false, "display kakoune version and exit"}},
+        {"ro", {false, "readonly mode"}},
+        {"help", {false, "display a help message and quit"}}}};
 
     try
     {
-        auto show_usage = [&]()
-        {
-            write_stdout(format("Usage: {} [options] [file]... [+<line>[:<col>]|+:]\n\n"
-                    "Options:\n"
-                    "{}\n"
-                    "Prefixing a positional argument with a plus (`+`) sign will place the\n"
-                    "cursor at a given set of coordinates, or the end of the buffer if the plus\n"
-                    "sign is followed only by a colon (`:`)\n",
-                    argv[0], generate_switches_doc(param_desc.switches)));
+        auto show_usage = [&]() {
+            write_stdout(
+                format("Usage: {} [options] [file]... [+<line>[:<col>]|+:]\n\n"
+                       "Options:\n"
+                       "{}\n"
+                       "Prefixing a positional argument with a plus (`+`) sign "
+                       "will place the\n"
+                       "cursor at a given set of coordinates, or the end of "
+                       "the buffer if the plus\n"
+                       "sign is followed only by a colon (`:`)\n",
+                       argv[0], generate_switches_doc(param_desc.switches)));
             return 0;
         };
 
-        const auto params = ArrayView<char*>{argv+1, argv + argc}
-                          | transform([](auto* s) { return String{s}; })
-                          | gather<Vector<String>>();
+        const auto params = ArrayView<char*>{argv + 1, argv + argc}
+                            | transform([](auto* s) { return String{s}; })
+                            | gather<Vector<String>>();
 
         if (contains(params, "--help"_sv))
             return show_usage();
@@ -969,18 +1089,19 @@ int main(int argc, char* argv[])
             return 0;
         }
 
-        const bool list_sessions = (bool)parser.get_switch("l");
+        const bool list_sessions  = (bool)parser.get_switch("l");
         const bool clear_sessions = (bool)parser.get_switch("clear");
         if (list_sessions or clear_sessions)
         {
-            const String username = get_user_name();
+            const String username    = get_user_name();
             const StringView tmp_dir = tmpdir();
-            for (auto& session : list_files(format("{}/kakoune/{}/", tmp_dir,
-                                                   username)))
+            for (auto& session :
+                 list_files(format("{}/kakoune/{}/", tmp_dir, username)))
             {
                 const bool valid = check_session(session);
                 if (list_sessions)
-                    write_stdout(format("{}{}\n", session, valid ? "" : " (dead)"));
+                    write_stdout(
+                        format("{}{}\n", session, valid ? "" : " (dead)"));
                 if (not valid and clear_sessions)
                 {
                     char socket_file[128];
@@ -994,11 +1115,12 @@ int main(int argc, char* argv[])
 
         if (auto session = parser.get_switch("p"))
         {
-            for (auto opt : { "c", "n", "s", "d", "e", "E", "ro" })
+            for (auto opt : {"c", "n", "s", "d", "e", "E", "ro"})
             {
                 if (parser.get_switch(opt))
                 {
-                    write_stderr(format("error: -{} is incompatible with -p\n", opt));
+                    write_stderr(
+                        format("error: -{} is incompatible with -p\n", opt));
                     return -1;
                 }
             }
@@ -1007,7 +1129,8 @@ int main(int argc, char* argv[])
 
         auto client_init = parser.get_switch("e").value_or(StringView{});
         auto server_init = parser.get_switch("E").value_or(StringView{});
-        const UIType ui_type = parse_ui_type(parser.get_switch("ui").value_or("ncurses"));
+        const UIType ui_type
+            = parse_ui_type(parser.get_switch("ui").value_or("ncurses"));
 
         if (auto keys = parser.get_switch("f"))
         {
@@ -1031,20 +1154,20 @@ int main(int argc, char* argv[])
         {
             if (not name.empty() and name[0_byte] == '+')
             {
-                if (name == "+" or name  == "+:")
+                if (name == "+" or name == "+:")
                 {
                     client_init = client_init + "; exec gj";
                     continue;
                 }
                 auto colon = find(name, ':');
-                if (auto line = str_to_int_ifp({name.begin()+1, colon}))
+                if (auto line = str_to_int_ifp({name.begin() + 1, colon}))
                 {
                     init_coord = BufferCoord{
-                        *line - 1,
-                        colon != name.end() ?
-                            str_to_int_ifp({colon+1, name.end()}).value_or(1) - 1
-                          : 0
-                    };
+                        *line - 1, colon != name.end()
+                                       ? str_to_int_ifp({colon + 1, name.end()})
+                                                 .value_or(1)
+                                             - 1
+                                       : 0};
                     continue;
                 }
             }
@@ -1054,47 +1177,63 @@ int main(int argc, char* argv[])
 
         if (auto server_session = parser.get_switch("c"))
         {
-            for (auto opt : { "n", "s", "d", "E", "ro" })
+            for (auto opt : {"n", "s", "d", "E", "ro"})
             {
                 if (parser.get_switch(opt))
                 {
-                    write_stderr(format("error: -{} is incompatible with -c\n", opt));
+                    write_stderr(
+                        format("error: -{} is incompatible with -c\n", opt));
                     return -1;
                 }
             }
             String new_files;
             for (auto name : files)
-                new_files += format("edit '{}';", escape(real_path(name), "'", '\\'));
+                new_files
+                    += format("edit '{}';", escape(real_path(name), "'", '\\'));
 
-            return run_client(*server_session, {}, new_files + client_init, init_coord, ui_type, false);
+            return run_client(*server_session, {}, new_files + client_init,
+                              init_coord, ui_type, false);
         }
         else
         {
             StringView session = parser.get_switch("s").value_or(StringView{});
             try
             {
-                auto flags = (parser.get_switch("n") ? ServerFlags::IgnoreKakrc : ServerFlags::None) |
-                             (parser.get_switch("d") ? ServerFlags::Daemon : ServerFlags::None) |
-                             (parser.get_switch("ro") ? ServerFlags::ReadOnly : ServerFlags::None) |
-                             (argc == 1 and isatty(0) ? ServerFlags::StartupInfo : ServerFlags::None);
-                auto debug_flags = option_from_string(Meta::Type<DebugFlags>{}, parser.get_switch("debug").value_or(""));
-                return run_server(session, server_init, client_init, init_coord, flags, ui_type, debug_flags, files);
+                auto flags
+                    = (parser.get_switch("n") ? ServerFlags::IgnoreKakrc
+                                              : ServerFlags::None)
+                      | (parser.get_switch("d") ? ServerFlags::Daemon
+                                                : ServerFlags::None)
+                      | (parser.get_switch("ro") ? ServerFlags::ReadOnly
+                                                 : ServerFlags::None)
+                      | (argc == 1 and isatty(0) ? ServerFlags::StartupInfo
+                                                 : ServerFlags::None);
+                auto debug_flags = option_from_string(
+                    Meta::Type<DebugFlags>{},
+                    parser.get_switch("debug").value_or(""));
+                return run_server(session, server_init, client_init, init_coord,
+                                  flags, ui_type, debug_flags, files);
             }
             catch (convert_to_client_mode& convert)
             {
-                return run_client(convert.session, convert.client_name,
-                                  format("try %^buffer '{}'; select '{}'^; echo converted to client only mode",
-                                         escape(convert.buffer_name, "'^", '\\'), convert.selections), {}, ui_type, true);
+                return run_client(
+                    convert.session, convert.client_name,
+                    format("try %^buffer '{}'; select '{}'^; echo converted to "
+                           "client only mode",
+                           escape(convert.buffer_name, "'^", '\\'),
+                           convert.selections),
+                    {}, ui_type, true);
             }
         }
     }
     catch (parameter_error& error)
     {
-        write_stderr(format("Error while parsing parameters: {}\n"
-                            "Valid switches:\n"
-                            "{}", error.what(),
-                            generate_switches_doc(param_desc.switches)));
-       return -1;
+        write_stderr(
+            format("Error while parsing parameters: {}\n"
+                   "Valid switches:\n"
+                   "{}",
+                   error.what(), generate_switches_doc(param_desc.switches)));
+        return -1;
     }
     catch (startup_error& error)
     {
@@ -1103,12 +1242,14 @@ int main(int argc, char* argv[])
     }
     catch (Kakoune::exception& error)
     {
-        write_stderr(format("uncaught exception ({}):\n{}\n", typeid(error).name(), error.what()));
+        write_stderr(format("uncaught exception ({}):\n{}\n",
+                            typeid(error).name(), error.what()));
         return -1;
     }
     catch (std::exception& error)
     {
-        write_stderr(format("uncaught exception ({}):\n{}\n", typeid(error).name(), error.what()));
+        write_stderr(format("uncaught exception ({}):\n{}\n",
+                            typeid(error).name(), error.what()));
         return -1;
     }
     catch (...)

--- a/src/memory.hh
+++ b/src/memory.hh
@@ -45,32 +45,58 @@ inline const char* domain_name(MemoryDomain domain)
 {
     switch (domain)
     {
-        case MemoryDomain::Undefined: return "Undefined";
-        case MemoryDomain::String: return "String";
-        case MemoryDomain::SharedString: return "SharedString";
-        case MemoryDomain::BufferContent: return "BufferContent";
-        case MemoryDomain::BufferMeta: return "BufferMeta";
-        case MemoryDomain::Options: return "Options";
-        case MemoryDomain::Highlight: return "Highlight";
-        case MemoryDomain::Regions: return "Regions";
-        case MemoryDomain::Display: return "Display";
-        case MemoryDomain::Mapping: return "Mapping";
-        case MemoryDomain::Commands: return "Commands";
-        case MemoryDomain::Hooks: return "Hooks";
-        case MemoryDomain::WordDB: return "WordDB";
-        case MemoryDomain::Aliases: return "Aliases";
-        case MemoryDomain::EnvVars: return "EnvVars";
-        case MemoryDomain::Faces: return "Faces";
-        case MemoryDomain::Values: return "Values";
-        case MemoryDomain::Registers: return "Registers";
-        case MemoryDomain::Client: return "Client";
-        case MemoryDomain::Selections: return "Selections";
-        case MemoryDomain::History: return "History";
-        case MemoryDomain::Remote: return "Remote";
-        case MemoryDomain::Events: return "Events";
-        case MemoryDomain::Completion: return "Completion";
-        case MemoryDomain::Regex: return "Regex";
-        case MemoryDomain::Count: break;
+        case MemoryDomain::Undefined:
+            return "Undefined";
+        case MemoryDomain::String:
+            return "String";
+        case MemoryDomain::SharedString:
+            return "SharedString";
+        case MemoryDomain::BufferContent:
+            return "BufferContent";
+        case MemoryDomain::BufferMeta:
+            return "BufferMeta";
+        case MemoryDomain::Options:
+            return "Options";
+        case MemoryDomain::Highlight:
+            return "Highlight";
+        case MemoryDomain::Regions:
+            return "Regions";
+        case MemoryDomain::Display:
+            return "Display";
+        case MemoryDomain::Mapping:
+            return "Mapping";
+        case MemoryDomain::Commands:
+            return "Commands";
+        case MemoryDomain::Hooks:
+            return "Hooks";
+        case MemoryDomain::WordDB:
+            return "WordDB";
+        case MemoryDomain::Aliases:
+            return "Aliases";
+        case MemoryDomain::EnvVars:
+            return "EnvVars";
+        case MemoryDomain::Faces:
+            return "Faces";
+        case MemoryDomain::Values:
+            return "Values";
+        case MemoryDomain::Registers:
+            return "Registers";
+        case MemoryDomain::Client:
+            return "Client";
+        case MemoryDomain::Selections:
+            return "Selections";
+        case MemoryDomain::History:
+            return "History";
+        case MemoryDomain::Remote:
+            return "Remote";
+        case MemoryDomain::Events:
+            return "Events";
+        case MemoryDomain::Completion:
+            return "Completion";
+        case MemoryDomain::Regex:
+            return "Regex";
+        case MemoryDomain::Count:
+            break;
     }
     kak_assert(false);
     return "";
@@ -96,10 +122,14 @@ struct Allocator
 
     Allocator() = default;
     template<typename U>
-    Allocator(const Allocator<U, domain>&) {}
+    Allocator(const Allocator<U, domain>&)
+    {}
 
     template<typename U>
-    struct rebind { using other = Allocator<U, domain>; };
+    struct rebind
+    {
+        using other = Allocator<U, domain>;
+    };
 
     T* allocate(size_t n)
     {
@@ -128,11 +158,16 @@ constexpr bool operator!=(const Allocator<T1, d1>&, const Allocator<T2, d2>&)
     return d1 != d2;
 }
 
-
-constexpr MemoryDomain memory_domain(Meta::AnyType) { return MemoryDomain::Undefined; }
+constexpr MemoryDomain memory_domain(Meta::AnyType)
+{
+    return MemoryDomain::Undefined;
+}
 
 template<typename T>
-constexpr decltype(T::Domain) memory_domain(Meta::Type<T>) { return T::Domain; }
+constexpr decltype(T::Domain) memory_domain(Meta::Type<T>)
+{
+    return T::Domain;
+}
 
 template<MemoryDomain d>
 struct UseMemoryDomain

--- a/src/meta.hh
+++ b/src/meta.hh
@@ -6,10 +6,14 @@ namespace Kakoune
 inline namespace Meta
 {
 
-struct AnyType{};
-template<typename T> struct Type : AnyType {};
+struct AnyType
+{};
+template<typename T>
+struct Type : AnyType
+{};
 
-template<typename T> using void_t = void;
+template<typename T>
+using void_t = void;
 
 }
 }

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -24,47 +24,28 @@ constexpr char control(char c) { return c & 037; }
 namespace Kakoune
 {
 
-using std::min;
 using std::max;
+using std::min;
 
-struct NCursesWin : WINDOW {};
+struct NCursesWin : WINDOW
+{};
 
 constexpr int NCursesUI::default_shift_function_key;
 
-static constexpr StringView assistant_cat[] =
-    { R"(  ___            )",
-      R"( (__ \           )",
-      R"(   / /          ╭)",
-      R"(  .' '·.        │)",
-      R"( '      ”       │)",
-      R"( ╰       /\_/|  │)",
-      R"(  | .         \ │)",
-      R"(  ╰_J`    | | | ╯)",
-      R"(      ' \__- _/  )",
-      R"(      \_\   \_\  )",
-      R"(                 )"};
+static constexpr StringView assistant_cat[]
+    = {R"(  ___            )", R"( (__ \           )", R"(   / /          ╭)",
+       R"(  .' '·.        │)", R"( '      ”       │)", R"( ╰       /\_/|  │)",
+       R"(  | .         \ │)", R"(  ╰_J`    | | | ╯)", R"(      ' \__- _/  )",
+       R"(      \_\   \_\  )", R"(                 )"};
 
-static constexpr StringView assistant_clippy[] =
-    { " ╭──╮   ",
-      " │  │   ",
-      " @  @  ╭",
-      " ││ ││ │",
-      " ││ ││ ╯",
-      " │╰─╯│  ",
-      " ╰───╯  ",
-      "        " };
+static constexpr StringView assistant_clippy[]
+    = {" ╭──╮   ", " │  │   ", " @  @  ╭", " ││ ││ │",
+       " ││ ││ ╯", " │╰─╯│  ", " ╰───╯  ", "        "};
 
-static constexpr StringView assistant_dilbert[] =
-    { R"(  დოოოოოდ   )",
-      R"(  |     |   )",
-      R"(  |     |  ╭)",
-      R"(  |-ᱛ ᱛ-|  │)",
-      R"( Ͼ   ∪   Ͽ │)",
-      R"(  |     |  ╯)",
-      R"( ˏ`-.ŏ.-´ˎ  )",
-      R"(     @      )",
-      R"(      @     )",
-      R"(            )"};
+static constexpr StringView assistant_dilbert[] = {
+    R"(  დოოოოოდ   )", R"(  |     |   )", R"(  |     |  ╭)", R"(  |-ᱛ ᱛ-|  │)",
+    R"( Ͼ   ∪   Ͽ │)", R"(  |     |  ╯)", R"( ˏ`-.ŏ.-´ˎ  )", R"(     @      )",
+    R"(      @     )", R"(            )"};
 
 static void set_attribute(WINDOW* window, int attribute, bool on)
 {
@@ -74,73 +55,102 @@ static void set_attribute(WINDOW* window, int attribute, bool on)
         wattroff(window, attribute);
 }
 
-template<typename T> T sq(T x) { return x * x; }
+template<typename T>
+T sq(T x)
+{
+    return x * x;
+}
 
-constexpr struct { unsigned char r, g, b; } builtin_colors[] = {
-    {0x00,0x00,0x00}, {0x80,0x00,0x00}, {0x00,0x80,0x00}, {0x80,0x80,0x00},
-    {0x00,0x00,0x80}, {0x80,0x00,0x80}, {0x00,0x80,0x80}, {0xc0,0xc0,0xc0},
-    {0x80,0x80,0x80}, {0xff,0x00,0x00}, {0x00,0xff,0x00}, {0xff,0xff,0x00},
-    {0x00,0x00,0xff}, {0xff,0x00,0xff}, {0x00,0xff,0xff}, {0xff,0xff,0xff},
-    {0x00,0x00,0x00}, {0x00,0x00,0x5f}, {0x00,0x00,0x87}, {0x00,0x00,0xaf},
-    {0x00,0x00,0xd7}, {0x00,0x00,0xff}, {0x00,0x5f,0x00}, {0x00,0x5f,0x5f},
-    {0x00,0x5f,0x87}, {0x00,0x5f,0xaf}, {0x00,0x5f,0xd7}, {0x00,0x5f,0xff},
-    {0x00,0x87,0x00}, {0x00,0x87,0x5f}, {0x00,0x87,0x87}, {0x00,0x87,0xaf},
-    {0x00,0x87,0xd7}, {0x00,0x87,0xff}, {0x00,0xaf,0x00}, {0x00,0xaf,0x5f},
-    {0x00,0xaf,0x87}, {0x00,0xaf,0xaf}, {0x00,0xaf,0xd7}, {0x00,0xaf,0xff},
-    {0x00,0xd7,0x00}, {0x00,0xd7,0x5f}, {0x00,0xd7,0x87}, {0x00,0xd7,0xaf},
-    {0x00,0xd7,0xd7}, {0x00,0xd7,0xff}, {0x00,0xff,0x00}, {0x00,0xff,0x5f},
-    {0x00,0xff,0x87}, {0x00,0xff,0xaf}, {0x00,0xff,0xd7}, {0x00,0xff,0xff},
-    {0x5f,0x00,0x00}, {0x5f,0x00,0x5f}, {0x5f,0x00,0x87}, {0x5f,0x00,0xaf},
-    {0x5f,0x00,0xd7}, {0x5f,0x00,0xff}, {0x5f,0x5f,0x00}, {0x5f,0x5f,0x5f},
-    {0x5f,0x5f,0x87}, {0x5f,0x5f,0xaf}, {0x5f,0x5f,0xd7}, {0x5f,0x5f,0xff},
-    {0x5f,0x87,0x00}, {0x5f,0x87,0x5f}, {0x5f,0x87,0x87}, {0x5f,0x87,0xaf},
-    {0x5f,0x87,0xd7}, {0x5f,0x87,0xff}, {0x5f,0xaf,0x00}, {0x5f,0xaf,0x5f},
-    {0x5f,0xaf,0x87}, {0x5f,0xaf,0xaf}, {0x5f,0xaf,0xd7}, {0x5f,0xaf,0xff},
-    {0x5f,0xd7,0x00}, {0x5f,0xd7,0x5f}, {0x5f,0xd7,0x87}, {0x5f,0xd7,0xaf},
-    {0x5f,0xd7,0xd7}, {0x5f,0xd7,0xff}, {0x5f,0xff,0x00}, {0x5f,0xff,0x5f},
-    {0x5f,0xff,0x87}, {0x5f,0xff,0xaf}, {0x5f,0xff,0xd7}, {0x5f,0xff,0xff},
-    {0x87,0x00,0x00}, {0x87,0x00,0x5f}, {0x87,0x00,0x87}, {0x87,0x00,0xaf},
-    {0x87,0x00,0xd7}, {0x87,0x00,0xff}, {0x87,0x5f,0x00}, {0x87,0x5f,0x5f},
-    {0x87,0x5f,0x87}, {0x87,0x5f,0xaf}, {0x87,0x5f,0xd7}, {0x87,0x5f,0xff},
-    {0x87,0x87,0x00}, {0x87,0x87,0x5f}, {0x87,0x87,0x87}, {0x87,0x87,0xaf},
-    {0x87,0x87,0xd7}, {0x87,0x87,0xff}, {0x87,0xaf,0x00}, {0x87,0xaf,0x5f},
-    {0x87,0xaf,0x87}, {0x87,0xaf,0xaf}, {0x87,0xaf,0xd7}, {0x87,0xaf,0xff},
-    {0x87,0xd7,0x00}, {0x87,0xd7,0x5f}, {0x87,0xd7,0x87}, {0x87,0xd7,0xaf},
-    {0x87,0xd7,0xd7}, {0x87,0xd7,0xff}, {0x87,0xff,0x00}, {0x87,0xff,0x5f},
-    {0x87,0xff,0x87}, {0x87,0xff,0xaf}, {0x87,0xff,0xd7}, {0x87,0xff,0xff},
-    {0xaf,0x00,0x00}, {0xaf,0x00,0x5f}, {0xaf,0x00,0x87}, {0xaf,0x00,0xaf},
-    {0xaf,0x00,0xd7}, {0xaf,0x00,0xff}, {0xaf,0x5f,0x00}, {0xaf,0x5f,0x5f},
-    {0xaf,0x5f,0x87}, {0xaf,0x5f,0xaf}, {0xaf,0x5f,0xd7}, {0xaf,0x5f,0xff},
-    {0xaf,0x87,0x00}, {0xaf,0x87,0x5f}, {0xaf,0x87,0x87}, {0xaf,0x87,0xaf},
-    {0xaf,0x87,0xd7}, {0xaf,0x87,0xff}, {0xaf,0xaf,0x00}, {0xaf,0xaf,0x5f},
-    {0xaf,0xaf,0x87}, {0xaf,0xaf,0xaf}, {0xaf,0xaf,0xd7}, {0xaf,0xaf,0xff},
-    {0xaf,0xd7,0x00}, {0xaf,0xd7,0x5f}, {0xaf,0xd7,0x87}, {0xaf,0xd7,0xaf},
-    {0xaf,0xd7,0xd7}, {0xaf,0xd7,0xff}, {0xaf,0xff,0x00}, {0xaf,0xff,0x5f},
-    {0xaf,0xff,0x87}, {0xaf,0xff,0xaf}, {0xaf,0xff,0xd7}, {0xaf,0xff,0xff},
-    {0xd7,0x00,0x00}, {0xd7,0x00,0x5f}, {0xd7,0x00,0x87}, {0xd7,0x00,0xaf},
-    {0xd7,0x00,0xd7}, {0xd7,0x00,0xff}, {0xd7,0x5f,0x00}, {0xd7,0x5f,0x5f},
-    {0xd7,0x5f,0x87}, {0xd7,0x5f,0xaf}, {0xd7,0x5f,0xd7}, {0xd7,0x5f,0xff},
-    {0xd7,0x87,0x00}, {0xd7,0x87,0x5f}, {0xd7,0x87,0x87}, {0xd7,0x87,0xaf},
-    {0xd7,0x87,0xd7}, {0xd7,0x87,0xff}, {0xd7,0xaf,0x00}, {0xd7,0xaf,0x5f},
-    {0xd7,0xaf,0x87}, {0xd7,0xaf,0xaf}, {0xd7,0xaf,0xd7}, {0xd7,0xaf,0xff},
-    {0xd7,0xd7,0x00}, {0xd7,0xd7,0x5f}, {0xd7,0xd7,0x87}, {0xd7,0xd7,0xaf},
-    {0xd7,0xd7,0xd7}, {0xd7,0xd7,0xff}, {0xd7,0xff,0x00}, {0xd7,0xff,0x5f},
-    {0xd7,0xff,0x87}, {0xd7,0xff,0xaf}, {0xd7,0xff,0xd7}, {0xd7,0xff,0xff},
-    {0xff,0x00,0x00}, {0xff,0x00,0x5f}, {0xff,0x00,0x87}, {0xff,0x00,0xaf},
-    {0xff,0x00,0xd7}, {0xff,0x00,0xff}, {0xff,0x5f,0x00}, {0xff,0x5f,0x5f},
-    {0xff,0x5f,0x87}, {0xff,0x5f,0xaf}, {0xff,0x5f,0xd7}, {0xff,0x5f,0xff},
-    {0xff,0x87,0x00}, {0xff,0x87,0x5f}, {0xff,0x87,0x87}, {0xff,0x87,0xaf},
-    {0xff,0x87,0xd7}, {0xff,0x87,0xff}, {0xff,0xaf,0x00}, {0xff,0xaf,0x5f},
-    {0xff,0xaf,0x87}, {0xff,0xaf,0xaf}, {0xff,0xaf,0xd7}, {0xff,0xaf,0xff},
-    {0xff,0xd7,0x00}, {0xff,0xd7,0x5f}, {0xff,0xd7,0x87}, {0xff,0xd7,0xaf},
-    {0xff,0xd7,0xd7}, {0xff,0xd7,0xff}, {0xff,0xff,0x00}, {0xff,0xff,0x5f},
-    {0xff,0xff,0x87}, {0xff,0xff,0xaf}, {0xff,0xff,0xd7}, {0xff,0xff,0xff},
-    {0x08,0x08,0x08}, {0x12,0x12,0x12}, {0x1c,0x1c,0x1c}, {0x26,0x26,0x26},
-    {0x30,0x30,0x30}, {0x3a,0x3a,0x3a}, {0x44,0x44,0x44}, {0x4e,0x4e,0x4e},
-    {0x58,0x58,0x58}, {0x60,0x60,0x60}, {0x66,0x66,0x66}, {0x76,0x76,0x76},
-    {0x80,0x80,0x80}, {0x8a,0x8a,0x8a}, {0x94,0x94,0x94}, {0x9e,0x9e,0x9e},
-    {0xa8,0xa8,0xa8}, {0xb2,0xb2,0xb2}, {0xbc,0xbc,0xbc}, {0xc6,0xc6,0xc6},
-    {0xd0,0xd0,0xd0}, {0xda,0xda,0xda}, {0xe4,0xe4,0xe4}, {0xee,0xee,0xee},
+constexpr struct
+{
+    unsigned char r, g, b;
+} builtin_colors[] = {
+    {0x00, 0x00, 0x00}, {0x80, 0x00, 0x00}, {0x00, 0x80, 0x00},
+    {0x80, 0x80, 0x00}, {0x00, 0x00, 0x80}, {0x80, 0x00, 0x80},
+    {0x00, 0x80, 0x80}, {0xc0, 0xc0, 0xc0}, {0x80, 0x80, 0x80},
+    {0xff, 0x00, 0x00}, {0x00, 0xff, 0x00}, {0xff, 0xff, 0x00},
+    {0x00, 0x00, 0xff}, {0xff, 0x00, 0xff}, {0x00, 0xff, 0xff},
+    {0xff, 0xff, 0xff}, {0x00, 0x00, 0x00}, {0x00, 0x00, 0x5f},
+    {0x00, 0x00, 0x87}, {0x00, 0x00, 0xaf}, {0x00, 0x00, 0xd7},
+    {0x00, 0x00, 0xff}, {0x00, 0x5f, 0x00}, {0x00, 0x5f, 0x5f},
+    {0x00, 0x5f, 0x87}, {0x00, 0x5f, 0xaf}, {0x00, 0x5f, 0xd7},
+    {0x00, 0x5f, 0xff}, {0x00, 0x87, 0x00}, {0x00, 0x87, 0x5f},
+    {0x00, 0x87, 0x87}, {0x00, 0x87, 0xaf}, {0x00, 0x87, 0xd7},
+    {0x00, 0x87, 0xff}, {0x00, 0xaf, 0x00}, {0x00, 0xaf, 0x5f},
+    {0x00, 0xaf, 0x87}, {0x00, 0xaf, 0xaf}, {0x00, 0xaf, 0xd7},
+    {0x00, 0xaf, 0xff}, {0x00, 0xd7, 0x00}, {0x00, 0xd7, 0x5f},
+    {0x00, 0xd7, 0x87}, {0x00, 0xd7, 0xaf}, {0x00, 0xd7, 0xd7},
+    {0x00, 0xd7, 0xff}, {0x00, 0xff, 0x00}, {0x00, 0xff, 0x5f},
+    {0x00, 0xff, 0x87}, {0x00, 0xff, 0xaf}, {0x00, 0xff, 0xd7},
+    {0x00, 0xff, 0xff}, {0x5f, 0x00, 0x00}, {0x5f, 0x00, 0x5f},
+    {0x5f, 0x00, 0x87}, {0x5f, 0x00, 0xaf}, {0x5f, 0x00, 0xd7},
+    {0x5f, 0x00, 0xff}, {0x5f, 0x5f, 0x00}, {0x5f, 0x5f, 0x5f},
+    {0x5f, 0x5f, 0x87}, {0x5f, 0x5f, 0xaf}, {0x5f, 0x5f, 0xd7},
+    {0x5f, 0x5f, 0xff}, {0x5f, 0x87, 0x00}, {0x5f, 0x87, 0x5f},
+    {0x5f, 0x87, 0x87}, {0x5f, 0x87, 0xaf}, {0x5f, 0x87, 0xd7},
+    {0x5f, 0x87, 0xff}, {0x5f, 0xaf, 0x00}, {0x5f, 0xaf, 0x5f},
+    {0x5f, 0xaf, 0x87}, {0x5f, 0xaf, 0xaf}, {0x5f, 0xaf, 0xd7},
+    {0x5f, 0xaf, 0xff}, {0x5f, 0xd7, 0x00}, {0x5f, 0xd7, 0x5f},
+    {0x5f, 0xd7, 0x87}, {0x5f, 0xd7, 0xaf}, {0x5f, 0xd7, 0xd7},
+    {0x5f, 0xd7, 0xff}, {0x5f, 0xff, 0x00}, {0x5f, 0xff, 0x5f},
+    {0x5f, 0xff, 0x87}, {0x5f, 0xff, 0xaf}, {0x5f, 0xff, 0xd7},
+    {0x5f, 0xff, 0xff}, {0x87, 0x00, 0x00}, {0x87, 0x00, 0x5f},
+    {0x87, 0x00, 0x87}, {0x87, 0x00, 0xaf}, {0x87, 0x00, 0xd7},
+    {0x87, 0x00, 0xff}, {0x87, 0x5f, 0x00}, {0x87, 0x5f, 0x5f},
+    {0x87, 0x5f, 0x87}, {0x87, 0x5f, 0xaf}, {0x87, 0x5f, 0xd7},
+    {0x87, 0x5f, 0xff}, {0x87, 0x87, 0x00}, {0x87, 0x87, 0x5f},
+    {0x87, 0x87, 0x87}, {0x87, 0x87, 0xaf}, {0x87, 0x87, 0xd7},
+    {0x87, 0x87, 0xff}, {0x87, 0xaf, 0x00}, {0x87, 0xaf, 0x5f},
+    {0x87, 0xaf, 0x87}, {0x87, 0xaf, 0xaf}, {0x87, 0xaf, 0xd7},
+    {0x87, 0xaf, 0xff}, {0x87, 0xd7, 0x00}, {0x87, 0xd7, 0x5f},
+    {0x87, 0xd7, 0x87}, {0x87, 0xd7, 0xaf}, {0x87, 0xd7, 0xd7},
+    {0x87, 0xd7, 0xff}, {0x87, 0xff, 0x00}, {0x87, 0xff, 0x5f},
+    {0x87, 0xff, 0x87}, {0x87, 0xff, 0xaf}, {0x87, 0xff, 0xd7},
+    {0x87, 0xff, 0xff}, {0xaf, 0x00, 0x00}, {0xaf, 0x00, 0x5f},
+    {0xaf, 0x00, 0x87}, {0xaf, 0x00, 0xaf}, {0xaf, 0x00, 0xd7},
+    {0xaf, 0x00, 0xff}, {0xaf, 0x5f, 0x00}, {0xaf, 0x5f, 0x5f},
+    {0xaf, 0x5f, 0x87}, {0xaf, 0x5f, 0xaf}, {0xaf, 0x5f, 0xd7},
+    {0xaf, 0x5f, 0xff}, {0xaf, 0x87, 0x00}, {0xaf, 0x87, 0x5f},
+    {0xaf, 0x87, 0x87}, {0xaf, 0x87, 0xaf}, {0xaf, 0x87, 0xd7},
+    {0xaf, 0x87, 0xff}, {0xaf, 0xaf, 0x00}, {0xaf, 0xaf, 0x5f},
+    {0xaf, 0xaf, 0x87}, {0xaf, 0xaf, 0xaf}, {0xaf, 0xaf, 0xd7},
+    {0xaf, 0xaf, 0xff}, {0xaf, 0xd7, 0x00}, {0xaf, 0xd7, 0x5f},
+    {0xaf, 0xd7, 0x87}, {0xaf, 0xd7, 0xaf}, {0xaf, 0xd7, 0xd7},
+    {0xaf, 0xd7, 0xff}, {0xaf, 0xff, 0x00}, {0xaf, 0xff, 0x5f},
+    {0xaf, 0xff, 0x87}, {0xaf, 0xff, 0xaf}, {0xaf, 0xff, 0xd7},
+    {0xaf, 0xff, 0xff}, {0xd7, 0x00, 0x00}, {0xd7, 0x00, 0x5f},
+    {0xd7, 0x00, 0x87}, {0xd7, 0x00, 0xaf}, {0xd7, 0x00, 0xd7},
+    {0xd7, 0x00, 0xff}, {0xd7, 0x5f, 0x00}, {0xd7, 0x5f, 0x5f},
+    {0xd7, 0x5f, 0x87}, {0xd7, 0x5f, 0xaf}, {0xd7, 0x5f, 0xd7},
+    {0xd7, 0x5f, 0xff}, {0xd7, 0x87, 0x00}, {0xd7, 0x87, 0x5f},
+    {0xd7, 0x87, 0x87}, {0xd7, 0x87, 0xaf}, {0xd7, 0x87, 0xd7},
+    {0xd7, 0x87, 0xff}, {0xd7, 0xaf, 0x00}, {0xd7, 0xaf, 0x5f},
+    {0xd7, 0xaf, 0x87}, {0xd7, 0xaf, 0xaf}, {0xd7, 0xaf, 0xd7},
+    {0xd7, 0xaf, 0xff}, {0xd7, 0xd7, 0x00}, {0xd7, 0xd7, 0x5f},
+    {0xd7, 0xd7, 0x87}, {0xd7, 0xd7, 0xaf}, {0xd7, 0xd7, 0xd7},
+    {0xd7, 0xd7, 0xff}, {0xd7, 0xff, 0x00}, {0xd7, 0xff, 0x5f},
+    {0xd7, 0xff, 0x87}, {0xd7, 0xff, 0xaf}, {0xd7, 0xff, 0xd7},
+    {0xd7, 0xff, 0xff}, {0xff, 0x00, 0x00}, {0xff, 0x00, 0x5f},
+    {0xff, 0x00, 0x87}, {0xff, 0x00, 0xaf}, {0xff, 0x00, 0xd7},
+    {0xff, 0x00, 0xff}, {0xff, 0x5f, 0x00}, {0xff, 0x5f, 0x5f},
+    {0xff, 0x5f, 0x87}, {0xff, 0x5f, 0xaf}, {0xff, 0x5f, 0xd7},
+    {0xff, 0x5f, 0xff}, {0xff, 0x87, 0x00}, {0xff, 0x87, 0x5f},
+    {0xff, 0x87, 0x87}, {0xff, 0x87, 0xaf}, {0xff, 0x87, 0xd7},
+    {0xff, 0x87, 0xff}, {0xff, 0xaf, 0x00}, {0xff, 0xaf, 0x5f},
+    {0xff, 0xaf, 0x87}, {0xff, 0xaf, 0xaf}, {0xff, 0xaf, 0xd7},
+    {0xff, 0xaf, 0xff}, {0xff, 0xd7, 0x00}, {0xff, 0xd7, 0x5f},
+    {0xff, 0xd7, 0x87}, {0xff, 0xd7, 0xaf}, {0xff, 0xd7, 0xd7},
+    {0xff, 0xd7, 0xff}, {0xff, 0xff, 0x00}, {0xff, 0xff, 0x5f},
+    {0xff, 0xff, 0x87}, {0xff, 0xff, 0xaf}, {0xff, 0xff, 0xd7},
+    {0xff, 0xff, 0xff}, {0x08, 0x08, 0x08}, {0x12, 0x12, 0x12},
+    {0x1c, 0x1c, 0x1c}, {0x26, 0x26, 0x26}, {0x30, 0x30, 0x30},
+    {0x3a, 0x3a, 0x3a}, {0x44, 0x44, 0x44}, {0x4e, 0x4e, 0x4e},
+    {0x58, 0x58, 0x58}, {0x60, 0x60, 0x60}, {0x66, 0x66, 0x66},
+    {0x76, 0x76, 0x76}, {0x80, 0x80, 0x80}, {0x8a, 0x8a, 0x8a},
+    {0x94, 0x94, 0x94}, {0x9e, 0x9e, 0x9e}, {0xa8, 0xa8, 0xa8},
+    {0xb2, 0xb2, 0xb2}, {0xbc, 0xbc, 0xbc}, {0xc6, 0xc6, 0xc6},
+    {0xd0, 0xd0, 0xd0}, {0xda, 0xda, 0xda}, {0xe4, 0xe4, 0xe4},
+    {0xee, 0xee, 0xee},
 };
 
 int NCursesUI::get_color(Color color)
@@ -153,9 +163,7 @@ int NCursesUI::get_color(Color color)
         kak_assert(color.color == Color::RGB);
         if (m_next_color > COLORS)
             m_next_color = 16;
-        init_color(m_next_color,
-                   color.r * 1000 / 255,
-                   color.g * 1000 / 255,
+        init_color(m_next_color, color.r * 1000 / 255, color.g * 1000 / 255,
                    color.b * 1000 / 255);
         m_colors[color] = m_next_color;
         return m_next_color++;
@@ -168,9 +176,8 @@ int NCursesUI::get_color(Color color)
         for (int i = 0; i < std::min(256, COLORS); ++i)
         {
             auto& col = builtin_colors[i];
-            int dist = sq(color.r - col.r)
-                     + sq(color.g - col.g)
-                     + sq(color.b - col.b);
+            int dist  = sq(color.r - col.r) + sq(color.g - col.g)
+                       + sq(color.b - col.b);
             if (dist < lowestDist)
             {
                 lowestDist = dist;
@@ -195,7 +202,8 @@ int NCursesUI::get_color_pair(const Face& face)
     }
 }
 
-void NCursesUI::set_face(NCursesWin* window, Face face, const Face& default_face)
+void NCursesUI::set_face(NCursesWin* window, Face face,
+                         const Face& default_face)
 {
     if (m_active_pair != -1)
         wattroff(window, COLOR_PAIR(m_active_pair));
@@ -213,13 +221,13 @@ void NCursesUI::set_face(NCursesWin* window, Face face, const Face& default_face
     set_attribute(window, A_BLINK, face.attributes & Attribute::Blink);
     set_attribute(window, A_BOLD, face.attributes & Attribute::Bold);
     set_attribute(window, A_DIM, face.attributes & Attribute::Dim);
-    #if defined(A_ITALIC)
+#if defined(A_ITALIC)
     set_attribute(window, A_ITALIC, face.attributes & Attribute::Italic);
-    #endif
+#endif
 }
 
 static sig_atomic_t resize_pending = 0;
-static sig_atomic_t sighup_raised = 0;
+static sig_atomic_t sighup_raised  = 0;
 
 template<sig_atomic_t* signal_flag>
 static void signal_handler(int)
@@ -229,35 +237,35 @@ static void signal_handler(int)
 }
 
 static const std::initializer_list<HashMap<Kakoune::Color, int>::Item>
-default_colors = {
-    { Color::Default,       -1 },
-    { Color::Black,          0 },
-    { Color::Red,            1 },
-    { Color::Green,          2 },
-    { Color::Yellow,         3 },
-    { Color::Blue,           4 },
-    { Color::Magenta,        5 },
-    { Color::Cyan,           6 },
-    { Color::White,          7 },
-    { Color::BrightBlack,    8 },
-    { Color::BrightRed,      9 },
-    { Color::BrightGreen,   10 },
-    { Color::BrightYellow,  11 },
-    { Color::BrightBlue,    12 },
-    { Color::BrightMagenta, 13 },
-    { Color::BrightCyan,    14 },
-    { Color::BrightWhite,   15 },
+    default_colors = {
+        {Color::Default, -1},
+        {Color::Black, 0},
+        {Color::Red, 1},
+        {Color::Green, 2},
+        {Color::Yellow, 3},
+        {Color::Blue, 4},
+        {Color::Magenta, 5},
+        {Color::Cyan, 6},
+        {Color::White, 7},
+        {Color::BrightBlack, 8},
+        {Color::BrightRed, 9},
+        {Color::BrightGreen, 10},
+        {Color::BrightYellow, 11},
+        {Color::BrightBlue, 12},
+        {Color::BrightMagenta, 13},
+        {Color::BrightCyan, 14},
+        {Color::BrightWhite, 15},
 };
 
 NCursesUI::NCursesUI()
     : m_stdin_watcher{0, FdEvents::Read,
                       [this](FDWatcher&, FdEvents, EventMode) {
-        if (not m_on_key)
-            return;
+                          if (not m_on_key)
+                              return;
 
-        while (auto key = get_next_key())
-            m_on_key(*key);
-      }},
+                          while (auto key = get_next_key())
+                              m_on_key(*key);
+                      }},
       m_assistant(assistant_clippy),
       m_colors{default_colors},
       m_cursor{CursorMode::Buffer, {}}
@@ -296,16 +304,16 @@ NCursesUI::~NCursesUI()
 
 void NCursesUI::Window::create(const DisplayCoord& p, const DisplayCoord& s)
 {
-    pos = p;
+    pos  = p;
     size = s;
-    win = (NCursesWin*)newpad((int)size.line, (int)size.column);
+    win  = (NCursesWin*)newpad((int)size.line, (int)size.column);
 }
 
 void NCursesUI::Window::destroy()
 {
     delwin(win);
-    win = nullptr;
-    pos = DisplayCoord{};
+    win  = nullptr;
+    pos  = DisplayCoord{};
     size = DisplayCoord{};
 }
 
@@ -314,15 +322,15 @@ void NCursesUI::Window::refresh()
     if (not win)
         return;
 
-    DisplayCoord max_pos = pos + size - DisplayCoord{1,1};
-    pnoutrefresh(win, 0, 0, (int)pos.line, (int)pos.column,
-                 (int)max_pos.line, (int)max_pos.column);
+    DisplayCoord max_pos = pos + size - DisplayCoord{1, 1};
+    pnoutrefresh(win, 0, 0, (int)pos.line, (int)pos.column, (int)max_pos.line,
+                 (int)max_pos.column);
 }
 
 void NCursesUI::redraw()
 {
-    pnoutrefresh(m_window, 0, 0, 0, 0,
-                 (int)m_dimensions.line + 1, (int)m_dimensions.column);
+    pnoutrefresh(m_window, 0, 0, 0, 0, (int)m_dimensions.line + 1,
+                 (int)m_dimensions.column);
 
     if (m_menu.columns != 0 or m_menu.pos.column > m_status_len)
         m_menu.refresh();
@@ -341,7 +349,7 @@ void NCursesUI::redraw()
 
 void NCursesUI::set_cursor(CursorMode mode, DisplayCoord coord)
 {
-    m_cursor = Cursor{ mode, coord };
+    m_cursor = Cursor{mode, coord};
 }
 
 void NCursesUI::refresh(bool force)
@@ -372,10 +380,10 @@ void NCursesUI::draw_line(NCursesWin* window, const DisplayLine& line,
             continue;
 
         const auto remaining_columns = max_column - col_index;
-        if (content.back() == '\n' and
-            content.column_length() - 1 < remaining_columns)
+        if (content.back() == '\n'
+            and content.column_length() - 1 < remaining_columns)
         {
-            add_str(window, content.substr(0, content.length()-1));
+            add_str(window, content.substr(0, content.length() - 1));
             waddch(window, ' ');
         }
         else
@@ -387,19 +395,18 @@ void NCursesUI::draw_line(NCursesWin* window, const DisplayLine& line,
     }
 }
 
-static const DisplayLine empty_line = { String(" "), {} };
+static const DisplayLine empty_line = {String(" "), {}};
 
 void NCursesUI::draw(const DisplayBuffer& display_buffer,
-                     const Face& default_face,
-                     const Face& padding_face)
+                     const Face& default_face, const Face& padding_face)
 {
     wbkgdset(m_window, COLOR_PAIR(get_color_pair(default_face)));
 
     check_resize();
 
-    const DisplayCoord dim = dimensions();
+    const DisplayCoord dim      = dimensions();
     const LineCount line_offset = content_line_offset();
-    LineCount line_index = line_offset;
+    LineCount line_index        = line_offset;
     for (const DisplayLine& line : display_buffer.lines())
     {
         wmove(m_window, (int)line_index, 0);
@@ -433,8 +440,8 @@ void NCursesUI::draw_status(const DisplayLine& status_line,
 
     draw_line(m_window, status_line, 0, m_dimensions.column, default_face);
 
-    const auto mode_len = mode_line.length();
-    m_status_len = status_line.length();
+    const auto mode_len  = mode_line.length();
+    m_status_len         = status_line.length();
     const auto remaining = m_dimensions.column - m_status_len;
     if (mode_len < remaining)
     {
@@ -446,18 +453,19 @@ void NCursesUI::draw_status(const DisplayLine& status_line,
     {
         DisplayLine trimmed_mode_line = mode_line;
         trimmed_mode_line.trim(mode_len + 2 - remaining, remaining - 2);
-        trimmed_mode_line.insert(trimmed_mode_line.begin(), { "…", {} });
+        trimmed_mode_line.insert(trimmed_mode_line.begin(), {"…", {}});
         kak_assert(trimmed_mode_line.length() == remaining - 1);
 
         ColumnCount col = m_dimensions.column - remaining + 1;
         wmove(m_window, status_line_pos, (int)col);
-        draw_line(m_window, trimmed_mode_line, col, m_dimensions.column, default_face);
+        draw_line(m_window, trimmed_mode_line, col, m_dimensions.column,
+                  default_face);
     }
 
     if (m_set_title)
     {
         constexpr char suffix[] = " - Kakoune\007";
-        char buf[4 + 511 + 2] = "\033]2;";
+        char buf[4 + 511 + 2]   = "\033]2;";
         // Fill title escape sequence buffer, removing non ascii characters
         auto buf_it = &buf[4], buf_end = &buf[4 + 511 - (sizeof(suffix) - 2)];
         for (auto& atom : mode_line)
@@ -487,7 +495,7 @@ void NCursesUI::check_resize(bool force)
     const int fd = open("/dev/tty", O_RDWR);
     if (fd < 0)
         return;
-    auto close_fd = on_scope_end([fd]{ ::close(fd); });
+    auto close_fd = on_scope_end([fd] { ::close(fd); });
 
     winsize ws;
     if (::ioctl(fd, TIOCGWINSZ, &ws) != 0)
@@ -495,9 +503,12 @@ void NCursesUI::check_resize(bool force)
 
     const bool info = (bool)m_info;
     const bool menu = (bool)m_menu;
-    if (m_window) delwin(m_window);
-    if (info) m_info.destroy();
-    if (menu) m_menu.destroy();
+    if (m_window)
+        delwin(m_window);
+    if (info)
+        m_info.destroy();
+    if (menu)
+        m_menu.destroy();
 
     resize_term(ws.ws_row, ws.ws_col);
 
@@ -507,7 +518,7 @@ void NCursesUI::check_resize(bool force)
     keypad(m_window, true);
     meta(m_window, true);
 
-    m_dimensions = DisplayCoord{ws.ws_row-1, ws.ws_col};
+    m_dimensions = DisplayCoord{ws.ws_row - 1, ws.ws_col};
 
     if (char* csr = tigetstr((char*)"csr"))
         putp(tparm(csr, 0, ws.ws_row));
@@ -518,7 +529,8 @@ void NCursesUI::check_resize(bool force)
         menu_show(items, m_menu.anchor, m_menu.fg, m_menu.bg, m_menu.style);
     }
     if (info)
-        info_show(m_info.title, m_info.content, m_info.anchor, m_info.face, m_info.style);
+        info_show(m_info.title, m_info.content, m_info.anchor, m_info.face,
+                  m_info.style);
 
     set_resize_pending();
     clearok(curscr, true);
@@ -572,8 +584,8 @@ Optional<Key> NCursesUI::get_next_key()
                 return res | Key::Modifiers::MousePos;
             };
 
-            return Key{ get_modifiers(ev.bstate),
-                        encode_coord({ ev.y - content_line_offset(), ev.x }) };
+            return Key{get_modifiers(ev.bstate),
+                       encode_coord({ev.y - content_line_offset(), ev.x})};
         }
     }
 
@@ -583,27 +595,49 @@ Optional<Key> NCursesUI::get_next_key()
 
         switch (c)
         {
-        case KEY_BACKSPACE: case 127: return {Key::Backspace};
-        case KEY_DC: return {Key::Delete};
-        case KEY_SDC: return shift(Key::Delete);
-        case KEY_UP: return {Key::Up};
-        case KEY_SR: return shift(Key::Up);
-        case KEY_DOWN: return {Key::Down};
-        case KEY_SF: return shift(Key::Down);
-        case KEY_LEFT: return {Key::Left};
-        case KEY_SLEFT: return shift(Key::Left);
-        case KEY_RIGHT: return {Key::Right};
-        case KEY_SRIGHT: return shift(Key::Right);
-        case KEY_PPAGE: return {Key::PageUp};
-        case KEY_SPREVIOUS: return shift(Key::PageUp);
-        case KEY_NPAGE: return {Key::PageDown};
-        case KEY_SNEXT: return shift(Key::PageDown);
-        case KEY_HOME: return {Key::Home};
-        case KEY_SHOME: return shift(Key::Home);
-        case KEY_END: return {Key::End};
-        case KEY_SEND: return shift(Key::End);
-        case KEY_BTAB: return shift(Key::Tab);
-        case KEY_RESIZE: return resize(dimensions());
+            case KEY_BACKSPACE:
+            case 127:
+                return {Key::Backspace};
+            case KEY_DC:
+                return {Key::Delete};
+            case KEY_SDC:
+                return shift(Key::Delete);
+            case KEY_UP:
+                return {Key::Up};
+            case KEY_SR:
+                return shift(Key::Up);
+            case KEY_DOWN:
+                return {Key::Down};
+            case KEY_SF:
+                return shift(Key::Down);
+            case KEY_LEFT:
+                return {Key::Left};
+            case KEY_SLEFT:
+                return shift(Key::Left);
+            case KEY_RIGHT:
+                return {Key::Right};
+            case KEY_SRIGHT:
+                return shift(Key::Right);
+            case KEY_PPAGE:
+                return {Key::PageUp};
+            case KEY_SPREVIOUS:
+                return shift(Key::PageUp);
+            case KEY_NPAGE:
+                return {Key::PageDown};
+            case KEY_SNEXT:
+                return shift(Key::PageDown);
+            case KEY_HOME:
+                return {Key::Home};
+            case KEY_SHOME:
+                return shift(Key::Home);
+            case KEY_END:
+                return {Key::End};
+            case KEY_SEND:
+                return shift(Key::End);
+            case KEY_BTAB:
+                return shift(Key::Tab);
+            case KEY_RESIZE:
+                return resize(dimensions());
         }
 
         if (c > 0 and c < 27)
@@ -638,19 +672,19 @@ Optional<Key> NCursesUI::get_next_key()
 
         if (c >= 0 and c < 256)
         {
-           ungetch(c);
-           struct getch_iterator
-           {
-               getch_iterator(WINDOW* win) : window(win) {}
-               int operator*() { return wgetch(window); }
-               getch_iterator& operator++() { return *this; }
-               getch_iterator& operator++(int) { return *this; }
-               bool operator== (const getch_iterator&) const { return false; }
+            ungetch(c);
+            struct getch_iterator
+            {
+                getch_iterator(WINDOW* win) : window(win) {}
+                int operator*() { return wgetch(window); }
+                getch_iterator& operator++() { return *this; }
+                getch_iterator& operator++(int) { return *this; }
+                bool operator==(const getch_iterator&) const { return false; }
 
                 WINDOW* window;
-           };
-           return Key{utf8::codepoint(getch_iterator{m_window},
-                                      getch_iterator{m_window})};
+            };
+            return Key{utf8::codepoint(getch_iterator{m_window},
+                                       getch_iterator{m_window})};
         }
         return {};
     };
@@ -664,9 +698,12 @@ Optional<Key> NCursesUI::get_next_key()
             const Codepoint csi_val = wgetch(m_window);
             switch (csi_val)
             {
-                case 'I': return {Key::FocusIn};
-                case 'O': return {Key::FocusOut};
-                default: break; // nothing
+                case 'I':
+                    return {Key::FocusIn};
+                case 'O':
+                    return {Key::FocusOut};
+                default:
+                    break; // nothing
             }
         }
         wtimeout(m_window, -1);
@@ -709,7 +746,7 @@ void NCursesUI::draw_menu()
         int i = m_menu.first_item;
         for (; i < item_count and pos < win_width; ++i)
         {
-            const DisplayLine& item = m_menu.items[i];
+            const DisplayLine& item      = m_menu.items[i];
             const ColumnCount item_width = item.length();
             draw_line(m_menu.win, item, 0, win_width - pos,
                       i == m_menu.selected_item ? m_menu.fg : m_menu.bg);
@@ -738,20 +775,22 @@ void NCursesUI::draw_menu()
 
     const ColumnCount column_width = (m_menu.size.column - 1) / m_menu.columns;
 
-    const LineCount mark_height = min(div_round_up(sq(win_height), menu_lines),
-                                      win_height);
+    const LineCount mark_height
+        = min(div_round_up(sq(win_height), menu_lines), win_height);
 
     const int menu_cols = div_round_up(item_count, (int)m_menu.size.line);
     const int first_col = m_menu.first_item / (int)m_menu.size.line;
 
-    const LineCount mark_line = (win_height - mark_height) * first_col / max(1, menu_cols - m_menu.columns);
+    const LineCount mark_line = (win_height - mark_height) * first_col
+                                / max(1, menu_cols - m_menu.columns);
 
     for (auto line = 0_line; line < win_height; ++line)
     {
         wmove(m_menu.win, (int)line, 0);
         for (int col = 0; col < m_menu.columns; ++col)
         {
-            int item_idx = (first_col + col) * (int)m_menu.size.line + (int)line;
+            int item_idx
+                = (first_col + col) * (int)m_menu.size.line + (int)line;
             if (item_idx >= item_count)
                 continue;
 
@@ -761,8 +800,8 @@ void NCursesUI::draw_menu()
             const ColumnCount pad = column_width - item.length();
             add_str(m_menu.win, String{' ', pad});
         }
-        const bool is_mark = line >= mark_line and
-                             line < mark_line + mark_height;
+        const bool is_mark
+            = line >= mark_line and line < mark_line + mark_height;
         wclrtoeol(m_menu.win);
         wmove(m_menu.win, (int)line, (int)m_menu.size.column - 1);
         wattron(m_menu.win, COLOR_PAIR(menu_bg));
@@ -775,9 +814,12 @@ static LineCount height_limit(MenuStyle style)
 {
     switch (style)
     {
-        case MenuStyle::Inline: return 10_line;
-        case MenuStyle::Prompt: return 10_line;
-        case MenuStyle::Search: return 3_line;
+        case MenuStyle::Inline:
+            return 10_line;
+        case MenuStyle::Prompt:
+            return 10_line;
+        case MenuStyle::Search:
+            return 3_line;
     }
     kak_assert(false);
     return 0_line;
@@ -794,9 +836,9 @@ void NCursesUI::menu_show(ConstArrayView<DisplayLine> items,
         m_dirty = true;
     }
 
-    m_menu.fg = fg;
-    m_menu.bg = bg;
-    m_menu.style = style;
+    m_menu.fg     = fg;
+    m_menu.bg     = bg;
+    m_menu.style  = style;
     m_menu.anchor = anchor;
 
     if (m_dimensions.column <= 2)
@@ -805,20 +847,30 @@ void NCursesUI::menu_show(ConstArrayView<DisplayLine> items,
     const int item_count = items.size();
     m_menu.items.clear(); // make sure it is empty
     m_menu.items.reserve(item_count);
-    const auto longest = accumulate(items | transform(&DisplayLine::length),
-                                    1_col, [](auto&& lhs, auto&& rhs) { return std::max(lhs, rhs); });
+    const auto longest
+        = accumulate(items | transform(&DisplayLine::length), 1_col,
+                     [](auto&& lhs, auto&& rhs) { return std::max(lhs, rhs); });
 
     const ColumnCount max_width = m_dimensions.column - 1;
-    const bool is_inline = style == MenuStyle::Inline;
-    const bool is_search = style == MenuStyle::Search;
-    m_menu.columns = is_search ? 0 : (is_inline ? 1 : max((int)(max_width / (longest+1)), 1));
+    const bool is_inline        = style == MenuStyle::Inline;
+    const bool is_search        = style == MenuStyle::Search;
+    m_menu.columns
+        = is_search
+              ? 0
+              : (is_inline ? 1 : max((int)(max_width / (longest + 1)), 1));
 
-    const LineCount max_height = min(height_limit(style), max(anchor.line, m_dimensions.line - anchor.line - 1));
-    const LineCount height = is_search ?
-        1 : (min<LineCount>(max_height, div_round_up(item_count, m_menu.columns)));
+    const LineCount max_height
+        = min(height_limit(style),
+              max(anchor.line, m_dimensions.line - anchor.line - 1));
+    const LineCount height
+        = is_search
+              ? 1
+              : (min<LineCount>(max_height,
+                                div_round_up(item_count, m_menu.columns)));
 
-    const ColumnCount maxlen = (m_menu.columns > 1 and item_count > 1) ?
-        max_width / m_menu.columns - 1 : max_width;
+    const ColumnCount maxlen = (m_menu.columns > 1 and item_count > 1)
+                                   ? max_width / m_menu.columns - 1
+                                   : max_width;
 
     for (auto& item : items)
     {
@@ -830,11 +882,12 @@ void NCursesUI::menu_show(ConstArrayView<DisplayLine> items,
     if (is_inline)
         anchor.line += content_line_offset();
 
-    LineCount line = anchor.line + 1;
-    ColumnCount column = std::max(0_col, std::min(anchor.column, m_dimensions.column - longest - 1));
+    LineCount line     = anchor.line + 1;
+    ColumnCount column = std::max(
+        0_col, std::min(anchor.column, m_dimensions.column - longest - 1));
     if (is_search)
     {
-        line = m_status_on_top ? 0_line : m_dimensions.line;
+        line   = m_status_on_top ? 0_line : m_dimensions.line;
         column = m_dimensions.column / 2;
     }
     else if (not is_inline)
@@ -842,18 +895,19 @@ void NCursesUI::menu_show(ConstArrayView<DisplayLine> items,
     else if (line + height > m_dimensions.line)
         line = anchor.line - height;
 
-    const auto width = is_search ? m_dimensions.column - m_dimensions.column / 2
-                                 : (is_inline ? min(longest+1, m_dimensions.column)
-                                              : m_dimensions.column);
+    const auto width = is_search
+                           ? m_dimensions.column - m_dimensions.column / 2
+                           : (is_inline ? min(longest + 1, m_dimensions.column)
+                                        : m_dimensions.column);
     m_menu.create({line, column}, {height, width});
     m_menu.selected_item = item_count;
-    m_menu.first_item = 0;
+    m_menu.first_item    = 0;
 
     draw_menu();
 
     if (m_info)
-        info_show(m_info.title, m_info.content,
-                  m_info.anchor, m_info.face, m_info.style);
+        info_show(m_info.title, m_info.content, m_info.anchor, m_info.face,
+                  m_info.style);
 }
 
 void NCursesUI::menu_select(int selected)
@@ -862,20 +916,20 @@ void NCursesUI::menu_select(int selected)
     if (selected < 0 or selected >= item_count)
     {
         m_menu.selected_item = -1;
-        m_menu.first_item = 0;
+        m_menu.first_item    = 0;
     }
     else if (m_menu.columns == 0) // Do not columnize
     {
-        m_menu.selected_item = selected;
+        m_menu.selected_item    = selected;
         const ColumnCount width = m_menu.size.column - 3;
-        int first = 0;
-        ColumnCount item_col = 0;
+        int first               = 0;
+        ColumnCount item_col    = 0;
         for (int i = 0; i <= selected; ++i)
         {
             const ColumnCount item_width = m_menu.items[i].length() + 1;
             if (item_col + item_width > width)
             {
-                first = i;
+                first    = i;
                 item_col = item_width;
             }
             else
@@ -886,13 +940,14 @@ void NCursesUI::menu_select(int selected)
     else
     {
         m_menu.selected_item = selected;
-        const int menu_cols = div_round_up(item_count, (int)m_menu.size.line);
-        const int first_col = m_menu.first_item / (int)m_menu.size.line;
+        const int menu_cols  = div_round_up(item_count, (int)m_menu.size.line);
+        const int first_col  = m_menu.first_item / (int)m_menu.size.line;
         const int selected_col = m_menu.selected_item / (int)m_menu.size.line;
         if (selected_col < first_col)
             m_menu.first_item = selected_col * (int)m_menu.size.line;
         if (selected_col >= first_col + m_menu.columns)
-            m_menu.first_item = min(selected_col, menu_cols - m_menu.columns) * (int)m_menu.size.line;
+            m_menu.first_item = min(selected_col, menu_cols - m_menu.columns)
+                                * (int)m_menu.size.line;
     }
     draw_menu();
 }
@@ -909,12 +964,13 @@ void NCursesUI::menu_hide()
 
     // Recompute info as it does not have to avoid the menu anymore
     if (m_info)
-        info_show(m_info.title, m_info.content, m_info.anchor, m_info.face, m_info.style);
+        info_show(m_info.title, m_info.content, m_info.anchor, m_info.face,
+                  m_info.style);
 }
 
 static DisplayCoord compute_pos(DisplayCoord anchor, DisplayCoord size,
-                             NCursesUI::Rect rect, NCursesUI::Rect to_avoid,
-                             bool prefer_above)
+                                NCursesUI::Rect rect, NCursesUI::Rect to_avoid,
+                                bool prefer_above)
 {
     DisplayCoord pos;
     if (prefer_above)
@@ -940,8 +996,9 @@ static DisplayCoord compute_pos(DisplayCoord anchor, DisplayCoord size,
         DisplayCoord end = pos + size;
 
         // check intersection
-        if (not (end.line < to_avoid.pos.line or end.column < to_avoid.pos.column or
-                 pos.line > to_avoid_end.line or pos.column > to_avoid_end.column))
+        if (not(end.line < to_avoid.pos.line or end.column < to_avoid.pos.column
+                or pos.line > to_avoid_end.line
+                or pos.column > to_avoid_end.column))
         {
             pos.line = min(to_avoid.pos.line, anchor.line) - size.line;
             // if above does not work, try below
@@ -959,12 +1016,13 @@ struct InfoBox
     Vector<String> contents;
 };
 
-InfoBox make_info_box(StringView title, StringView message, ColumnCount max_width,
+InfoBox make_info_box(StringView title, StringView message,
+                      ColumnCount max_width,
                       ConstArrayView<StringView> assistant)
 {
     DisplayCoord assistant_size;
     if (not assistant.empty())
-        assistant_size = { (int)assistant.size(), assistant[0].column_length() };
+        assistant_size = {(int)assistant.size(), assistant[0].column_length()};
 
     InfoBox result{};
 
@@ -978,9 +1036,12 @@ InfoBox make_info_box(StringView title, StringView message, ColumnCount max_widt
     for (auto& line : lines)
         bubble_width = max(bubble_width, line.column_length());
 
-    auto line_count = max(assistant_size.line-1, LineCount{(int)lines.size()} + 2);
-    result.size = DisplayCoord{line_count, bubble_width + assistant_size.column + 4};
-    const auto assistant_top_margin = (line_count - assistant_size.line+1) / 2;
+    auto line_count
+        = max(assistant_size.line - 1, LineCount{(int)lines.size()} + 2);
+    result.size
+        = DisplayCoord{line_count, bubble_width + assistant_size.column + 4};
+    const auto assistant_top_margin
+        = (line_count - assistant_size.line + 1) / 2;
     for (LineCount i = 0; i < line_count; ++i)
     {
         String line;
@@ -988,9 +1049,10 @@ InfoBox make_info_box(StringView title, StringView message, ColumnCount max_widt
         if (not assistant.empty())
         {
             if (i >= assistant_top_margin)
-                line += assistant[(int)min(i - assistant_top_margin, assistant_size.line-1)];
+                line += assistant[(int)min(i - assistant_top_margin,
+                                           assistant_size.line - 1)];
             else
-                line += assistant[(int)assistant_size.line-1];
+                line += assistant[(int)assistant_size.line - 1];
         }
         if (i == 0)
         {
@@ -1001,13 +1063,14 @@ InfoBox make_info_box(StringView title, StringView message, ColumnCount max_widt
                 auto dash_count = bubble_width - title.column_length() - 2;
                 String left{dash, dash_count / 2};
                 String right{dash, dash_count - dash_count / 2};
-                line += "╭─" + left + "┤" + title +"├" + right +"─╮";
+                line += "╭─" + left + "┤" + title + "├" + right + "─╮";
             }
         }
         else if (i < lines.size() + 1)
         {
             auto& info_line = lines[(int)i - 1];
-            const ColumnCount padding = bubble_width - info_line.column_length();
+            const ColumnCount padding
+                = bubble_width - info_line.column_length();
             line += "│ " + info_line + String{' ', padding} + " │";
         }
         else if (i == lines.size() + 1)
@@ -1024,7 +1087,8 @@ InfoBox make_simple_info_box(StringView contents, ColumnCount max_width)
     for (auto& line : wrap_lines(contents, max_width))
     {
         ++info_box.size.line;
-        info_box.size.column = std::max(line.column_length(), info_box.size.column);
+        info_box.size.column
+            = std::max(line.column_length(), info_box.size.column);
         info_box.contents.push_back(line.str());
     }
     return info_box;
@@ -1035,24 +1099,30 @@ void NCursesUI::info_show(StringView title, StringView content,
 {
     info_hide();
 
-    m_info.title = title.str();
+    m_info.title   = title.str();
     m_info.content = content.str();
-    m_info.anchor = anchor;
-    m_info.face = face;
-    m_info.style = style;
+    m_info.anchor  = anchor;
+    m_info.face    = face;
+    m_info.style   = style;
 
     const Rect rect = {content_line_offset(), m_dimensions};
     InfoBox info_box;
     if (style == InfoStyle::Prompt)
     {
-        info_box = make_info_box(m_info.title, m_info.content, m_dimensions.column, m_assistant);
-        anchor = DisplayCoord{m_status_on_top ? 0 : m_dimensions.line, m_dimensions.column-1};
-        anchor = compute_pos(anchor, info_box.size, rect, m_menu, style == InfoStyle::InlineAbove);
+        info_box = make_info_box(m_info.title, m_info.content,
+                                 m_dimensions.column, m_assistant);
+        anchor   = DisplayCoord{m_status_on_top ? 0 : m_dimensions.line,
+                              m_dimensions.column - 1};
+        anchor   = compute_pos(anchor, info_box.size, rect, m_menu,
+                             style == InfoStyle::InlineAbove);
     }
     else if (style == InfoStyle::Modal)
     {
-        info_box = make_info_box(m_info.title, m_info.content, m_dimensions.column, {});
-        auto half = [](const DisplayCoord& c) { return DisplayCoord{c.line / 2, c.column / 2}; };
+        info_box  = make_info_box(m_info.title, m_info.content,
+                                 m_dimensions.column, {});
+        auto half = [](const DisplayCoord& c) {
+            return DisplayCoord{c.line / 2, c.column / 2};
+        };
         anchor = rect.pos + half(rect.size) - half(info_box.size);
     }
     else if (style == InfoStyle::MenuDoc)
@@ -1060,15 +1130,17 @@ void NCursesUI::info_show(StringView title, StringView content,
         if (not m_menu)
             return;
 
-        const auto right_max_width = m_dimensions.column - (m_menu.pos.column + m_menu.size.column);
+        const auto right_max_width
+            = m_dimensions.column - (m_menu.pos.column + m_menu.size.column);
         const auto left_max_width = m_menu.pos.column;
-        const auto max_width = std::max(right_max_width, left_max_width);
+        const auto max_width      = std::max(right_max_width, left_max_width);
         if (max_width < 4)
             return;
 
-        info_box = make_simple_info_box(m_info.content, max_width);
+        info_box    = make_simple_info_box(m_info.content, max_width);
         anchor.line = m_menu.pos.line;
-        if (info_box.size.column <= right_max_width or right_max_width >= left_max_width)
+        if (info_box.size.column <= right_max_width
+            or right_max_width >= left_max_width)
             anchor.column = m_menu.pos.column + m_menu.size.column;
         else
             anchor.column = m_menu.pos.column - info_box.size.column;
@@ -1080,7 +1152,8 @@ void NCursesUI::info_show(StringView title, StringView content,
             return;
 
         info_box = make_simple_info_box(m_info.content, max_width);
-        anchor = compute_pos(anchor, info_box.size, rect, m_menu, style == InfoStyle::InlineAbove);
+        anchor   = compute_pos(anchor, info_box.size, rect, m_menu,
+                             style == InfoStyle::InlineAbove);
 
         anchor.line += content_line_offset();
     }
@@ -1120,10 +1193,7 @@ void NCursesUI::set_on_key(OnKeyCallback callback)
     EventManager::instance().force_signal(0);
 }
 
-DisplayCoord NCursesUI::dimensions()
-{
-    return m_dimensions;
-}
+DisplayCoord NCursesUI::dimensions() { return m_dimensions; }
 
 LineCount NCursesUI::content_line_offset() const
 {
@@ -1136,10 +1206,7 @@ void NCursesUI::set_resize_pending()
     EventManager::instance().force_signal(0);
 }
 
-void NCursesUI::abort()
-{
-    endwin();
-}
+void NCursesUI::abort() { endwin(); }
 
 void NCursesUI::enable_mouse(bool enabled)
 {
@@ -1180,37 +1247,38 @@ void NCursesUI::set_ui_options(const Options& options)
     }
 
     {
-        auto it = options.find("ncurses_status_on_top"_sv);
-        m_status_on_top = it != options.end() and
-            (it->value == "yes" or it->value == "true");
+        auto it         = options.find("ncurses_status_on_top"_sv);
+        m_status_on_top = it != options.end()
+                          and (it->value == "yes" or it->value == "true");
     }
 
     {
-        auto it = options.find("ncurses_set_title"_sv);
-        m_set_title = it == options.end() or
-            (it->value == "yes" or it->value == "true");
+        auto it     = options.find("ncurses_set_title"_sv);
+        m_set_title = it == options.end()
+                      or (it->value == "yes" or it->value == "true");
     }
 
     {
-        auto it = options.find("ncurses_shift_function_key"_sv);
-        m_shift_function_key = it != options.end() ?
-            str_to_int_ifp(it->value).value_or(default_shift_function_key)
-          : default_shift_function_key;
+        auto it              = options.find("ncurses_shift_function_key"_sv);
+        m_shift_function_key = it != options.end()
+                                   ? str_to_int_ifp(it->value).value_or(
+                                         default_shift_function_key)
+                                   : default_shift_function_key;
     }
 
     {
-        auto it = options.find("ncurses_change_colors"_sv);
-        auto value = it == options.end() or
-            (it->value == "yes" or it->value == "true");
+        auto it    = options.find("ncurses_change_colors"_sv);
+        auto value = it == options.end()
+                     or (it->value == "yes" or it->value == "true");
 
         if (can_change_color() and m_change_colors != value)
         {
             fputs("\033]104;\007", stdout); // try to reset palette
             fflush(stdout);
             m_colorpairs.clear();
-            m_colors = default_colors;
-            m_next_color = 16;
-            m_next_pair = 1;
+            m_colors      = default_colors;
+            m_next_color  = 16;
+            m_next_pair   = 1;
             m_active_pair = -1;
         }
         m_change_colors = value;
@@ -1218,17 +1286,20 @@ void NCursesUI::set_ui_options(const Options& options)
 
     {
         auto enable_mouse_it = options.find("ncurses_enable_mouse"_sv);
-        enable_mouse(enable_mouse_it == options.end() or
-                     enable_mouse_it->value == "yes" or
-                     enable_mouse_it->value == "true");
+        enable_mouse(enable_mouse_it == options.end()
+                     or enable_mouse_it->value == "yes"
+                     or enable_mouse_it->value == "true");
 
-        auto wheel_up_it = options.find("ncurses_wheel_up_button"_sv);
-        m_wheel_up_button = wheel_up_it != options.end() ?
-            str_to_int_ifp(wheel_up_it->value).value_or(4) : 4;
+        auto wheel_up_it  = options.find("ncurses_wheel_up_button"_sv);
+        m_wheel_up_button = wheel_up_it != options.end()
+                                ? str_to_int_ifp(wheel_up_it->value).value_or(4)
+                                : 4;
 
         auto wheel_down_it = options.find("ncurses_wheel_down_button"_sv);
-        m_wheel_down_button = wheel_down_it != options.end() ?
-            str_to_int_ifp(wheel_down_it->value).value_or(5) : 5;
+        m_wheel_down_button
+            = wheel_down_it != options.end()
+                  ? str_to_int_ifp(wheel_down_it->value).value_or(5)
+                  : 5;
     }
 }
 

--- a/src/ncurses_ui.hh
+++ b/src/ncurses_ui.hh
@@ -26,23 +26,20 @@ public:
 
     bool is_ok() const override { return m_window != nullptr; }
 
-    void draw(const DisplayBuffer& display_buffer,
-              const Face& default_face,
+    void draw(const DisplayBuffer& display_buffer, const Face& default_face,
               const Face& padding_face) override;
 
     void draw_status(const DisplayLine& status_line,
                      const DisplayLine& mode_line,
                      const Face& default_face) override;
 
-    void menu_show(ConstArrayView<DisplayLine> items,
-                   DisplayCoord anchor, Face fg, Face bg,
-                   MenuStyle style) override;
+    void menu_show(ConstArrayView<DisplayLine> items, DisplayCoord anchor,
+                   Face fg, Face bg, MenuStyle style) override;
     void menu_select(int selected) override;
     void menu_hide() override;
 
-    void info_show(StringView title, StringView content,
-                   DisplayCoord anchor, Face face,
-                   InfoStyle style) override;
+    void info_show(StringView title, StringView content, DisplayCoord anchor,
+                   Face face, InfoStyle style) override;
     void info_hide() override;
 
     void set_cursor(CursorMode mode, DisplayCoord coord) override;
@@ -81,8 +78,8 @@ private:
     using ColorPair = std::pair<Color, Color>;
     HashMap<Color, int, MemoryDomain::Faces> m_colors;
     HashMap<ColorPair, int, MemoryDomain::Faces> m_colorpairs;
-    int m_next_color = 16;
-    int m_next_pair = 1;
+    int m_next_color  = 16;
+    int m_next_pair   = 1;
     int m_active_pair = -1;
 
     struct Window : Rect
@@ -106,8 +103,8 @@ private:
         DisplayCoord anchor;
         MenuStyle style;
         int selected_item = 0;
-        int first_item = 0;
-        int columns = 1;
+        int first_item    = 0;
+        int columns       = 1;
     } m_menu;
 
     void draw_menu();
@@ -137,14 +134,14 @@ private:
 
     void enable_mouse(bool enabled);
 
-    bool m_mouse_enabled = false;
-    int m_wheel_up_button = 4;
+    bool m_mouse_enabled    = false;
+    int m_wheel_up_button   = 4;
     int m_wheel_down_button = 5;
 
     static constexpr int default_shift_function_key = 12;
     int m_shift_function_key = default_shift_function_key;
 
-    bool m_set_title = true;
+    bool m_set_title     = true;
     bool m_change_colors = true;
 
     bool m_dirty = false;

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -39,11 +39,11 @@ enum class SelectMode
 
 void merge_selections(Selection& sel, const Selection& new_sel)
 {
-    const bool forward = sel.cursor() >= sel.anchor();
+    const bool forward     = sel.cursor() >= sel.anchor();
     const bool new_forward = new_sel.cursor() > new_sel.anchor();
     if (forward and new_forward)
         sel.anchor() = std::min(sel.anchor(), new_sel.anchor());
-    const bool backward = sel.cursor() <= sel.anchor();
+    const bool backward     = sel.cursor() <= sel.anchor();
     const bool new_backward = new_sel.cursor() < new_sel.anchor();
     if (backward and new_backward)
         sel.anchor() = std::max(sel.anchor(), new_sel.anchor());
@@ -56,12 +56,18 @@ UnitTest test_merge_selection{[] {
         merge_selections(sel, new_sel);
         return sel;
     };
-    kak_assert(merge({{0, 1}, {0, 2} }, {{0, 3}, {0, 4}}) == Selection{{0, 1}, {0, 4}});
-    kak_assert(merge({{0, 1}, {0, 2} }, {{0, 1}, {0, 2}}) == Selection{{0, 1}, {0, 2}});
-    kak_assert(merge({{0, 1}, {0, 2} }, {{0, 0}, {0, 0}}) == Selection{{0, 1}, {0, 0}});
-    kak_assert(merge({{0, 1}, {0, 2} }, {{0, 0}, {0, 3}}) == Selection{{0, 0}, {0, 3}});
-    kak_assert(merge({{0, 1}, {0, 3} }, {{0, 4}, {0, 2}}) == Selection{{0, 1}, {0, 2}});
-    kak_assert(merge({{0, 1}, {0, 2} }, {{0, 1}, {0, 1}}) == Selection{{0, 1}, {0, 1}});
+    kak_assert(merge({{0, 1}, {0, 2}}, {{0, 3}, {0, 4}})
+               == Selection{{0, 1}, {0, 4}});
+    kak_assert(merge({{0, 1}, {0, 2}}, {{0, 1}, {0, 2}})
+               == Selection{{0, 1}, {0, 2}});
+    kak_assert(merge({{0, 1}, {0, 2}}, {{0, 0}, {0, 0}})
+               == Selection{{0, 1}, {0, 0}});
+    kak_assert(merge({{0, 1}, {0, 2}}, {{0, 0}, {0, 3}})
+               == Selection{{0, 0}, {0, 3}});
+    kak_assert(merge({{0, 1}, {0, 3}}, {{0, 4}, {0, 2}})
+               == Selection{{0, 1}, {0, 2}});
+    kak_assert(merge({{0, 1}, {0, 2}}, {{0, 1}, {0, 1}})
+               == Selection{{0, 1}, {0, 1}});
 }};
 
 template<SelectMode mode, typename T>
@@ -85,7 +91,7 @@ void select(Context& context, T func)
         for (int i = 0; i < (int)selections.size(); ++i)
         {
             auto& sel = selections[i];
-            auto res = func(context, sel);
+            auto res  = func(context, sel);
             if (not res)
             {
                 to_remove.push_back(i);
@@ -113,7 +119,8 @@ void select(Context& context, T func)
     selections.check_invariant();
 }
 
-template<SelectMode mode, Optional<Selection> (*func)(const Context&, const Selection&)>
+template<SelectMode mode,
+         Optional<Selection> (*func)(const Context&, const Selection&)>
 void select(Context& context, NormalParams)
 {
     select<mode>(context, func);
@@ -123,7 +130,7 @@ template<SelectMode mode, typename Func>
 void select_and_set_last(Context& context, Func&& func)
 {
     context.set_last_select(
-        [func](Context& context){ select<mode>(context, func); });
+        [func](Context& context) { select<mode>(context, func); });
     return select<mode>(context, func);
 }
 
@@ -132,7 +139,7 @@ void select_coord(Buffer& buffer, BufferCoord coord, SelectionList& selections)
 {
     coord = buffer.clamp(coord);
     if (mode == SelectMode::Replace)
-        selections = SelectionList{ buffer, coord };
+        selections = SelectionList{buffer, coord};
     else if (mode == SelectMode::Extend)
     {
         for (auto& sel : selections)
@@ -165,9 +172,9 @@ String build_autoinfo_for_mapping(Context& context, KeymapMode mode,
     Vector<std::pair<String, StringView>> descs;
     for (auto& built_in : built_ins)
     {
-        String keys = join(built_in.keys |
-                           filter([&](Key k){ return not keymaps.is_mapped(k, mode); }) |
-                           transform(key_to_str),
+        String keys = join(built_in.keys | filter([&](Key k) {
+                               return not keymaps.is_mapped(k, mode);
+                           }) | transform(key_to_str),
                            ',', false);
         if (not keys.empty())
             descs.emplace_back(std::move(keys), built_in.docstring);
@@ -187,8 +194,7 @@ String build_autoinfo_for_mapping(Context& context, KeymapMode mode,
 
     String res;
     for (auto& desc : descs)
-        res += format("{}:{}{}\n",
-                      desc.first,
+        res += format("{}:{}{}\n", desc.first,
                       String{' ', max_len - desc.first.column_length() + 1},
                       desc.second);
     return res;
@@ -200,133 +206,154 @@ void goto_commands(Context& context, NormalParams params)
     if (params.count != 0)
     {
         context.push_jump();
-        select_coord<mode>(context.buffer(), LineCount{params.count - 1}, context.selections());
+        select_coord<mode>(context.buffer(), LineCount{params.count - 1},
+                           context.selections());
         if (context.has_window())
-            context.window().center_line(LineCount{params.count-1});
+            context.window().center_line(LineCount{params.count - 1});
     }
     else
     {
-        on_next_key_with_autoinfo(context, KeymapMode::Goto,
-                                 [](Key key, Context& context) {
-            auto cp = key.codepoint();
-            if (not cp or key == Key::Escape)
-                return;
-            auto& buffer = context.buffer();
-            switch (to_lower(*cp))
-            {
-            case 'g':
-            case 'k':
-                context.push_jump();
-                select_coord<mode>(buffer, BufferCoord{0,0}, context.selections());
-                break;
-            case 'l':
-                select<mode, select_to_line_end<true>>(context, {});
-                break;
-            case 'h':
-                select<mode, select_to_line_begin<true>>(context, {});
-                break;
-            case 'i':
-                select<mode, select_to_first_non_blank>(context, {});
-                break;
-            case 'j':
-                context.push_jump();
-                select_coord<mode>(buffer, buffer.line_count() - 1, context.selections());
-                break;
-            case 'e':
-                context.push_jump();
-                select_coord<mode>(buffer, buffer.back_coord(), context.selections());
-                break;
-            case 't':
-                if (context.has_window())
-                {
-                    auto line = context.window().position().line;
-                    select_coord<mode>(buffer, line, context.selections());
-                }
-                break;
-            case 'b':
-                if (context.has_window())
-                {
-                    auto& window = context.window();
-                    auto line = window.position().line + window.dimensions().line - 1;
-                    select_coord<mode>(buffer, line, context.selections());
-                }
-                break;
-            case 'c':
-                if (context.has_window())
-                {
-                    auto& window = context.window();
-                    auto line = window.position().line + window.dimensions().line / 2;
-                    select_coord<mode>(buffer, line, context.selections());
-                }
-                break;
-            case 'a':
-            {
-                Buffer* target = nullptr;
-                if (not context.has_client() or
-                    not (target = context.client().last_buffer()))
-                {
-                    throw runtime_error("no last buffer");
-                    break;
-                }
-                context.push_jump();
-                context.change_buffer(*target);
-                break;
-            }
-            case 'f':
-            {
-                auto filename = content(buffer, context.selections().main());
-                static constexpr char forbidden[] = { '\'', '\\', '\0' };
-                if (any_of(filename, [](char c){ return contains(forbidden, c); }))
+        on_next_key_with_autoinfo(
+            context, KeymapMode::Goto,
+            [](Key key, Context& context) {
+                auto cp = key.codepoint();
+                if (not cp or key == Key::Escape)
                     return;
-
-                auto paths = context.options()["path"].get<Vector<String, MemoryDomain::Options>>();
-                const StringView buffer_dir = split_path(buffer.name()).first;
-                String path = find_file(filename, buffer_dir, paths);
-                if (path.empty())
-                    throw runtime_error(format("unable to find file '{}'", filename));
-
-                Buffer* buffer = BufferManager::instance().get_buffer_ifp(path);
-                if (not buffer)
+                auto& buffer = context.buffer();
+                switch (to_lower(*cp))
                 {
-                    buffer = open_file_buffer(path, context.hooks_disabled() ?
-                                                      Buffer::Flags::NoHooks
-                                                    : Buffer::Flags::None);
-                    buffer->flags() &= ~Buffer::Flags::NoHooks;
-                }
+                    case 'g':
+                    case 'k':
+                        context.push_jump();
+                        select_coord<mode>(buffer, BufferCoord{0, 0},
+                                           context.selections());
+                        break;
+                    case 'l':
+                        select<mode, select_to_line_end<true>>(context, {});
+                        break;
+                    case 'h':
+                        select<mode, select_to_line_begin<true>>(context, {});
+                        break;
+                    case 'i':
+                        select<mode, select_to_first_non_blank>(context, {});
+                        break;
+                    case 'j':
+                        context.push_jump();
+                        select_coord<mode>(buffer, buffer.line_count() - 1,
+                                           context.selections());
+                        break;
+                    case 'e':
+                        context.push_jump();
+                        select_coord<mode>(buffer, buffer.back_coord(),
+                                           context.selections());
+                        break;
+                    case 't':
+                        if (context.has_window())
+                        {
+                            auto line = context.window().position().line;
+                            select_coord<mode>(buffer, line,
+                                               context.selections());
+                        }
+                        break;
+                    case 'b':
+                        if (context.has_window())
+                        {
+                            auto& window = context.window();
+                            auto line    = window.position().line
+                                        + window.dimensions().line - 1;
+                            select_coord<mode>(buffer, line,
+                                               context.selections());
+                        }
+                        break;
+                    case 'c':
+                        if (context.has_window())
+                        {
+                            auto& window = context.window();
+                            auto line    = window.position().line
+                                        + window.dimensions().line / 2;
+                            select_coord<mode>(buffer, line,
+                                               context.selections());
+                        }
+                        break;
+                    case 'a':
+                    {
+                        Buffer* target = nullptr;
+                        if (not context.has_client()
+                            or not(target = context.client().last_buffer()))
+                        {
+                            throw runtime_error("no last buffer");
+                            break;
+                        }
+                        context.push_jump();
+                        context.change_buffer(*target);
+                        break;
+                    }
+                    case 'f':
+                    {
+                        auto filename
+                            = content(buffer, context.selections().main());
+                        static constexpr char forbidden[] = {'\'', '\\', '\0'};
+                        if (any_of(filename, [](char c) {
+                                return contains(forbidden, c);
+                            }))
+                            return;
 
-                if (buffer != &context.buffer())
-                {
-                    context.push_jump();
-                    context.change_buffer(*buffer);
+                        auto paths
+                            = context.options()["path"]
+                                  .get<Vector<String, MemoryDomain::Options>>();
+                        const StringView buffer_dir
+                            = split_path(buffer.name()).first;
+                        String path = find_file(filename, buffer_dir, paths);
+                        if (path.empty())
+                            throw runtime_error(
+                                format("unable to find file '{}'", filename));
+
+                        Buffer* buffer
+                            = BufferManager::instance().get_buffer_ifp(path);
+                        if (not buffer)
+                        {
+                            buffer = open_file_buffer(
+                                path, context.hooks_disabled()
+                                          ? Buffer::Flags::NoHooks
+                                          : Buffer::Flags::None);
+                            buffer->flags() &= ~Buffer::Flags::NoHooks;
+                        }
+
+                        if (buffer != &context.buffer())
+                        {
+                            context.push_jump();
+                            context.change_buffer(*buffer);
+                        }
+                        break;
+                    }
+                    case '.':
+                    {
+                        context.push_jump();
+                        auto pos = buffer.last_modification_coord();
+                        if (not pos)
+                            throw runtime_error(
+                                "no last modification position");
+                        if (*pos >= buffer.back_coord())
+                            pos = buffer.back_coord();
+                        select_coord<mode>(buffer, *pos, context.selections());
+                        break;
+                    }
                 }
-                break;
-            }
-            case '.':
-            {
-                context.push_jump();
-                auto pos = buffer.last_modification_coord();
-                if (not pos)
-                    throw runtime_error("no last modification position");
-                if (*pos >= buffer.back_coord())
-                    pos = buffer.back_coord();
-                select_coord<mode>(buffer, *pos, context.selections());
-                break;
-            }
-            }
-        }, (mode == SelectMode::Extend ? "goto (extend to)" : "goto"),
-        build_autoinfo_for_mapping(context, KeymapMode::Goto,
-            {{{'g','k'},"buffer top"},
-             {{'l'},    "line end"},
-             {{'h'},    "line begin"},
-             {{'i'},    "line non blank start"},
-             {{'j'},    "buffer bottom"},
-             {{'e'},    "buffer end"},
-             {{'t'},    "window top"},
-             {{'b'},    "window bottom"},
-             {{'c'},    "window center"},
-             {{'a'},    "last buffer"},
-             {{'f'},    "file"},
-             {{'.'},    "last buffer change"}}));
+            },
+            (mode == SelectMode::Extend ? "goto (extend to)" : "goto"),
+            build_autoinfo_for_mapping(context, KeymapMode::Goto,
+                                       {{{'g', 'k'}, "buffer top"},
+                                        {{'l'}, "line end"},
+                                        {{'h'}, "line begin"},
+                                        {{'i'}, "line non blank start"},
+                                        {{'j'}, "buffer bottom"},
+                                        {{'e'}, "buffer end"},
+                                        {{'t'}, "window top"},
+                                        {{'b'}, "window bottom"},
+                                        {{'c'}, "window center"},
+                                        {{'a'}, "last buffer"},
+                                        {{'f'}, "file"},
+                                        {{'.'}, "last buffer change"}}));
     }
 }
 
@@ -334,79 +361,85 @@ template<bool lock>
 void view_commands(Context& context, NormalParams params)
 {
     const int count = params.count;
-    on_next_key_with_autoinfo(context, KeymapMode::View,
-                             [count](Key key, Context& context) {
-        if (key == Key::Escape)
-            return;
+    on_next_key_with_autoinfo(
+        context, KeymapMode::View,
+        [count](Key key, Context& context) {
+            if (key == Key::Escape)
+                return;
 
-        if (lock)
-            view_commands<true>(context, { count, 0 });
+            if (lock)
+                view_commands<true>(context, {count, 0});
 
-        auto cp = key.codepoint();
-        if (not cp or not context.has_window())
-            return;
+            auto cp = key.codepoint();
+            if (not cp or not context.has_window())
+                return;
 
-        const BufferCoord cursor = context.selections().main().cursor();
-        Window& window = context.window();
-        switch (to_lower(*cp))
-        {
-        case 'v':
-        case 'c':
-            window.center_line(cursor.line);
-            break;
-        case 'm':
-            window.center_column(
-                context.buffer()[cursor.line].column_count_to(cursor.column));
-            break;
-        case 't':
-            window.display_line_at(cursor.line, 0);
-            break;
-        case 'b':
-            window.display_line_at(cursor.line, window.dimensions().line-1);
-            break;
-        case 'h':
-            window.scroll(-std::max<ColumnCount>(1, count));
-            break;
-        case 'j':
-            window.scroll( std::max<LineCount>(1, count));
-            break;
-        case 'k':
-            window.scroll(-std::max<LineCount>(1, count));
-            break;
-        case 'l':
-            window.scroll( std::max<ColumnCount>(1, count));
-            break;
-        }
-    }, lock ? "view (lock)" : "view",
-    build_autoinfo_for_mapping(context, KeymapMode::View,
-        {{{'v','c'}, "center cursor (vertically)"},
-         {{'m'},     "center cursor (horizontally)"},
-         {{'t'},     "cursor on top"},
-         {{'b'},     "cursor on bottom"},
-         {{'h'},     "scroll left"},
-         {{'j'},     "scroll down"},
-         {{'k'},     "scroll up"},
-         {{'l'},     "scroll right"}}));
+            const BufferCoord cursor = context.selections().main().cursor();
+            Window& window           = context.window();
+            switch (to_lower(*cp))
+            {
+                case 'v':
+                case 'c':
+                    window.center_line(cursor.line);
+                    break;
+                case 'm':
+                    window.center_column(
+                        context.buffer()[cursor.line].column_count_to(
+                            cursor.column));
+                    break;
+                case 't':
+                    window.display_line_at(cursor.line, 0);
+                    break;
+                case 'b':
+                    window.display_line_at(cursor.line,
+                                           window.dimensions().line - 1);
+                    break;
+                case 'h':
+                    window.scroll(-std::max<ColumnCount>(1, count));
+                    break;
+                case 'j':
+                    window.scroll(std::max<LineCount>(1, count));
+                    break;
+                case 'k':
+                    window.scroll(-std::max<LineCount>(1, count));
+                    break;
+                case 'l':
+                    window.scroll(std::max<ColumnCount>(1, count));
+                    break;
+            }
+        },
+        lock ? "view (lock)" : "view",
+        build_autoinfo_for_mapping(context, KeymapMode::View,
+                                   {{{'v', 'c'}, "center cursor (vertically)"},
+                                    {{'m'}, "center cursor (horizontally)"},
+                                    {{'t'}, "cursor on top"},
+                                    {{'b'}, "cursor on bottom"},
+                                    {{'h'}, "scroll left"},
+                                    {{'j'}, "scroll down"},
+                                    {{'k'}, "scroll up"},
+                                    {{'l'}, "scroll right"}}));
 }
 
 void replace_with_char(Context& context, NormalParams)
 {
-    on_next_key_with_autoinfo(context, KeymapMode::None,
-                             [](Key key, Context& context) {
-        auto cp = key.codepoint();
-        if (not cp or key == Key::Escape)
-            return;
-        ScopedEdition edition(context);
-        Buffer& buffer = context.buffer();
-        SelectionList& selections = context.selections();
-        Vector<String> strings;
-        for (auto& sel : selections)
-        {
-            CharCount count = char_length(buffer, sel);
-            strings.emplace_back(*cp, count);
-        }
-        selections.insert(strings, InsertMode::Replace);
-    }, "replace with char", "enter char to replace with\n");
+    on_next_key_with_autoinfo(
+        context, KeymapMode::None,
+        [](Key key, Context& context) {
+            auto cp = key.codepoint();
+            if (not cp or key == Key::Escape)
+                return;
+            ScopedEdition edition(context);
+            Buffer& buffer            = context.buffer();
+            SelectionList& selections = context.selections();
+            Vector<String> strings;
+            for (auto& sel : selections)
+            {
+                CharCount count = char_length(buffer, sel);
+                strings.emplace_back(*cp, count);
+            }
+            selections.insert(strings, InsertMode::Replace);
+        },
+        "replace with char", "enter char to replace with\n");
 }
 
 Codepoint swap_case(Codepoint cp)
@@ -421,14 +454,14 @@ void for_each_codepoint(Context& context, NormalParams)
     using Utf8It = utf8::iterator<BufferIterator>;
 
     ScopedEdition edition(context);
-    Buffer& buffer = context.buffer();
+    Buffer& buffer            = context.buffer();
     SelectionList& selections = context.selections();
     Vector<String> strings;
     for (auto& sel : selections)
     {
         String str;
         for (auto begin = Utf8It{buffer.iterator_at(sel.min()), buffer},
-                  end = Utf8It{buffer.iterator_at(sel.max()), buffer}+1;
+                  end   = Utf8It{buffer.iterator_at(sel.max()), buffer} + 1;
              begin != end; ++begin)
             utf8::dump(std::back_inserter(str), func(*begin));
 
@@ -446,10 +479,12 @@ void command(Context& context, NormalParams params)
 
     context.input_handler().prompt(
         ":", {}, context.main_sel_register_value(':').str(),
-        context.faces()["Prompt"], PromptFlags::DropHistoryEntriesWithBlankPrefix,
-        [](const Context& context, CompletionFlags flags,
-           StringView cmd_line, ByteCount pos) {
-               return CommandManager::instance().complete(context, flags, cmd_line, pos);
+        context.faces()["Prompt"],
+        PromptFlags::DropHistoryEntriesWithBlankPrefix,
+        [](const Context& context, CompletionFlags flags, StringView cmd_line,
+           ByteCount pos) {
+            return CommandManager::instance().complete(context, flags, cmd_line,
+                                                       pos);
         },
         [params](StringView cmdline, PromptEvent event, Context& context) {
             if (context.has_client())
@@ -457,18 +492,25 @@ void command(Context& context, NormalParams params)
                 context.client().info_hide();
                 if (event == PromptEvent::Change)
                 {
-                    auto info = CommandManager::instance().command_info(context, cmdline);
-                    context.input_handler().set_prompt_face(context.faces()[info ? "Prompt" : "Error"]);
+                    auto info = CommandManager::instance().command_info(
+                        context, cmdline);
+                    context.input_handler().set_prompt_face(
+                        context.faces()[info ? "Prompt" : "Error"]);
 
-                    auto autoinfo = context.options()["autoinfo"].get<AutoInfo>();
+                    auto autoinfo
+                        = context.options()["autoinfo"].get<AutoInfo>();
                     if (autoinfo & AutoInfo::Command)
                     {
-                        if (cmdline.length() == 1 and is_horizontal_blank(cmdline[0_byte]))
-                            context.client().info_show("prompt",
-                                                       "commands preceded by a blank wont be saved to history",
-                                                       {}, InfoStyle::Prompt);
+                        if (cmdline.length() == 1
+                            and is_horizontal_blank(cmdline[0_byte]))
+                            context.client().info_show(
+                                "prompt",
+                                "commands preceded by a blank wont be saved to "
+                                "history",
+                                {}, InfoStyle::Prompt);
                         else if (info and not info->info.empty())
-                            context.client().info_show(info->name, info->info, {}, InfoStyle::Prompt);
+                            context.client().info_show(info->name, info->info,
+                                                       {}, InfoStyle::Prompt);
                     }
                 }
             }
@@ -477,22 +519,22 @@ void command(Context& context, NormalParams params)
                 if (cmdline.empty())
                     cmdline = context.main_sel_register_value(':');
                 else if (not is_blank(cmdline[0]))
-                    RegisterManager::instance()[':'].set(context, cmdline.str());
+                    RegisterManager::instance()[':'].set(context,
+                                                         cmdline.str());
 
-                EnvVarMap env_vars = {
-                    { "count", to_string(params.count) },
-                    { "register", String{&params.reg, 1} }
-                };
-                CommandManager::instance().execute(
-                    cmdline, context, { {}, env_vars });
+                EnvVarMap env_vars = {{"count", to_string(params.count)},
+                                      {"register", String{&params.reg, 1}}};
+                CommandManager::instance().execute(cmdline, context,
+                                                   {{}, env_vars});
             }
         });
 }
 
-void apply_diff(Buffer& buffer, BufferCoord pos, StringView before, StringView after)
+void apply_diff(Buffer& buffer, BufferCoord pos, StringView before,
+                StringView after)
 {
-    // The diff algorithm is O(ND) with N the sum of string len, and D the diff count
-    // do not use it if our data is too big
+    // The diff algorithm is O(ND) with N the sum of string len, and D the diff
+    // count do not use it if our data is too big
     constexpr ByteCount size_limit = 100 * 1024;
     if (before.length() + after.length() > size_limit)
     {
@@ -501,22 +543,24 @@ void apply_diff(Buffer& buffer, BufferCoord pos, StringView before, StringView a
         return;
     }
 
-    auto diffs = find_diff(before.begin(), (int)before.length(), after.begin(), (int)after.length());
+    auto diffs = find_diff(before.begin(), (int)before.length(), after.begin(),
+                           (int)after.length());
 
     for (auto& diff : diffs)
     {
         switch (diff.mode)
         {
-        case Diff::Keep:
-            pos = buffer.advance(pos, diff.len);
-            break;
-        case Diff::Add:
-            buffer.insert(pos, after.substr(ByteCount{diff.posB}, ByteCount{diff.len}));
-            pos = buffer.advance(pos, diff.len);
-            break;
-        case Diff::Remove:
-            buffer.erase(pos, buffer.advance(pos, diff.len));
-            break;
+            case Diff::Keep:
+                pos = buffer.advance(pos, diff.len);
+                break;
+            case Diff::Add:
+                buffer.insert(pos, after.substr(ByteCount{diff.posB},
+                                                ByteCount{diff.len}));
+                pos = buffer.advance(pos, diff.len);
+                break;
+            case Diff::Remove:
+                buffer.erase(pos, buffer.advance(pos, diff.len));
+                break;
         }
     }
 }
@@ -526,11 +570,10 @@ void pipe(Context& context, NormalParams)
 {
     const char* prompt = replace ? "pipe:" : "pipe-to:";
     context.input_handler().prompt(
-        prompt, {}, context.main_sel_register_value("|").str(), context.faces()["Prompt"],
-        PromptFlags::DropHistoryEntriesWithBlankPrefix,
-        shell_complete,
-        [](StringView cmdline, PromptEvent event, Context& context)
-        {
+        prompt, {}, context.main_sel_register_value("|").str(),
+        context.faces()["Prompt"],
+        PromptFlags::DropHistoryEntriesWithBlankPrefix, shell_complete,
+        [](StringView cmdline, PromptEvent event, Context& context) {
             if (event != PromptEvent::Validate)
                 return;
 
@@ -542,12 +585,13 @@ void pipe(Context& context, NormalParams)
             if (cmdline.empty())
                 return;
 
-            Buffer& buffer = context.buffer();
+            Buffer& buffer           = context.buffer();
             SelectionList selections = context.selections();
-            auto restore_sels = on_scope_end([&, old_main = selections.main_index()] {
-                selections.set_main_index(old_main);
-                context.selections() = std::move(selections);
-            });
+            auto restore_sels
+                = on_scope_end([&, old_main = selections.main_index()] {
+                      selections.set_main_index(old_main);
+                      context.selections() = std::move(selections);
+                  });
             if (replace)
             {
                 ScopedEdition edition(context);
@@ -557,8 +601,10 @@ void pipe(Context& context, NormalParams)
                 {
                     selections.set_main_index(i);
                     auto& sel = selections.main();
-                    const auto beg = changes_tracker.get_new_coord_tolerant(sel.min());
-                    const auto end = changes_tracker.get_new_coord_tolerant(sel.max());
+                    const auto beg
+                        = changes_tracker.get_new_coord_tolerant(sel.min());
+                    const auto end
+                        = changes_tracker.get_new_coord_tolerant(sel.max());
 
                     String in = buffer.string(beg, buffer.char_next(end));
                     const bool insert_eol = in.back() != '\n';
@@ -568,15 +614,16 @@ void pipe(Context& context, NormalParams)
                     // Needed in case we read selections inside the cmdline
                     context.selections_write_only() = selections;
 
-                    String out = ShellManager::instance().eval(
-                        cmdline, context, in,
-                        ShellManager::Flags::WaitForStdout).first;
+                    String out = ShellManager::instance()
+                                     .eval(cmdline, context, in,
+                                           ShellManager::Flags::WaitForStdout)
+                                     .first;
 
                     if (insert_eol)
                     {
-                        in.resize(in.length()-1, 0);
+                        in.resize(in.length() - 1, 0);
                         if (not out.empty() and out.back() == '\n')
-                            out.resize(out.length()-1, 0);
+                            out.resize(out.length() - 1, 0);
                     }
                     apply_diff(buffer, beg, in, out);
 
@@ -588,9 +635,9 @@ void pipe(Context& context, NormalParams)
                 for (int i = 0; i < selections.size(); ++i)
                 {
                     selections.set_main_index(i);
-                    ShellManager::instance().eval(cmdline, context,
-                                                  content(buffer, selections.main()),
-                                                  ShellManager::Flags::None);
+                    ShellManager::instance().eval(
+                        cmdline, context, content(buffer, selections.main()),
+                        ShellManager::Flags::None);
                 }
             }
         });
@@ -599,13 +646,13 @@ void pipe(Context& context, NormalParams)
 template<InsertMode mode>
 void insert_output(Context& context, NormalParams)
 {
-    const char* prompt = mode == InsertMode::Insert ? "insert-output:" : "append-output:";
+    const char* prompt
+        = mode == InsertMode::Insert ? "insert-output:" : "append-output:";
     context.input_handler().prompt(
-        prompt, {}, context.main_sel_register_value("|").str(), context.faces()["Prompt"],
-        PromptFlags::DropHistoryEntriesWithBlankPrefix,
-        shell_complete,
-        [](StringView cmdline, PromptEvent event, Context& context)
-        {
+        prompt, {}, context.main_sel_register_value("|").str(),
+        context.faces()["Prompt"],
+        PromptFlags::DropHistoryEntriesWithBlankPrefix, shell_complete,
+        [](StringView cmdline, PromptEvent event, Context& context) {
             if (event != PromptEvent::Validate)
                 return;
 
@@ -617,8 +664,10 @@ void insert_output(Context& context, NormalParams)
             if (cmdline.empty())
                 return;
 
-            auto str = ShellManager::instance().eval(
-                cmdline, context, {}, ShellManager::Flags::WaitForStdout).first;
+            auto str = ShellManager::instance()
+                           .eval(cmdline, context, {},
+                                 ShellManager::Flags::WaitForStdout)
+                           .first;
             ScopedEdition edition(context);
             context.selections().insert(str, mode);
         });
@@ -628,9 +677,9 @@ void yank(Context& context, NormalParams params)
 {
     const char reg = params.reg ? params.reg : '"';
     RegisterManager::instance()[reg].set(context, context.selections_content());
-    context.print_status({ format("yanked {} selections to register {}",
-                                  context.selections().size(), reg),
-                           context.faces()["Information"] });
+    context.print_status({format("yanked {} selections to register {}",
+                                 context.selections().size(), reg),
+                          context.faces()["Information"]});
 }
 
 template<bool yank>
@@ -639,7 +688,8 @@ void erase_selections(Context& context, NormalParams params)
     if (yank)
     {
         const char reg = params.reg ? params.reg : '"';
-        RegisterManager::instance()[reg].set(context, context.selections_content());
+        RegisterManager::instance()[reg].set(context,
+                                             context.selections_content());
     }
     ScopedEdition edition(context);
     context.selections().erase();
@@ -651,7 +701,8 @@ void change(Context& context, NormalParams params)
     if (yank)
     {
         const char reg = params.reg ? params.reg : '"';
-        RegisterManager::instance()[reg].set(context, context.selections_content());
+        RegisterManager::instance()[reg].set(context,
+                                             context.selections_content());
     }
     enter_insert_mode<InsertMode::Replace>(context, params);
 }
@@ -660,19 +711,23 @@ InsertMode adapt_for_linewise(InsertMode mode)
 {
     switch (mode)
     {
-        case InsertMode::Append: return InsertMode::InsertAtNextLineBegin;
-        case InsertMode::Insert: return InsertMode::InsertAtLineBegin;
-        case InsertMode::Replace: return InsertMode::Replace;
-        default: return InsertMode::Insert;
+        case InsertMode::Append:
+            return InsertMode::InsertAtNextLineBegin;
+        case InsertMode::Insert:
+            return InsertMode::InsertAtLineBegin;
+        case InsertMode::Replace:
+            return InsertMode::Replace;
+        default:
+            return InsertMode::Insert;
     }
 }
 
 template<InsertMode mode>
 void paste(Context& context, NormalParams params)
 {
-    const char reg = params.reg ? params.reg : '"';
-    auto strings = RegisterManager::instance()[reg].get(context);
-    const bool linewise = any_of(strings, [](StringView str) {
+    const char reg            = params.reg ? params.reg : '"';
+    auto strings              = RegisterManager::instance()[reg].get(context);
+    const bool linewise       = any_of(strings, [](StringView str) {
         return not str.empty() and str.back() == '\n';
     });
     const auto effective_mode = linewise ? adapt_for_linewise(mode) : mode;
@@ -684,8 +739,8 @@ void paste(Context& context, NormalParams params)
 template<InsertMode mode>
 void paste_all(Context& context, NormalParams params)
 {
-    const char reg = params.reg ? params.reg : '"';
-    auto strings = RegisterManager::instance()[reg].get(context);
+    const char reg            = params.reg ? params.reg : '"';
+    auto strings              = RegisterManager::instance()[reg].get(context);
     InsertMode effective_mode = mode;
     String all;
     Vector<ByteCount> offsets;
@@ -715,7 +770,7 @@ void paste_all(Context& context, NormalParams params)
         for (auto offset : offsets)
         {
             result.emplace_back(buffer.advance(ins_pos, pos),
-                                buffer.advance(ins_pos, offset-1));
+                                buffer.advance(ins_pos, offset - 1));
             pos = offset;
         }
     }
@@ -725,41 +780,49 @@ void paste_all(Context& context, NormalParams params)
 
 constexpr RegexCompileFlags direction_flags(MatchDirection direction)
 {
-    return (direction == MatchDirection::Forward) ?
-        RegexCompileFlags::None : RegexCompileFlags::Backward | RegexCompileFlags::NoForward;
+    return (direction == MatchDirection::Forward)
+               ? RegexCompileFlags::None
+               : RegexCompileFlags::Backward | RegexCompileFlags::NoForward;
 }
 
 template<MatchDirection direction = MatchDirection::Forward, typename T>
 void regex_prompt(Context& context, String prompt, String default_regex, T func)
 {
-    DisplayCoord position = context.has_window() ? context.window().position() : DisplayCoord{};
+    DisplayCoord position
+        = context.has_window() ? context.window().position() : DisplayCoord{};
     SelectionList selections = context.selections();
     context.input_handler().prompt(
         std::move(prompt), {}, default_regex, context.faces()["Prompt"],
         PromptFlags::Search,
-        [](const Context& context, CompletionFlags, StringView regex, ByteCount pos) -> Completions {
+        [](const Context& context, CompletionFlags, StringView regex,
+           ByteCount pos) -> Completions {
             auto current_word = [](StringView s) {
                 auto it = s.end();
-                while (it != s.begin() and is_word(*(it-1)))
+                while (it != s.begin() and is_word(*(it - 1)))
                     --it;
                 StringView res{it, s.end()};
                 if (it == s.begin() or res.empty())
                     return res;
 
                 int backslashes = 0;
-                for (auto bs = it; bs != s.begin() && *(bs-1) == '\\'; --bs)
+                for (auto bs = it; bs != s.begin() && *(bs - 1) == '\\'; --bs)
                     ++backslashes;
                 return (backslashes % 2 == 1) ? res.substr(1_byte) : res;
             };
 
             const auto word = current_word(regex.substr(0_byte, pos));
-            auto matches = get_word_db(context.buffer()).find_matching(word);
+            auto matches    = get_word_db(context.buffer()).find_matching(word);
             constexpr size_t max_count = 100;
             CandidateList candidates;
             candidates.reserve(std::min(matches.size(), max_count));
-            for_n_best(matches, max_count, [](auto& lhs, auto& rhs) { return rhs < lhs; },
-                       [&](auto&& m) { candidates.push_back(m.candidate().str()); return true; });
-            return {(int)(word.begin() - regex.begin()), pos,  std::move(candidates) };
+            for_n_best(matches, max_count,
+                       [](auto& lhs, auto& rhs) { return rhs < lhs; },
+                       [&](auto&& m) {
+                           candidates.push_back(m.candidate().str());
+                           return true;
+                       });
+            return {(int)(word.begin() - regex.begin()), pos,
+                    std::move(candidates)};
         },
         [=](StringView str, PromptEvent event, Context& context) mutable {
             try
@@ -767,7 +830,8 @@ void regex_prompt(Context& context, String prompt, String default_regex, T func)
                 if (event != PromptEvent::Change and context.has_client())
                     context.client().info_hide();
 
-                const bool incsearch = context.options()["incsearch"].get<bool>();
+                const bool incsearch
+                    = context.options()["incsearch"].get<bool>();
                 if (incsearch)
                 {
                     selections.update();
@@ -775,7 +839,8 @@ void regex_prompt(Context& context, String prompt, String default_regex, T func)
                     if (context.has_window())
                         context.window().set_position(position);
 
-                    context.input_handler().set_prompt_face(context.faces()["Prompt"]);
+                    context.input_handler().set_prompt_face(
+                        context.faces()["Prompt"]);
                 }
 
                 if (not incsearch and event == PromptEvent::Change)
@@ -785,14 +850,17 @@ void regex_prompt(Context& context, String prompt, String default_regex, T func)
                     context.push_jump();
 
                 if (not str.empty() or event == PromptEvent::Validate)
-                    func(Regex{str.empty() ? default_regex : str, direction_flags(direction)}, event, context);
+                    func(Regex{str.empty() ? default_regex : str,
+                               direction_flags(direction)},
+                         event, context);
             }
             catch (regex_error& err)
             {
                 if (event == PromptEvent::Validate)
                     throw;
                 else
-                    context.input_handler().set_prompt_face(context.faces()["Error"]);
+                    context.input_handler().set_prompt_face(
+                        context.faces()["Error"]);
             }
             catch (runtime_error&)
             {
@@ -808,74 +876,84 @@ void regex_prompt(Context& context, String prompt, String default_regex, T func)
 template<MatchDirection direction>
 void select_next_matches(Context& context, const Regex& regex, int count)
 {
-     auto& selections = context.selections();
-     do {
-         bool wrapped = false;
-         for (auto& sel : selections)
-             sel = keep_direction(find_next_match<direction>(context, sel, regex, wrapped), sel);
-         selections.sort_and_merge_overlapping();
-     } while (--count > 0);
+    auto& selections = context.selections();
+    do
+    {
+        bool wrapped = false;
+        for (auto& sel : selections)
+            sel = keep_direction(
+                find_next_match<direction>(context, sel, regex, wrapped), sel);
+        selections.sort_and_merge_overlapping();
+    } while (--count > 0);
 }
 
 template<MatchDirection direction>
 void extend_to_next_matches(Context& context, const Regex& regex, int count)
 {
-     Vector<Selection> new_sels;
-     auto& selections = context.selections();
-     do {
-         bool wrapped = false;
-         size_t main_index = selections.main_index();
-         for (auto& sel : selections)
-         {
-             auto new_sel = find_next_match<direction>(context, sel, regex, wrapped);
-             if (not wrapped)
-             {
-                 new_sels.push_back(sel);
-                 merge_selections(new_sels.back(), new_sel);
-             }
-             else if (new_sels.size() <= main_index)
-                 --main_index;
-         }
-         if (new_sels.empty())
-             throw runtime_error{"All selections wrapped"};
+    Vector<Selection> new_sels;
+    auto& selections = context.selections();
+    do
+    {
+        bool wrapped      = false;
+        size_t main_index = selections.main_index();
+        for (auto& sel : selections)
+        {
+            auto new_sel
+                = find_next_match<direction>(context, sel, regex, wrapped);
+            if (not wrapped)
+            {
+                new_sels.push_back(sel);
+                merge_selections(new_sels.back(), new_sel);
+            }
+            else if (new_sels.size() <= main_index)
+                --main_index;
+        }
+        if (new_sels.empty())
+            throw runtime_error{"All selections wrapped"};
 
-         selections.set(std::move(new_sels), main_index);
-         new_sels.clear();
-     } while (--count > 0);
+        selections.set(std::move(new_sels), main_index);
+        new_sels.clear();
+    } while (--count > 0);
 }
 
 template<SelectMode mode, MatchDirection direction>
 void search(Context& context, NormalParams params)
 {
-    constexpr StringView prompt = mode == SelectMode::Extend ?
-        (direction == MatchDirection::Forward ? "search (extend):" : "reverse search (extend):")
-      : (direction == MatchDirection::Forward ? "search:"          : "reverse search:");
+    constexpr StringView prompt
+        = mode == SelectMode::Extend
+              ? (direction == MatchDirection::Forward
+                     ? "search (extend):"
+                     : "reverse search (extend):")
+              : (direction == MatchDirection::Forward ? "search:"
+                                                      : "reverse search:");
 
-    const char reg = to_lower(params.reg ? params.reg : '/');
+    const char reg  = to_lower(params.reg ? params.reg : '/');
     const int count = params.count;
 
     auto reg_content = RegisterManager::instance()[reg].get(context);
     Vector<String> saved_reg{reg_content.begin(), reg_content.end()};
-    const int main_index = std::min(context.selections().main_index(), saved_reg.size()-1);
+    const int main_index
+        = std::min(context.selections().main_index(), saved_reg.size() - 1);
 
-    regex_prompt<direction>(context, prompt.str(), saved_reg[main_index],
-                 [reg, count, saved_reg]
-                 (const Regex& regex, PromptEvent event, Context& context) {
-                     if (event == PromptEvent::Abort)
-                     {
-                         RegisterManager::instance()[reg].set(context, saved_reg);
-                         return;
-                     }
-                     RegisterManager::instance()[reg].set(context, regex.str());
+    regex_prompt<direction>(
+        context, prompt.str(), saved_reg[main_index],
+        [reg, count, saved_reg](const Regex& regex, PromptEvent event,
+                                Context& context) {
+            if (event == PromptEvent::Abort)
+            {
+                RegisterManager::instance()[reg].set(context, saved_reg);
+                return;
+            }
+            RegisterManager::instance()[reg].set(context, regex.str());
 
-                     if (regex.empty() or regex.str().empty())
-                         return;
+            if (regex.empty() or regex.str().empty())
+                return;
 
-                     if (mode == SelectMode::Extend)
-                         extend_to_next_matches<direction>(context, regex, count);
-                     else
-                         select_next_matches<direction>(context, regex, count);
-                 });
+            if (mode == SelectMode::Extend)
+                extend_to_next_matches<direction>(context, regex, count);
+            else
+                select_next_matches<direction>(context, regex, count);
+        });
 }
 
 template<SelectMode mode, MatchDirection direction>
@@ -886,19 +964,23 @@ void search_next(Context& context, NormalParams params)
     if (not str.empty())
     {
         Regex regex{str, direction_flags(direction)};
-        auto& selections = context.selections();
+        auto& selections  = context.selections();
         bool main_wrapped = false;
-        do {
+        do
+        {
             bool wrapped = false;
             if (mode == SelectMode::Replace)
             {
                 auto& sel = selections.main();
-                sel = keep_direction(find_next_match<direction>(context, sel, regex, wrapped), sel);
+                sel       = keep_direction(
+                    find_next_match<direction>(context, sel, regex, wrapped),
+                    sel);
             }
             else if (mode == SelectMode::Append)
             {
                 auto sel = keep_direction(
-                    find_next_match<direction>(context, selections.main(), regex, wrapped),
+                    find_next_match<direction>(context, selections.main(),
+                                               regex, wrapped),
                     selections.main());
                 selections.push_back(std::move(sel));
                 selections.set_main_index(selections.size() - 1);
@@ -908,7 +990,8 @@ void search_next(Context& context, NormalParams params)
         } while (--params.count > 0);
 
         if (main_wrapped)
-            context.print_status({"main selection search wrapped around buffer", context.faces()["Information"]});
+            context.print_status({"main selection search wrapped around buffer",
+                                  context.faces()["Information"]});
     }
     else
         throw runtime_error("no search pattern");
@@ -918,22 +1001,22 @@ template<bool smart>
 void use_selection_as_search_pattern(Context& context, NormalParams params)
 {
     Vector<String> patterns;
-    auto& sels = context.selections();
+    auto& sels         = context.selections();
     const auto& buffer = context.buffer();
     for (auto& sel : sels)
     {
         const auto beg = sel.min(), end = buffer.char_next(sel.max());
-        patterns.push_back(format("{}{}{}",
-                                  smart and is_bow(buffer, beg) ? "\\b" : "",
-                                  escape(buffer.string(beg, end), "^$\\.*+?()[]{}|", '\\'),
-                                  smart and is_eow(buffer, end) ? "\\b" : ""));
+        patterns.push_back(
+            format("{}{}{}", smart and is_bow(buffer, beg) ? "\\b" : "",
+                   escape(buffer.string(beg, end), "^$\\.*+?()[]{}|", '\\'),
+                   smart and is_eow(buffer, end) ? "\\b" : ""));
     }
 
     const char reg = to_lower(params.reg ? params.reg : '/');
 
-    context.print_status({
-        format("register '{}' set to '{}'", reg, fix_atom_text(patterns[sels.main_index()])),
-        context.faces()["Information"] });
+    context.print_status({format("register '{}' set to '{}'", reg,
+                                 fix_atom_text(patterns[sels.main_index()])),
+                          context.faces()["Information"]});
 
     RegisterManager::instance()[reg].set(context, patterns);
 
@@ -944,76 +1027,86 @@ void use_selection_as_search_pattern(Context& context, NormalParams params)
 
 void select_regex(Context& context, NormalParams params)
 {
-    const char reg = to_lower(params.reg ? params.reg : '/');
+    const char reg    = to_lower(params.reg ? params.reg : '/');
     const int capture = params.count;
-    auto prompt = capture ? format("select (capture {}):", capture) :  "select:"_str;
+    auto prompt
+        = capture ? format("select (capture {}):", capture) : "select:"_str;
 
     auto reg_content = RegisterManager::instance()[reg].get(context);
     Vector<String> saved_reg{reg_content.begin(), reg_content.end()};
-    const int main_index = std::min(context.selections().main_index(), saved_reg.size()-1);
+    const int main_index
+        = std::min(context.selections().main_index(), saved_reg.size() - 1);
 
     regex_prompt(context, std::move(prompt), saved_reg[main_index],
-                 [reg, capture, saved_reg](Regex ex, PromptEvent event, Context& context) {
-         if (event == PromptEvent::Abort)
-         {
-             RegisterManager::instance()[reg].set(context, saved_reg);
-             return;
-         }
+                 [reg, capture, saved_reg](Regex ex, PromptEvent event,
+                                           Context& context) {
+                     if (event == PromptEvent::Abort)
+                     {
+                         RegisterManager::instance()[reg].set(context,
+                                                              saved_reg);
+                         return;
+                     }
 
-        RegisterManager::instance()[reg].set(context, ex.str());
+                     RegisterManager::instance()[reg].set(context, ex.str());
 
-        if (not ex.empty() and not ex.str().empty())
-            select_all_matches(context.selections(), ex, capture);
-    });
+                     if (not ex.empty() and not ex.str().empty())
+                         select_all_matches(context.selections(), ex, capture);
+                 });
 }
 
 void split_regex(Context& context, NormalParams params)
 {
-    const char reg = to_lower(params.reg ? params.reg : '/');
+    const char reg    = to_lower(params.reg ? params.reg : '/');
     const int capture = params.count;
-    auto prompt = capture ? format("split (on capture {}):", (int)capture) :  "split:"_str;
+    auto prompt       = capture ? format("split (on capture {}):", (int)capture)
+                          : "split:"_str;
 
     auto reg_content = RegisterManager::instance()[reg].get(context);
     Vector<String> saved_reg{reg_content.begin(), reg_content.end()};
-    const int main_index = std::min(context.selections().main_index(), saved_reg.size()-1);
+    const int main_index
+        = std::min(context.selections().main_index(), saved_reg.size() - 1);
 
     regex_prompt(context, std::move(prompt), saved_reg[main_index],
-                 [reg, capture, saved_reg](Regex ex, PromptEvent event, Context& context) {
-         if (event == PromptEvent::Abort)
-         {
-             RegisterManager::instance()[reg].set(context, saved_reg);
-             return;
-         }
+                 [reg, capture, saved_reg](Regex ex, PromptEvent event,
+                                           Context& context) {
+                     if (event == PromptEvent::Abort)
+                     {
+                         RegisterManager::instance()[reg].set(context,
+                                                              saved_reg);
+                         return;
+                     }
 
-        RegisterManager::instance()[reg].set(context, ex.str());
+                     RegisterManager::instance()[reg].set(context, ex.str());
 
-        if (not ex.empty() and not ex.str().empty())
-            split_selections(context.selections(), ex, capture);
-    });
+                     if (not ex.empty() and not ex.str().empty())
+                         split_selections(context.selections(), ex, capture);
+                 });
 }
 
 void split_lines(Context& context, NormalParams params)
 {
     const LineCount count{params.count == 0 ? 1 : params.count};
     auto& selections = context.selections();
-    auto& buffer = context.buffer();
+    auto& buffer     = context.buffer();
     Vector<Selection> res;
     for (auto& sel : selections)
     {
         if (sel.anchor().line == sel.cursor().line)
         {
-             res.push_back(std::move(sel));
-             continue;
+            res.push_back(std::move(sel));
+            continue;
         }
         auto min = sel.min();
         auto max = sel.max();
         for (auto line = min.line; line <= max.line; line += count)
         {
-            auto last_line = std::min(line + count - 1, buffer.line_count() - 1);
-            res.push_back(keep_direction({
-                    std::max<BufferCoord>(min, line),
-                    std::min<BufferCoord>(max, {last_line, buffer[last_line].length() - 1})
-                }, sel));
+            auto last_line
+                = std::min(line + count - 1, buffer.line_count() - 1);
+            res.push_back(keep_direction(
+                {std::max<BufferCoord>(min, line),
+                 std::min<BufferCoord>(
+                     max, {last_line, buffer[last_line].length() - 1})},
+                sel));
         }
     }
     selections = std::move(res);
@@ -1040,13 +1133,14 @@ void join_lines_select_spaces(Context& context, NormalParams)
     {
         const LineCount min_line = sel.min().line;
         const LineCount max_line = sel.max().line;
-        auto end_line = std::min(buffer.line_count()-1,
+        auto end_line            = std::min(buffer.line_count() - 1,
                                  max_line + (min_line == max_line ? 1 : 0));
         for (LineCount line = min_line; line < end_line; ++line)
         {
-            auto begin = buffer.iterator_at({line, buffer[line].length()-1});
-            auto end = std::find_if_not(begin+1, buffer.end(), is_horizontal_blank);
-            selections.emplace_back(begin.coord(), (end-1).coord());
+            auto begin = buffer.iterator_at({line, buffer[line].length() - 1});
+            auto end   = std::find_if_not(begin + 1, buffer.end(),
+                                        is_horizontal_blank);
+            selections.emplace_back(begin.coord(), (end - 1).coord());
         }
     }
     if (selections.empty())
@@ -1059,7 +1153,7 @@ void join_lines_select_spaces(Context& context, NormalParams)
 void join_lines(Context& context, NormalParams params)
 {
     SelectionList sels{context.selections()};
-    auto restore_sels = on_scope_end([&]{
+    auto restore_sels = on_scope_end([&] {
         sels.update();
         context.selections_write_only() = std::move(sels);
     });
@@ -1070,46 +1164,51 @@ void join_lines(Context& context, NormalParams params)
 template<bool matching>
 void keep(Context& context, NormalParams params)
 {
-    constexpr StringView prompt = matching ? "keep matching:" : "keep not matching:";
+    constexpr StringView prompt
+        = matching ? "keep matching:" : "keep not matching:";
 
     const char reg = to_lower(params.reg ? params.reg : '/');
-    auto saved_reg = RegisterManager::instance()[reg].get(context) | gather<Vector<String>>();
-    const int main_index = std::min(context.selections().main_index(), saved_reg.size()-1);
+    auto saved_reg = RegisterManager::instance()[reg].get(context)
+                     | gather<Vector<String>>();
+    const int main_index
+        = std::min(context.selections().main_index(), saved_reg.size() - 1);
 
-    regex_prompt(context, prompt.str(), saved_reg[main_index],
-                 [saved_reg, reg]
-                 (const Regex& regex, PromptEvent event, Context& context) {
+    regex_prompt(
+        context, prompt.str(), saved_reg[main_index],
+        [saved_reg, reg](const Regex& regex, PromptEvent event,
+                         Context& context) {
+            if (event == PromptEvent::Abort)
+            {
+                RegisterManager::instance()[reg].set(context, saved_reg);
+                return;
+            }
+            if (not context.history_disabled())
+                RegisterManager::instance()[reg].set(context, regex.str());
 
-        if (event == PromptEvent::Abort)
-        {
-            RegisterManager::instance()[reg].set(context, saved_reg);
-            return;
-        }
-        if (not context.history_disabled())
-            RegisterManager::instance()[reg].set(context, regex.str());
+            if (regex.empty() or regex.str().empty())
+                return;
 
-        if (regex.empty() or regex.str().empty())
-            return;
-
-        const Buffer& buffer = context.buffer();
-        Vector<Selection> keep;
-        for (auto& sel : context.selections())
-        {
-            auto begin = buffer.iterator_at(sel.min());
-            auto end = utf8::next(buffer.iterator_at(sel.max()), buffer.end());
-            // We do not consider if end is on an eol, as it seems to
-            // give more intuitive behaviours in keep use cases.
-            const auto flags = match_flags(is_bol(begin.coord()), false,
-                                           is_bow(buffer, begin.coord()),
-                                           is_eow(buffer, end.coord())) |
-                               RegexExecFlags::AnyMatch;
-            if (regex_search(begin, end, begin, end, regex, flags) == matching)
-                keep.push_back(sel);
-        }
-        if (keep.empty())
-            throw runtime_error("no selections remaining");
-        context.selections_write_only() = std::move(keep);
-    });
+            const Buffer& buffer = context.buffer();
+            Vector<Selection> keep;
+            for (auto& sel : context.selections())
+            {
+                auto begin = buffer.iterator_at(sel.min());
+                auto end
+                    = utf8::next(buffer.iterator_at(sel.max()), buffer.end());
+                // We do not consider if end is on an eol, as it seems to
+                // give more intuitive behaviours in keep use cases.
+                const auto flags = match_flags(is_bol(begin.coord()), false,
+                                               is_bow(buffer, begin.coord()),
+                                               is_eow(buffer, end.coord()))
+                                   | RegexExecFlags::AnyMatch;
+                if (regex_search(begin, end, begin, end, regex, flags)
+                    == matching)
+                    keep.push_back(sel);
+            }
+            if (keep.empty())
+                throw runtime_error("no selections remaining");
+            context.selections_write_only() = std::move(keep);
+        });
 }
 
 void keep_pipe(Context& context, NormalParams)
@@ -1121,18 +1220,21 @@ void keep_pipe(Context& context, NormalParams)
             if (event != PromptEvent::Validate)
                 return;
             const Buffer& buffer = context.buffer();
-            auto& shell_manager = ShellManager::instance();
+            auto& shell_manager  = ShellManager::instance();
             Vector<Selection> keep;
 
-            auto& selections = context.selections();
+            auto& selections      = context.selections();
             const size_t old_main = selections.main_index();
-            size_t new_main = -1;
+            size_t new_main       = -1;
             for (int i = 0; i < selections.size(); ++i)
             {
                 auto& sel = selections[i];
                 selections.set_main_index(i);
-                if (shell_manager.eval(cmdline, context, content(buffer, sel),
-                                       ShellManager::Flags::None).second == 0)
+                if (shell_manager
+                        .eval(cmdline, context, content(buffer, sel),
+                              ShellManager::Flags::None)
+                        .second
+                    == 0)
                 {
                     keep.push_back(sel);
                     if (i >= old_main and new_main == (size_t)-1)
@@ -1144,27 +1246,29 @@ void keep_pipe(Context& context, NormalParams)
             if (new_main == -1)
                 new_main = keep.size() - 1;
             context.selections_write_only().set(std::move(keep), new_main);
-    });
+        });
 }
 template<bool indent_empty = false>
 void indent(Context& context, NormalParams params)
 {
-    CharCount count = params.count ? params.count : 1;
+    CharCount count        = params.count ? params.count : 1;
     CharCount indent_width = context.options()["indentwidth"].get<int>();
-    String indent = indent_width == 0 ? String{'\t', count} : String{' ', indent_width * count};
+    String indent          = indent_width == 0 ? String{'\t', count}
+                                      : String{' ', indent_width * count};
 
     auto& buffer = context.buffer();
     Vector<Selection> sels;
     LineCount last_line = 0;
     for (auto& sel : context.selections())
     {
-        for (auto line = std::max(last_line, sel.min().line); line < sel.max().line+1; ++line)
+        for (auto line = std::max(last_line, sel.min().line);
+             line < sel.max().line + 1; ++line)
         {
             if (indent_empty or buffer[line].length() > 1)
                 sels.emplace_back(line, line);
         }
         // avoid reindenting the same line if multiple selections are on it
-        last_line = sel.max().line+1;
+        last_line = sel.max().line + 1;
     }
     if (not sels.empty())
     {
@@ -1177,8 +1281,8 @@ void indent(Context& context, NormalParams params)
 template<bool deindent_incomplete = true>
 void deindent(Context& context, NormalParams params)
 {
-    ColumnCount count = params.count ? params.count : 1;
-    ColumnCount tabstop = context.options()["tabstop"].get<int>();
+    ColumnCount count        = params.count ? params.count : 1;
+    ColumnCount tabstop      = context.options()["tabstop"].get<int>();
     ColumnCount indent_width = context.options()["indentwidth"].get<int>();
     if (indent_width == 0)
         indent_width = tabstop;
@@ -1190,10 +1294,10 @@ void deindent(Context& context, NormalParams params)
     for (auto& sel : context.selections())
     {
         for (auto line = std::max(sel.min().line, last_line);
-             line < sel.max().line+1; ++line)
+             line < sel.max().line + 1; ++line)
         {
             ColumnCount width = 0;
-            auto content = buffer[line];
+            auto content      = buffer[line];
             for (auto column = 0_byte; column < content.length(); ++column)
             {
                 const char c = content[column];
@@ -1204,7 +1308,7 @@ void deindent(Context& context, NormalParams params)
                 else
                 {
                     if (deindent_incomplete and width != 0)
-                        sels.emplace_back(line, BufferCoord{line, column-1});
+                        sels.emplace_back(line, BufferCoord{line, column - 1});
                     break;
                 }
                 if (width == indent_width)
@@ -1230,138 +1334,153 @@ void select_object(Context& context, NormalParams params)
 {
     auto get_title = [] {
         const auto whole_flags = (ObjectFlags::ToBegin | ObjectFlags::ToEnd);
-        const bool whole = (flags & whole_flags) == whole_flags;
-        return format("{} {}{}surrounding object{}",
-                      mode == SelectMode::Extend ? "extend" : "select",
-                      whole ? "" : "to ",
-                      flags & ObjectFlags::Inner ? "inner " : "",
-                      whole ? "" : (flags & ObjectFlags::ToBegin ? " begin" : " end"));
+        const bool whole       = (flags & whole_flags) == whole_flags;
+        return format(
+            "{} {}{}surrounding object{}",
+            mode == SelectMode::Extend ? "extend" : "select",
+            whole ? "" : "to ", flags & ObjectFlags::Inner ? "inner " : "",
+            whole ? "" : (flags & ObjectFlags::ToBegin ? " begin" : " end"));
     };
 
     const int count = params.count <= 0 ? 0 : params.count - 1;
-    on_next_key_with_autoinfo(context, KeymapMode::Object,
-                             [count](Key key, Context& context) {
-        if (key == Key::Escape)
-            return;
+    on_next_key_with_autoinfo(
+        context, KeymapMode::Object,
+        [count](Key key, Context& context) {
+            if (key == Key::Escape)
+                return;
 
-        static constexpr struct ObjectType
-        {
-            Key key;
-            Optional<Selection> (*func)(const Context&, const Selection&, int, ObjectFlags);
-        } selectors[] = {
-            { 'w', select_word<Word> },
-            { alt('w'), select_word<WORD> },
-            { 's', select_sentence },
-            { 'p', select_paragraph },
-            { ' ', select_whitespaces },
-            { 'i', select_indent },
-            { 'n', select_number },
-            { 'u', select_argument },
-        };
-        auto obj_it = find(selectors | transform(&ObjectType::key), key).base();
-        if (obj_it != std::end(selectors))
-            return select_and_set_last<mode>(
-                context, std::bind(obj_it->func, _1, _2, count, flags));
+            static constexpr struct ObjectType
+            {
+                Key key;
+                Optional<Selection> (*func)(const Context&, const Selection&,
+                                            int, ObjectFlags);
+            } selectors[] = {
+                {'w', select_word<Word>},  {alt('w'), select_word<WORD>},
+                {'s', select_sentence},    {'p', select_paragraph},
+                {' ', select_whitespaces}, {'i', select_indent},
+                {'n', select_number},      {'u', select_argument},
+            };
+            auto obj_it
+                = find(selectors | transform(&ObjectType::key), key).base();
+            if (obj_it != std::end(selectors))
+                return select_and_set_last<mode>(
+                    context, std::bind(obj_it->func, _1, _2, count, flags));
 
-        if (key == 'c')
-        {
-            const bool info = show_auto_info_ifn(
-                "Enter object desc",
-                "format: <open regex>,<close regex>\n"
-                "        escape commas with '\\'",
-                AutoInfo::Command, context);
+            if (key == 'c')
+            {
+                const bool info
+                    = show_auto_info_ifn("Enter object desc",
+                                         "format: <open regex>,<close regex>\n"
+                                         "        escape commas with '\\'",
+                                         AutoInfo::Command, context);
 
-            context.input_handler().prompt(
-                "object desc:", {}, {}, context.faces()["Prompt"],
-                PromptFlags::None, complete_nothing,
-                [count,info](StringView cmdline, PromptEvent event, Context& context) {
-                    if (event != PromptEvent::Change)
-                        hide_auto_info_ifn(context, info);
-                    if (event != PromptEvent::Validate)
-                        return;
+                context.input_handler().prompt(
+                    "object desc:", {}, {}, context.faces()["Prompt"],
+                    PromptFlags::None, complete_nothing,
+                    [count, info](StringView cmdline, PromptEvent event,
+                                  Context& context) {
+                        if (event != PromptEvent::Change)
+                            hide_auto_info_ifn(context, info);
+                        if (event != PromptEvent::Validate)
+                            return;
 
-                    struct error : runtime_error { error(size_t) : runtime_error{"desc parsing failed, expected <open>,<close>"} {} };
+                        struct error : runtime_error
+                        {
+                            error(size_t)
+                                : runtime_error{
+                                      "desc parsing failed, expected "
+                                      "<open>,<close>"}
+                            {}
+                        };
 
-                    auto params = cmdline | split<StringView>(',', '\\') |
-                        transform(unescape<',', '\\'>) | static_gather<error, 2>();
+                        auto params = cmdline | split<StringView>(',', '\\')
+                                      | transform(unescape<',', '\\'>)
+                                      | static_gather<error, 2>();
 
-                    if (params[0].empty() or params[1].empty())
-                        throw error{0};
+                        if (params[0].empty() or params[1].empty())
+                            throw error{0};
 
-                    select_and_set_last<mode>(
-                        context, std::bind(select_surrounding, _1, _2,
-                                           Regex{params[0], RegexCompileFlags::Backward},
-                                           Regex{params[1], RegexCompileFlags::Backward},
-                                           count, flags));
-                });
-            return;
-        }
+                        select_and_set_last<mode>(
+                            context,
+                            std::bind(
+                                select_surrounding, _1, _2,
+                                Regex{params[0], RegexCompileFlags::Backward},
+                                Regex{params[1], RegexCompileFlags::Backward},
+                                count, flags));
+                    });
+                return;
+            }
 
-        static constexpr struct SurroundingPair
-        {
-            char opening;
-            char closing;
-            char name;
-        } surrounding_pairs[] = {
-            { '(', ')', 'b' },
-            { '{', '}', 'B' },
-            { '[', ']', 'r' },
-            { '<', '>', 'a' },
-            { '"', '"', 'Q' },
-            { '\'', '\'', 'q' },
-            { '`', '`', 'g' },
-        };
-        auto pair_it = find_if(surrounding_pairs,
-                               [key](const SurroundingPair& s) {
-                                   return key == s.opening or key == s.closing or
-                                          (s.name != 0 and key == s.name);
-                               });
-        if (pair_it != std::end(surrounding_pairs))
-            return select_and_set_last<mode>(
-                context, std::bind(select_surrounding, _1, _2,
-                                   Regex{format("\\Q{}", pair_it->opening), RegexCompileFlags::Backward},
-                                   Regex{format("\\Q{}", pair_it->closing), RegexCompileFlags::Backward},
-                                   count, flags));
+            static constexpr struct SurroundingPair
+            {
+                char opening;
+                char closing;
+                char name;
+            } surrounding_pairs[] = {
+                {'(', ')', 'b'}, {'{', '}', 'B'}, {'[', ']', 'r'},
+                {'<', '>', 'a'}, {'"', '"', 'Q'}, {'\'', '\'', 'q'},
+                {'`', '`', 'g'},
+            };
+            auto pair_it
+                = find_if(surrounding_pairs, [key](const SurroundingPair& s) {
+                      return key == s.opening or key == s.closing
+                             or (s.name != 0 and key == s.name);
+                  });
+            if (pair_it != std::end(surrounding_pairs))
+                return select_and_set_last<mode>(
+                    context, std::bind(select_surrounding, _1, _2,
+                                       Regex{format("\\Q{}", pair_it->opening),
+                                             RegexCompileFlags::Backward},
+                                       Regex{format("\\Q{}", pair_it->closing),
+                                             RegexCompileFlags::Backward},
+                                       count, flags));
 
-        if (not key.codepoint())
-            return;
+            if (not key.codepoint())
+                return;
 
-        const Codepoint cp = *key.codepoint();
-        if (is_punctuation(cp, {}))
-        {
-            auto re = Regex{"\\Q" + to_string(cp), RegexCompileFlags::Backward};
-            return select_and_set_last<mode>(
-                context, std::bind(select_surrounding, _1, _2,
-                                   re, re, count, flags));
-        }
-    }, get_title(),
-    build_autoinfo_for_mapping(context, KeymapMode::Object,
-        {{{'b','(',')'}, "parenthesis block"},
-         {{'B','{','}'}, "braces block"},
-         {{'r','[',']'}, "brackets block"},
-         {{'a','<','>'}, "angle block"},
-         {{'"','Q'},     "double quote string"},
-         {{'\'','q'},    "single quote string"},
-         {{'`','g'},     "grave quote string"},
-         {{'w'},         "word"},
-         {{alt('w')},    "WORD"},
-         {{'s'},         "sentence"},
-         {{'p'},         "paragraph"},
-         {{' '},         "whitespaces"},
-         {{'i'},         "indent"},
-         {{'u'},         "argument"},
-         {{'n'},         "number"},
-         {{'c'},         "custom object desc"}}));
+            const Codepoint cp = *key.codepoint();
+            if (is_punctuation(cp, {}))
+            {
+                auto re
+                    = Regex{"\\Q" + to_string(cp), RegexCompileFlags::Backward};
+                return select_and_set_last<mode>(
+                    context, std::bind(select_surrounding, _1, _2, re, re,
+                                       count, flags));
+            }
+        },
+        get_title(),
+        build_autoinfo_for_mapping(context, KeymapMode::Object,
+                                   {{{'b', '(', ')'}, "parenthesis block"},
+                                    {{'B', '{', '}'}, "braces block"},
+                                    {{'r', '[', ']'}, "brackets block"},
+                                    {{'a', '<', '>'}, "angle block"},
+                                    {{'"', 'Q'}, "double quote string"},
+                                    {{'\'', 'q'}, "single quote string"},
+                                    {{'`', 'g'}, "grave quote string"},
+                                    {{'w'}, "word"},
+                                    {{alt('w')}, "WORD"},
+                                    {{'s'}, "sentence"},
+                                    {{'p'}, "paragraph"},
+                                    {{' '}, "whitespaces"},
+                                    {{'i'}, "indent"},
+                                    {{'u'}, "argument"},
+                                    {{'n'}, "number"},
+                                    {{'c'}, "custom object desc"}}));
 }
 
-enum Direction { Backward = -1, Forward = 1 };
+enum Direction
+{
+    Backward = -1,
+    Forward  = 1
+};
 
 template<Direction direction, bool half = false>
 void scroll(Context& context, NormalParams params)
 {
-    Window& window = context.window();
+    Window& window  = context.window();
     const int count = params.count ? params.count : 1;
-    const LineCount offset = (window.dimensions().line - 2) / (half ? 2 : 1) * count;
+    const LineCount offset
+        = (window.dimensions().line - 2) / (half ? 2 : 1) * count;
 
     scroll_window(context, offset * direction);
 }
@@ -1369,23 +1488,24 @@ void scroll(Context& context, NormalParams params)
 template<Direction direction>
 void copy_selections_on_next_lines(Context& context, NormalParams params)
 {
-    auto& selections = context.selections();
-    auto& buffer = context.buffer();
+    auto& selections          = context.selections();
+    auto& buffer              = context.buffer();
     const ColumnCount tabstop = context.options()["tabstop"].get<int>();
     Vector<Selection> result;
     size_t main_index = 0;
     for (auto& sel : selections)
     {
-        const bool is_main = (&sel == &selections.main());
-        auto anchor = sel.anchor();
-        auto cursor = sel.cursor();
+        const bool is_main     = (&sel == &selections.main());
+        auto anchor            = sel.anchor();
+        auto cursor            = sel.cursor();
         ColumnCount cursor_col = get_column(buffer, tabstop, cursor);
         ColumnCount anchor_col = get_column(buffer, tabstop, anchor);
 
         if (is_main)
             main_index = result.size();
         result.push_back(std::move(sel));
-        const LineCount height = std::max(anchor.line, cursor.line) - std::min(anchor.line, cursor.line) + 1;
+        const LineCount height = std::max(anchor.line, cursor.line)
+                                 - std::min(anchor.line, cursor.line) + 1;
         const size_t max_lines = std::max(params.count, 1);
 
         for (size_t i = 0, nb_sels = 0; nb_sels < max_lines; ++i)
@@ -1395,20 +1515,25 @@ void copy_selections_on_next_lines(Context& context, NormalParams params)
             const LineCount anchor_line = anchor.line + offset;
             const LineCount cursor_line = cursor.line + offset;
 
-            if (anchor_line < 0 or cursor_line < 0 or
-                anchor_line >= buffer.line_count() or cursor_line >= buffer.line_count())
+            if (anchor_line < 0 or cursor_line < 0
+                or anchor_line >= buffer.line_count()
+                or cursor_line >= buffer.line_count())
                 break;
 
-            const ByteCount anchor_byte = get_byte_to_column(buffer, tabstop, {anchor_line, anchor_col});
-            const ByteCount cursor_byte = get_byte_to_column(buffer, tabstop, {cursor_line, cursor_col});
+            const ByteCount anchor_byte = get_byte_to_column(
+                buffer, tabstop, {anchor_line, anchor_col});
+            const ByteCount cursor_byte = get_byte_to_column(
+                buffer, tabstop, {cursor_line, cursor_col});
 
-            if (anchor_byte != buffer[anchor_line].length() and
-                cursor_byte != buffer[cursor_line].length())
+            if (anchor_byte != buffer[anchor_line].length()
+                and cursor_byte != buffer[cursor_line].length())
             {
                 if (is_main)
                     main_index = result.size();
-                result.emplace_back(BufferCoord{anchor_line, anchor_byte},
-                                    BufferCoordAndTarget{cursor_line, cursor_byte, cursor.target});
+                result.emplace_back(
+                    BufferCoord{anchor_line, anchor_byte},
+                    BufferCoordAndTarget{cursor_line, cursor_byte,
+                                         cursor.target});
 
                 nb_sels++;
             }
@@ -1421,13 +1546,13 @@ void copy_selections_on_next_lines(Context& context, NormalParams params)
 template<Direction direction>
 void rotate_selections(Context& context, NormalParams params)
 {
-    const int count = params.count ? params.count : 1;
+    const int count  = params.count ? params.count : 1;
     auto& selections = context.selections();
-    const int index = selections.main_index();
-    const int num = selections.size();
-    selections.set_main_index((direction == Forward) ?
-                                (index + count) % num
-                              : (index + (num - count % num)) % num);
+    const int index  = selections.main_index();
+    const int num    = selections.size();
+    selections.set_main_index((direction == Forward)
+                                  ? (index + count) % num
+                                  : (index + (num - count % num)) % num);
 }
 
 template<Direction direction>
@@ -1438,17 +1563,19 @@ void rotate_selections_content(Context& context, NormalParams params)
     auto strings = context.selections_content();
     if (group == 0 or group > (int)strings.size())
         group = (int)strings.size();
-    count = count % group;
+    count            = count % group;
     auto& selections = context.selections();
-    auto main = strings.begin() + selections.main_index();
-    for (auto it = strings.begin(); it != strings.end(); )
+    auto main        = strings.begin() + selections.main_index();
+    for (auto it = strings.begin(); it != strings.end();)
     {
         auto end = std::min(strings.end(), it + group);
-        auto new_beg = (direction == Direction::Forward) ? end - count : it + count;
+        auto new_beg
+            = (direction == Direction::Forward) ? end - count : it + count;
         std::rotate(it, new_beg, end);
 
         if (it <= main and main < end)
-            main = main < new_beg ? end - (new_beg - main) : it + (main - new_beg);
+            main = main < new_beg ? end - (new_beg - main)
+                                  : it + (main - new_beg);
         it = end;
     }
     selections.insert(strings, InsertMode::Replace);
@@ -1457,10 +1584,10 @@ void rotate_selections_content(Context& context, NormalParams params)
 
 enum class SelectFlags
 {
-    None = 0,
-    Reverse = 1,
+    None      = 0,
+    Reverse   = 1,
     Inclusive = 2,
-    Extend = 4
+    Extend    = 4
 };
 
 constexpr bool with_bit_ops(Meta::Type<SelectFlags>) { return true; }
@@ -1475,20 +1602,23 @@ void select_to_next_char(Context& context, NormalParams params)
                       flags & SelectFlags::Reverse ? "previous" : "next");
     };
 
-    on_next_key_with_autoinfo(context, KeymapMode::None,
-                             [params](Key key, Context& context) {
-        auto cp = key.codepoint();
-        if (not cp or key == Key::Escape)
-            return;
-        constexpr auto new_flags = flags & SelectFlags::Extend ? SelectMode::Extend
-                                                               : SelectMode::Replace;
-        select_and_set_last<new_flags>(
-            context,
-            std::bind(flags & SelectFlags::Reverse ? select_to_reverse
-                                                   : select_to,
-                      _1, _2, *cp, params.count,
-                      flags & SelectFlags::Inclusive));
-    }, get_title(), "enter char to select to");
+    on_next_key_with_autoinfo(
+        context, KeymapMode::None,
+        [params](Key key, Context& context) {
+            auto cp = key.codepoint();
+            if (not cp or key == Key::Escape)
+                return;
+            constexpr auto new_flags = flags & SelectFlags::Extend
+                                           ? SelectMode::Extend
+                                           : SelectMode::Replace;
+            select_and_set_last<new_flags>(
+                context,
+                std::bind(flags & SelectFlags::Reverse ? select_to_reverse
+                                                       : select_to,
+                          _1, _2, *cp, params.count,
+                          flags & SelectFlags::Inclusive));
+        },
+        get_title(), "enter char to select to");
 }
 
 void start_or_end_macro_recording(Context& context, NormalParams params)
@@ -1499,7 +1629,8 @@ void start_or_end_macro_recording(Context& context, NormalParams params)
     {
         const char reg = to_lower(params.reg ? params.reg : '@');
         if (not is_basic_alpha(reg) and reg != '@')
-            throw runtime_error("macros can only use the '@' and alphabetic registers");
+            throw runtime_error(
+                "macros can only use the '@' and alphabetic registers");
         context.input_handler().start_recording(reg);
     }
 }
@@ -1514,19 +1645,21 @@ void replay_macro(Context& context, NormalParams params)
 {
     const char reg = to_lower(params.reg ? params.reg : '@');
     if (not is_basic_alpha(reg) and reg != '@')
-        throw runtime_error("macros can only use the '@' and alphabetic registers");
+        throw runtime_error(
+            "macros can only use the '@' and alphabetic registers");
 
     static bool running_macros[27] = {};
-    const size_t idx = reg != '@' ? (size_t)(reg - 'a') : 26;
+    const size_t idx               = reg != '@' ? (size_t)(reg - 'a') : 26;
     if (running_macros[idx])
         throw runtime_error("recursive macros call detected");
 
-    ConstArrayView<String> reg_val = RegisterManager::instance()[reg].get(context);
+    ConstArrayView<String> reg_val
+        = RegisterManager::instance()[reg].get(context);
     if (reg_val.empty() or reg_val[0].empty())
         throw runtime_error(format("register '{}' is empty", reg));
 
     running_macros[idx] = true;
-    auto stop = on_scope_end([&]{ running_macros[idx] = false; });
+    auto stop           = on_scope_end([&] { running_macros[idx] = false; });
 
     auto keys = parse_keys(reg_val[0]);
     ScopedEdition edition(context);
@@ -1541,9 +1674,9 @@ template<Direction direction>
 void jump(Context& context, NormalParams params)
 {
     const int count = std::max(1, params.count);
-    auto jump = (direction == Forward) ?
-                 context.jump_list().forward(context, count) :
-                 context.jump_list().backward(context, count);
+    auto jump       = (direction == Forward)
+                    ? context.jump_list().forward(context, count)
+                    : context.jump_list().backward(context, count);
 
     Buffer* oldbuf = &context.buffer();
     Buffer& buffer = const_cast<Buffer&>(jump.buffer());
@@ -1555,19 +1688,20 @@ void jump(Context& context, NormalParams params)
 void push_selections(Context& context, NormalParams)
 {
     context.push_jump(true);
-    context.print_status({ format("saved {} selections", context.selections().size()),
-                           context.faces()["Information"] });
+    context.print_status(
+        {format("saved {} selections", context.selections().size()),
+         context.faces()["Information"]});
 }
 
 void align(Context& context, NormalParams)
 {
-    auto& selections = context.selections();
-    auto& buffer = context.buffer();
+    auto& selections          = context.selections();
+    auto& buffer              = context.buffer();
     const ColumnCount tabstop = context.options()["tabstop"].get<int>();
 
     Vector<Vector<const Selection*>> columns;
     LineCount last_line = -1;
-    size_t column = 0;
+    size_t column       = 0;
     for (auto& sel : selections)
     {
         auto line = sel.cursor().line;
@@ -1576,7 +1710,7 @@ void align(Context& context, NormalParams)
 
         column = (line == last_line) ? column + 1 : 0;
         if (column >= columns.size())
-            columns.resize(column+1);
+            columns.resize(column + 1);
         columns[column].push_back(&sel);
         last_line = line;
     }
@@ -1586,23 +1720,26 @@ void align(Context& context, NormalParams)
     {
         ColumnCount maxcol = 0;
         for (auto& sel : col)
-            maxcol = std::max(get_column(buffer, tabstop, sel->cursor()), maxcol);
+            maxcol
+                = std::max(get_column(buffer, tabstop, sel->cursor()), maxcol);
         for (auto& sel : col)
         {
-            auto insert_coord = sel->min();
-            ColumnCount lastcol = get_column(buffer, tabstop, sel->cursor());
+            auto insert_coord    = sel->min();
+            ColumnCount lastcol  = get_column(buffer, tabstop, sel->cursor());
             ColumnCount inscount = maxcol - lastcol;
             String padstr;
             if (not use_tabs)
-                padstr = String{ ' ', inscount };
+                padstr = String{' ', inscount};
             else
             {
                 ColumnCount inscol = get_column(buffer, tabstop, insert_coord);
                 ColumnCount targetcol = inscol + inscount;
-                ColumnCount tabcol = inscol - (inscol % tabstop);
-                CharCount tabs = (int)((targetcol - tabcol) / tabstop);
-                CharCount spaces = (int)(targetcol - (tabs ? (tabcol + (int)tabs * tabstop) : inscol));
-                padstr = String{ '\t', tabs } + String{ ' ', spaces };
+                ColumnCount tabcol    = inscol - (inscol % tabstop);
+                CharCount tabs        = (int)((targetcol - tabcol) / tabstop);
+                CharCount spaces
+                    = (int)(targetcol
+                            - (tabs ? (tabcol + (int)tabs * tabstop) : inscol));
+                padstr = String{'\t', tabs} + String{' ', spaces};
             }
             buffer.insert(insert_coord, padstr);
         }
@@ -1612,8 +1749,8 @@ void align(Context& context, NormalParams)
 
 void copy_indent(Context& context, NormalParams params)
 {
-    int selection = params.count;
-    auto& buffer = context.buffer();
+    int selection    = params.count;
+    auto& buffer     = context.buffer();
     auto& selections = context.selections();
     Vector<LineCount> lines;
     for (auto sel : selections)
@@ -1626,12 +1763,12 @@ void copy_indent(Context& context, NormalParams params)
     if (selection == 0)
         selection = context.selections().main_index() + 1;
 
-    auto ref_line = selections[selection-1].min().line;
-    auto line = buffer[ref_line];
-    auto it = line.begin();
+    auto ref_line = selections[selection - 1].min().line;
+    auto line     = buffer[ref_line];
+    auto it       = line.begin();
     while (it != line.end() and is_horizontal_blank(*it))
         ++it;
-    const StringView indent = line.substr(0_byte, (int)(it-line.begin()));
+    const StringView indent = line.substr(0_byte, (int)(it - line.begin()));
 
     ScopedEdition edition{context};
     for (auto& l : lines)
@@ -1639,7 +1776,7 @@ void copy_indent(Context& context, NormalParams params)
         if (l == ref_line)
             continue;
 
-        auto line = buffer[l];
+        auto line   = buffer[l];
         ByteCount i = 0;
         while (i < line.length() and is_horizontal_blank(line[i]))
             ++i;
@@ -1649,15 +1786,16 @@ void copy_indent(Context& context, NormalParams params)
 
 void tabs_to_spaces(Context& context, NormalParams params)
 {
-    auto& buffer = context.buffer();
+    auto& buffer                  = context.buffer();
     const ColumnCount opt_tabstop = context.options()["tabstop"].get<int>();
     const ColumnCount tabstop = params.count == 0 ? opt_tabstop : params.count;
     Vector<Selection> tabs;
     Vector<String> spaces;
     for (auto& sel : context.selections())
     {
-        for (auto it = buffer.iterator_at(sel.min()),
-                  end = buffer.iterator_at(sel.max())+1; it != end; ++it)
+        for (auto it  = buffer.iterator_at(sel.min()),
+                  end = buffer.iterator_at(sel.max()) + 1;
+             it != end; ++it)
         {
             if (*it == '\t')
             {
@@ -1669,33 +1807,37 @@ void tabs_to_spaces(Context& context, NormalParams params)
         }
     }
     if (not tabs.empty())
-        SelectionList{ buffer, std::move(tabs) }.insert(spaces, InsertMode::Replace);
+        SelectionList{buffer, std::move(tabs)}.insert(spaces,
+                                                      InsertMode::Replace);
 }
 
 void spaces_to_tabs(Context& context, NormalParams params)
 {
-    auto& buffer = context.buffer();
+    auto& buffer                  = context.buffer();
     const ColumnCount opt_tabstop = context.options()["tabstop"].get<int>();
     const ColumnCount tabstop = params.count == 0 ? opt_tabstop : params.count;
     Vector<Selection> spaces;
     for (auto& sel : context.selections())
     {
-        for (auto it = buffer.iterator_at(sel.min()),
-                  end = buffer.iterator_at(sel.max())+1; it != end;)
+        for (auto it  = buffer.iterator_at(sel.min()),
+                  end = buffer.iterator_at(sel.max()) + 1;
+             it != end;)
         {
             if (*it == ' ')
             {
                 auto spaces_beg = it;
-                auto spaces_end = spaces_beg+1;
-                ColumnCount col = get_column(buffer, opt_tabstop, spaces_end.coord());
-                while (spaces_end != end and
-                       *spaces_end == ' ' and (col % tabstop) != 0)
+                auto spaces_end = spaces_beg + 1;
+                ColumnCount col
+                    = get_column(buffer, opt_tabstop, spaces_end.coord());
+                while (spaces_end != end and *spaces_end == ' '
+                       and (col % tabstop) != 0)
                 {
                     ++spaces_end;
                     ++col;
                 }
                 if ((col % tabstop) == 0)
-                    spaces.emplace_back(spaces_beg.coord(), (spaces_end-1).coord());
+                    spaces.emplace_back(spaces_beg.coord(),
+                                        (spaces_end - 1).coord());
                 else if (spaces_end != end and *spaces_end == '\t')
                     spaces.emplace_back(spaces_beg.coord(), spaces_end.coord());
                 it = spaces_end;
@@ -1705,20 +1847,21 @@ void spaces_to_tabs(Context& context, NormalParams params)
         }
     }
     if (not spaces.empty())
-        SelectionList{ buffer, std::move(spaces) }.insert("\t"_str, InsertMode::Replace);
+        SelectionList{buffer, std::move(spaces)}.insert("\t"_str,
+                                                        InsertMode::Replace);
 }
 
 void trim_selections(Context& context, NormalParams)
 {
-    auto& buffer = context.buffer();
+    auto& buffer     = context.buffer();
     auto& selections = context.selections();
     Vector<int> to_remove;
 
     for (int i = 0; i < (int)selections.size(); ++i)
     {
         auto& sel = selections[i];
-        auto beg = buffer.iterator_at(sel.min());
-        auto end = buffer.iterator_at(sel.max());
+        auto beg  = buffer.iterator_at(sel.min());
+        auto end  = buffer.iterator_at(sel.max());
         while (beg != end and is_blank(*beg))
             ++beg;
         while (beg != end and is_blank(*end))
@@ -1742,23 +1885,32 @@ void trim_selections(Context& context, NormalParams)
 SelectionList read_selections_from_register(char reg, Context& context)
 {
     if (not is_basic_alpha(reg) and reg != '^')
-        throw runtime_error("selections can only be saved to the '^' and alphabetic registers");
+        throw runtime_error(
+            "selections can only be saved to the '^' and alphabetic registers");
 
     auto content = RegisterManager::instance()[reg].get(context);
 
     if (content.size() < 2)
-        throw runtime_error(format("register '{}' does not contain a selections desc", reg));
+        throw runtime_error(
+            format("register '{}' does not contain a selections desc", reg));
 
-    struct error : runtime_error { error(size_t) : runtime_error{"expected <buffer>@<timestamp>@main_index"} {} };
-    const auto desc = content[0] | split<StringView>('@') | static_gather<error, 3>();
-    Buffer& buffer = BufferManager::instance().get_buffer(desc[0]);
+    struct error : runtime_error
+    {
+        error(size_t)
+            : runtime_error{"expected <buffer>@<timestamp>@main_index"}
+        {}
+    };
+    const auto desc
+        = content[0] | split<StringView>('@') | static_gather<error, 3>();
+    Buffer& buffer         = BufferManager::instance().get_buffer(desc[0]);
     const size_t timestamp = str_to_int(desc[1]);
-    size_t main = str_to_int(desc[2]);
+    size_t main            = str_to_int(desc[2]);
 
     if (timestamp > buffer.timestamp())
         throw runtime_error{"register '{}' refers to an invalid timestamp"};
 
-    auto sels = content | skip(1) | transform(selection_from_string) | gather<Vector<Selection>>();
+    auto sels = content | skip(1) | transform(selection_from_string)
+                | gather<Vector<Selection>>();
     sort_selections(sels, main);
     merge_overlapping_selections(sels, main);
     if (timestamp < buffer.timestamp())
@@ -1786,18 +1938,26 @@ CombineOp key_to_combine_op(Key key)
 {
     switch (key.key)
     {
-        case 'a': return CombineOp::Append;
-        case 'u': return CombineOp::Union;
-        case 'i': return CombineOp::Intersect;
-        case '<': return CombineOp::SelectLeftmostCursor;
-        case '>': return CombineOp::SelectRightmostCursor;
-        case '+': return CombineOp::SelectLongest;
-        case '-': return CombineOp::SelectShortest;
+        case 'a':
+            return CombineOp::Append;
+        case 'u':
+            return CombineOp::Union;
+        case 'i':
+            return CombineOp::Intersect;
+        case '<':
+            return CombineOp::SelectLeftmostCursor;
+        case '>':
+            return CombineOp::SelectRightmostCursor;
+        case '+':
+            return CombineOp::SelectLongest;
+        case '-':
+            return CombineOp::SelectShortest;
     }
     throw runtime_error{format("no such combine operator: '{}'", key.key)};
 }
 
-void combine_selection(const Buffer& buffer, Selection& sel, const Selection& other, CombineOp op)
+void combine_selection(const Buffer& buffer, Selection& sel,
+                       const Selection& other, CombineOp op)
 {
     switch (op)
     {
@@ -1825,7 +1985,8 @@ void combine_selection(const Buffer& buffer, Selection& sel, const Selection& ot
             if (char_length(buffer, sel) > char_length(buffer, other))
                 sel = other;
             break;
-        default: kak_assert(false);
+        default:
+            kak_assert(false);
     }
 }
 
@@ -1835,40 +1996,44 @@ void combine_selections(Context& context, SelectionList list, Func func)
     if (&context.buffer() != &list.buffer())
         throw runtime_error{"cannot combine selections from different buffers"};
 
-    on_next_key_with_autoinfo(context, KeymapMode::None,
-                             [func, list](Key key, Context& context) mutable {
-                                 if (key == Key::Escape)
-                                     return;
+    on_next_key_with_autoinfo(
+        context, KeymapMode::None,
+        [func, list](Key key, Context& context) mutable {
+            if (key == Key::Escape)
+                return;
 
-                                 const auto op = key_to_combine_op(key);
-                                 auto& sels = context.selections();
-                                 list.update();
-                                 if (op == CombineOp::Append)
-                                 {
-                                     const auto main_index = list.size() + sels.main_index();
-                                     for (auto& sel : sels)
-                                         list.push_back(sel);
-                                     list.set_main_index(main_index);
-                                     list.sort_and_merge_overlapping();
-                                 }
-                                 else
-                                 {
-                                     if (list.size() != sels.size())
-                                         throw runtime_error{format("the two selection lists don't have the same number of elements ({} vs {})",
-                                                                    list.size(), sels.size())};
-                                     for (int i = 0; i < list.size(); ++i)
-                                         combine_selection(sels.buffer(), list[i], sels[i], op);
-                                     list.set_main_index(sels.main_index());
-                                 }
-                                 func(context, std::move(list));
-                             }, "enter combining operator",
-                             "'a': append lists\n"
-                             "'u': union\n"
-                             "'i': intersection\n"
-                             "'<': select leftmost cursor\n"
-                             "'>': select rightmost cursor\n"
-                             "'+': select longest\n"
-                             "'-': select shortest\n");
+            const auto op = key_to_combine_op(key);
+            auto& sels    = context.selections();
+            list.update();
+            if (op == CombineOp::Append)
+            {
+                const auto main_index = list.size() + sels.main_index();
+                for (auto& sel : sels)
+                    list.push_back(sel);
+                list.set_main_index(main_index);
+                list.sort_and_merge_overlapping();
+            }
+            else
+            {
+                if (list.size() != sels.size())
+                    throw runtime_error{
+                        format("the two selection lists don't have the same "
+                               "number of elements ({} vs {})",
+                               list.size(), sels.size())};
+                for (int i = 0; i < list.size(); ++i)
+                    combine_selection(sels.buffer(), list[i], sels[i], op);
+                list.set_main_index(sels.main_index());
+            }
+            func(context, std::move(list));
+        },
+        "enter combining operator",
+        "'a': append lists\n"
+        "'u': union\n"
+        "'i': intersection\n"
+        "'<': select leftmost cursor\n"
+        "'>': select rightmost cursor\n"
+        "'+': select longest\n"
+        "'-': select shortest\n");
 }
 
 template<bool combine>
@@ -1876,24 +2041,30 @@ void save_selections(Context& context, NormalParams params)
 {
     const char reg = to_lower(params.reg ? params.reg : '^');
     if (not is_basic_alpha(reg) and reg != '^')
-        throw runtime_error("selections can only be saved to the '^' and alphabetic registers");
+        throw runtime_error(
+            "selections can only be saved to the '^' and alphabetic registers");
 
-    auto content = RegisterManager::instance()[reg].get(context);
+    auto content     = RegisterManager::instance()[reg].get(context);
     const bool empty = content.size() == 1 and content[0].empty();
 
     auto save_to_reg = [reg](Context& context, const SelectionList& sels) {
         auto& buffer = context.buffer();
-        auto descs = concatenated(ConstArrayView<String>{format("{}@{}@{}", buffer.name(), buffer.timestamp(), sels.main_index())},
-                                  sels | transform(selection_to_string)) | gather<Vector<String>>();
+        auto descs   = concatenated(ConstArrayView<String>{format(
+                                      "{}@{}@{}", buffer.name(),
+                                      buffer.timestamp(), sels.main_index())},
+                                  sels | transform(selection_to_string))
+                     | gather<Vector<String>>();
         RegisterManager::instance()[reg].set(context, descs);
 
-        context.print_status({format("{} {} selections to register '{}'",
-                                     combine ? "Combined" : "Saved", sels.size(), reg),
-                              context.faces()["Information"]});
+        context.print_status(
+            {format("{} {} selections to register '{}'",
+                    combine ? "Combined" : "Saved", sels.size(), reg),
+             context.faces()["Information"]});
     };
 
     if (combine and not empty)
-        combine_selections(context, read_selections_from_register(reg, context), save_to_reg);
+        combine_selections(context, read_selections_from_register(reg, context),
+                           save_to_reg);
     else
         save_to_reg(context, context.selections());
 }
@@ -1901,15 +2072,16 @@ void save_selections(Context& context, NormalParams params)
 template<bool combine>
 void restore_selections(Context& context, NormalParams params)
 {
-    const char reg = to_lower(params.reg ? params.reg : '^');
+    const char reg  = to_lower(params.reg ? params.reg : '^');
     auto selections = read_selections_from_register(reg, context);
 
     auto set_selections = [reg](Context& context, SelectionList sels) {
-        auto size = sels.size();
+        auto size                       = sels.size();
         context.selections_write_only() = std::move(sels);
-        context.print_status({format("{} {} selections from register '{}'",
-                                     combine ? "Combined" : "Restored", size, reg),
-                              context.faces()["Information"]});
+        context.print_status(
+            {format("{} {} selections from register '{}'",
+                    combine ? "Combined" : "Restored", size, reg),
+             context.faces()["Information"]});
     };
 
     if (not combine)
@@ -1924,7 +2096,7 @@ void restore_selections(Context& context, NormalParams params)
 
 void undo(Context& context, NormalParams params)
 {
-    Buffer& buffer = context.buffer();
+    Buffer& buffer   = context.buffer();
     size_t timestamp = buffer.timestamp();
     if (buffer.undo(std::max(1, params.count)))
     {
@@ -1938,7 +2110,7 @@ void undo(Context& context, NormalParams params)
 
 void redo(Context& context, NormalParams params)
 {
-    Buffer& buffer = context.buffer();
+    Buffer& buffer   = context.buffer();
     size_t timestamp = buffer.timestamp();
     if (buffer.redo(std::max(1, params.count)))
     {
@@ -1953,10 +2125,11 @@ void redo(Context& context, NormalParams params)
 template<Direction direction>
 void move_in_history(Context& context, NormalParams params)
 {
-    Buffer& buffer = context.buffer();
+    Buffer& buffer   = context.buffer();
     size_t timestamp = buffer.timestamp();
-    const int count = std::max(1, params.count);
-    const int history_id = (size_t)buffer.current_history_id() + direction * count;
+    const int count  = std::max(1, params.count);
+    const int history_id
+        = (size_t)buffer.current_history_id() + direction * count;
     const int max_history_id = (int)buffer.next_history_id() - 1;
     if (buffer.move_to((Buffer::HistoryId)history_id))
     {
@@ -1964,32 +2137,36 @@ void move_in_history(Context& context, NormalParams params)
         if (not ranges.empty())
             context.selections_write_only() = std::move(ranges);
 
-        context.print_status({ format("moved to change #{} ({})",
-                               history_id, max_history_id),
-                               context.faces()["Information"] });
+        context.print_status(
+            {format("moved to change #{} ({})", history_id, max_history_id),
+             context.faces()["Information"]});
     }
     else
-        throw runtime_error(format("no such change: #{} ({})",
-                            history_id, max_history_id));
+        throw runtime_error(
+            format("no such change: #{} ({})", history_id, max_history_id));
 }
 
 void exec_user_mappings(Context& context, NormalParams params)
 {
-    on_next_key_with_autoinfo(context, KeymapMode::None,
-                             [params](Key key, Context& context) mutable {
-        if (not context.keymaps().is_mapped(key, KeymapMode::User))
-            return;
+    on_next_key_with_autoinfo(
+        context, KeymapMode::None,
+        [params](Key key, Context& context) mutable {
+            if (not context.keymaps().is_mapped(key, KeymapMode::User))
+                return;
 
-        auto& mapping = context.keymaps().get_mapping(key, KeymapMode::User);
-        ScopedSetBool disable_keymaps(context.keymaps_disabled());
+            auto& mapping
+                = context.keymaps().get_mapping(key, KeymapMode::User);
+            ScopedSetBool disable_keymaps(context.keymaps_disabled());
 
-        InputHandler::ScopedForceNormal force_normal{context.input_handler(), params};
+            InputHandler::ScopedForceNormal force_normal{
+                context.input_handler(), params};
 
-        ScopedEdition edition(context);
-        for (auto& key : mapping.keys)
-            context.input_handler().handle_key(key);
-    }, "user mapping",
-    build_autoinfo_for_mapping(context, KeymapMode::User, {}));
+            ScopedEdition edition(context);
+            for (auto& key : mapping.keys)
+                context.input_handler().handle_key(key);
+        },
+        "user mapping",
+        build_autoinfo_for_mapping(context, KeymapMode::User, {}));
 }
 
 template<bool above>
@@ -1998,11 +2175,12 @@ void add_empty_line(Context& context, NormalParams params)
     int count = std::max(params.count, 1);
     String new_lines{'\n', CharCount{count}};
     auto& buffer = context.buffer();
-    auto& sels = context.selections();
+    auto& sels   = context.selections();
     ScopedEdition edition{context};
     for (int i = 0; i < sels.size(); ++i)
     {
-        auto line = (above ? sels[i].min().line : sels[i].max().line + 1) + (i * count);
+        auto line = (above ? sels[i].min().line : sels[i].max().line + 1)
+                    + (i * count);
         buffer.insert(line, new_lines);
     }
 }
@@ -2013,11 +2191,15 @@ class Repeated
 public:
     constexpr Repeated(T t) : m_func(t) {}
 
-    void operator() (Context& context, NormalParams params)
+    void operator()(Context& context, NormalParams params)
     {
         ScopedEdition edition(context);
-        do { m_func(context, {0, params.reg}); } while(--params.count > 0);
+        do
+        {
+            m_func(context, {0, params.reg});
+        } while (--params.count > 0);
     }
+
 private:
     T m_func;
 };
@@ -2026,19 +2208,24 @@ template<void (*func)(Context&, NormalParams)>
 void repeated(Context& context, NormalParams params)
 {
     ScopedEdition edition(context);
-    do { func(context, {0, params.reg}); } while(--params.count > 0);
+    do
+    {
+        func(context, {0, params.reg});
+    } while (--params.count > 0);
 }
 
-template<typename Type, Direction direction, SelectMode mode = SelectMode::Replace>
+template<typename Type, Direction direction,
+         SelectMode mode = SelectMode::Replace>
 void move_cursor(Context& context, NormalParams params)
 {
     kak_assert(mode == SelectMode::Replace or mode == SelectMode::Extend);
-    const Type offset{direction * std::max(params.count,1)};
+    const Type offset{direction * std::max(params.count, 1)};
     const ColumnCount tabstop = context.options()["tabstop"].get<int>();
-    auto& selections = context.selections();
+    auto& selections          = context.selections();
     for (auto& sel : selections)
     {
-        auto cursor = context.buffer().offset_coord(sel.cursor(), offset, tabstop, true);
+        auto cursor  = context.buffer().offset_coord(sel.cursor(), offset,
+                                                    tabstop, true);
         sel.anchor() = mode == SelectMode::Extend ? sel.anchor() : cursor;
         sel.cursor() = cursor;
     }
@@ -2053,18 +2240,19 @@ void select_whole_buffer(Context& context, NormalParams)
 void keep_selection(Context& context, NormalParams p)
 {
     auto& selections = context.selections();
-    const int index = p.count ? p.count-1 : selections.main_index();
+    const int index  = p.count ? p.count - 1 : selections.main_index();
     if (index >= selections.size())
         throw runtime_error{format("invalid selection index: {}", index)};
 
-    selections = SelectionList{ selections.buffer(), std::move(selections[index]) };
+    selections
+        = SelectionList{selections.buffer(), std::move(selections[index])};
     selections.check_invariant();
 }
 
 void remove_selection(Context& context, NormalParams p)
 {
     auto& selections = context.selections();
-    const int index = p.count ? p.count-1 : selections.main_index();
+    const int index  = p.count ? p.count - 1 : selections.main_index();
     if (index >= selections.size())
         throw runtime_error{format("invalid selection index: {}", index)};
     if (selections.size() == 1)
@@ -2085,8 +2273,8 @@ void flip_selections(Context& context, NormalParams)
     for (auto& sel : context.selections())
     {
         const BufferCoord tmp = sel.anchor();
-        sel.anchor() = sel.cursor();
-        sel.cursor() = tmp;
+        sel.anchor()          = sel.cursor();
+        sel.cursor()          = tmp;
     }
     context.selections().check_invariant();
 }
@@ -2120,205 +2308,381 @@ void force_redraw(Context& context, NormalParams)
 template<typename T, MemoryDomain domain>
 using KeymapBackend = Vector<T, domain>;
 
-static const HashMap<Key, NormalCmd, MemoryDomain::Undefined, KeymapBackend> keymap = {
-    { {'h'}, {"move left", move_cursor<CharCount, Backward>} },
-    { {'j'}, {"move down", move_cursor<LineCount, Forward>} },
-    { {'k'}, {"move up",  move_cursor<LineCount, Backward>} },
-    { {'l'}, {"move right", move_cursor<CharCount, Forward>} },
+static const HashMap<Key, NormalCmd, MemoryDomain::Undefined, KeymapBackend>
+    keymap = {
+        {{'h'}, {"move left", move_cursor<CharCount, Backward>}},
+        {{'j'}, {"move down", move_cursor<LineCount, Forward>}},
+        {{'k'}, {"move up", move_cursor<LineCount, Backward>}},
+        {{'l'}, {"move right", move_cursor<CharCount, Forward>}},
 
-    { {Key::Left}, { "move left", move_cursor<CharCount, Backward>} },
-    { {Key::Down}, { "move down", move_cursor<LineCount, Forward>} },
-    { {Key::Up}, {   "move up", move_cursor<LineCount, Backward>} },
-    { {Key::Right}, {"move right", move_cursor<CharCount, Forward>} },
+        {{Key::Left}, {"move left", move_cursor<CharCount, Backward>}},
+        {{Key::Down}, {"move down", move_cursor<LineCount, Forward>}},
+        {{Key::Up}, {"move up", move_cursor<LineCount, Backward>}},
+        {{Key::Right}, {"move right", move_cursor<CharCount, Forward>}},
 
-    { {'H'}, {"extend left", move_cursor<CharCount, Backward, SelectMode::Extend>} },
-    { {'J'}, {"extend down", move_cursor<LineCount, Forward, SelectMode::Extend>} },
-    { {'K'}, {"extend up", move_cursor<LineCount, Backward, SelectMode::Extend>} },
-    { {'L'}, {"extend right", move_cursor<CharCount, Forward, SelectMode::Extend>} },
+        {{'H'},
+         {"extend left", move_cursor<CharCount, Backward, SelectMode::Extend>}},
+        {{'J'},
+         {"extend down", move_cursor<LineCount, Forward, SelectMode::Extend>}},
+        {{'K'},
+         {"extend up", move_cursor<LineCount, Backward, SelectMode::Extend>}},
+        {{'L'},
+         {"extend right", move_cursor<CharCount, Forward, SelectMode::Extend>}},
 
-    { shift(Key::Left), {"extend left", move_cursor<CharCount, Backward, SelectMode::Extend>} },
-    { shift(Key::Down), {"extend down", move_cursor<LineCount, Forward, SelectMode::Extend>} },
-    { shift(Key::Up), {"extend up", move_cursor<LineCount, Backward, SelectMode::Extend>} },
-    { shift(Key::Right), {"extend right", move_cursor<CharCount, Forward, SelectMode::Extend>} },
+        {shift(Key::Left),
+         {"extend left", move_cursor<CharCount, Backward, SelectMode::Extend>}},
+        {shift(Key::Down),
+         {"extend down", move_cursor<LineCount, Forward, SelectMode::Extend>}},
+        {shift(Key::Up),
+         {"extend up", move_cursor<LineCount, Backward, SelectMode::Extend>}},
+        {shift(Key::Right),
+         {"extend right", move_cursor<CharCount, Forward, SelectMode::Extend>}},
 
-    { {'t'}, {"select to next character", select_to_next_char<SelectFlags::None>} },
-    { {'f'}, {"select to next character included", select_to_next_char<SelectFlags::Inclusive>} },
-    { {'T'}, {"extend to next character", select_to_next_char<SelectFlags::Extend>} },
-    { {'F'}, {"extend to next character included", select_to_next_char<SelectFlags::Inclusive | SelectFlags::Extend>} },
-    { {alt('t')}, {"select to previous character", select_to_next_char<SelectFlags::Reverse>} },
-    { {alt('f')}, {"select to previous character included", select_to_next_char<SelectFlags::Inclusive | SelectFlags::Reverse>} },
-    { {alt('T')}, {"extend to previous character", select_to_next_char<SelectFlags::Extend | SelectFlags::Reverse>} },
-    { {alt('F')}, {"extend to previous character included", select_to_next_char<SelectFlags::Inclusive | SelectFlags::Extend | SelectFlags::Reverse>} },
+        {{'t'},
+         {"select to next character", select_to_next_char<SelectFlags::None>}},
+        {{'f'},
+         {"select to next character included",
+          select_to_next_char<SelectFlags::Inclusive>}},
+        {{'T'},
+         {"extend to next character",
+          select_to_next_char<SelectFlags::Extend>}},
+        {{'F'},
+         {"extend to next character included",
+          select_to_next_char<SelectFlags::Inclusive | SelectFlags::Extend>}},
+        {{alt('t')},
+         {"select to previous character",
+          select_to_next_char<SelectFlags::Reverse>}},
+        {{alt('f')},
+         {"select to previous character included",
+          select_to_next_char<SelectFlags::Inclusive | SelectFlags::Reverse>}},
+        {{alt('T')},
+         {"extend to previous character",
+          select_to_next_char<SelectFlags::Extend | SelectFlags::Reverse>}},
+        {{alt('F')},
+         {"extend to previous character included",
+          select_to_next_char<SelectFlags::Inclusive | SelectFlags::Extend
+                              | SelectFlags::Reverse>}},
 
-    { {'d'}, {"erase selected text", erase_selections<true>} },
-    { {alt('d')}, {"erase selected text, without yanking", erase_selections<false>} },
-    { {'c'}, {"change selected text", change<true>} },
-    { {alt('c')}, {"change selected text, without yanking", change<false>} },
-    { {'i'}, {"insert before selected text", enter_insert_mode<InsertMode::Insert>} },
-    { {'I'}, {"insert at line begin", enter_insert_mode<InsertMode::InsertAtLineBegin>} },
-    { {'a'}, {"insert after selected text", enter_insert_mode<InsertMode::Append>} },
-    { {'A'}, {"insert at line end", enter_insert_mode<InsertMode::AppendAtLineEnd>} },
-    { {'o'}, {"insert on new line below", enter_insert_mode<InsertMode::OpenLineBelow>} },
-    { {'O'}, {"insert on new line above", enter_insert_mode<InsertMode::OpenLineAbove>} },
-    { {'r'}, {"replace with character", replace_with_char} },
+        {{'d'}, {"erase selected text", erase_selections<true>}},
+        {{alt('d')},
+         {"erase selected text, without yanking", erase_selections<false>}},
+        {{'c'}, {"change selected text", change<true>}},
+        {{alt('c')}, {"change selected text, without yanking", change<false>}},
+        {{'i'},
+         {"insert before selected text",
+          enter_insert_mode<InsertMode::Insert>}},
+        {{'I'},
+         {"insert at line begin",
+          enter_insert_mode<InsertMode::InsertAtLineBegin>}},
+        {{'a'},
+         {"insert after selected text", enter_insert_mode<InsertMode::Append>}},
+        {{'A'},
+         {"insert at line end",
+          enter_insert_mode<InsertMode::AppendAtLineEnd>}},
+        {{'o'},
+         {"insert on new line below",
+          enter_insert_mode<InsertMode::OpenLineBelow>}},
+        {{'O'},
+         {"insert on new line above",
+          enter_insert_mode<InsertMode::OpenLineAbove>}},
+        {{'r'}, {"replace with character", replace_with_char}},
 
-    { {alt('o')}, {"add a new empty line below", add_empty_line<false>} },
-    { {alt('O')}, {"add a new empty line above", add_empty_line<true>} },
+        {{alt('o')}, {"add a new empty line below", add_empty_line<false>}},
+        {{alt('O')}, {"add a new empty line above", add_empty_line<true>}},
 
-    { {'g'}, {"go to location", goto_commands<SelectMode::Replace>} },
-    { {'G'}, {"extend to location", goto_commands<SelectMode::Extend>} },
+        {{'g'}, {"go to location", goto_commands<SelectMode::Replace>}},
+        {{'G'}, {"extend to location", goto_commands<SelectMode::Extend>}},
 
-    { {'v'}, {"move view", view_commands<false>} },
-    { {'V'}, {"move view (locked)", view_commands<true>} },
+        {{'v'}, {"move view", view_commands<false>}},
+        {{'V'}, {"move view (locked)", view_commands<true>}},
 
-    { {'y'}, {"yank selected text", yank} },
-    { {'p'}, {"paste after selected text", repeated<paste<InsertMode::Append>>} },
-    { {'P'}, {"paste before selected text", repeated<paste<InsertMode::Insert>>} },
-    { {alt('p')}, {"paste every yanked selection after selected text", paste_all<InsertMode::Append>} },
-    { {alt('P')}, {"paste every yanked selection before selected text", paste_all<InsertMode::Insert>} },
-    { {'R'}, {"replace selected text with yanked text", paste<InsertMode::Replace>} },
-    { {alt('R')}, {"replace selected text with every yanked text", paste_all<InsertMode::Replace>} },
+        {{'y'}, {"yank selected text", yank}},
+        {{'p'},
+         {"paste after selected text", repeated<paste<InsertMode::Append>>}},
+        {{'P'},
+         {"paste before selected text", repeated<paste<InsertMode::Insert>>}},
+        {{alt('p')},
+         {"paste every yanked selection after selected text",
+          paste_all<InsertMode::Append>}},
+        {{alt('P')},
+         {"paste every yanked selection before selected text",
+          paste_all<InsertMode::Insert>}},
+        {{'R'},
+         {"replace selected text with yanked text",
+          paste<InsertMode::Replace>}},
+        {{alt('R')},
+         {"replace selected text with every yanked text",
+          paste_all<InsertMode::Replace>}},
 
-    { {'s'}, {"select regex matches in selected text", select_regex} },
-    { {'S'}, {"split selected text on regex matches", split_regex} },
-    { {alt('s')}, {"split selected text on line ends", split_lines} },
-    { {alt('S')}, {"select selection boundaries", select_boundaries} },
+        {{'s'}, {"select regex matches in selected text", select_regex}},
+        {{'S'}, {"split selected text on regex matches", split_regex}},
+        {{alt('s')}, {"split selected text on line ends", split_lines}},
+        {{alt('S')}, {"select selection boundaries", select_boundaries}},
 
-    { {'.'}, {"repeat last insert command", repeat_last_insert} },
-    { {alt('.')}, {"repeat last object select/character find", repeat_last_select} },
+        {{'.'}, {"repeat last insert command", repeat_last_insert}},
+        {{alt('.')},
+         {"repeat last object select/character find", repeat_last_select}},
 
-    { {'%'}, {"select whole buffer", select_whole_buffer} },
+        {{'%'}, {"select whole buffer", select_whole_buffer}},
 
-    { {':'}, {"enter command prompt", command} },
-    { {'|'}, {"pipe each selection through filter and replace with output", pipe<true>} },
-    { {alt('|')}, {"pipe each selection through command and ignore output", pipe<false>} },
-    { {'!'}, {"insert command output", insert_output<InsertMode::Insert>} },
-    { {alt('!')}, {"append command output", insert_output<InsertMode::Append>} },
+        {{':'}, {"enter command prompt", command}},
+        {{'|'},
+         {"pipe each selection through filter and replace with output",
+          pipe<true>}},
+        {{alt('|')},
+         {"pipe each selection through command and ignore output",
+          pipe<false>}},
+        {{'!'}, {"insert command output", insert_output<InsertMode::Insert>}},
+        {{alt('!')},
+         {"append command output", insert_output<InsertMode::Append>}},
 
-    { {' '}, {"remove all selections except main", keep_selection} },
-    { {alt(' ')}, {"remove main selection", remove_selection} },
-    { {';'}, {"reduce selections to their cursor", clear_selections} },
-    { {alt(';')}, {"swap selections cursor and anchor", flip_selections} },
-    { {alt(':')}, {"ensure selection cursor is after anchor", ensure_forward} },
-    { {alt('_')}, {"merge consecutive selections", merge_consecutive} },
+        {{' '}, {"remove all selections except main", keep_selection}},
+        {{alt(' ')}, {"remove main selection", remove_selection}},
+        {{';'}, {"reduce selections to their cursor", clear_selections}},
+        {{alt(';')}, {"swap selections cursor and anchor", flip_selections}},
+        {{alt(':')},
+         {"ensure selection cursor is after anchor", ensure_forward}},
+        {{alt('_')}, {"merge consecutive selections", merge_consecutive}},
 
-    { {'w'}, {"select to next word start", repeated<&select<SelectMode::Replace, select_to_next_word<Word>>>} },
-    { {'e'}, {"select to next word end", repeated<select<SelectMode::Replace, select_to_next_word_end<Word>>>} },
-    { {'b'}, {"select to previous word start", repeated<select<SelectMode::Replace, select_to_previous_word<Word>>>} },
-    { {'W'}, {"extend to next word start", repeated<select<SelectMode::Extend, select_to_next_word<Word>>>} },
-    { {'E'}, {"extend to next word end", repeated<select<SelectMode::Extend, select_to_next_word_end<Word>>>} },
-    { {'B'}, {"extend to previous word start", repeated<select<SelectMode::Extend, select_to_previous_word<Word>>>} },
+        {{'w'},
+         {"select to next word start",
+          repeated<&select<SelectMode::Replace, select_to_next_word<Word>>>}},
+        {{'e'},
+         {"select to next word end",
+          repeated<
+              select<SelectMode::Replace, select_to_next_word_end<Word>>>}},
+        {{'b'},
+         {"select to previous word start",
+          repeated<
+              select<SelectMode::Replace, select_to_previous_word<Word>>>}},
+        {{'W'},
+         {"extend to next word start",
+          repeated<select<SelectMode::Extend, select_to_next_word<Word>>>}},
+        {{'E'},
+         {"extend to next word end",
+          repeated<select<SelectMode::Extend, select_to_next_word_end<Word>>>}},
+        {{'B'},
+         {"extend to previous word start",
+          repeated<select<SelectMode::Extend, select_to_previous_word<Word>>>}},
 
-    { {alt('w')}, {"select to next WORD start", repeated<select<SelectMode::Replace, select_to_next_word<WORD>>>} },
-    { {alt('e')}, {"select to next WORD end", repeated<select<SelectMode::Replace, select_to_next_word_end<WORD>>>} },
-    { {alt('b')}, {"select to previous WORD start", repeated<select<SelectMode::Replace, select_to_previous_word<WORD>>>} },
-    { {alt('W')}, {"extend to next WORD start", repeated<select<SelectMode::Extend, select_to_next_word<WORD>>>} },
-    { {alt('E')}, {"extend to next WORD end", repeated<select<SelectMode::Extend, select_to_next_word_end<WORD>>>} },
-    { {alt('B')}, {"extend to previous WORD start", repeated<select<SelectMode::Extend, select_to_previous_word<WORD>>>} },
+        {{alt('w')},
+         {"select to next WORD start",
+          repeated<select<SelectMode::Replace, select_to_next_word<WORD>>>}},
+        {{alt('e')},
+         {"select to next WORD end",
+          repeated<
+              select<SelectMode::Replace, select_to_next_word_end<WORD>>>}},
+        {{alt('b')},
+         {"select to previous WORD start",
+          repeated<
+              select<SelectMode::Replace, select_to_previous_word<WORD>>>}},
+        {{alt('W')},
+         {"extend to next WORD start",
+          repeated<select<SelectMode::Extend, select_to_next_word<WORD>>>}},
+        {{alt('E')},
+         {"extend to next WORD end",
+          repeated<select<SelectMode::Extend, select_to_next_word_end<WORD>>>}},
+        {{alt('B')},
+         {"extend to previous WORD start",
+          repeated<select<SelectMode::Extend, select_to_previous_word<WORD>>>}},
 
-    { {alt('l')}, {"select to line end", repeated<select<SelectMode::Replace, select_to_line_end<false>>>} },
-    { {Key::End}, {"select to line end", repeated<select<SelectMode::Replace, select_to_line_end<false>>>} },
-    { {alt('L')}, {"extend to line end", repeated<select<SelectMode::Extend, select_to_line_end<false>>>} },
-    { shift(Key::End), {"extend to line end", repeated<select<SelectMode::Extend, select_to_line_end<false>>>} },
-    { {alt('h')}, {"select to line begin", repeated<select<SelectMode::Replace, select_to_line_begin<false>>>} },
-    { {Key::Home}, {"select to line begin", repeated<select<SelectMode::Replace, select_to_line_begin<false>>>} },
-    { {alt('H')}, {"extend to line begin", repeated<select<SelectMode::Extend, select_to_line_begin<false>>>} },
-    { shift(Key::Home), {"extend to line begin", repeated<select<SelectMode::Extend, select_to_line_begin<false>>>} },
+        {{alt('l')},
+         {"select to line end",
+          repeated<select<SelectMode::Replace, select_to_line_end<false>>>}},
+        {{Key::End},
+         {"select to line end",
+          repeated<select<SelectMode::Replace, select_to_line_end<false>>>}},
+        {{alt('L')},
+         {"extend to line end",
+          repeated<select<SelectMode::Extend, select_to_line_end<false>>>}},
+        {shift(Key::End),
+         {"extend to line end",
+          repeated<select<SelectMode::Extend, select_to_line_end<false>>>}},
+        {{alt('h')},
+         {"select to line begin",
+          repeated<select<SelectMode::Replace, select_to_line_begin<false>>>}},
+        {{Key::Home},
+         {"select to line begin",
+          repeated<select<SelectMode::Replace, select_to_line_begin<false>>>}},
+        {{alt('H')},
+         {"extend to line begin",
+          repeated<select<SelectMode::Extend, select_to_line_begin<false>>>}},
+        {shift(Key::Home),
+         {"extend to line begin",
+          repeated<select<SelectMode::Extend, select_to_line_begin<false>>>}},
 
-    { {'x'}, {"select line", repeated<select<SelectMode::Replace, select_line>>} },
-    { {'X'}, {"extend line", repeated<select<SelectMode::Extend, select_line>>} },
-    { {alt('x')}, {"extend selections to whole lines", select<SelectMode::Replace, select_lines>} },
-    { {alt('X')}, {"crop selections to whole lines", select<SelectMode::Replace, trim_partial_lines>} },
+        {{'x'},
+         {"select line", repeated<select<SelectMode::Replace, select_line>>}},
+        {{'X'},
+         {"extend line", repeated<select<SelectMode::Extend, select_line>>}},
+        {{alt('x')},
+         {"extend selections to whole lines",
+          select<SelectMode::Replace, select_lines>}},
+        {{alt('X')},
+         {"crop selections to whole lines",
+          select<SelectMode::Replace, trim_partial_lines>}},
 
-    { {'m'}, {"select to matching character", select<SelectMode::Replace, select_matching<true>>} },
-    { {alt('m')}, {"backward select to matching character", select<SelectMode::Replace, select_matching<false>>} },
-    { {'M'}, {"extend to matching character", select<SelectMode::Extend, select_matching<true>>} },
-    { {alt('M')}, {"backward extend to matching character", select<SelectMode::Extend, select_matching<false>>} },
+        {{'m'},
+         {"select to matching character",
+          select<SelectMode::Replace, select_matching<true>>}},
+        {{alt('m')},
+         {"backward select to matching character",
+          select<SelectMode::Replace, select_matching<false>>}},
+        {{'M'},
+         {"extend to matching character",
+          select<SelectMode::Extend, select_matching<true>>}},
+        {{alt('M')},
+         {"backward extend to matching character",
+          select<SelectMode::Extend, select_matching<false>>}},
 
-    { {'/'}, {"select next given regex match", search<SelectMode::Replace, MatchDirection::Forward>} },
-    { {'?'}, {"extend with next given regex match", search<SelectMode::Extend, MatchDirection::Forward>} },
-    { {alt('/')}, {"select previous given regex match", search<SelectMode::Replace, MatchDirection::Backward>} },
-    { {alt('?')}, {"extend with previous given regex match", search<SelectMode::Extend, MatchDirection::Backward>} },
-    { {'n'}, {"select next current search pattern match", search_next<SelectMode::Replace, MatchDirection::Forward>} },
-    { {'N'}, {"extend with next current search pattern match", search_next<SelectMode::Append, MatchDirection::Forward>} },
-    { {alt('n')}, {"select previous current search pattern match", search_next<SelectMode::Replace, MatchDirection::Backward>} },
-    { {alt('N')}, {"extend with previous current search pattern match", search_next<SelectMode::Append, MatchDirection::Backward>} },
-    { {'*'}, {"set search pattern to main selection content", use_selection_as_search_pattern<true>} },
-    { {alt('*')}, {"set search pattern to main selection content, do not detect words", use_selection_as_search_pattern<false>} },
+        {{'/'},
+         {"select next given regex match",
+          search<SelectMode::Replace, MatchDirection::Forward>}},
+        {{'?'},
+         {"extend with next given regex match",
+          search<SelectMode::Extend, MatchDirection::Forward>}},
+        {{alt('/')},
+         {"select previous given regex match",
+          search<SelectMode::Replace, MatchDirection::Backward>}},
+        {{alt('?')},
+         {"extend with previous given regex match",
+          search<SelectMode::Extend, MatchDirection::Backward>}},
+        {{'n'},
+         {"select next current search pattern match",
+          search_next<SelectMode::Replace, MatchDirection::Forward>}},
+        {{'N'},
+         {"extend with next current search pattern match",
+          search_next<SelectMode::Append, MatchDirection::Forward>}},
+        {{alt('n')},
+         {"select previous current search pattern match",
+          search_next<SelectMode::Replace, MatchDirection::Backward>}},
+        {{alt('N')},
+         {"extend with previous current search pattern match",
+          search_next<SelectMode::Append, MatchDirection::Backward>}},
+        {{'*'},
+         {"set search pattern to main selection content",
+          use_selection_as_search_pattern<true>}},
+        {{alt('*')},
+         {"set search pattern to main selection content, do not detect words",
+          use_selection_as_search_pattern<false>}},
 
-    { {'u'}, {"undo", undo} },
-    { {'U'}, {"redo", redo} },
-    { {alt('u')}, {"move backward in history", move_in_history<Direction::Backward>} },
-    { {alt('U')}, {"move forward in history", move_in_history<Direction::Forward>} },
+        {{'u'}, {"undo", undo}},
+        {{'U'}, {"redo", redo}},
+        {{alt('u')},
+         {"move backward in history", move_in_history<Direction::Backward>}},
+        {{alt('U')},
+         {"move forward in history", move_in_history<Direction::Forward>}},
 
-    { {alt('i')}, {"select inner object", select_object<ObjectFlags::ToBegin | ObjectFlags::ToEnd | ObjectFlags::Inner>} },
-    { {alt('a')}, {"select whole object", select_object<ObjectFlags::ToBegin | ObjectFlags::ToEnd>} },
-    { {'['}, {"select to object start", select_object<ObjectFlags::ToBegin>} },
-    { {']'}, {"select to object end", select_object<ObjectFlags::ToEnd>} },
-    { {'{'}, {"extend to object start", select_object<ObjectFlags::ToBegin, SelectMode::Extend>} },
-    { {'}'}, {"extend to object end", select_object<ObjectFlags::ToEnd, SelectMode::Extend>} },
-    { {alt('[')}, {"select to inner object start", select_object<ObjectFlags::ToBegin | ObjectFlags::Inner>} },
-    { {alt(']')}, {"select to inner object end", select_object<ObjectFlags::ToEnd | ObjectFlags::Inner>} },
-    { {alt('{')}, {"extend to inner object start", select_object<ObjectFlags::ToBegin | ObjectFlags::Inner, SelectMode::Extend>} },
-    { {alt('}')}, {"extend to inner object end", select_object<ObjectFlags::ToEnd | ObjectFlags::Inner, SelectMode::Extend>} },
+        {{alt('i')},
+         {"select inner object",
+          select_object<ObjectFlags::ToBegin | ObjectFlags::ToEnd
+                        | ObjectFlags::Inner>}},
+        {{alt('a')},
+         {"select whole object",
+          select_object<ObjectFlags::ToBegin | ObjectFlags::ToEnd>}},
+        {{'['},
+         {"select to object start", select_object<ObjectFlags::ToBegin>}},
+        {{']'}, {"select to object end", select_object<ObjectFlags::ToEnd>}},
+        {{'{'},
+         {"extend to object start",
+          select_object<ObjectFlags::ToBegin, SelectMode::Extend>}},
+        {{'}'},
+         {"extend to object end",
+          select_object<ObjectFlags::ToEnd, SelectMode::Extend>}},
+        {{alt('[')},
+         {"select to inner object start",
+          select_object<ObjectFlags::ToBegin | ObjectFlags::Inner>}},
+        {{alt(']')},
+         {"select to inner object end",
+          select_object<ObjectFlags::ToEnd | ObjectFlags::Inner>}},
+        {{alt('{')},
+         {"extend to inner object start",
+          select_object<ObjectFlags::ToBegin | ObjectFlags::Inner,
+                        SelectMode::Extend>}},
+        {{alt('}')},
+         {"extend to inner object end",
+          select_object<ObjectFlags::ToEnd | ObjectFlags::Inner,
+                        SelectMode::Extend>}},
 
-    { {alt('j')}, {"join lines", join_lines} },
-    { {alt('J')}, {"join lines and select spaces", join_lines_select_spaces} },
+        {{alt('j')}, {"join lines", join_lines}},
+        {{alt('J')},
+         {"join lines and select spaces", join_lines_select_spaces}},
 
-    { {alt('k')}, {"keep selections matching given regex", keep<true>} },
-    { {alt('K')}, {"keep selections not matching given regex", keep<false>} },
-    { {'$'}, {"pipe each selection through shell command and keep the ones whose command succeed", keep_pipe} },
+        {{alt('k')}, {"keep selections matching given regex", keep<true>}},
+        {{alt('K')}, {"keep selections not matching given regex", keep<false>}},
+        {{'$'},
+         {"pipe each selection through shell command and keep the ones whose "
+          "command succeed",
+          keep_pipe}},
 
-    { {'<'}, {"deindent", deindent<true>} },
-    { {'>'}, {"indent", indent<false>} },
-    { {alt('>')}, {"indent, including empty lines", indent<true>} },
-    { {alt('<')}, {"deindent, not including incomplete indent", deindent<false>} },
+        {{'<'}, {"deindent", deindent<true>}},
+        {{'>'}, {"indent", indent<false>}},
+        {{alt('>')}, {"indent, including empty lines", indent<true>}},
+        {{alt('<')},
+         {"deindent, not including incomplete indent", deindent<false>}},
 
-    { {/*ctrl('i')*/Key::Tab}, {"jump forward in jump list",jump<Forward>} }, // until we can distinguish tab a ctrl('i')
-    { {ctrl('o')}, {"jump backward in jump list", jump<Backward>} },
-    { {ctrl('s')}, {"push current selections in jump list", push_selections} },
+        {{/*ctrl('i')*/ Key::Tab},
+         {"jump forward in jump list",
+          jump<Forward>}}, // until we can distinguish tab a ctrl('i')
+        {{ctrl('o')}, {"jump backward in jump list", jump<Backward>}},
+        {{ctrl('s')},
+         {"push current selections in jump list", push_selections}},
 
-    { {')'}, {"rotate main selection forward", rotate_selections<Forward>} },
-    { {'('}, {"rotate main selection backward", rotate_selections<Backward>} },
-    { {alt(')')}, {"rotate selections content forward", rotate_selections_content<Forward>} },
-    { {alt('(')}, {"rotate selections content backward", rotate_selections_content<Backward>} },
+        {{')'}, {"rotate main selection forward", rotate_selections<Forward>}},
+        {{'('},
+         {"rotate main selection backward", rotate_selections<Backward>}},
+        {{alt(')')},
+         {"rotate selections content forward",
+          rotate_selections_content<Forward>}},
+        {{alt('(')},
+         {"rotate selections content backward",
+          rotate_selections_content<Backward>}},
 
-    { {'q'}, {"replay recorded macro", replay_macro} },
-    { {'Q'}, {"start or end macro recording", start_or_end_macro_recording} },
+        {{'q'}, {"replay recorded macro", replay_macro}},
+        {{'Q'}, {"start or end macro recording", start_or_end_macro_recording}},
 
-    { {Key::Escape}, {"end macro recording", end_macro_recording} },
+        {{Key::Escape}, {"end macro recording", end_macro_recording}},
 
-    { {'`'}, {"convert to lower case in selections", for_each_codepoint<to_lower>} },
-    { {'~'}, {"convert to upper case in selections", for_each_codepoint<to_upper>} },
-    { {alt('`')}, { "swap case in selections", for_each_codepoint<swap_case>} },
+        {{'`'},
+         {"convert to lower case in selections", for_each_codepoint<to_lower>}},
+        {{'~'},
+         {"convert to upper case in selections", for_each_codepoint<to_upper>}},
+        {{alt('`')},
+         {"swap case in selections", for_each_codepoint<swap_case>}},
 
-    { {'&'}, {"align selection cursors", align} },
-    { {alt('&')}, {"copy indentation", copy_indent} },
+        {{'&'}, {"align selection cursors", align}},
+        {{alt('&')}, {"copy indentation", copy_indent}},
 
-    { {'@'}, {"convert tabs to spaces in selections", tabs_to_spaces} },
-    { {alt('@')}, {"convert spaces to tabs in selections", spaces_to_tabs} },
+        {{'@'}, {"convert tabs to spaces in selections", tabs_to_spaces}},
+        {{alt('@')}, {"convert spaces to tabs in selections", spaces_to_tabs}},
 
-    { {'_'}, {"trim selections", trim_selections} },
+        {{'_'}, {"trim selections", trim_selections}},
 
-    { {'C'}, {"copy selection on next lines", copy_selections_on_next_lines<Forward>} },
-    { {alt('C')}, {"copy selection on previous lines", copy_selections_on_next_lines<Backward>} },
+        {{'C'},
+         {"copy selection on next lines",
+          copy_selections_on_next_lines<Forward>}},
+        {{alt('C')},
+         {"copy selection on previous lines",
+          copy_selections_on_next_lines<Backward>}},
 
-    { {','}, {"user mappings", exec_user_mappings} },
+        {{','}, {"user mappings", exec_user_mappings}},
 
-    { {Key::PageUp}, {  "scroll one page up", scroll<Backward>} },
-    { {Key::PageDown}, {"scroll one page down", scroll<Forward>} },
+        {{Key::PageUp}, {"scroll one page up", scroll<Backward>}},
+        {{Key::PageDown}, {"scroll one page down", scroll<Forward>}},
 
-    { {ctrl('b')}, {"scroll one page up", scroll<Backward >} },
-    { {ctrl('f')}, {"scroll one page down", scroll<Forward>} },
-    { {ctrl('u')}, {"scroll half a page up", scroll<Backward, true>} },
-    { {ctrl('d')}, {"scroll half a page down", scroll<Forward, true>} },
+        {{ctrl('b')}, {"scroll one page up", scroll<Backward>}},
+        {{ctrl('f')}, {"scroll one page down", scroll<Forward>}},
+        {{ctrl('u')}, {"scroll half a page up", scroll<Backward, true>}},
+        {{ctrl('d')}, {"scroll half a page down", scroll<Forward, true>}},
 
-    { {'z'}, {"restore selections from register", restore_selections<false>} },
-    { {alt('z')}, {"combine selections from register", restore_selections<true>} },
-    { {'Z'}, {"save selections to register", save_selections<false>} },
-    { {alt('Z')}, {"combine selections to register", save_selections<true>} },
+        {{'z'},
+         {"restore selections from register", restore_selections<false>}},
+        {{alt('z')},
+         {"combine selections from register", restore_selections<true>}},
+        {{'Z'}, {"save selections to register", save_selections<false>}},
+        {{alt('Z')}, {"combine selections to register", save_selections<true>}},
 
-    { {ctrl('l')}, {"force redraw", force_redraw} },
+        {{ctrl('l')}, {"force redraw", force_redraw}},
 };
 
 Optional<NormalCmd> get_normal_command(Key key)

--- a/src/normal.hh
+++ b/src/normal.hh
@@ -20,7 +20,7 @@ struct NormalParams
 
 struct NormalCmd
 {
-    StringView docstring = {};
+    StringView docstring                                = {};
     void (*func)(Context& context, NormalParams params) = nullptr;
 };
 

--- a/src/option.hh
+++ b/src/option.hh
@@ -18,8 +18,8 @@ inline String option_to_string(bool opt);
 
 // Default fallback to single value functions
 template<typename T>
-decltype(option_from_string(Meta::Type<T>{}, StringView{}))
-option_from_strings(Meta::Type<T>, ConstArrayView<String> strs)
+decltype(option_from_string(Meta::Type<T>{}, StringView{})) option_from_strings(
+    Meta::Type<T>, ConstArrayView<String> strs)
 {
     if (strs.size() != 1)
         throw runtime_error("expected a single value for option");
@@ -27,8 +27,8 @@ option_from_strings(Meta::Type<T>, ConstArrayView<String> strs)
 }
 
 template<typename T>
-Vector<decltype(option_to_string(std::declval<T>()))>
-option_to_strings(const T& opt)
+Vector<decltype(option_to_string(std::declval<T>()))> option_to_strings(
+    const T& opt)
 {
     return Vector<String>{option_to_string(opt)};
 }
@@ -61,7 +61,7 @@ struct PrefixedList
 
     friend bool operator!=(const PrefixedList& lhs, const PrefixedList& rhs)
     {
-        return not (lhs == rhs);
+        return not(lhs == rhs);
     }
 };
 
@@ -83,11 +83,11 @@ constexpr bool with_bit_ops(Meta::Type<DebugFlags>) { return true; }
 constexpr auto enum_desc(Meta::Type<DebugFlags>)
 {
     return make_array<EnumDesc<DebugFlags>, 5>({
-        { DebugFlags::Hooks, "hooks" },
-        { DebugFlags::Shell, "shell" },
-        { DebugFlags::Profile, "profile" },
-        { DebugFlags::Keys, "keys" },
-        { DebugFlags::Commands, "commands" },
+        {DebugFlags::Hooks, "hooks"},
+        {DebugFlags::Shell, "shell"},
+        {DebugFlags::Profile, "profile"},
+        {DebugFlags::Keys, "keys"},
+        {DebugFlags::Commands, "commands"},
     });
 }
 

--- a/src/option_manager.cc
+++ b/src/option_manager.cc
@@ -7,14 +7,14 @@ namespace Kakoune
 {
 
 OptionDesc::OptionDesc(String name, String docstring, OptionFlags flags)
-    : m_name(std::move(name)), m_docstring(std::move(docstring)),
-    m_flags(flags) {}
+    : m_name(std::move(name)), m_docstring(std::move(docstring)), m_flags(flags)
+{}
 
 Option::Option(const OptionDesc& desc, OptionManager& manager)
-    : m_manager(manager), m_desc(desc) {}
+    : m_manager(manager), m_desc(desc)
+{}
 
-OptionManager::OptionManager(OptionManager& parent)
-    : m_parent(&parent)
+OptionManager::OptionManager(OptionManager& parent) : m_parent(&parent)
 {
     parent.register_watcher(*this);
 }
@@ -43,7 +43,9 @@ void OptionManager::unregister_watcher(OptionManagerWatcher& watcher) const
 struct option_not_found : public runtime_error
 {
     option_not_found(StringView name)
-        : runtime_error(format("option not found: '{}'. Use declare-option first", name)) {}
+        : runtime_error(
+              format("option not found: '{}'. Use declare-option first", name))
+    {}
 };
 
 Option& OptionManager::get_local_option(StringView name)
@@ -54,11 +56,11 @@ Option& OptionManager::get_local_option(StringView name)
     else if (m_parent)
     {
         auto* clone = (*m_parent)[name].clone(*this);
-        return *m_options.insert({clone->name(), std::unique_ptr<Option>{clone}});
+        return *m_options.insert(
+            {clone->name(), std::unique_ptr<Option>{clone}});
     }
     else
         throw option_not_found(name);
-
 }
 
 Option& OptionManager::operator[](StringView name)
@@ -84,7 +86,7 @@ void OptionManager::unset_option(StringView name)
     if (it != m_options.end())
     {
         auto& parent_option = (*m_parent)[name];
-        const bool changed = not parent_option.has_same_value(*it->value);
+        const bool changed  = not parent_option.has_same_value(*it->value);
         m_options.erase(name);
         if (changed)
             on_option_changed(parent_option);
@@ -101,7 +103,8 @@ void OptionManager::on_option_changed(const Option& option)
     auto watchers = m_watchers;
     for (auto* watcher : watchers)
     {
-        if (contains(m_watchers, watcher)) // make sure this watcher is still alive
+        if (contains(m_watchers,
+                     watcher)) // make sure this watcher is still alive
             watcher->on_option_changed(option);
     }
 }
@@ -110,10 +113,10 @@ CandidateList OptionsRegistry::complete_option_name(StringView prefix,
                                                     ByteCount cursor_pos) const
 {
     using OptionPtr = std::unique_ptr<const OptionDesc>;
-    return complete(prefix, cursor_pos, m_descs |
-                    filter([](const OptionPtr& desc)
-                           { return not (desc->flags() & OptionFlags::Hidden); }) |
-                    transform(&OptionDesc::name));
+    return complete(prefix, cursor_pos,
+                    m_descs | filter([](const OptionPtr& desc) {
+                        return not(desc->flags() & OptionFlags::Hidden);
+                    }) | transform(&OptionDesc::name));
 }
 
 }

--- a/src/option_manager.hh
+++ b/src/option_manager.hh
@@ -40,7 +40,7 @@ public:
 private:
     String m_name;
     String m_docstring;
-    OptionFlags  m_flags;
+    OptionFlags m_flags;
 };
 
 class Option : public UseMemoryDomain<MemoryDomain::Options>
@@ -48,16 +48,20 @@ class Option : public UseMemoryDomain<MemoryDomain::Options>
 public:
     virtual ~Option() = default;
 
-    template<typename T> const T& get() const;
-    template<typename T> T& get_mutable();
-    template<typename T> void set(const T& val, bool notify=true);
-    template<typename T> bool is_of_type() const;
+    template<typename T>
+    const T& get() const;
+    template<typename T>
+    T& get_mutable();
+    template<typename T>
+    void set(const T& val, bool notify = true);
+    template<typename T>
+    bool is_of_type() const;
 
-    virtual String get_as_string(Quoting quoting) const = 0;
-    virtual Vector<String> get_as_strings() const = 0;
+    virtual String get_as_string(Quoting quoting) const        = 0;
+    virtual Vector<String> get_as_strings() const              = 0;
     virtual void set_from_strings(ConstArrayView<String> strs) = 0;
     virtual void add_from_strings(ConstArrayView<String> strs) = 0;
-    virtual void update(const Context& context) = 0;
+    virtual void update(const Context& context)                = 0;
 
     virtual bool has_same_value(const Option& other) const = 0;
 
@@ -87,8 +91,8 @@ public:
     OptionManager(OptionManager& parent);
     ~OptionManager();
 
-    Option& operator[] (StringView name);
-    const Option& operator[] (StringView name) const;
+    Option& operator[](StringView name);
+    const Option& operator[](StringView name) const;
     Option& get_local_option(StringView name);
 
     void unset_option(StringView name);
@@ -97,26 +101,32 @@ public:
     {
         auto merge = [](auto&& first, const OptionMap& second) {
             return concatenated(std::forward<decltype(first)>(first)
-                                | filter([&second](auto& i) { return not second.contains(i.key); }),
+                                    | filter([&second](auto& i) {
+                                          return not second.contains(i.key);
+                                      }),
                                 second);
         };
         static const OptionMap empty;
-        auto& parent = m_parent ? m_parent->m_options : empty;
-        auto& grand_parent = (m_parent and m_parent->m_parent) ? m_parent->m_parent->m_options : empty;
-        return merge(merge(grand_parent, parent), m_options) | transform(&OptionMap::Item::value);
+        auto& parent       = m_parent ? m_parent->m_options : empty;
+        auto& grand_parent = (m_parent and m_parent->m_parent)
+                                 ? m_parent->m_parent->m_options
+                                 : empty;
+        return merge(merge(grand_parent, parent), m_options)
+               | transform(&OptionMap::Item::value);
     }
 
     void register_watcher(OptionManagerWatcher& watcher) const;
     void unregister_watcher(OptionManagerWatcher& watcher) const;
 
     void on_option_changed(const Option& option) override;
+
 private:
-    OptionManager()
-        : m_parent(nullptr) {}
+    OptionManager() : m_parent(nullptr) {}
     // the only one allowed to construct a root option manager
     friend class Scope;
     friend class OptionsRegistry;
-    using OptionMap = HashMap<StringView, std::unique_ptr<Option>, MemoryDomain::Options>;
+    using OptionMap
+        = HashMap<StringView, std::unique_ptr<Option>, MemoryDomain::Options>;
 
     OptionMap m_options;
     OptionManager* m_parent;
@@ -129,7 +139,8 @@ class TypedOption : public Option
 {
 public:
     TypedOption(OptionManager& manager, const OptionDesc& desc, const T& value)
-        : Option(desc, manager), m_value(value) {}
+        : Option(desc, manager), m_value(value)
+    {}
 
     void set(T value, bool notify = true)
     {
@@ -174,6 +185,7 @@ public:
     {
         return other.is_of_type<T>() and other.get<T>() == m_value;
     }
+
 private:
     virtual void validate(const T& value) const {}
     T m_value;
@@ -189,10 +201,15 @@ class TypedCheckedOption : public TypedOption<T>
         return new TypedCheckedOption{manager, this->m_desc, this->get()};
     }
 
-    void validate(const T& value) const override { if (validator != nullptr) validator(value); }
+    void validate(const T& value) const override
+    {
+        if (validator != nullptr)
+            validator(value);
+    }
 };
 
-template<typename T> const T& Option::get() const
+template<typename T>
+const T& Option::get() const
 {
     auto* typed_opt = dynamic_cast<const TypedOption<T>*>(this);
     if (not typed_opt)
@@ -201,12 +218,14 @@ template<typename T> const T& Option::get() const
     return typed_opt->get();
 }
 
-template<typename T> T& Option::get_mutable()
+template<typename T>
+T& Option::get_mutable()
 {
     return const_cast<T&>(get<T>());
 }
 
-template<typename T> void Option::set(const T& val, bool notify)
+template<typename T>
+void Option::set(const T& val, bool notify)
 {
     auto* typed_opt = dynamic_cast<TypedOption<T>*>(this);
     if (not typed_opt)
@@ -215,7 +234,8 @@ template<typename T> void Option::set(const T& val, bool notify)
     return typed_opt->set(val, notify);
 }
 
-template<typename T> bool Option::is_of_type() const
+template<typename T>
+bool Option::is_of_type() const
 {
     return dynamic_cast<const TypedOption<T>*>(this) != nullptr;
 }
@@ -223,7 +243,9 @@ template<typename T> bool Option::is_of_type() const
 class OptionsRegistry
 {
 public:
-    OptionsRegistry(OptionManager& global_manager) : m_global_manager(global_manager) {}
+    OptionsRegistry(OptionManager& global_manager)
+        : m_global_manager(global_manager)
+    {}
 
     template<typename T, void (*validator)(const T&) = nullptr>
     Option& declare_option(StringView name, StringView docstring,
@@ -235,34 +257,46 @@ public:
         };
 
         if (not all_of(name, is_option_identifier))
-            throw runtime_error{format("name '{}' contains char out of [a-zA-Z0-9_]", name)};
+            throw runtime_error{
+                format("name '{}' contains char out of [a-zA-Z0-9_]", name)};
 
         auto& opts = m_global_manager.m_options;
-        auto it = opts.find(name);
+        auto it    = opts.find(name);
         if (it != opts.end())
         {
             if (it->value->is_of_type<T>() and it->value->flags() == flags)
                 return *it->value;
-            throw runtime_error{format("option '{}' already declared with different type or flags", name)};
+            throw runtime_error{format(
+                "option '{}' already declared with different type or flags",
+                name)};
         }
-        String doc =  docstring.empty() ? format("[{}]", option_type_name(Meta::Type<T>{}))
-                                        : format("[{}] - {}", option_type_name(Meta::Type<T>{}), docstring);
+        String doc = docstring.empty()
+                         ? format("[{}]", option_type_name(Meta::Type<T>{}))
+                         : format("[{}] - {}",
+                                  option_type_name(Meta::Type<T>{}), docstring);
         m_descs.emplace_back(new OptionDesc{name.str(), std::move(doc), flags});
         return *opts.insert({m_descs.back()->name(),
-                             std::make_unique<TypedCheckedOption<T, validator>>(m_global_manager, *m_descs.back(), value)});
+                             std::make_unique<TypedCheckedOption<T, validator>>(
+                                 m_global_manager, *m_descs.back(), value)});
     }
 
     const OptionDesc* option_desc(StringView name) const
     {
-        auto it = find_if(m_descs,
-                          [&name](const std::unique_ptr<const OptionDesc>& opt)
-                          { return opt->name() == name; });
+        auto it = find_if(
+            m_descs, [&name](const std::unique_ptr<const OptionDesc>& opt) {
+                return opt->name() == name;
+            });
         return it != m_descs.end() ? it->get() : nullptr;
     }
 
-    bool option_exists(StringView name) const { return option_desc(name) != nullptr; }
+    bool option_exists(StringView name) const
+    {
+        return option_desc(name) != nullptr;
+    }
 
-    CandidateList complete_option_name(StringView prefix, ByteCount cursor_pos) const;
+    CandidateList complete_option_name(StringView prefix,
+                                       ByteCount cursor_pos) const;
+
 private:
     OptionManager& m_global_manager;
     Vector<std::unique_ptr<const OptionDesc>, MemoryDomain::Options> m_descs;

--- a/src/option_types.cc
+++ b/src/option_types.cc
@@ -4,12 +4,12 @@
 namespace Kakoune
 {
 
-UnitTest test_option_parsing{[]{
-    auto check = [](auto&& value, ConstArrayView<String> strs)
-    {
+UnitTest test_option_parsing{[] {
+    auto check = [](auto&& value, ConstArrayView<String> strs) {
         auto repr = option_to_strings(value);
         kak_assert(strs == ConstArrayView<String>{repr});
-        auto parsed = option_from_strings(Meta::Type<std::decay_t<decltype(value)>>{}, strs);
+        auto parsed = option_from_strings(
+            Meta::Type<std::decay_t<decltype(value)>>{}, strs);
         kak_assert(parsed == value);
     };
 
@@ -17,7 +17,8 @@ UnitTest test_option_parsing{[]{
     check(true, {"true"});
     check(Vector<String>{"foo", "bar:", "baz"}, {"foo", "bar:", "baz"});
     check(Vector<int>{10, 20, 30}, {"10", "20", "30"});
-    check(HashMap<String, int>{{"foo", 10}, {"b=r", 20}, {"b:z", 30}}, {"foo=10", "b\\=r=20", "b:z=30"});
+    check(HashMap<String, int>{{"foo", 10}, {"b=r", 20}, {"b:z", 30}},
+          {"foo=10", "b\\=r=20", "b:z=30"});
     check(DebugFlags::Keys | DebugFlags::Hooks, {"hooks|keys"});
 }};
 

--- a/src/option_types.hh
+++ b/src/option_types.hh
@@ -19,14 +19,17 @@ namespace Kakoune
 {
 
 template<typename T>
-std::enable_if_t<std::is_same<decltype(option_to_string(std::declval<T>())), String>::value, String>
+std::enable_if_t<
+    std::is_same<decltype(option_to_string(std::declval<T>())), String>::value,
+    String>
 option_to_string(const T& value, Quoting)
 {
     return option_to_string(value);
 }
 
 template<typename T, typename... Rest>
-constexpr bool option_needs_quoting(Meta::Type<T> type, Meta::Type<Rest>... rest)
+constexpr bool option_needs_quoting(Meta::Type<T> type,
+                                    Meta::Type<Rest>... rest)
 {
     return option_needs_quoting(type) or option_needs_quoting(rest...);
 }
@@ -46,16 +49,20 @@ constexpr decltype(T::option_type_name) option_type_name(Meta::Type<T>)
 }
 
 template<typename Enum>
-std::enable_if_t<std::is_enum<Enum>::value, String>
-option_type_name(Meta::Type<Enum>)
+std::enable_if_t<std::is_enum<Enum>::value, String> option_type_name(
+    Meta::Type<Enum>)
 {
-    return format("{}({})", with_bit_ops(Meta::Type<Enum>{}) ? "flags" : "enum",
-                  join(enum_desc(Meta::Type<Enum>{}) |
-                       transform(&EnumDesc<Enum>::name), '|'));
+    return format(
+        "{}({})", with_bit_ops(Meta::Type<Enum>{}) ? "flags" : "enum",
+        join(enum_desc(Meta::Type<Enum>{}) | transform(&EnumDesc<Enum>::name),
+             '|'));
 }
 
 inline String option_to_string(int opt) { return to_string(opt); }
-inline int option_from_string(Meta::Type<int>, StringView str) { return str_to_int(str); }
+inline int option_from_string(Meta::Type<int>, StringView str)
+{
+    return str_to_int(str);
+}
 inline bool option_add(int& opt, StringView str)
 {
     auto val = str_to_int(str);
@@ -65,7 +72,10 @@ inline bool option_add(int& opt, StringView str)
 constexpr StringView option_type_name(Meta::Type<int>) { return "int"; }
 
 inline String option_to_string(size_t opt) { return to_string(opt); }
-inline size_t option_from_string(Meta::Type<size_t>, StringView str) { return str_to_int(str); }
+inline size_t option_from_string(Meta::Type<size_t>, StringView str)
+{
+    return str_to_int(str);
+}
 
 inline String option_to_string(bool opt) { return opt ? "true" : "false"; }
 inline bool option_from_string(Meta::Type<bool>, StringView str)
@@ -86,19 +96,26 @@ inline Codepoint option_from_string(Meta::Type<Codepoint>, StringView str)
         throw runtime_error{format("'{}' is not a single codepoint", str)};
     return str[0_char];
 }
-constexpr StringView option_type_name(Meta::Type<Codepoint>) { return "codepoint"; }
+constexpr StringView option_type_name(Meta::Type<Codepoint>)
+{
+    return "codepoint";
+}
 constexpr bool option_needs_quoting(Meta::Type<Codepoint>) { return true; }
 
 template<typename T, MemoryDomain domain>
 Vector<String> option_to_strings(const Vector<T, domain>& opt)
 {
-    return opt | transform([](const T& t) { return option_to_string(t); }) | gather<Vector<String>>();
+    return opt | transform([](const T& t) { return option_to_string(t); })
+           | gather<Vector<String>>();
 }
 
 template<typename T, MemoryDomain domain>
 String option_to_string(const Vector<T, domain>& opt, Quoting quoting)
 {
-    return join(opt | transform([=](const T& t) { return quote_ifn<T>(option_to_string(t), quoting); }), ' ', false);
+    return join(opt | transform([=](const T& t) {
+                    return quote_ifn<T>(option_to_string(t), quoting);
+                }),
+                ' ', false);
 }
 
 template<typename T, MemoryDomain domain>
@@ -106,20 +123,23 @@ void option_list_postprocess(Vector<T, domain>& opt)
 {}
 
 template<typename T, MemoryDomain domain>
-Vector<T, domain> option_from_strings(Meta::Type<Vector<T, domain>>, ConstArrayView<String> strs)
+Vector<T, domain> option_from_strings(Meta::Type<Vector<T, domain>>,
+                                      ConstArrayView<String> strs)
 {
-    auto res =  strs | transform([](auto&& s) { return option_from_string(Meta::Type<T>{}, s); })
-                     | gather<Vector<T, domain>>();
+    auto res = strs | transform([](auto&& s) {
+                   return option_from_string(Meta::Type<T>{}, s);
+               })
+               | gather<Vector<T, domain>>();
     option_list_postprocess(res);
     return res;
 }
 
 template<typename T, MemoryDomain domain>
-bool option_add_from_strings(Vector<T, domain>& opt, ConstArrayView<String> strs)
+bool option_add_from_strings(Vector<T, domain>& opt,
+                             ConstArrayView<String> strs)
 {
     auto vec = option_from_strings(Meta::Type<Vector<T, domain>>{}, strs);
-    opt.insert(opt.end(),
-               std::make_move_iterator(vec.begin()),
+    opt.insert(opt.end(), std::make_move_iterator(vec.begin()),
                std::make_move_iterator(vec.end()));
     option_list_postprocess(opt);
     return not vec.empty();
@@ -135,42 +155,51 @@ template<typename Key, typename Value, MemoryDomain domain>
 Vector<String> option_to_strings(const HashMap<Key, Value, domain>& opt)
 {
     return opt | transform([](auto&& item) {
-        return format("{}={}",
-                      escape(option_to_string(item.key), '=', '\\'),
-                      escape(option_to_string(item.value), '=', '\\'));
-    }) | gather<Vector<String>>();
+               return format("{}={}",
+                             escape(option_to_string(item.key), '=', '\\'),
+                             escape(option_to_string(item.value), '=', '\\'));
+           })
+           | gather<Vector<String>>();
 }
 
 template<typename Key, typename Value, MemoryDomain domain>
 String option_to_string(const HashMap<Key, Value, domain>& opt, Quoting quoting)
 {
-    return join(opt | transform([=](auto&& item) {
-        return quote_ifn<Key, Value>(
-            format("{}={}",
-                   escape(option_to_string(item.key), '=', '\\'),
-                   escape(option_to_string(item.value), '=', '\\')), quoting);
-    }), ' ', false);
+    return join(
+        opt | transform([=](auto&& item) {
+            return quote_ifn<Key, Value>(
+                format("{}={}", escape(option_to_string(item.key), '=', '\\'),
+                       escape(option_to_string(item.value), '=', '\\')),
+                quoting);
+        }),
+        ' ', false);
 }
 
 template<typename Key, typename Value, MemoryDomain domain>
-bool option_add_from_strings(HashMap<Key, Value, domain>& opt, ConstArrayView<String> strs)
+bool option_add_from_strings(HashMap<Key, Value, domain>& opt,
+                             ConstArrayView<String> strs)
 {
     bool changed = false;
     for (auto&& str : strs)
     {
-        struct error : runtime_error { error(size_t) : runtime_error{"map option expects key=value"} {} };
+        struct error : runtime_error
+        {
+            error(size_t) : runtime_error{"map option expects key=value"} {}
+        };
         auto key_value = str | split<StringView>('=', '\\')
-                             | transform(unescape<'=', '\\'>)
-                             | static_gather<error, 2>();
+                         | transform(unescape<'=', '\\'>)
+                         | static_gather<error, 2>();
 
-        opt[option_from_string(Meta::Type<Key>{}, key_value[0])] = option_from_string(Meta::Type<Value>{}, key_value[1]);
+        opt[option_from_string(Meta::Type<Key>{}, key_value[0])]
+            = option_from_string(Meta::Type<Value>{}, key_value[1]);
         changed = true;
     }
     return changed;
 }
 
 template<typename Key, typename Value, MemoryDomain domain>
-HashMap<Key, Value, domain> option_from_strings(Meta::Type<HashMap<Key, Value, domain>>, ConstArrayView<String> str)
+HashMap<Key, Value, domain> option_from_strings(
+    Meta::Type<HashMap<Key, Value, domain>>, ConstArrayView<String> str)
 {
     HashMap<Key, Value, domain> res;
     option_add_from_strings(res, str);
@@ -187,62 +216,79 @@ String option_type_name(Meta::Type<HashMap<K, V, D>>)
 constexpr char tuple_separator = '|';
 
 template<typename... Types, size_t... I>
-String option_to_string_impl(const std::tuple<Types...>& opt, std::index_sequence<I...>)
+String option_to_string_impl(const std::tuple<Types...>& opt,
+                             std::index_sequence<I...>)
 {
-    return join(make_array({option_to_string(std::get<I>(opt))...}), tuple_separator);
+    return join(make_array({option_to_string(std::get<I>(opt))...}),
+                tuple_separator);
 }
 
 template<typename... Types>
 String option_to_string(const std::tuple<Types...>& opt)
 {
-    return option_to_string_impl(opt, std::make_index_sequence<sizeof...(Types)>());
+    return option_to_string_impl(opt,
+                                 std::make_index_sequence<sizeof...(Types)>());
 }
 
 template<typename... Types, size_t... I>
-std::tuple<Types...> option_from_string_impl(Meta::Type<std::tuple<Types...>>, StringView str,
+std::tuple<Types...> option_from_string_impl(Meta::Type<std::tuple<Types...>>,
+                                             StringView str,
                                              std::index_sequence<I...>)
 {
     struct error : runtime_error
     {
-        error(size_t i) : runtime_error{i < sizeof...(Types) ?
-                                          "not enough elements in tuple"
-                                        : "too many elements in tuple"} {}
+        error(size_t i)
+            : runtime_error{i < sizeof...(Types)
+                                ? "not enough elements in tuple"
+                                : "too many elements in tuple"}
+        {}
     };
     auto elems = str | split<StringView>(tuple_separator, '\\')
-                     | transform(unescape<tuple_separator, '\\'>)
-                     | static_gather<error, sizeof...(Types)>();
-    return std::tuple<Types...>{option_from_string(Meta::Type<Types>{}, elems[I])...};
+                 | transform(unescape<tuple_separator, '\\'>)
+                 | static_gather<error, sizeof...(Types)>();
+    return std::tuple<Types...>{
+        option_from_string(Meta::Type<Types>{}, elems[I])...};
 }
 
 template<typename... Types>
-std::tuple<Types...> option_from_string(Meta::Type<std::tuple<Types...>>, StringView str)
+std::tuple<Types...> option_from_string(Meta::Type<std::tuple<Types...>>,
+                                        StringView str)
 {
-    return option_from_string_impl(Meta::Type<std::tuple<Types...>>{}, str,
-                                   std::make_index_sequence<sizeof...(Types)>());
+    return option_from_string_impl(
+        Meta::Type<std::tuple<Types...>>{}, str,
+        std::make_index_sequence<sizeof...(Types)>());
 }
 
 template<typename RealType, typename ValueType>
-inline String option_to_string(const StronglyTypedNumber<RealType, ValueType>& opt)
+inline String option_to_string(
+    const StronglyTypedNumber<RealType, ValueType>& opt)
 {
     return to_string(opt);
 }
 
 template<typename Number>
-std::enable_if_t<std::is_base_of<StronglyTypedNumber<Number, int>, Number>::value, Number>
+std::enable_if_t<
+    std::is_base_of<StronglyTypedNumber<Number, int>, Number>::value, Number>
 option_from_string(Meta::Type<Number>, StringView str)
 {
-     return Number{str_to_int(str)};
+    return Number{str_to_int(str)};
 }
 
 template<typename RealType, typename ValueType>
-inline bool option_add(StronglyTypedNumber<RealType, ValueType>& opt, StringView str)
+inline bool option_add(StronglyTypedNumber<RealType, ValueType>& opt,
+                       StringView str)
 {
     int val = str_to_int(str);
     opt += val;
     return val != 0;
 }
 
-struct WorstMatch { template<typename T> WorstMatch(T&&) {} };
+struct WorstMatch
+{
+    template<typename T>
+    WorstMatch(T&&)
+    {}
+};
 
 inline bool option_add(WorstMatch, StringView)
 {
@@ -257,17 +303,23 @@ inline void option_update(WorstMatch, const Context&)
 }
 
 template<typename Coord>
-std::enable_if_t<std::is_base_of<LineAndColumn<Coord, decltype(Coord::line), decltype(Coord::column)>, Coord>::value, Coord>
+std::enable_if_t<std::is_base_of<LineAndColumn<Coord, decltype(Coord::line),
+                                               decltype(Coord::column)>,
+                                 Coord>::value,
+                 Coord>
 option_from_string(Meta::Type<Coord>, StringView str)
 {
-    struct error : runtime_error { error(size_t) : runtime_error{"expected <line>,<column>"} {} };
-    auto vals = str | split<StringView>(',')
-                    | static_gather<error, 2>();
+    struct error : runtime_error
+    {
+        error(size_t) : runtime_error{"expected <line>,<column>"} {}
+    };
+    auto vals = str | split<StringView>(',') | static_gather<error, 2>();
     return {str_to_int(vals[0]), str_to_int(vals[1])};
 }
 
 template<typename EffectiveType, typename LineType, typename ColumnType>
-inline String option_to_string(const LineAndColumn<EffectiveType, LineType, ColumnType>& opt)
+inline String option_to_string(
+    const LineAndColumn<EffectiveType, LineType, ColumnType>& opt)
 {
     return format("{},{}", opt.line, opt.column);
 }
@@ -279,7 +331,7 @@ EnableIfWithBitOps<Flags, String> option_to_string(Flags flags)
     String res;
     for (int i = 0; i < desc.size(); ++i)
     {
-        if (not (flags & desc[i].value))
+        if (not(flags & desc[i].value))
             continue;
         if (not res.empty())
             res += "|";
@@ -292,7 +344,8 @@ template<typename Enum, typename = decltype(enum_desc(Meta::Type<Enum>{}))>
 EnableIfWithoutBitOps<Enum, String> option_to_string(Enum e)
 {
     constexpr auto desc = enum_desc(Meta::Type<Enum>{});
-    auto it = find_if(desc, [e](const EnumDesc<Enum>& d) { return d.value == e; });
+    auto it
+        = find_if(desc, [e](const EnumDesc<Enum>& d) { return d.value == e; });
     if (it != desc.end())
         return it->name.str();
     kak_assert(false);
@@ -300,13 +353,15 @@ EnableIfWithoutBitOps<Enum, String> option_to_string(Enum e)
 }
 
 template<typename Flags, typename = decltype(enum_desc(Meta::Type<Flags>{}))>
-EnableIfWithBitOps<Flags, Flags> option_from_string(Meta::Type<Flags>, StringView str)
+EnableIfWithBitOps<Flags, Flags> option_from_string(Meta::Type<Flags>,
+                                                    StringView str)
 {
     constexpr auto desc = enum_desc(Meta::Type<Flags>{});
     Flags flags{};
     for (auto s : str | split<StringView>('|'))
     {
-        auto it = find_if(desc, [s](const EnumDesc<Flags>& d) { return d.name == s; });
+        auto it = find_if(
+            desc, [s](const EnumDesc<Flags>& d) { return d.name == s; });
         if (it == desc.end())
             throw runtime_error(format("invalid flag value '{}'", s));
         flags |= it->value;
@@ -315,10 +370,12 @@ EnableIfWithBitOps<Flags, Flags> option_from_string(Meta::Type<Flags>, StringVie
 }
 
 template<typename Enum, typename = decltype(enum_desc(Meta::Type<Enum>{}))>
-EnableIfWithoutBitOps<Enum, Enum> option_from_string(Meta::Type<Enum>, StringView str)
+EnableIfWithoutBitOps<Enum, Enum> option_from_string(Meta::Type<Enum>,
+                                                     StringView str)
 {
     constexpr auto desc = enum_desc(Meta::Type<Enum>{});
-    auto it = find_if(desc, [str](const EnumDesc<Enum>& d) { return d.name == str; });
+    auto it             = find_if(desc,
+                      [str](const EnumDesc<Enum>& d) { return d.name == str; });
     if (it == desc.end())
         throw runtime_error(format("invalid enum value '{}'", str));
     return it->value;
@@ -337,28 +394,33 @@ inline Vector<String> option_to_strings(const PrefixedList<P, T>& opt)
 {
     Vector<String> res{option_to_string(opt.prefix)};
     auto list = option_to_strings(opt.list);
-    res.insert(res.end(), std::make_move_iterator(list.begin()), std::make_move_iterator(list.end()));
+    res.insert(res.end(), std::make_move_iterator(list.begin()),
+               std::make_move_iterator(list.end()));
     return res;
 }
 
 template<typename P, typename T>
 inline String option_to_string(const PrefixedList<P, T>& opt, Quoting quoting)
 {
-    return option_to_string(opt.prefix, quoting) + " " + option_to_string(opt.list, quoting);
+    return option_to_string(opt.prefix, quoting) + " "
+           + option_to_string(opt.list, quoting);
 }
 
 template<typename P, typename T>
-inline PrefixedList<P, T> option_from_strings(Meta::Type<PrefixedList<P, T>>, ConstArrayView<String> strs)
+inline PrefixedList<P, T> option_from_strings(Meta::Type<PrefixedList<P, T>>,
+                                              ConstArrayView<String> strs)
 {
     if (strs.empty())
         return {{}, {}};
 
     return {option_from_string(Meta::Type<P>{}, strs[0]),
-            option_from_strings(Meta::Type<Vector<T, MemoryDomain::Options>>{}, strs.subrange(1))};
+            option_from_strings(Meta::Type<Vector<T, MemoryDomain::Options>>{},
+                                strs.subrange(1))};
 }
 
 template<typename P, typename T>
-inline bool option_add_from_strings(PrefixedList<P, T>& opt, ConstArrayView<String> str)
+inline bool option_add_from_strings(PrefixedList<P, T>& opt,
+                                    ConstArrayView<String> str)
 {
     return option_add_from_strings(opt.list, str);
 }

--- a/src/optional.hh
+++ b/src/optional.hh
@@ -16,15 +16,14 @@ public:
     Optional(const T& other) : m_valid{true} { new (&m_value) T(other); }
     Optional(T&& other) : m_valid{true} { new (&m_value) T(std::move(other)); }
 
-    Optional(const Optional& other)
-        : m_valid{other.m_valid}
+    Optional(const Optional& other) : m_valid{other.m_valid}
     {
         if (m_valid)
             new (&m_value) T(other.m_value);
     }
 
-    Optional(Optional&& other)
-        noexcept(noexcept(new (nullptr) T(std::move(other.m_value))))
+    Optional(Optional&& other) noexcept(
+        noexcept(new (nullptr) T(std::move(other.m_value))))
         : m_valid{other.m_valid}
     {
         if (m_valid)
@@ -53,8 +52,8 @@ public:
 
     bool operator==(const Optional& other) const
     {
-        return m_valid == other.m_valid and
-               (not m_valid or m_value == other.m_value);
+        return m_valid == other.m_valid
+               and (not m_valid or m_value == other.m_value);
     }
 
     bool operator!=(const Optional& other) const { return !(*this == other); }
@@ -79,17 +78,32 @@ public:
         kak_assert(m_valid);
         return &m_value;
     }
-    const T* operator->() const { return const_cast<Optional&>(*this).operator->(); }
+    const T* operator->() const
+    {
+        return const_cast<Optional&>(*this).operator->();
+    }
 
     template<typename U>
-    T value_or(U&& fallback) const { return m_valid ? m_value : T{std::forward<U>(fallback)}; }
+    T value_or(U&& fallback) const
+    {
+        return m_valid ? m_value : T{std::forward<U>(fallback)};
+    }
 
-    void reset() { destruct_ifn(); m_valid = false; }
+    void reset()
+    {
+        destruct_ifn();
+        m_valid = false;
+    }
 
 private:
-    void destruct_ifn() { if (m_valid) m_value.~T(); }
+    void destruct_ifn()
+    {
+        if (m_valid)
+            m_value.~T();
+    }
 
-    struct Empty {};
+    struct Empty
+    {};
     union
     {
         Empty m_empty; // disable default construction of value

--- a/src/parameters_parser.cc
+++ b/src/parameters_parser.cc
@@ -11,26 +11,30 @@ String generate_switches_doc(const SwitchMap& switches)
     if (switches.empty())
         return res;
 
-    auto switch_len = [](auto& sw) { return sw.key.column_length() + (sw.value.takes_arg ? 5 : 0); };
+    auto switch_len = [](auto& sw) {
+        return sw.key.column_length() + (sw.value.takes_arg ? 5 : 0);
+    };
     auto switches_len = switches | transform(switch_len);
-    const ColumnCount maxlen = *std::max_element(switches_len.begin(), switches_len.end());
+    const ColumnCount maxlen
+        = *std::max_element(switches_len.begin(), switches_len.end());
 
-    for (auto& sw : switches) {
-        res += format("-{} {}{}{}\n",
-                      sw.key,
-                      sw.value.takes_arg ? "<arg>" : "",
+    for (auto& sw : switches)
+    {
+        res += format("-{} {}{}{}\n", sw.key, sw.value.takes_arg ? "<arg>" : "",
                       String{' ', maxlen - switch_len(sw) + 1},
                       sw.value.description);
     }
     return res;
 }
 
-ParametersParser::ParametersParser(ParameterList params, const ParameterDesc& desc)
-    : m_params(params),
-      m_desc(desc)
+ParametersParser::ParametersParser(ParameterList params,
+                                   const ParameterDesc& desc)
+    : m_params(params), m_desc(desc)
 {
-    const bool switches_only_at_start = desc.flags & ParameterDesc::Flags::SwitchesOnlyAtStart;
-    const bool ignore_unknown_switches = desc.flags & ParameterDesc::Flags::IgnoreUnknownSwitches;
+    const bool switches_only_at_start
+        = desc.flags & ParameterDesc::Flags::SwitchesOnlyAtStart;
+    const bool ignore_unknown_switches
+        = desc.flags & ParameterDesc::Flags::IgnoreUnknownSwitches;
     bool only_pos = desc.flags & ParameterDesc::Flags::SwitchesAsPositional;
 
     Vector<bool> switch_seen(desc.switches.size(), false);
@@ -38,7 +42,8 @@ ParametersParser::ParametersParser(ParameterList params, const ParameterDesc& de
     {
         if (not only_pos and not ignore_unknown_switches and params[i] == "--")
             only_pos = true;
-        else if (not only_pos and not params[i].empty() and params[i][0_byte] == '-')
+        else if (not only_pos and not params[i].empty()
+                 and params[i][0_byte] == '-')
         {
             auto it = m_desc.switches.find(params[i].substr(1_byte));
             if (it == m_desc.switches.end())
@@ -55,11 +60,12 @@ ParametersParser::ParametersParser(ParameterList params, const ParameterDesc& de
 
             auto switch_index = it - m_desc.switches.begin();
             if (switch_seen[switch_index])
-                throw runtime_error{format("switch '-{}' specified more than once", it->key)};
+                throw runtime_error{
+                    format("switch '-{}' specified more than once", it->key)};
             switch_seen[switch_index] = true;
 
             if (it->value.takes_arg and ++i == params.size())
-               throw missing_option_value(it->key);
+                throw missing_option_value(it->key);
         }
         else // positional
         {
@@ -80,8 +86,9 @@ Optional<StringView> ParametersParser::get_switch(StringView name) const
     for (size_t i = 0; i < m_params.size(); ++i)
     {
         const auto& param = m_params[i];
-        if (param.substr(0_byte, 1_byte) == "-" and param.substr(1_byte) == name)
-            return it->value.takes_arg ? m_params[i+1] : StringView{};
+        if (param.substr(0_byte, 1_byte) == "-"
+            and param.substr(1_byte) == name)
+            return it->value.takes_arg ? m_params[i + 1] : StringView{};
 
         if (param == "--")
             break;

--- a/src/parameters_parser.hh
+++ b/src/parameters_parser.hh
@@ -23,13 +23,15 @@ struct parameter_error : public runtime_error
 struct unknown_option : public parameter_error
 {
     unknown_option(StringView name)
-        : parameter_error(format("unknown option '{}'", name)) {}
+        : parameter_error(format("unknown option '{}'", name))
+    {}
 };
 
-struct missing_option_value: public parameter_error
+struct missing_option_value : public parameter_error
 {
     missing_option_value(StringView name)
-        : parameter_error(format("missing value for option '{}'", name)) {}
+        : parameter_error(format("missing value for option '{}'", name))
+    {}
 };
 
 struct wrong_argument_count : public parameter_error
@@ -51,7 +53,7 @@ struct ParameterDesc
 {
     enum class Flags
     {
-        None = 0,
+        None                  = 0,
         SwitchesOnlyAtStart   = 0b0001,
         SwitchesAsPositional  = 0b0010,
         IgnoreUnknownSwitches = 0b0100
@@ -59,7 +61,7 @@ struct ParameterDesc
     friend constexpr bool with_bit_ops(Meta::Type<Flags>) { return true; }
 
     SwitchMap switches;
-    Flags flags = Flags::None;
+    Flags flags            = Flags::None;
     size_t min_positionals = 0;
     size_t max_positionals = -1;
 };
@@ -83,13 +85,23 @@ struct ParametersParser
     struct iterator : std::iterator<std::forward_iterator_tag, String>
     {
         iterator(const ParametersParser& parser, size_t index)
-            : m_parser(parser), m_index(index) {}
+            : m_parser(parser), m_index(index)
+        {}
 
         const String& operator*() const { return m_parser[m_index]; }
         const String* operator->() const { return &m_parser[m_index]; }
 
-        iterator& operator++() { ++m_index; return *this; }
-        iterator operator++(int) { auto copy = *this; ++m_index; return copy; }
+        iterator& operator++()
+        {
+            ++m_index;
+            return *this;
+        }
+        iterator operator++(int)
+        {
+            auto copy = *this;
+            ++m_index;
+            return copy;
+        }
 
         bool operator==(const iterator& other) const
         {
@@ -99,19 +111,19 @@ struct ParametersParser
 
         bool operator!=(const iterator& other) const
         {
-            return not (*this == other);
+            return not(*this == other);
         }
 
     private:
         const ParametersParser& m_parser;
-        size_t                  m_index;
+        size_t m_index;
     };
 
     // positional parameters count
     size_t positional_count() const { return m_positional_indices.size(); }
 
     // access positional parameter by index
-    const String& operator[] (size_t index) const
+    const String& operator[](size_t index) const
     {
         kak_assert(index < positional_count());
         return m_params[m_positional_indices[index]];
@@ -119,12 +131,19 @@ struct ParametersParser
 
     ConstArrayView<String> positionals_from(size_t first) const
     {
-        kak_assert(m_desc.flags & (ParameterDesc::Flags::SwitchesOnlyAtStart | ParameterDesc::Flags::SwitchesAsPositional));
-        return m_params.subrange(first < m_positional_indices.size() ? m_positional_indices[first] : -1);
+        kak_assert(m_desc.flags
+                   & (ParameterDesc::Flags::SwitchesOnlyAtStart
+                      | ParameterDesc::Flags::SwitchesAsPositional));
+        return m_params.subrange(first < m_positional_indices.size()
+                                     ? m_positional_indices[first]
+                                     : -1);
     }
 
     iterator begin() const { return iterator(*this, 0); }
-    iterator end() const { return iterator(*this, m_positional_indices.size()); }
+    iterator end() const
+    {
+        return iterator(*this, m_positional_indices.size());
+    }
 
 private:
     ParameterList m_params;

--- a/src/range.hh
+++ b/src/range.hh
@@ -17,7 +17,7 @@ struct Range
 
     friend bool operator!=(const Range& lhs, const Range& rhs)
     {
-        return not (lhs == rhs);
+        return not(lhs == rhs);
     }
 
     friend size_t hash_value(const Range& range)

--- a/src/ranges.cc
+++ b/src/ranges.cc
@@ -7,21 +7,26 @@ namespace Kakoune
 {
 
 UnitTest test_ranges{[] {
-    auto check_equal = [](auto&& container, ConstArrayView<StringView> expected) {
-        kak_assert(std::equal(container.begin(), container.end(), expected.begin(), expected.end()));
-    };
+    auto check_equal
+        = [](auto&& container, ConstArrayView<StringView> expected) {
+              kak_assert(std::equal(container.begin(), container.end(),
+                                    expected.begin(), expected.end()));
+          };
     check_equal("a,b,c"_sv | split<StringView>(','), {"a", "b", "c"});
-    check_equal(",b,c"_sv  | split<StringView>(','), {"", "b", "c"});
-    check_equal(",b,"_sv   | split<StringView>(','), {"", "b", ""});
-    check_equal(","_sv     | split<StringView>(','), {"", ""});
-    check_equal(""_sv      | split<StringView>(','), {});
+    check_equal(",b,c"_sv | split<StringView>(','), {"", "b", "c"});
+    check_equal(",b,"_sv | split<StringView>(','), {"", "b", ""});
+    check_equal(","_sv | split<StringView>(','), {"", ""});
+    check_equal(""_sv | split<StringView>(','), {});
 
     check_equal(R"(a\,,\,b,\,)"_sv | split<StringView>(',', '\\')
-                                   | transform(unescape<',', '\\'>), {"a,", ",b", ","});
+                    | transform(unescape<',', '\\'>),
+                {"a,", ",b", ","});
     check_equal(R"(\,\,)"_sv | split<StringView>(',', '\\')
-                             | transform(unescape<',', '\\'>), {",,"});
+                    | transform(unescape<',', '\\'>),
+                {",,"});
     check_equal(R"(\\,\\,)"_sv | split<StringView>(',', '\\')
-                               | transform(unescape<',', '\\'>), {R"(\)", R"(\)", ""});
+                    | transform(unescape<',', '\\'>),
+                {R"(\)", R"(\)", ""});
 }};
 
 }

--- a/src/ranges.hh
+++ b/src/ranges.hh
@@ -12,23 +12,35 @@
 namespace Kakoune
 {
 
-template<typename Func> struct ViewFactory { Func func; };
+template<typename Func>
+struct ViewFactory
+{
+    Func func;
+};
 
 template<typename Func>
-ViewFactory<std::decay_t<Func>>
-make_view_factory(Func&& func) { return {std::forward<Func>(func)}; }
+ViewFactory<std::decay_t<Func>> make_view_factory(Func&& func)
+{
+    return {std::forward<Func>(func)};
+}
 
 template<typename Range, typename Func>
-decltype(auto) operator| (Range&& range, ViewFactory<Func> factory)
+decltype(auto) operator|(Range&& range, ViewFactory<Func> factory)
 {
     return factory.func(std::forward<Range>(range));
 }
 
 template<typename Range>
-struct decay_range_impl { using type = std::decay_t<Range>; };
+struct decay_range_impl
+{
+    using type = std::decay_t<Range>;
+};
 
 template<typename Range>
-struct decay_range_impl<Range&> { using type = Range&; };
+struct decay_range_impl<Range&>
+{
+    using type = Range&;
+};
 
 template<typename Range>
 using decay_range = typename decay_range_impl<Range>::type;
@@ -37,7 +49,7 @@ template<typename Range>
 struct ReverseView
 {
     decltype(auto) begin() { return m_range.rbegin(); }
-    decltype(auto) end()   { return m_range.rend(); }
+    decltype(auto) end() { return m_range.rend(); }
 
     Range m_range;
 };
@@ -60,7 +72,7 @@ template<typename Range>
 struct SkipView
 {
     auto begin() const { return std::next(std::begin(m_range), m_skip_count); }
-    auto end()   const { return std::end(m_range); }
+    auto end() const { return std::end(m_range); }
 
     Range m_range;
     size_t m_skip_count;
@@ -79,8 +91,9 @@ struct FilterView
 {
     using RangeIt = IteratorOf<Range>;
 
-    struct Iterator : std::iterator<std::forward_iterator_tag,
-                                    typename std::iterator_traits<RangeIt>::value_type>
+    struct Iterator
+        : std::iterator<std::forward_iterator_tag,
+                        typename std::iterator_traits<RangeIt>::value_type>
     {
         Iterator(Filter& filter, RangeIt it, RangeIt end)
             : m_it{std::move(it)}, m_end{std::move(end)}, m_filter{&filter}
@@ -89,8 +102,18 @@ struct FilterView
         }
 
         decltype(auto) operator*() { return *m_it; }
-        Iterator& operator++() { ++m_it; do_filter(); return *this; }
-        Iterator operator++(int) { auto copy = *this; ++(*this); return copy; }
+        Iterator& operator++()
+        {
+            ++m_it;
+            do_filter();
+            return *this;
+        }
+        Iterator operator++(int)
+        {
+            auto copy = *this;
+            ++(*this);
+            return copy;
+        }
 
         friend bool operator==(const Iterator& lhs, const Iterator& rhs)
         {
@@ -99,7 +122,7 @@ struct FilterView
 
         friend bool operator!=(const Iterator& lhs, const Iterator& rhs)
         {
-            return not (lhs == rhs);
+            return not(lhs == rhs);
         }
 
         const RangeIt& base() const { return m_it; }
@@ -107,7 +130,7 @@ struct FilterView
     private:
         void do_filter()
         {
-            while (m_it != m_end and not (*m_filter)(*m_it))
+            while (m_it != m_end and not(*m_filter)(*m_it))
                 ++m_it;
         }
 
@@ -116,8 +139,14 @@ struct FilterView
         Filter* m_filter;
     };
 
-    Iterator begin() const { return {m_filter, std::begin(m_range), std::end(m_range)}; }
-    Iterator end()   const { return {m_filter, std::end(m_range), std::end(m_range)}; }
+    Iterator begin() const
+    {
+        return {m_filter, std::begin(m_range), std::end(m_range)};
+    }
+    Iterator end() const
+    {
+        return {m_filter, std::end(m_range), std::end(m_range)};
+    }
 
     Range m_range;
     mutable Filter m_filter;
@@ -128,7 +157,8 @@ inline auto filter(Filter f)
 {
     return make_view_factory([f = std::move(f)](auto&& range) {
         using Range = decltype(range);
-        return FilterView<decay_range<Range>, Filter>{std::forward<Range>(range), std::move(f)};
+        return FilterView<decay_range<Range>, Filter>{
+            std::forward<Range>(range), std::move(f)};
     });
 }
 
@@ -136,37 +166,86 @@ template<typename Range, typename Transform>
 struct TransformView
 {
     using RangeIt = IteratorOf<Range>;
-    using ResType = decltype(std::declval<Transform>()(*std::declval<RangeIt>()));
+    using ResType
+        = decltype(std::declval<Transform>()(*std::declval<RangeIt>()));
 
     struct Iterator
     {
-        using iterator_category = typename std::iterator_traits<RangeIt>::iterator_category;
+        using iterator_category =
+            typename std::iterator_traits<RangeIt>::iterator_category;
         using value_type = std::remove_reference_t<ResType>;
-        using difference_type = typename std::iterator_traits<RangeIt>::difference_type;
-        using pointer = value_type*;
+        using difference_type =
+            typename std::iterator_traits<RangeIt>::difference_type;
+        using pointer   = value_type*;
         using reference = value_type&;
 
         Iterator(Transform& transform, RangeIt it)
-            : m_it{std::move(it)}, m_transform{&transform} {}
+            : m_it{std::move(it)}, m_transform{&transform}
+        {}
 
         decltype(auto) operator*() { return (*m_transform)(*m_it); }
-        decltype(auto) operator[](difference_type i) const { return (*m_transform)(m_it[i]); }
+        decltype(auto) operator[](difference_type i) const
+        {
+            return (*m_transform)(m_it[i]);
+        }
 
-        Iterator& operator++() { ++m_it; return *this; }
-        Iterator operator++(int) { auto copy = *this; ++m_it; return copy; }
+        Iterator& operator++()
+        {
+            ++m_it;
+            return *this;
+        }
+        Iterator operator++(int)
+        {
+            auto copy = *this;
+            ++m_it;
+            return copy;
+        }
 
-        Iterator& operator--() { --m_it; return *this; }
-        Iterator operator--(int) { auto copy = *this; --m_it; return copy; }
+        Iterator& operator--()
+        {
+            --m_it;
+            return *this;
+        }
+        Iterator operator--(int)
+        {
+            auto copy = *this;
+            --m_it;
+            return copy;
+        }
 
-        Iterator& operator+=(difference_type diff) { m_it += diff; return *this; }
-        Iterator& operator-=(difference_type diff) { m_it -= diff; return *this; }
+        Iterator& operator+=(difference_type diff)
+        {
+            m_it += diff;
+            return *this;
+        }
+        Iterator& operator-=(difference_type diff)
+        {
+            m_it -= diff;
+            return *this;
+        }
 
-        Iterator operator+(difference_type diff) { return {*m_transform, m_it + diff}; }
-        Iterator operator-(difference_type diff) { return {*m_transform, m_it - diff}; }
+        Iterator operator+(difference_type diff)
+        {
+            return {*m_transform, m_it + diff};
+        }
+        Iterator operator-(difference_type diff)
+        {
+            return {*m_transform, m_it - diff};
+        }
 
-        friend bool operator==(const Iterator& lhs, const Iterator& rhs) { return lhs.m_it == rhs.m_it; }
-        friend bool operator!=(const Iterator& lhs, const Iterator& rhs) { return not (lhs == rhs); }
-        friend difference_type operator-(const Iterator& lhs, const Iterator& rhs) { return lhs.m_it - rhs.m_it; }
+        friend bool operator==(const Iterator& lhs, const Iterator& rhs)
+        {
+            return lhs.m_it == rhs.m_it;
+        }
+        friend bool operator!=(const Iterator& lhs, const Iterator& rhs)
+        {
+            return not(lhs == rhs);
+        }
+        friend difference_type operator-(const Iterator& lhs,
+                                         const Iterator& rhs)
+        {
+            return lhs.m_it - rhs.m_it;
+        }
 
         RangeIt base() const { return m_it; }
 
@@ -176,7 +255,7 @@ struct TransformView
     };
 
     Iterator begin() const { return {m_transform, std::begin(m_range)}; }
-    Iterator end()   const { return {m_transform, std::end(m_range)}; }
+    Iterator end() const { return {m_transform, std::end(m_range)}; }
 
     Range m_range;
     mutable Transform m_transform;
@@ -187,7 +266,8 @@ inline auto transform(Transform t)
 {
     return make_view_factory([t = std::move(t)](auto&& range) {
         using Range = decltype(range);
-        return TransformView<decay_range<Range>, Transform>{std::forward<Range>(range), std::move(t)};
+        return TransformView<decay_range<Range>, Transform>{
+            std::forward<Range>(range), std::move(t)};
     });
 }
 
@@ -197,20 +277,26 @@ inline auto transform(M T::*m)
     return transform(std::mem_fn(std::forward<decltype(m)>(m)));
 }
 
-template<typename Range, bool escape = false,
-         typename Element = ValueOf<Range>,
+template<typename Range, bool escape = false, typename Element = ValueOf<Range>,
          typename ValueTypeParam = void>
 struct SplitView
 {
     using RangeIt = IteratorOf<Range>;
-    using ValueType = std::conditional_t<std::is_same<void, ValueTypeParam>::value,
-                                         std::pair<IteratorOf<Range>, IteratorOf<Range>>,
-                                         ValueTypeParam>;
+    using ValueType
+        = std::conditional_t<std::is_same<void, ValueTypeParam>::value,
+                             std::pair<IteratorOf<Range>, IteratorOf<Range>>,
+                             ValueTypeParam>;
 
     struct Iterator : std::iterator<std::forward_iterator_tag, ValueType>
     {
-        Iterator(RangeIt pos, const RangeIt& end, Element separator, Element escaper)
-         : done{pos == end}, pos{pos}, sep{pos}, end(end), separator{std::move(separator)}, escaper{std::move(escaper)}
+        Iterator(RangeIt pos, const RangeIt& end, Element separator,
+                 Element escaper)
+            : done{pos == end},
+              pos{pos},
+              sep{pos},
+              end(end),
+              separator{std::move(separator)},
+              escaper{std::move(escaper)}
         {
             bool escaped = false;
             while (sep != end and (escaped or *sep != separator))
@@ -220,11 +306,26 @@ struct SplitView
             }
         }
 
-        Iterator& operator++() { advance(); return *this; }
-        Iterator operator++(int) { auto copy = *this; advance(); return copy; }
+        Iterator& operator++()
+        {
+            advance();
+            return *this;
+        }
+        Iterator operator++(int)
+        {
+            auto copy = *this;
+            advance();
+            return copy;
+        }
 
-        bool operator==(const Iterator& other) const { return pos == other.pos and done == other.done; }
-        bool operator!=(const Iterator& other) const { return pos != other.pos or done != other.done; }
+        bool operator==(const Iterator& other) const
+        {
+            return pos == other.pos and done == other.done;
+        }
+        bool operator!=(const Iterator& other) const
+        {
+            return pos != other.pos or done != other.done;
+        }
 
         ValueType operator*() { return {pos, sep}; }
 
@@ -233,12 +334,12 @@ struct SplitView
         {
             if (sep == end)
             {
-                pos = end;
+                pos  = end;
                 done = true;
                 return;
             }
 
-            pos = sep+1;
+            pos          = sep + 1;
             bool escaped = escape and *sep == escaper;
             for (sep = pos; sep != end; ++sep)
             {
@@ -256,8 +357,14 @@ struct SplitView
         Element escaper;
     };
 
-    Iterator begin() const { return {std::begin(m_range), std::end(m_range), m_separator, m_escaper}; }
-    Iterator end()   const { return {std::end(m_range), std::end(m_range), m_separator, m_escaper}; }
+    Iterator begin() const
+    {
+        return {std::begin(m_range), std::end(m_range), m_separator, m_escaper};
+    }
+    Iterator end() const
+    {
+        return {std::end(m_range), std::end(m_range), m_separator, m_escaper};
+    }
 
     Range m_range;
     Element m_separator;
@@ -269,49 +376,73 @@ auto split(Element separator)
 {
     return make_view_factory([s = std::move(separator)](auto&& range) {
         using Range = decltype(range);
-        return SplitView<decay_range<Range>, false, Element, ValueType>{std::forward<Range>(range), std::move(s), {}};
+        return SplitView<decay_range<Range>, false, Element, ValueType>{
+            std::forward<Range>(range), std::move(s), {}};
     });
 }
 
 template<typename ValueType = void, typename Element>
 auto split(Element separator, Element escaper)
 {
-    return make_view_factory([s = std::move(separator), e = std::move(escaper)](auto&& range) {
-        using Range = decltype(range);
-        return SplitView<decay_range<Range>, true, Element, ValueType>{std::forward<Range>(range), std::move(s), std::move(e)};
-    });
+    return make_view_factory(
+        [s = std::move(separator), e = std::move(escaper)](auto&& range) {
+            using Range = decltype(range);
+            return SplitView<decay_range<Range>, true, Element, ValueType>{
+                std::forward<Range>(range), std::move(s), std::move(e)};
+        });
 }
 
 template<typename Range1, typename Range2>
 struct ConcatView
 {
-    using RangeIt1 = decltype(std::declval<Range1>().begin());
-    using RangeIt2 = decltype(std::declval<Range2>().begin());
-    using ValueType = typename std::common_type_t<typename std::iterator_traits<RangeIt1>::value_type,
-                                                  typename std::iterator_traits<RangeIt2>::value_type>;
+    using RangeIt1  = decltype(std::declval<Range1>().begin());
+    using RangeIt2  = decltype(std::declval<Range2>().begin());
+    using ValueType = typename std::common_type_t<
+        typename std::iterator_traits<RangeIt1>::value_type,
+        typename std::iterator_traits<RangeIt2>::value_type>;
 
     struct Iterator : std::iterator<std::forward_iterator_tag, ValueType>
     {
-        static_assert(std::is_convertible<typename std::iterator_traits<RangeIt1>::value_type, ValueType>::value, "");
-        static_assert(std::is_convertible<typename std::iterator_traits<RangeIt2>::value_type, ValueType>::value, "");
+        static_assert(std::is_convertible<
+                          typename std::iterator_traits<RangeIt1>::value_type,
+                          ValueType>::value,
+                      "");
+        static_assert(std::is_convertible<
+                          typename std::iterator_traits<RangeIt2>::value_type,
+                          ValueType>::value,
+                      "");
 
         Iterator(RangeIt1 it1, RangeIt1 end1, RangeIt2 it2)
-            : m_it1(std::move(it1)), m_end1(std::move(end1)),
-              m_it2(std::move(it2)) {}
+            : m_it1(std::move(it1)),
+              m_end1(std::move(end1)),
+              m_it2(std::move(it2))
+        {}
 
         decltype(auto) operator*() { return is2() ? *m_it2 : *m_it1; }
-        Iterator& operator++() { if (is2()) ++m_it2; else ++m_it1; return *this; }
-        Iterator operator++(int) { auto copy = *this; ++*this; return copy; }
+        Iterator& operator++()
+        {
+            if (is2())
+                ++m_it2;
+            else
+                ++m_it1;
+            return *this;
+        }
+        Iterator operator++(int)
+        {
+            auto copy = *this;
+            ++*this;
+            return copy;
+        }
 
         friend bool operator==(const Iterator& lhs, const Iterator& rhs)
         {
-            return lhs.m_it1 == rhs.m_it1 and lhs.m_end1 == rhs.m_end1 and
-                   lhs.m_it2 == rhs.m_it2;
+            return lhs.m_it1 == rhs.m_it1 and lhs.m_end1 == rhs.m_end1
+                   and lhs.m_it2 == rhs.m_it2;
         }
 
         friend bool operator!=(const Iterator& lhs, const Iterator& rhs)
         {
-            return not (lhs == rhs);
+            return not(lhs == rhs);
         }
 
     private:
@@ -323,10 +454,17 @@ struct ConcatView
     };
 
     ConcatView(Range1& range1, Range2& range2)
-        : m_range1(range1), m_range2(range2) {}
+        : m_range1(range1), m_range2(range2)
+    {}
 
-    Iterator begin() const { return {m_range1.begin(), m_range1.end(), m_range2.begin()}; }
-    Iterator end()   const { return {m_range1.end(), m_range1.end(), m_range2.end()}; }
+    Iterator begin() const
+    {
+        return {m_range1.begin(), m_range1.end(), m_range2.begin()};
+    }
+    Iterator end() const
+    {
+        return {m_range1.end(), m_range1.end(), m_range2.end()};
+    }
 
 private:
     Range1 m_range1;
@@ -334,7 +472,8 @@ private:
 };
 
 template<typename Range1, typename Range2>
-ConcatView<decay_range<Range1>, decay_range<Range2>> concatenated(Range1&& range1, Range2&& range2)
+ConcatView<decay_range<Range1>, decay_range<Range2>> concatenated(
+    Range1&& range1, Range2&& range2)
 {
     return {range1, range2};
 }
@@ -342,14 +481,16 @@ ConcatView<decay_range<Range1>, decay_range<Range2>> concatenated(Range1&& range
 template<typename Range, typename T>
 auto find(Range&& range, const T& value)
 {
-    using std::begin; using std::end;
+    using std::begin;
+    using std::end;
     return std::find(begin(range), end(range), value);
 }
 
 template<typename Range, typename T>
 auto find_if(Range&& range, T op)
 {
-    using std::begin; using std::end;
+    using std::begin;
+    using std::end;
     return std::find_if(begin(range), end(range), op);
 }
 
@@ -363,14 +504,16 @@ bool contains(Range&& range, const T& value)
 template<typename Range, typename T>
 bool all_of(Range&& range, T op)
 {
-    using std::begin; using std::end;
+    using std::begin;
+    using std::end;
     return std::all_of(begin(range), end(range), op);
 }
 
 template<typename Range, typename T>
 bool any_of(Range&& range, T op)
 {
-    using std::begin; using std::end;
+    using std::begin;
+    using std::end;
     return std::any_of(begin(range), end(range), op);
 }
 
@@ -389,14 +532,16 @@ void unordered_erase(Range&& vec, U&& value)
 template<typename Range, typename Init, typename BinOp>
 Init accumulate(Range&& c, Init&& init, BinOp&& op)
 {
-    using std::begin; using std::end;
+    using std::begin;
+    using std::end;
     return std::accumulate(begin(c), end(c), init, op);
 }
 
 template<typename Range, typename Compare, typename Func>
 void for_n_best(Range&& c, size_t count, Compare&& compare, Func&& func)
 {
-    using std::begin; using std::end;
+    using std::begin;
+    using std::end;
     auto b = begin(c), e = end(c);
     std::make_heap(b, e, compare);
     while (count > 0 and b != e)
@@ -411,7 +556,8 @@ template<typename Container>
 auto gather()
 {
     return make_view_factory([](auto&& range) {
-        using std::begin; using std::end;
+        using std::begin;
+        using std::end;
         return Container(begin(range), end(range));
     });
 }
@@ -419,17 +565,20 @@ auto gather()
 template<typename ExceptionType, size_t... Indexes>
 auto elements(bool exact_size = false)
 {
-    return make_view_factory([=] (auto&& range) {
-        using std::begin; using std::end;
+    return make_view_factory([=](auto&& range) {
+        using std::begin;
+        using std::end;
         auto it = begin(range), end_it = end(range);
-        size_t i = 0;
+        size_t i  = 0;
         auto elem = [&](size_t index) {
             for (; i < index; ++i)
-                if (++it == end_it) throw ExceptionType{i};
+                if (++it == end_it)
+                    throw ExceptionType{i};
             return *it;
         };
         // Note that initializer lists elements are guaranteed to be sequenced
-        Array<std::decay_t<decltype(*begin(range))>, sizeof...(Indexes)> res{{elem(Indexes)...}};
+        Array<std::decay_t<decltype(*begin(range))>, sizeof...(Indexes)> res{
+            {elem(Indexes)...}};
         if (exact_size and ++it != end_it)
             throw ExceptionType{++i};
         return res;

--- a/src/ranked_match.hh
+++ b/src/ranked_match.hh
@@ -25,7 +25,10 @@ struct RankedMatch
 
     const StringView& candidate() const { return m_candidate; }
     bool operator<(const RankedMatch& other) const;
-    bool operator==(const RankedMatch& other) const { return m_candidate == other.m_candidate; }
+    bool operator==(const RankedMatch& other) const
+    {
+        return m_candidate == other.m_candidate;
+    }
 
     explicit operator bool() const { return not m_candidate.empty(); }
 
@@ -48,9 +51,9 @@ private:
     friend constexpr bool with_bit_ops(Meta::Type<Flags>) { return true; }
 
     StringView m_candidate{};
-    Flags m_flags = Flags::None;
+    Flags m_flags                   = Flags::None;
     int m_word_boundary_match_count = 0;
-    int m_max_index = 0;
+    int m_max_index                 = 0;
 };
 
 }

--- a/src/regex.cc
+++ b/src/regex.cc
@@ -4,14 +4,10 @@ namespace Kakoune
 {
 
 Regex::Regex(StringView re, RegexCompileFlags flags)
-    : m_impl{new CompiledRegex{compile_regex(re, flags)}},
-      m_str{re.str()}
+    : m_impl{new CompiledRegex{compile_regex(re, flags)}}, m_str{re.str()}
 {}
 
-String option_to_string(const Regex& re)
-{
-    return re.str();
-}
+String option_to_string(const Regex& re) { return re.str(); }
 
 Regex option_from_string(Meta::Type<Regex>, StringView str)
 {

--- a/src/register_manager.cc
+++ b/src/register_manager.cc
@@ -12,18 +12,10 @@ Register& RegisterManager::operator[](StringView reg) const
     if (reg.length() == 1)
         return (*this)[reg[0_byte]];
 
-    static const HashMap<String, Codepoint> reg_names = {
-        { "slash", '/' },
-        { "dquote", '"' },
-        { "pipe", '|' },
-        { "caret", '^' },
-        { "arobase", '@' },
-        { "percent", '%' },
-        { "dot", '.' },
-        { "hash", '#' },
-        { "underscore", '_' },
-        { "colon", ':' }
-    };
+    static const HashMap<String, Codepoint> reg_names
+        = {{"slash", '/'},      {"dquote", '"'},  {"pipe", '|'}, {"caret", '^'},
+           {"arobase", '@'},    {"percent", '%'}, {"dot", '.'},  {"hash", '#'},
+           {"underscore", '_'}, {"colon", ':'}};
     auto it = reg_names.find(reg);
     if (it == reg_names.end())
         throw runtime_error(format("no such register: '{}'", reg));
@@ -32,7 +24,7 @@ Register& RegisterManager::operator[](StringView reg) const
 
 Register& RegisterManager::operator[](Codepoint c) const
 {
-    c = to_lower(c);
+    c       = to_lower(c);
     auto it = m_registers.find(c);
     if (it == m_registers.end())
         throw runtime_error(format("no such register: '{}'", c));

--- a/src/register_manager.hh
+++ b/src/register_manager.hh
@@ -19,7 +19,7 @@ public:
     virtual ~Register() = default;
 
     virtual void set(Context& context, ConstArrayView<String> values) = 0;
-    virtual ConstArrayView<String> get(const Context& context) = 0;
+    virtual ConstArrayView<String> get(const Context& context)        = 0;
 };
 
 // static value register, which can be modified
@@ -39,6 +39,7 @@ public:
         else
             return ConstArrayView<String>(m_content);
     }
+
 protected:
     Vector<String, MemoryDomain::Registers> m_content;
 };
@@ -50,7 +51,8 @@ class DynamicRegister : public StaticRegister
 {
 public:
     DynamicRegister(Getter getter, Setter setter)
-        : m_getter(std::move(getter)), m_setter(std::move(setter)) {}
+        : m_getter(std::move(getter)), m_setter(std::move(setter))
+    {}
 
     void set(Context& context, ConstArrayView<String> values) override
     {
@@ -71,17 +73,18 @@ private:
 template<typename Func>
 std::unique_ptr<Register> make_dyn_reg(Func func)
 {
-    auto setter = [](Context&, ConstArrayView<String>)
-    {
+    auto setter = [](Context&, ConstArrayView<String>) {
         throw runtime_error("this register is not assignable");
     };
-    return std::make_unique<DynamicRegister<Func, decltype(setter)>>(std::move(func), setter);
+    return std::make_unique<DynamicRegister<Func, decltype(setter)>>(
+        std::move(func), setter);
 }
 
 template<typename Getter, typename Setter>
 std::unique_ptr<Register> make_dyn_reg(Getter getter, Setter setter)
 {
-    return std::make_unique<DynamicRegister<Getter, Setter>>(std::move(getter), std::move(setter));
+    return std::make_unique<DynamicRegister<Getter, Setter>>(std::move(getter),
+                                                             std::move(setter));
 }
 
 class NullRegister : public Register
@@ -103,7 +106,8 @@ public:
     void add_register(Codepoint c, std::unique_ptr<Register> reg);
 
 protected:
-    HashMap<Codepoint, std::unique_ptr<Register>, MemoryDomain::Registers> m_registers;
+    HashMap<Codepoint, std::unique_ptr<Register>, MemoryDomain::Registers>
+        m_registers;
 };
 
 }

--- a/src/remote.hh
+++ b/src/remote.hh
@@ -20,7 +20,8 @@ struct disconnected : runtime_error
 class FDWatcher;
 class UserInterface;
 
-template<typename T> struct Optional;
+template<typename T>
+struct Optional;
 struct BufferCoord;
 
 using RemoteBuffer = Vector<char, MemoryDomain::Remote>;
@@ -30,17 +31,19 @@ using RemoteBuffer = Vector<char, MemoryDomain::Remote>;
 class RemoteClient
 {
 public:
-    RemoteClient(StringView session, StringView name, std::unique_ptr<UserInterface>&& ui,
-                 int pid, const EnvVarMap& env_vars, StringView init_command,
+    RemoteClient(StringView session, StringView name,
+                 std::unique_ptr<UserInterface>&& ui, int pid,
+                 const EnvVarMap& env_vars, StringView init_command,
                  Optional<BufferCoord> init_coord);
 
     bool is_ui_ok() const;
     const Optional<int>& exit_status() const { return m_exit_status; }
+
 private:
     std::unique_ptr<UserInterface> m_ui;
-    std::unique_ptr<FDWatcher>     m_socket_watcher;
-    RemoteBuffer                   m_send_buffer;
-    Optional<int>                  m_exit_status;
+    std::unique_ptr<FDWatcher> m_socket_watcher;
+    RemoteBuffer m_send_buffer;
+    Optional<int> m_exit_status;
 };
 
 void send_command(StringView session, StringView command);

--- a/src/safe_ptr.hh
+++ b/src/safe_ptr.hh
@@ -10,9 +10,9 @@
 #include <utility>
 
 #ifdef SAFE_PTR_TRACK_CALLSTACKS
-#include "backtrace.hh"
-#include "vector.hh"
-#include <algorithm>
+#    include "backtrace.hh"
+#    include "vector.hh"
+#    include <algorithm>
 #endif
 
 namespace Kakoune
@@ -28,9 +28,9 @@ public:
     ~SafeCountable()
     {
         kak_assert(m_count == 0);
-        #ifdef SAFE_PTR_TRACK_CALLSTACKS
+#    ifdef SAFE_PTR_TRACK_CALLSTACKS
         kak_assert(m_callstacks.empty());
-        #endif
+#    endif
     }
 
     SafeCountable(const SafeCountable&) {}
@@ -41,7 +41,7 @@ public:
 
 private:
     friend struct SafeCountablePolicy;
-    #ifdef SAFE_PTR_TRACK_CALLSTACKS
+#    ifdef SAFE_PTR_TRACK_CALLSTACKS
     struct Callstack
     {
         Callstack(void* p) : ptr(p) {}
@@ -50,7 +50,7 @@ private:
     };
 
     mutable Vector<Callstack> m_callstacks;
-    #endif
+#    endif
     mutable int m_count = 0;
 #endif
 };
@@ -61,31 +61,34 @@ struct SafeCountablePolicy
     static void inc_ref(const SafeCountable* sc, void* ptr) noexcept
     {
         ++sc->m_count;
-        #ifdef SAFE_PTR_TRACK_CALLSTACKS
+#    ifdef SAFE_PTR_TRACK_CALLSTACKS
         sc->m_callstacks.emplace_back(ptr);
-        #endif
+#    endif
     }
 
     static void dec_ref(const SafeCountable* sc, void* ptr) noexcept
     {
         --sc->m_count;
         kak_assert(sc->m_count >= 0);
-        #ifdef SAFE_PTR_TRACK_CALLSTACKS
-        auto it = std::find_if(sc->m_callstacks.begin(), sc->m_callstacks.end(),
-                               [=](const SafeCountable::Callstack& cs) { return cs.ptr == ptr; });
+#    ifdef SAFE_PTR_TRACK_CALLSTACKS
+        auto it = std::find_if(
+            sc->m_callstacks.begin(), sc->m_callstacks.end(),
+            [=](const SafeCountable::Callstack& cs) { return cs.ptr == ptr; });
         kak_assert(it != sc->m_callstacks.end());
         sc->m_callstacks.erase(it);
-        #endif
+#    endif
     }
 
-    static void ptr_moved(const SafeCountable* sc, void* from, void* to) noexcept
+    static void ptr_moved(const SafeCountable* sc, void* from,
+                          void* to) noexcept
     {
-        #ifdef SAFE_PTR_TRACK_CALLSTACKS
-        auto it = std::find_if(sc->m_callstacks.begin(), sc->m_callstacks.end(),
-                               [=](const SafeCountable::Callstack& cs) { return cs.ptr == from; });
+#    ifdef SAFE_PTR_TRACK_CALLSTACKS
+        auto it = std::find_if(
+            sc->m_callstacks.begin(), sc->m_callstacks.end(),
+            [=](const SafeCountable::Callstack& cs) { return cs.ptr == from; });
         kak_assert(it != sc->m_callstacks.end());
         it->ptr = to;
-        #endif
+#    endif
     }
 #else
     static void inc_ref(const SafeCountable*, void* ptr) noexcept {}

--- a/src/scope.cc
+++ b/src/scope.cc
@@ -4,23 +4,20 @@
 namespace Kakoune
 {
 
-GlobalScope::GlobalScope()
-    : m_option_registry(m_options)
+GlobalScope::GlobalScope() : m_option_registry(m_options)
 {
     options().register_watcher(*this);
 }
 
-GlobalScope::~GlobalScope()
-{
-    options().unregister_watcher(*this);
-}
+GlobalScope::~GlobalScope() { options().unregister_watcher(*this); }
 
 void GlobalScope::on_option_changed(const Option& option)
 {
     Context empty_context{Context::EmptyContextFlag{}};
-    hooks().run_hook(Hook::GlobalSetOption,
-                     format("{}={}", option.name(), option.get_as_string(Quoting::Kakoune)),
-                     empty_context);
+    hooks().run_hook(
+        Hook::GlobalSetOption,
+        format("{}={}", option.name(), option.get_as_string(Quoting::Kakoune)),
+        empty_context);
 }
 
 }

--- a/src/scope.hh
+++ b/src/scope.hh
@@ -21,45 +21,49 @@ public:
           m_keymaps(parent.keymaps()),
           m_aliases(parent.aliases()),
           m_faces(parent.faces()),
-          m_highlighters(parent.highlighters()) {}
+          m_highlighters(parent.highlighters())
+    {}
 
-    OptionManager&       options()            { return m_options; }
-    const OptionManager& options()      const { return m_options; }
-    HookManager&         hooks()              { return m_hooks; }
-    const HookManager&   hooks()        const { return m_hooks; }
-    KeymapManager&       keymaps()            { return m_keymaps; }
-    const KeymapManager& keymaps()      const { return m_keymaps; }
-    AliasRegistry&       aliases()            { return m_aliases; }
-    const AliasRegistry& aliases()      const { return m_aliases; }
-    FaceRegistry&        faces()              { return m_faces; }
-    const FaceRegistry&  faces()        const { return m_faces; }
-    Highlighters&        highlighters()       { return m_highlighters; }
-    const Highlighters&  highlighters() const { return m_highlighters; }
+    OptionManager& options() { return m_options; }
+    const OptionManager& options() const { return m_options; }
+    HookManager& hooks() { return m_hooks; }
+    const HookManager& hooks() const { return m_hooks; }
+    KeymapManager& keymaps() { return m_keymaps; }
+    const KeymapManager& keymaps() const { return m_keymaps; }
+    AliasRegistry& aliases() { return m_aliases; }
+    const AliasRegistry& aliases() const { return m_aliases; }
+    FaceRegistry& faces() { return m_faces; }
+    const FaceRegistry& faces() const { return m_faces; }
+    Highlighters& highlighters() { return m_highlighters; }
+    const Highlighters& highlighters() const { return m_highlighters; }
 
 private:
     friend class GlobalScope;
     Scope() = default;
 
     OptionManager m_options;
-    HookManager   m_hooks;
+    HookManager m_hooks;
     KeymapManager m_keymaps;
     AliasRegistry m_aliases;
-    FaceRegistry  m_faces;
-    Highlighters  m_highlighters;
+    FaceRegistry m_faces;
+    Highlighters m_highlighters;
 };
 
-class GlobalScope : public Scope, public OptionManagerWatcher, public Singleton<GlobalScope>
+class GlobalScope : public Scope,
+                    public OptionManagerWatcher,
+                    public Singleton<GlobalScope>
 {
-    public:
-        GlobalScope();
-        ~GlobalScope();
+public:
+    GlobalScope();
+    ~GlobalScope();
 
-        OptionsRegistry& option_registry() { return m_option_registry; }
-        const OptionsRegistry& option_registry() const { return m_option_registry; }
-    private:
-        void on_option_changed(const Option& option);
+    OptionsRegistry& option_registry() { return m_option_registry; }
+    const OptionsRegistry& option_registry() const { return m_option_registry; }
 
-        OptionsRegistry m_option_registry;
+private:
+    void on_option_changed(const Option& option);
+
+    OptionsRegistry m_option_registry;
 };
 
 }

--- a/src/selection.hh
+++ b/src/selection.hh
@@ -14,11 +14,10 @@ struct Selection
     static constexpr MemoryDomain Domain = MemoryDomain::Selections;
 
     Selection() = default;
-    Selection(BufferCoord pos) : Selection(pos,pos) {}
-    Selection(BufferCoord anchor, BufferCoord cursor,
-              CaptureList captures = {})
-        : m_anchor{anchor}, m_cursor{cursor},
-          m_captures(std::move(captures)) {}
+    Selection(BufferCoord pos) : Selection(pos, pos) {}
+    Selection(BufferCoord anchor, BufferCoord cursor, CaptureList captures = {})
+        : m_anchor{anchor}, m_cursor{cursor}, m_captures(std::move(captures))
+    {}
 
     BufferCoord& anchor() { return m_anchor; }
     BufferCoordAndTarget& cursor() { return m_cursor; }
@@ -37,14 +36,21 @@ struct Selection
     CaptureList& captures() { return m_captures; }
     const CaptureList& captures() const { return m_captures; }
 
-    bool operator== (const Selection& other) const
+    bool operator==(const Selection& other) const
     {
         return m_anchor == other.m_anchor and m_cursor == other.m_cursor;
     }
 
-    // When selections are single char, we want the anchor to be considered min, and cursor max
-    const BufferCoord& min() const { return m_anchor <= m_cursor ? m_anchor : m_cursor; }
-    const BufferCoord& max() const { return m_anchor <= m_cursor ? m_cursor : m_anchor; }
+    // When selections are single char, we want the anchor to be considered min,
+    // and cursor max
+    const BufferCoord& min() const
+    {
+        return m_anchor <= m_cursor ? m_anchor : m_cursor;
+    }
+    const BufferCoord& max() const
+    {
+        return m_anchor <= m_cursor ? m_cursor : m_anchor;
+    }
 
     BufferCoord& min() { return m_anchor <= m_cursor ? m_anchor : m_cursor; }
     BufferCoord& max() { return m_anchor <= m_cursor ? m_cursor : m_anchor; }
@@ -91,8 +97,10 @@ struct SelectionList
     SelectionList(Buffer& buffer, Vector<Selection> s);
     SelectionList(Buffer& buffer, Vector<Selection> s, size_t timestamp);
 
-    struct UnsortedTag {};
-    SelectionList(UnsortedTag, Buffer& buffer, Vector<Selection> s, size_t timestamp, size_t main);
+    struct UnsortedTag
+    {};
+    SelectionList(UnsortedTag, Buffer& buffer, Vector<Selection> s,
+                  size_t timestamp, size_t main);
 
     void update();
 
@@ -101,7 +109,11 @@ struct SelectionList
     const Selection& main() const { return (*this)[m_main]; }
     Selection& main() { return (*this)[m_main]; }
     size_t main_index() const { return m_main; }
-    void set_main_index(size_t main) { kak_assert(main < size()); m_main = main; }
+    void set_main_index(size_t main)
+    {
+        kak_assert(main < size());
+        m_main = main;
+    }
 
     void push_back(const Selection& sel) { m_selections.push_back(sel); }
     void push_back(Selection&& sel) { m_selections.push_back(std::move(sel)); }
@@ -112,7 +124,7 @@ struct SelectionList
     void set(Vector<Selection> list, size_t main);
     SelectionList& operator=(Vector<Selection> list)
     {
-        const size_t main_index = list.size()-1;
+        const size_t main_index = list.size() - 1;
         set(std::move(list), main_index);
         return *this;
     }
@@ -129,8 +141,15 @@ struct SelectionList
 
     size_t size() const { return m_selections.size(); }
 
-    bool operator==(const SelectionList& other) const { return m_buffer == other.m_buffer and m_selections == other.m_selections; }
-    bool operator!=(const SelectionList& other) const { return not ((*this) == other); }
+    bool operator==(const SelectionList& other) const
+    {
+        return m_buffer == other.m_buffer
+               and m_selections == other.m_selections;
+    }
+    bool operator!=(const SelectionList& other) const
+    {
+        return not((*this) == other);
+    }
 
     void sort();
     void merge_overlapping();
@@ -158,7 +177,8 @@ Vector<Selection> compute_modified_ranges(Buffer& buffer, size_t timestamp);
 String selection_to_string(const Selection& selection);
 String selection_list_to_string(const SelectionList& selection);
 Selection selection_from_string(StringView desc);
-SelectionList selection_list_from_string(Buffer& buffer, ConstArrayView<String> descs);
+SelectionList selection_list_from_string(Buffer& buffer,
+                                         ConstArrayView<String> descs);
 
 }
 

--- a/src/selectors.cc
+++ b/src/selectors.cc
@@ -39,31 +39,36 @@ Selection utf8_range(const Utf8Iterator& first, const Utf8Iterator& last)
 
 ConstArrayView<Codepoint> get_extra_word_chars(const Context& context)
 {
-    return context.options()["extra_word_chars"].get<Vector<Codepoint, MemoryDomain::Options>>();
+    return context.options()["extra_word_chars"]
+        .get<Vector<Codepoint, MemoryDomain::Options>>();
 }
 
 }
 
 template<WordType word_type>
-Optional<Selection>
-select_to_next_word(const Context& context, const Selection& selection)
+Optional<Selection> select_to_next_word(const Context& context,
+                                        const Selection& selection)
 {
     auto extra_word_chars = get_extra_word_chars(context);
-    auto& buffer = context.buffer();
+    auto& buffer          = context.buffer();
     Utf8Iterator begin{buffer.iterator_at(selection.cursor()), buffer};
-    if (begin+1 == buffer.end())
+    if (begin + 1 == buffer.end())
         return {};
-    if (categorize<word_type>(*begin, extra_word_chars) !=
-        categorize<word_type>(*(begin+1), extra_word_chars))
+    if (categorize<word_type>(*begin, extra_word_chars)
+        != categorize<word_type>(*(begin + 1), extra_word_chars))
         ++begin;
 
     if (not skip_while(begin, buffer.end(),
                        [](Codepoint c) { return is_eol(c); }))
         return {};
-    Utf8Iterator end = begin+1;
+    Utf8Iterator end = begin + 1;
 
-    auto is_word = [&](Codepoint c) { return Kakoune::is_word<word_type>(c, extra_word_chars); };
-    auto is_punctuation = [&](Codepoint c) { return Kakoune::is_punctuation(c, extra_word_chars); };
+    auto is_word = [&](Codepoint c) {
+        return Kakoune::is_word<word_type>(c, extra_word_chars);
+    };
+    auto is_punctuation = [&](Codepoint c) {
+        return Kakoune::is_punctuation(c, extra_word_chars);
+    };
 
     if (is_word(*begin))
         skip_while(end, buffer.end(), is_word);
@@ -72,22 +77,24 @@ select_to_next_word(const Context& context, const Selection& selection)
 
     skip_while(end, buffer.end(), is_horizontal_blank);
 
-    return utf8_range(begin, end-1);
+    return utf8_range(begin, end - 1);
 }
-template Optional<Selection> select_to_next_word<WordType::Word>(const Context&, const Selection&);
-template Optional<Selection> select_to_next_word<WordType::WORD>(const Context&, const Selection&);
+template Optional<Selection> select_to_next_word<WordType::Word>(
+    const Context&, const Selection&);
+template Optional<Selection> select_to_next_word<WordType::WORD>(
+    const Context&, const Selection&);
 
 template<WordType word_type>
-Optional<Selection>
-select_to_next_word_end(const Context& context, const Selection& selection)
+Optional<Selection> select_to_next_word_end(const Context& context,
+                                            const Selection& selection)
 {
     auto extra_word_chars = get_extra_word_chars(context);
-    auto& buffer = context.buffer();
+    auto& buffer          = context.buffer();
     Utf8Iterator begin{buffer.iterator_at(selection.cursor()), buffer};
-    if (begin+1 == buffer.end())
+    if (begin + 1 == buffer.end())
         return {};
-    if (categorize<word_type>(*begin, extra_word_chars) !=
-        categorize<word_type>(*(begin+1), extra_word_chars))
+    if (categorize<word_type>(*begin, extra_word_chars)
+        != categorize<word_type>(*(begin + 1), extra_word_chars))
         ++begin;
 
     if (not skip_while(begin, buffer.end(),
@@ -96,58 +103,74 @@ select_to_next_word_end(const Context& context, const Selection& selection)
     Utf8Iterator end = begin;
     skip_while(end, buffer.end(), is_horizontal_blank);
 
-    auto is_word = [&](Codepoint c) { return Kakoune::is_word<word_type>(c, extra_word_chars); };
-    auto is_punctuation = [&](Codepoint c) { return Kakoune::is_punctuation(c, extra_word_chars); };
+    auto is_word = [&](Codepoint c) {
+        return Kakoune::is_word<word_type>(c, extra_word_chars);
+    };
+    auto is_punctuation = [&](Codepoint c) {
+        return Kakoune::is_punctuation(c, extra_word_chars);
+    };
 
     if (is_word(*end))
         skip_while(end, buffer.end(), is_word);
     else if (is_punctuation(*end))
         skip_while(end, buffer.end(), is_punctuation);
 
-    return utf8_range(begin, end-1);
+    return utf8_range(begin, end - 1);
 }
-template Optional<Selection> select_to_next_word_end<WordType::Word>(const Context&, const Selection&);
-template Optional<Selection> select_to_next_word_end<WordType::WORD>(const Context&, const Selection&);
+template Optional<Selection> select_to_next_word_end<WordType::Word>(
+    const Context&, const Selection&);
+template Optional<Selection> select_to_next_word_end<WordType::WORD>(
+    const Context&, const Selection&);
 
 template<WordType word_type>
-Optional<Selection>
-select_to_previous_word(const Context& context, const Selection& selection)
+Optional<Selection> select_to_previous_word(const Context& context,
+                                            const Selection& selection)
 {
     auto extra_word_chars = get_extra_word_chars(context);
-    auto& buffer = context.buffer();
+    auto& buffer          = context.buffer();
     Utf8Iterator begin{buffer.iterator_at(selection.cursor()), buffer};
     if (begin == buffer.begin())
         return {};
-    if (categorize<word_type>(*begin, extra_word_chars) !=
-        categorize<word_type>(*(begin-1), extra_word_chars))
+    if (categorize<word_type>(*begin, extra_word_chars)
+        != categorize<word_type>(*(begin - 1), extra_word_chars))
         --begin;
 
-    skip_while_reverse(begin, buffer.begin(), [](Codepoint c){ return is_eol(c); });
+    skip_while_reverse(begin, buffer.begin(),
+                       [](Codepoint c) { return is_eol(c); });
     Utf8Iterator end = begin;
 
-    auto is_word = [&](Codepoint c) { return Kakoune::is_word<word_type>(c, extra_word_chars); };
-    auto is_punctuation = [&](Codepoint c) { return Kakoune::is_punctuation(c, extra_word_chars); };
+    auto is_word = [&](Codepoint c) {
+        return Kakoune::is_word<word_type>(c, extra_word_chars);
+    };
+    auto is_punctuation = [&](Codepoint c) {
+        return Kakoune::is_punctuation(c, extra_word_chars);
+    };
 
-    bool with_end = skip_while_reverse(end, buffer.begin(), is_horizontal_blank);
+    bool with_end
+        = skip_while_reverse(end, buffer.begin(), is_horizontal_blank);
     if (is_word(*end))
         with_end = skip_while_reverse(end, buffer.begin(), is_word);
     else if (is_punctuation(*end))
         with_end = skip_while_reverse(end, buffer.begin(), is_punctuation);
 
-    return utf8_range(begin, with_end ? end : end+1);
+    return utf8_range(begin, with_end ? end : end + 1);
 }
-template Optional<Selection> select_to_previous_word<WordType::Word>(const Context&, const Selection&);
-template Optional<Selection> select_to_previous_word<WordType::WORD>(const Context&, const Selection&);
+template Optional<Selection> select_to_previous_word<WordType::Word>(
+    const Context&, const Selection&);
+template Optional<Selection> select_to_previous_word<WordType::WORD>(
+    const Context&, const Selection&);
 
 template<WordType word_type>
-Optional<Selection>
-select_word(const Context& context, const Selection& selection,
-            int count, ObjectFlags flags)
+Optional<Selection> select_word(const Context& context,
+                                const Selection& selection, int count,
+                                ObjectFlags flags)
 {
     auto extra_word_chars = get_extra_word_chars(context);
-    auto& buffer = context.buffer();
+    auto& buffer          = context.buffer();
 
-    auto is_word = [&](Codepoint c) { return Kakoune::is_word<word_type>(c, extra_word_chars); };
+    auto is_word = [&](Codepoint c) {
+        return Kakoune::is_word<word_type>(c, extra_word_chars);
+    };
 
     Utf8Iterator first{buffer.iterator_at(selection.cursor()), buffer};
     if (not is_word(*first))
@@ -163,90 +186,102 @@ select_word(const Context& context, const Selection& selection,
     if (flags & ObjectFlags::ToEnd)
     {
         skip_while(last, buffer.end(), is_word);
-        if (not (flags & ObjectFlags::Inner))
+        if (not(flags & ObjectFlags::Inner))
             skip_while(last, buffer.end(), is_horizontal_blank);
         --last;
     }
     return (flags & ObjectFlags::ToEnd) ? utf8_range(first, last)
                                         : utf8_range(last, first);
 }
-template Optional<Selection> select_word<WordType::Word>(const Context&, const Selection&, int, ObjectFlags);
-template Optional<Selection> select_word<WordType::WORD>(const Context&, const Selection&, int, ObjectFlags);
+template Optional<Selection> select_word<WordType::Word>(const Context&,
+                                                         const Selection&, int,
+                                                         ObjectFlags);
+template Optional<Selection> select_word<WordType::WORD>(const Context&,
+                                                         const Selection&, int,
+                                                         ObjectFlags);
 
-Optional<Selection>
-select_line(const Context& context, const Selection& selection)
+Optional<Selection> select_line(const Context& context,
+                                const Selection& selection)
 {
     auto& buffer = context.buffer();
-    auto line = selection.cursor().line;
+    auto line    = selection.cursor().line;
     // Next line if line fully selected
-    if (selection.anchor() <= BufferCoord{line, 0_byte} and
-        selection.cursor() == BufferCoord{line, buffer[line].length() - 1} and
-        line != buffer.line_count() - 1)
+    if (selection.anchor() <= BufferCoord{line, 0_byte}
+        and selection.cursor() == BufferCoord{line, buffer[line].length() - 1}
+        and line != buffer.line_count() - 1)
         ++line;
     return target_eol({{line, 0_byte}, {line, buffer[line].length() - 1}});
 }
 
 template<bool only_move>
-Optional<Selection>
-select_to_line_end(const Context& context, const Selection& selection)
+Optional<Selection> select_to_line_end(const Context& context,
+                                       const Selection& selection)
 {
-    auto& buffer = context.buffer();
+    auto& buffer      = context.buffer();
     BufferCoord begin = selection.cursor();
-    LineCount line = begin.line;
-    BufferCoord end = utf8::previous(buffer.iterator_at({line, buffer[line].length() - 1}),
-                                     buffer.iterator_at(line)).coord();
+    LineCount line    = begin.line;
+    BufferCoord end
+        = utf8::previous(buffer.iterator_at({line, buffer[line].length() - 1}),
+                         buffer.iterator_at(line))
+              .coord();
     if (end < begin) // Do not go backward when cursor is on eol
         end = begin;
     return target_eol({only_move ? end : begin, end});
 }
-template Optional<Selection> select_to_line_end<false>(const Context&, const Selection&);
-template Optional<Selection> select_to_line_end<true>(const Context&, const Selection&);
+template Optional<Selection> select_to_line_end<false>(const Context&,
+                                                       const Selection&);
+template Optional<Selection> select_to_line_end<true>(const Context&,
+                                                      const Selection&);
 
 template<bool only_move>
-Optional<Selection>
-select_to_line_begin(const Context&, const Selection& selection)
+Optional<Selection> select_to_line_begin(const Context&,
+                                         const Selection& selection)
 {
     BufferCoord begin = selection.cursor();
-    BufferCoord end = begin.line;
+    BufferCoord end   = begin.line;
     return Selection{only_move ? end : begin, end};
 }
-template Optional<Selection> select_to_line_begin<false>(const Context&, const Selection&);
-template Optional<Selection> select_to_line_begin<true>(const Context&, const Selection&);
+template Optional<Selection> select_to_line_begin<false>(const Context&,
+                                                         const Selection&);
+template Optional<Selection> select_to_line_begin<true>(const Context&,
+                                                        const Selection&);
 
-Optional<Selection>
-select_to_first_non_blank(const Context& context, const Selection& selection)
+Optional<Selection> select_to_first_non_blank(const Context& context,
+                                              const Selection& selection)
 {
     auto& buffer = context.buffer();
-    auto it = buffer.iterator_at(selection.cursor().line);
-    skip_while(it, buffer.iterator_at(selection.cursor().line+1),
+    auto it      = buffer.iterator_at(selection.cursor().line);
+    skip_while(it, buffer.iterator_at(selection.cursor().line + 1),
                is_horizontal_blank);
     return {it.coord()};
 }
 
 template<bool forward>
-Optional<Selection>
-select_matching(const Context& context, const Selection& selection)
+Optional<Selection> select_matching(const Context& context,
+                                    const Selection& selection)
 {
-    auto& buffer = context.buffer();
-    auto& matching_pairs = context.options()["matching_pairs"].get<Vector<Codepoint, MemoryDomain::Options>>();
+    auto& buffer         = context.buffer();
+    auto& matching_pairs = context.options()["matching_pairs"]
+                               .get<Vector<Codepoint, MemoryDomain::Options>>();
     Utf8Iterator it{buffer.iterator_at(selection.cursor()), buffer};
     auto match = matching_pairs.end();
 
-    if (forward) while (it != buffer.end())
-    {
-        match = find(matching_pairs, *it);
-        if (match != matching_pairs.end())
-            break;
-        ++it;
-    }
-    else while (true)
-    {
-        match = find(matching_pairs, *it);
-        if (match != matching_pairs.end()
-            or it == buffer.begin())
-            break;
-        --it;
-    }
+    if (forward)
+        while (it != buffer.end())
+        {
+            match = find(matching_pairs, *it);
+            if (match != matching_pairs.end())
+                break;
+            ++it;
+        }
+    else
+        while (true)
+        {
+            match = find(matching_pairs, *it);
+            if (match != matching_pairs.end() or it == buffer.begin())
+                break;
+            --it;
+        }
 
     if (match == matching_pairs.end())
         return {};
@@ -255,9 +290,9 @@ select_matching(const Context& context, const Selection& selection)
 
     if (((match - matching_pairs.begin()) % 2) == 0)
     {
-        int level = 0;
+        int level               = 0;
         const Codepoint opening = *match;
-        const Codepoint closing = *(match+1);
+        const Codepoint closing = *(match + 1);
         while (it != buffer.end())
         {
             if (*it == opening)
@@ -269,8 +304,8 @@ select_matching(const Context& context, const Selection& selection)
     }
     else
     {
-        int level = 0;
-        const Codepoint opening = *(match-1);
+        int level               = 0;
+        const Codepoint opening = *(match - 1);
         const Codepoint closing = *match;
         while (true)
         {
@@ -285,31 +320,35 @@ select_matching(const Context& context, const Selection& selection)
     }
     return {};
 }
-template Optional<Selection>
-select_matching<true>(const Context& context, const Selection& selection);
-template Optional<Selection>
-select_matching<false>(const Context& context, const Selection& selection);
+template Optional<Selection> select_matching<true>(const Context& context,
+                                                   const Selection& selection);
+template Optional<Selection> select_matching<false>(const Context& context,
+                                                    const Selection& selection);
 
 template<typename Iterator, typename Container>
-Optional<std::pair<Iterator, Iterator>>
-find_opening(Iterator pos, const Container& container,
-             const Regex& opening, const Regex& closing,
-             int level, bool nestable)
+Optional<std::pair<Iterator, Iterator>> find_opening(Iterator pos,
+                                                     const Container& container,
+                                                     const Regex& opening,
+                                                     const Regex& closing,
+                                                     int level, bool nestable)
 {
     MatchResults<Iterator> res;
     // When on the token of a non-nestable block, we want to consider it opening
-    if (nestable and
-        backward_regex_search(container.begin(), pos,
-                              container.begin(), container.end(), res, closing) and
-        res[0].second == pos)
+    if (nestable
+        and backward_regex_search(container.begin(), pos, container.begin(),
+                                  container.end(), res, closing)
+        and res[0].second == pos)
         pos = res[0].first;
 
     using RegexIt = RegexIterator<Iterator, MatchDirection::Backward>;
-    for (auto match : RegexIt{container.begin(), pos, container.begin(), container.end(), opening})
+    for (auto match : RegexIt{container.begin(), pos, container.begin(),
+                              container.end(), opening})
     {
         if (nestable)
         {
-            for (auto m [[gnu::unused]] : RegexIt{match[0].second, pos, container.begin(), container.end(), closing})
+            for (auto m [[gnu::unused]] :
+                 RegexIt{match[0].second, pos, container.begin(),
+                         container.end(), closing})
                 ++level;
         }
 
@@ -322,22 +361,27 @@ find_opening(Iterator pos, const Container& container,
 }
 
 template<typename Iterator, typename Container>
-Optional<std::pair<Iterator, Iterator>>
-find_closing(Iterator pos, const Container& container,
-             const Regex& opening, const Regex& closing,
-             int level, bool nestable)
+Optional<std::pair<Iterator, Iterator>> find_closing(Iterator pos,
+                                                     const Container& container,
+                                                     const Regex& opening,
+                                                     const Regex& closing,
+                                                     int level, bool nestable)
 {
     MatchResults<Iterator> res;
     if (regex_search(pos, container.end(), container.begin(), container.end(),
-                     res, opening) and res[0].first == pos)
+                     res, opening)
+        and res[0].first == pos)
         pos = res[0].second;
 
     using RegexIt = RegexIterator<Iterator, MatchDirection::Forward>;
-    for (auto match : RegexIt{pos, container.end(), container.begin(), container.end(), closing})
+    for (auto match : RegexIt{pos, container.end(), container.begin(),
+                              container.end(), closing})
     {
         if (nestable)
         {
-            for (auto m [[gnu::unused]] : RegexIt{pos, match[0].first, container.begin(), container.end(), opening})
+            for (auto m [[gnu::unused]] :
+                 RegexIt{pos, match[0].first, container.begin(),
+                         container.end(), opening})
                 ++level;
         }
 
@@ -350,22 +394,22 @@ find_closing(Iterator pos, const Container& container,
 }
 
 template<typename Container, typename Iterator>
-Optional<std::pair<Iterator, Iterator>>
-find_surrounding(const Container& container, Iterator pos,
-                 const Regex& opening, const Regex& closing,
-                 ObjectFlags flags, int level)
+Optional<std::pair<Iterator, Iterator>> find_surrounding(
+    const Container& container, Iterator pos, const Regex& opening,
+    const Regex& closing, ObjectFlags flags, int level)
 {
     const bool nestable = opening != closing;
-    auto first = pos;
-    auto last = pos;
+    auto first          = pos;
+    auto last           = pos;
     if (flags & ObjectFlags::ToBegin)
     {
-        if (auto res = find_opening(first+1, container, opening, closing, level, nestable))
+        if (auto res = find_opening(first + 1, container, opening, closing,
+                                    level, nestable))
         {
             first = (flags & ObjectFlags::Inner) ? res->second : res->first;
             if (flags & ObjectFlags::ToEnd) // ensure we find the matching end
             {
-                last = res->first;
+                last  = res->first;
                 level = 0;
             }
         }
@@ -374,9 +418,11 @@ find_surrounding(const Container& container, Iterator pos,
     }
     if (flags & ObjectFlags::ToEnd)
     {
-        if (auto res = find_closing(last, container, opening, closing, level, nestable))
-            last = (flags & ObjectFlags::Inner) ? utf8::previous(res->first, container.begin())
-                                                : utf8::previous(res->second, container.begin());
+        if (auto res
+            = find_closing(last, container, opening, closing, level, nestable))
+            last = (flags & ObjectFlags::Inner)
+                       ? utf8::previous(res->first, container.begin())
+                       : utf8::previous(res->second, container.begin());
         else
             return {};
     }
@@ -386,31 +432,35 @@ find_surrounding(const Container& container, Iterator pos,
     return std::pair<Iterator, Iterator>{first, last};
 }
 
-Optional<Selection>
-select_surrounding(const Context& context, const Selection& selection,
-                   const Regex& opening, const Regex& closing, int level,
-                   ObjectFlags flags)
+Optional<Selection> select_surrounding(const Context& context,
+                                       const Selection& selection,
+                                       const Regex& opening,
+                                       const Regex& closing, int level,
+                                       ObjectFlags flags)
 {
     auto& buffer = context.buffer();
-    auto pos = buffer.iterator_at(selection.cursor());
+    auto pos     = buffer.iterator_at(selection.cursor());
 
     auto res = find_surrounding(buffer, pos, opening, closing, flags, level);
 
     // If the ends we're changing didn't move, find the parent
-    if (res and not (flags & ObjectFlags::Inner) and
-        (res->first.coord() == selection.min() or not (flags & ObjectFlags::ToBegin)) and
-        (res->second.coord() == selection.max() or not (flags & ObjectFlags::ToEnd)))
-        res = find_surrounding(buffer, pos, opening, closing, flags, level+1);
+    if (res and not(flags & ObjectFlags::Inner)
+        and (res->first.coord() == selection.min()
+             or not(flags & ObjectFlags::ToBegin))
+        and (res->second.coord() == selection.max()
+             or not(flags & ObjectFlags::ToEnd)))
+        res = find_surrounding(buffer, pos, opening, closing, flags, level + 1);
 
     if (res)
-        return (flags & ObjectFlags::ToEnd) ? utf8_range(res->first, res->second)
-                                            : utf8_range(res->second, res->first);
+        return (flags & ObjectFlags::ToEnd)
+                   ? utf8_range(res->first, res->second)
+                   : utf8_range(res->second, res->first);
     return {};
 }
 
-Optional<Selection>
-select_to(const Context& context, const Selection& selection,
-          Codepoint c, int count, bool inclusive)
+Optional<Selection> select_to(const Context& context,
+                              const Selection& selection, Codepoint c,
+                              int count, bool inclusive)
 {
     auto& buffer = context.buffer();
     Utf8Iterator begin{buffer.iterator_at(selection.cursor()), buffer};
@@ -421,15 +471,14 @@ select_to(const Context& context, const Selection& selection,
         skip_while(end, buffer.end(), [c](Codepoint cur) { return cur != c; });
         if (end == buffer.end())
             return {};
-    }
-    while (--count > 0);
+    } while (--count > 0);
 
-    return utf8_range(begin, inclusive ? end : end-1);
+    return utf8_range(begin, inclusive ? end : end - 1);
 }
 
-Optional<Selection>
-select_to_reverse(const Context& context, const Selection& selection,
-                  Codepoint c, int count, bool inclusive)
+Optional<Selection> select_to_reverse(const Context& context,
+                                      const Selection& selection, Codepoint c,
+                                      int count, bool inclusive)
 {
     auto& buffer = context.buffer();
     Utf8Iterator begin{buffer.iterator_at(selection.cursor()), buffer};
@@ -440,24 +489,23 @@ select_to_reverse(const Context& context, const Selection& selection,
         if (skip_while_reverse(end, buffer.begin(),
                                [c](Codepoint cur) { return cur != c; }))
             return {};
-    }
-    while (--count > 0);
+    } while (--count > 0);
 
-    return utf8_range(begin, inclusive ? end : end+1);
+    return utf8_range(begin, inclusive ? end : end + 1);
 }
 
-Optional<Selection>
-select_number(const Context& context, const Selection& selection,
-              int count, ObjectFlags flags)
+Optional<Selection> select_number(const Context& context,
+                                  const Selection& selection, int count,
+                                  ObjectFlags flags)
 {
     auto is_number = [&](char c) {
-        return (c >= '0' and c <= '9') or
-               (not (flags & ObjectFlags::Inner) and c == '.');
+        return (c >= '0' and c <= '9')
+               or (not(flags & ObjectFlags::Inner) and c == '.');
     };
 
-    auto& buffer = context.buffer();
+    auto& buffer         = context.buffer();
     BufferIterator first = buffer.iterator_at(selection.cursor());
-    BufferIterator last = first;
+    BufferIterator last  = first;
 
     if (not is_number(*first) and *first != '-')
         return {};
@@ -465,8 +513,8 @@ select_number(const Context& context, const Selection& selection,
     if (flags & ObjectFlags::ToBegin)
     {
         skip_while_reverse(first, buffer.begin(), is_number);
-        if (not is_number(*first) and *first != '-' and
-            first+1 != buffer.end())
+        if (not is_number(*first) and *first != '-'
+            and first + 1 != buffer.end())
             ++first;
     }
 
@@ -479,26 +527,27 @@ select_number(const Context& context, const Selection& selection,
             --last;
     }
 
-    return (flags & ObjectFlags::ToEnd) ? Selection{first.coord(), last.coord()}
-                                        : Selection{last.coord(), first.coord()};
+    return (flags & ObjectFlags::ToEnd)
+               ? Selection{first.coord(), last.coord()}
+               : Selection{last.coord(), first.coord()};
 }
 
-Optional<Selection>
-select_sentence(const Context& context, const Selection& selection,
-                int count, ObjectFlags flags)
+Optional<Selection> select_sentence(const Context& context,
+                                    const Selection& selection, int count,
+                                    ObjectFlags flags)
 {
-    auto is_end_of_sentence = [](char c) {
-        return c == '.' or c == ';' or c == '!' or c == '?';
-    };
+    auto is_end_of_sentence
+        = [](char c) { return c == '.' or c == ';' or c == '!' or c == '?'; };
 
-    auto& buffer = context.buffer();
+    auto& buffer         = context.buffer();
     BufferIterator first = buffer.iterator_at(selection.cursor());
 
-    if (not (flags & ObjectFlags::ToEnd) and first != buffer.begin())
+    if (not(flags & ObjectFlags::ToEnd) and first != buffer.begin())
     {
-        BufferIterator prev_non_blank = first-1;
-        skip_while_reverse(prev_non_blank, buffer.begin(),
-                           [](char c) { return is_horizontal_blank(c) or is_eol(c); });
+        BufferIterator prev_non_blank = first - 1;
+        skip_while_reverse(prev_non_blank, buffer.begin(), [](char c) {
+            return is_horizontal_blank(c) or is_eol(c);
+        });
         if (is_end_of_sentence(*prev_non_blank))
             first = prev_non_blank;
     }
@@ -510,8 +559,8 @@ select_sentence(const Context& context, const Selection& selection,
         bool saw_non_blank = false;
         while (first != buffer.begin())
         {
-            char cur = *first;
-            char prev = *(first-1);
+            char cur  = *first;
+            char prev = *(first - 1);
             if (not is_horizontal_blank(cur))
                 saw_non_blank = true;
             if (is_eol(prev) and is_eol(cur))
@@ -524,7 +573,7 @@ select_sentence(const Context& context, const Selection& selection,
                 if (saw_non_blank)
                     break;
                 else if (flags & ObjectFlags::ToEnd)
-                    last = first-1;
+                    last = first - 1;
             }
             --first;
         }
@@ -535,35 +584,37 @@ select_sentence(const Context& context, const Selection& selection,
         while (last != buffer.end())
         {
             char cur = *last;
-            if (is_end_of_sentence(cur) or
-                (is_eol(cur) and (last+1 == buffer.end() or is_eol(*(last+1)))))
+            if (is_end_of_sentence(cur)
+                or (is_eol(cur)
+                    and (last + 1 == buffer.end() or is_eol(*(last + 1)))))
                 break;
             ++last;
         }
-        if (not (flags & ObjectFlags::Inner) and last != buffer.end())
+        if (not(flags & ObjectFlags::Inner) and last != buffer.end())
         {
             ++last;
             skip_while(last, buffer.end(), is_horizontal_blank);
             --last;
         }
     }
-    return (flags & ObjectFlags::ToEnd) ? Selection{first.coord(), last.coord()}
-                                        : Selection{last.coord(), first.coord()};
+    return (flags & ObjectFlags::ToEnd)
+               ? Selection{first.coord(), last.coord()}
+               : Selection{last.coord(), first.coord()};
 }
 
-Optional<Selection>
-select_paragraph(const Context& context, const Selection& selection,
-                 int count, ObjectFlags flags)
+Optional<Selection> select_paragraph(const Context& context,
+                                     const Selection& selection, int count,
+                                     ObjectFlags flags)
 {
-    auto& buffer = context.buffer();
+    auto& buffer         = context.buffer();
     BufferIterator first = buffer.iterator_at(selection.cursor());
 
-    if (not (flags & ObjectFlags::ToEnd) and first.coord() > BufferCoord{0,1} and
-        *(first-1) == '\n' and *(first-2) == '\n')
+    if (not(flags & ObjectFlags::ToEnd) and first.coord() > BufferCoord{0, 1}
+        and *(first - 1) == '\n' and *(first - 2) == '\n')
         --first;
-    else if ((flags & ObjectFlags::ToEnd) and
-             first != buffer.begin() and (first+1) != buffer.end() and
-             *(first-1) == '\n' and *first == '\n')
+    else if ((flags & ObjectFlags::ToEnd) and first != buffer.begin()
+             and (first + 1) != buffer.end() and *(first - 1) == '\n'
+             and *first == '\n')
         ++first;
 
     BufferIterator last = first;
@@ -571,13 +622,13 @@ select_paragraph(const Context& context, const Selection& selection,
     if ((flags & ObjectFlags::ToBegin) and first != buffer.begin())
     {
         skip_while_reverse(first, buffer.begin(),
-                           [](Codepoint c){ return is_eol(c); });
+                           [](Codepoint c) { return is_eol(c); });
         if (flags & ObjectFlags::ToEnd)
             last = first;
         while (first != buffer.begin())
         {
-            char cur = *first;
-            char prev = *(first-1);
+            char cur  = *first;
+            char prev = *(first - 1);
             if (is_eol(prev) and is_eol(cur))
             {
                 ++first;
@@ -592,30 +643,32 @@ select_paragraph(const Context& context, const Selection& selection,
             ++last;
         while (last != buffer.end())
         {
-            if (last != buffer.begin() and is_eol(*last) and is_eol(*(last-1)))
+            if (last != buffer.begin() and is_eol(*last)
+                and is_eol(*(last - 1)))
             {
-                if (not (flags & ObjectFlags::Inner))
+                if (not(flags & ObjectFlags::Inner))
                     skip_while(last, buffer.end(),
-                               [](Codepoint c){ return is_eol(c); });
+                               [](Codepoint c) { return is_eol(c); });
                 break;
             }
             ++last;
         }
         --last;
     }
-    return (flags & ObjectFlags::ToEnd) ? Selection{first.coord(), last.coord()}
-                                        : Selection{last.coord(), first.coord()};
+    return (flags & ObjectFlags::ToEnd)
+               ? Selection{first.coord(), last.coord()}
+               : Selection{last.coord(), first.coord()};
 }
 
-Optional<Selection>
-select_whitespaces(const Context& context, const Selection& selection,
-                   int count, ObjectFlags flags)
+Optional<Selection> select_whitespaces(const Context& context,
+                                       const Selection& selection, int count,
+                                       ObjectFlags flags)
 {
     auto is_whitespace = [&](char c) {
-        return c == ' ' or c == '\t' or
-            (not (flags & ObjectFlags::Inner) and c == '\n');
+        return c == ' ' or c == '\t'
+               or (not(flags & ObjectFlags::Inner) and c == '\n');
     };
-    auto& buffer = context.buffer();
+    auto& buffer         = context.buffer();
     BufferIterator first = buffer.iterator_at(selection.cursor());
     BufferIterator last  = first;
 
@@ -639,13 +692,14 @@ select_whitespaces(const Context& context, const Selection& selection,
             --last;
         }
     }
-    return (flags & ObjectFlags::ToEnd) ? Selection{first.coord(), last.coord()}
-                                        : Selection{last.coord(), first.coord()};
+    return (flags & ObjectFlags::ToEnd)
+               ? Selection{first.coord(), last.coord()}
+               : Selection{last.coord(), first.coord()};
 }
 
-Optional<Selection>
-select_indent(const Context& context, const Selection& selection,
-              int count, ObjectFlags flags)
+Optional<Selection> select_indent(const Context& context,
+                                  const Selection& selection, int count,
+                                  ObjectFlags flags)
 {
     auto get_indent = [](StringView str, int tabstop) {
         CharCount indent = 0;
@@ -653,7 +707,7 @@ select_indent(const Context& context, const Selection& selection,
         {
             if (c == ' ')
                 ++indent;
-            else if (c =='\t')
+            else if (c == '\t')
                 indent = (indent / tabstop + 1) * tabstop;
             else
                 break;
@@ -661,38 +715,39 @@ select_indent(const Context& context, const Selection& selection,
         return indent;
     };
 
-    auto get_current_indent = [&](const Buffer& buffer, LineCount line, int tabstop)
-    {
-        for (auto l = line; l >= 0; --l)
-            if (buffer[l] != "\n"_sv)
-                return get_indent(buffer[l], tabstop);
-        for (auto l = line+1; l < buffer.line_count(); ++l)
-            if (buffer[l] != "\n"_sv)
-                return get_indent(buffer[l], tabstop);
-        return 0_char;
-    };
+    auto get_current_indent
+        = [&](const Buffer& buffer, LineCount line, int tabstop) {
+              for (auto l = line; l >= 0; --l)
+                  if (buffer[l] != "\n"_sv)
+                      return get_indent(buffer[l], tabstop);
+              for (auto l = line + 1; l < buffer.line_count(); ++l)
+                  if (buffer[l] != "\n"_sv)
+                      return get_indent(buffer[l], tabstop);
+              return 0_char;
+          };
 
     auto is_only_whitespaces = [](StringView str) {
         auto it = str.begin();
         skip_while(it, str.end(),
-                   [](char c){ return c == ' ' or c == '\t' or c == '\n'; });
+                   [](char c) { return c == ' ' or c == '\t' or c == '\n'; });
         return it == str.end();
     };
 
     const bool to_begin = flags & ObjectFlags::ToBegin;
     const bool to_end   = flags & ObjectFlags::ToEnd;
 
-    auto& buffer = context.buffer();
-    int tabstop = context.options()["tabstop"].get<int>();
-    auto pos = selection.cursor();
+    auto& buffer         = context.buffer();
+    int tabstop          = context.options()["tabstop"].get<int>();
+    auto pos             = selection.cursor();
     const LineCount line = pos.line;
-    const auto indent = get_current_indent(buffer, line, tabstop);
+    const auto indent    = get_current_indent(buffer, line, tabstop);
 
     LineCount begin_line = line - 1;
     if (to_begin)
     {
-        while (begin_line >= 0 and (buffer[begin_line] == "\n"_sv or
-                                    get_indent(buffer[begin_line], tabstop) >= indent))
+        while (begin_line >= 0
+               and (buffer[begin_line] == "\n"_sv
+                    or get_indent(buffer[begin_line], tabstop) >= indent))
             --begin_line;
     }
     ++begin_line;
@@ -700,53 +755,73 @@ select_indent(const Context& context, const Selection& selection,
     if (to_end)
     {
         const LineCount end = buffer.line_count();
-        while (end_line < end and (buffer[end_line] == "\n"_sv or
-                                   get_indent(buffer[end_line], tabstop) >= indent))
+        while (end_line < end
+               and (buffer[end_line] == "\n"_sv
+                    or get_indent(buffer[end_line], tabstop) >= indent))
             ++end_line;
     }
     --end_line;
     // remove only whitespaces lines in inner mode
     if (flags & ObjectFlags::Inner)
     {
-        while (begin_line < end_line and
-               is_only_whitespaces(buffer[begin_line]))
+        while (begin_line < end_line
+               and is_only_whitespaces(buffer[begin_line]))
             ++begin_line;
-        while (begin_line < end_line and
-               is_only_whitespaces(buffer[end_line]))
+        while (begin_line < end_line and is_only_whitespaces(buffer[end_line]))
             --end_line;
     }
 
     auto first = to_begin ? begin_line : pos;
-    auto last = to_end ? BufferCoord{end_line, buffer[end_line].length() - 1} : pos;
+    auto last
+        = to_end ? BufferCoord{end_line, buffer[end_line].length() - 1} : pos;
     return to_end ? Selection{first, last} : Selection{last, first};
 }
 
-Optional<Selection>
-select_argument(const Context& context, const Selection& selection,
-                int level, ObjectFlags flags)
+Optional<Selection> select_argument(const Context& context,
+                                    const Selection& selection, int level,
+                                    ObjectFlags flags)
 {
-    enum Class { None, Opening, Closing, Delimiter };
+    enum Class
+    {
+        None,
+        Opening,
+        Closing,
+        Delimiter
+    };
     auto classify = [](Codepoint c) {
         switch (c)
         {
-        case '(': case '[': case '{': return Opening;
-        case ')': case ']': case '}': return Closing;
-        case ',': case ';': return Delimiter;
-        default: return None;
+            case '(':
+            case '[':
+            case '{':
+                return Opening;
+            case ')':
+            case ']':
+            case '}':
+                return Closing;
+            case ',':
+            case ';':
+                return Delimiter;
+            default:
+                return None;
         }
     };
 
-    auto& buffer = context.buffer();
+    auto& buffer       = context.buffer();
     BufferIterator pos = buffer.iterator_at(selection.cursor());
     switch (classify(*pos))
     {
-        //case Closing: if (pos+1 != buffer.end()) ++pos; break;
+        // case Closing: if (pos+1 != buffer.end()) ++pos; break;
         case Opening:
-        case Delimiter: if (pos != buffer.begin()) --pos; break;
-        default: break;
+        case Delimiter:
+            if (pos != buffer.begin())
+                --pos;
+            break;
+        default:
+            break;
     };
 
-    bool first_arg = false;
+    bool first_arg       = false;
     BufferIterator begin = pos;
     for (int lev = level; begin != buffer.begin(); --begin)
     {
@@ -766,7 +841,7 @@ select_argument(const Context& context, const Selection& selection,
         }
     }
 
-    bool last_arg = false;
+    bool last_arg      = false;
     BufferIterator end = pos;
     for (int lev = level; end != buffer.end(); ++end)
     {
@@ -782,9 +857,9 @@ select_argument(const Context& context, const Selection& selection,
         else if (c == Delimiter and lev == 0)
         {
             // include whitespaces *after* the delimiter only for first argument
-            if (first_arg and not (flags & ObjectFlags::Inner))
+            if (first_arg and not(flags & ObjectFlags::Inner))
             {
-                while (end + 1 != buffer.end() and is_blank(*(end+1)))
+                while (end + 1 != buffer.end() and is_blank(*(end + 1)))
                     ++end;
             }
             break;
@@ -805,45 +880,45 @@ select_argument(const Context& context, const Selection& selection,
     if (end == buffer.end())
         --end;
 
-    if (flags & ObjectFlags::ToBegin and not (flags & ObjectFlags::ToEnd))
+    if (flags & ObjectFlags::ToBegin and not(flags & ObjectFlags::ToEnd))
         return Selection{pos.coord(), begin.coord()};
     return Selection{(flags & ObjectFlags::ToBegin ? begin : pos).coord(),
                      end.coord()};
 }
 
-Optional<Selection>
-select_lines(const Context& context, const Selection& selection)
+Optional<Selection> select_lines(const Context& context,
+                                 const Selection& selection)
 {
-    auto& buffer = context.buffer();
-    BufferCoord anchor = selection.anchor();
-    BufferCoord cursor  = selection.cursor();
+    auto& buffer               = context.buffer();
+    BufferCoord anchor         = selection.anchor();
+    BufferCoord cursor         = selection.cursor();
     BufferCoord& to_line_start = anchor <= cursor ? anchor : cursor;
-    BufferCoord& to_line_end = anchor <= cursor ? cursor : anchor;
+    BufferCoord& to_line_end   = anchor <= cursor ? cursor : anchor;
 
     to_line_start.column = 0;
-    to_line_end.column = buffer[to_line_end.line].length()-1;
+    to_line_end.column   = buffer[to_line_end.line].length() - 1;
 
     return target_eol({anchor, cursor});
 }
 
-Optional<Selection>
-trim_partial_lines(const Context& context, const Selection& selection)
+Optional<Selection> trim_partial_lines(const Context& context,
+                                       const Selection& selection)
 {
-    auto& buffer = context.buffer();
-    BufferCoord anchor = selection.anchor();
-    BufferCoord cursor  = selection.cursor();
+    auto& buffer               = context.buffer();
+    BufferCoord anchor         = selection.anchor();
+    BufferCoord cursor         = selection.cursor();
     BufferCoord& to_line_start = anchor <= cursor ? anchor : cursor;
-    BufferCoord& to_line_end = anchor <= cursor ? cursor : anchor;
+    BufferCoord& to_line_end   = anchor <= cursor ? cursor : anchor;
 
     if (to_line_start.column != 0)
-        to_line_start = to_line_start.line+1;
-    if (to_line_end.column != buffer[to_line_end.line].length()-1)
+        to_line_start = to_line_start.line + 1;
+    if (to_line_end.column != buffer[to_line_end.line].length() - 1)
     {
         if (to_line_end.line == 0)
             return {};
 
-        auto prev_line = to_line_end.line-1;
-        to_line_end = BufferCoord{ prev_line, buffer[prev_line].length()-1 };
+        auto prev_line = to_line_end.line - 1;
+        to_line_end    = BufferCoord{prev_line, buffer[prev_line].length() - 1};
     }
 
     if (to_line_start > to_line_end)
@@ -855,63 +930,70 @@ trim_partial_lines(const Context& context, const Selection& selection)
 void select_buffer(SelectionList& selections)
 {
     auto& buffer = selections.buffer();
-    selections = SelectionList{ buffer, target_eol({{0,0}, buffer.back_coord()}) };
+    selections
+        = SelectionList{buffer, target_eol({{0, 0}, buffer.back_coord()})};
 }
 
-static RegexExecFlags
-match_flags(const Buffer& buf, const BufferIterator& begin, const BufferIterator& end)
+static RegexExecFlags match_flags(const Buffer& buf,
+                                  const BufferIterator& begin,
+                                  const BufferIterator& end)
 {
     return match_flags(is_bol(begin.coord()), is_eol(buf, end.coord()),
                        is_bow(buf, begin.coord()), is_eow(buf, end.coord()));
 }
 
 static bool find_next(const Buffer& buffer, const BufferIterator& pos,
-                      MatchResults<BufferIterator>& matches,
-                      const Regex& ex, bool& wrapped)
+                      MatchResults<BufferIterator>& matches, const Regex& ex,
+                      bool& wrapped)
 {
-    if (pos != buffer.end() and
-        regex_search(pos, buffer.end(), buffer.begin(), buffer.end(),
-                     matches, ex, match_flags(buffer, pos, buffer.end())))
+    if (pos != buffer.end()
+        and regex_search(pos, buffer.end(), buffer.begin(), buffer.end(),
+                         matches, ex, match_flags(buffer, pos, buffer.end())))
         return true;
     wrapped = true;
-    return regex_search(buffer.begin(), buffer.end(), buffer.begin(), buffer.end(),
-                        matches, ex, match_flags(buffer, buffer.begin(), buffer.end()));
+    return regex_search(buffer.begin(), buffer.end(), buffer.begin(),
+                        buffer.end(), matches, ex,
+                        match_flags(buffer, buffer.begin(), buffer.end()));
 }
 
 static bool find_prev(const Buffer& buffer, const BufferIterator& pos,
-                      MatchResults<BufferIterator>& matches,
-                      const Regex& ex, bool& wrapped)
+                      MatchResults<BufferIterator>& matches, const Regex& ex,
+                      bool& wrapped)
 {
-    if (pos != buffer.begin() and
-        backward_regex_search(buffer.begin(), pos, buffer.begin(), buffer.end(),
-                              matches, ex,
-                              match_flags(buffer, buffer.begin(), pos) |
-                              RegexExecFlags::NotInitialNull))
+    if (pos != buffer.begin()
+        and backward_regex_search(buffer.begin(), pos, buffer.begin(),
+                                  buffer.end(), matches, ex,
+                                  match_flags(buffer, buffer.begin(), pos)
+                                      | RegexExecFlags::NotInitialNull))
         return true;
     wrapped = true;
-    return backward_regex_search(buffer.begin(), buffer.end(), buffer.begin(), buffer.end(),
-                                 matches, ex,
-                                 match_flags(buffer, buffer.begin(), buffer.end()) |
-                                 RegexExecFlags::NotInitialNull);
+    return backward_regex_search(
+        buffer.begin(), buffer.end(), buffer.begin(), buffer.end(), matches, ex,
+        match_flags(buffer, buffer.begin(), buffer.end())
+            | RegexExecFlags::NotInitialNull);
 }
 
 template<MatchDirection direction>
-Selection find_next_match(const Context& context, const Selection& sel, const Regex& regex, bool& wrapped)
+Selection find_next_match(const Context& context, const Selection& sel,
+                          const Regex& regex, bool& wrapped)
 {
     auto& buffer = context.buffer();
     MatchResults<BufferIterator> matches;
-    auto pos = buffer.iterator_at(direction == MatchDirection::Backward ? sel.min() : sel.max());
-    wrapped = false;
-    const bool found = (direction == MatchDirection::Forward) ?
-        find_next(buffer, utf8::next(pos, buffer.end()), matches, regex, wrapped)
-      : find_prev(buffer, pos, matches, regex, wrapped);
+    auto pos = buffer.iterator_at(
+        direction == MatchDirection::Backward ? sel.min() : sel.max());
+    wrapped          = false;
+    const bool found = (direction == MatchDirection::Forward)
+                           ? find_next(buffer, utf8::next(pos, buffer.end()),
+                                       matches, regex, wrapped)
+                           : find_prev(buffer, pos, matches, regex, wrapped);
 
     if (not found or matches[0].first == buffer.end())
         throw runtime_error(format("no matches found: '{}'", regex.str()));
 
     CaptureList captures;
     for (const auto& match : matches)
-        captures.push_back(buffer.string(match.first.coord(), match.second.coord()));
+        captures.push_back(
+            buffer.string(match.first.coord(), match.second.coord()));
 
     auto begin = matches[0].first, end = matches[0].second;
     end = (begin == end) ? end : utf8::previous(end, begin);
@@ -920,12 +1002,19 @@ Selection find_next_match(const Context& context, const Selection& sel, const Re
 
     return {begin.coord(), end.coord(), std::move(captures)};
 }
-template Selection find_next_match<MatchDirection::Forward>(const Context&, const Selection&, const Regex&, bool&);
-template Selection find_next_match<MatchDirection::Backward>(const Context&, const Selection&, const Regex&, bool&);
+template Selection find_next_match<MatchDirection::Forward>(const Context&,
+                                                            const Selection&,
+                                                            const Regex&,
+                                                            bool&);
+template Selection find_next_match<MatchDirection::Backward>(const Context&,
+                                                             const Selection&,
+                                                             const Regex&,
+                                                             bool&);
 
 using RegexIt = RegexIterator<BufferIterator>;
 
-void select_all_matches(SelectionList& selections, const Regex& regex, int capture)
+void select_all_matches(SelectionList& selections, const Regex& regex,
+                        int capture)
 {
     const int mark_count = (int)regex.mark_count();
     if (capture < 0 or capture > mark_count)
@@ -937,7 +1026,8 @@ void select_all_matches(SelectionList& selections, const Regex& regex, int captu
     {
         auto sel_beg = buffer.iterator_at(sel.min());
         auto sel_end = utf8::next(buffer.iterator_at(sel.max()), buffer.end());
-        RegexIt re_it(sel_beg, sel_end, regex, match_flags(buffer, sel_beg, sel_end));
+        RegexIt re_it(sel_beg, sel_end, regex,
+                      match_flags(buffer, sel_beg, sel_end));
         RegexIt re_end;
 
         for (; re_it != re_end; ++re_it)
@@ -950,13 +1040,14 @@ void select_all_matches(SelectionList& selections, const Regex& regex, int captu
             CaptureList captures;
             captures.reserve(mark_count);
             for (const auto& match : *re_it)
-                captures.push_back(buffer.string(match.first.coord(),
-                                                 match.second.coord()));
+                captures.push_back(
+                    buffer.string(match.first.coord(), match.second.coord()));
 
-            result.push_back(
-                keep_direction({ begin.coord(),
-                                 (begin == end ? end : utf8::previous(end, begin)).coord(),
-                                 std::move(captures) }, sel));
+            result.push_back(keep_direction(
+                {begin.coord(),
+                 (begin == end ? end : utf8::previous(end, begin)).coord(),
+                 std::move(captures)},
+                sel));
         }
     }
     if (result.empty())
@@ -967,21 +1058,23 @@ void select_all_matches(SelectionList& selections, const Regex& regex, int captu
     selections = SelectionList{buffer, std::move(result)};
 }
 
-void split_selections(SelectionList& selections, const Regex& regex, int capture)
+void split_selections(SelectionList& selections, const Regex& regex,
+                      int capture)
 {
     if (capture < 0 or capture > (int)regex.mark_count())
         throw runtime_error("invalid capture number");
 
     Vector<Selection> result;
-    auto& buffer = selections.buffer();
-    auto buf_end = buffer.end();
+    auto& buffer   = selections.buffer();
+    auto buf_end   = buffer.end();
     auto buf_begin = buffer.begin();
     for (auto& sel : selections)
     {
-        auto begin = buffer.iterator_at(sel.min());
+        auto begin   = buffer.iterator_at(sel.min());
         auto sel_end = utf8::next(buffer.iterator_at(sel.max()), buffer.end());
 
-        RegexIt re_it(begin, sel_end, regex, match_flags(buffer, begin, sel_end));
+        RegexIt re_it(begin, sel_end, regex,
+                      match_flags(buffer, begin, sel_end));
         RegexIt re_end;
 
         for (; re_it != re_end; ++re_it)
@@ -992,13 +1085,15 @@ void split_selections(SelectionList& selections, const Regex& regex, int capture
 
             if (end != buf_begin)
             {
-                auto sel_end = (begin == end) ? end : utf8::previous(end, begin);
-                result.push_back(keep_direction({ begin.coord(), sel_end.coord() }, sel));
+                auto sel_end
+                    = (begin == end) ? end : utf8::previous(end, begin);
+                result.push_back(
+                    keep_direction({begin.coord(), sel_end.coord()}, sel));
             }
             begin = (*re_it)[capture].second;
         }
         if (begin.coord() <= sel.max())
-            result.push_back(keep_direction({ begin.coord(), sel.max() }, sel));
+            result.push_back(keep_direction({begin.coord(), sel.max()}, sel));
     }
     if (result.empty())
         throw runtime_error("nothing selected");
@@ -1006,38 +1101,48 @@ void split_selections(SelectionList& selections, const Regex& regex, int capture
     selections = std::move(result);
 }
 
-UnitTest test_find_surrounding{[]()
-{
-    StringView s = "{foo [bar { baz[] }]}";
-    auto check_equal = [&](const char* pos, StringView opening, StringView closing,
-                           ObjectFlags flags, int level, StringView expected) {
-        auto res = find_surrounding(s, pos,
-                                    Regex{"\\Q" + opening, RegexCompileFlags::Backward},
-                                    Regex{"\\Q" + closing, RegexCompileFlags::Backward},
-                                    flags, level);
+UnitTest test_find_surrounding{[]() {
+    StringView s     = "{foo [bar { baz[] }]}";
+    auto check_equal = [&](const char* pos, StringView opening,
+                           StringView closing, ObjectFlags flags, int level,
+                           StringView expected) {
+        auto res = find_surrounding(
+            s, pos, Regex{"\\Q" + opening, RegexCompileFlags::Backward},
+            Regex{"\\Q" + closing, RegexCompileFlags::Backward}, flags, level);
         kak_assert(res);
         auto min = std::min(res->first, res->second),
              max = std::max(res->first, res->second);
-        kak_assert(StringView{min, max+1} == expected);
+        kak_assert(StringView{min, max + 1} == expected);
     };
 
-    check_equal(s.begin() + 13, '{', '}', ObjectFlags::ToBegin | ObjectFlags::ToEnd, 0, "{ baz[] }");
-    check_equal(s.begin() + 13, '[', ']', ObjectFlags::ToBegin | ObjectFlags::ToEnd | ObjectFlags::Inner, 0, "bar { baz[] }");
-    check_equal(s.begin() + 5, '[', ']', ObjectFlags::ToBegin | ObjectFlags::ToEnd, 0, "[bar { baz[] }]");
-    check_equal(s.begin() + 10, '{', '}', ObjectFlags::ToBegin | ObjectFlags::ToEnd, 0, "{ baz[] }");
-    check_equal(s.begin() + 16, '[', ']', ObjectFlags::ToBegin | ObjectFlags::ToEnd | ObjectFlags::Inner, 0, "]");
-    check_equal(s.begin() + 18, '[', ']', ObjectFlags::ToBegin | ObjectFlags::ToEnd, 0, "[bar { baz[] }]");
+    check_equal(s.begin() + 13, '{', '}',
+                ObjectFlags::ToBegin | ObjectFlags::ToEnd, 0, "{ baz[] }");
+    check_equal(s.begin() + 13, '[', ']',
+                ObjectFlags::ToBegin | ObjectFlags::ToEnd | ObjectFlags::Inner,
+                0, "bar { baz[] }");
+    check_equal(s.begin() + 5, '[', ']',
+                ObjectFlags::ToBegin | ObjectFlags::ToEnd, 0,
+                "[bar { baz[] }]");
+    check_equal(s.begin() + 10, '{', '}',
+                ObjectFlags::ToBegin | ObjectFlags::ToEnd, 0, "{ baz[] }");
+    check_equal(s.begin() + 16, '[', ']',
+                ObjectFlags::ToBegin | ObjectFlags::ToEnd | ObjectFlags::Inner,
+                0, "]");
+    check_equal(s.begin() + 18, '[', ']',
+                ObjectFlags::ToBegin | ObjectFlags::ToEnd, 0,
+                "[bar { baz[] }]");
     check_equal(s.begin() + 6, '[', ']', ObjectFlags::ToBegin, 0, "[b");
 
     s = "[*][] foo";
-    kak_assert(not find_surrounding(s, s.begin() + 6,
-                                    Regex{"\\Q[", RegexCompileFlags::Backward},
-                                    Regex{"\\Q]", RegexCompileFlags::Backward},
-                                    ObjectFlags::ToBegin, 0));
+    kak_assert(not find_surrounding(
+        s, s.begin() + 6, Regex{"\\Q[", RegexCompileFlags::Backward},
+        Regex{"\\Q]", RegexCompileFlags::Backward}, ObjectFlags::ToBegin, 0));
 
     s = "begin foo begin bar end end";
-    check_equal(s.begin() + 6, "begin", "end", ObjectFlags::ToBegin | ObjectFlags::ToEnd, 0, s);
-    check_equal(s.begin() + 22, "begin", "end", ObjectFlags::ToBegin | ObjectFlags::ToEnd, 0, "begin bar end");
+    check_equal(s.begin() + 6, "begin", "end",
+                ObjectFlags::ToBegin | ObjectFlags::ToEnd, 0, s);
+    check_equal(s.begin() + 22, "begin", "end",
+                ObjectFlags::ToBegin | ObjectFlags::ToEnd, 0, "begin bar end");
 }};
 
 }

--- a/src/selectors.hh
+++ b/src/selectors.hh
@@ -17,41 +17,41 @@ inline Selection keep_direction(Selection res, const Selection& ref)
 }
 
 template<WordType word_type>
-Optional<Selection>
-select_to_next_word(const Context& context, const Selection& selection);
+Optional<Selection> select_to_next_word(const Context& context,
+                                        const Selection& selection);
 
 template<WordType word_type>
-Optional<Selection>
-select_to_next_word_end(const Context& context, const Selection& selection);
+Optional<Selection> select_to_next_word_end(const Context& context,
+                                            const Selection& selection);
 
 template<WordType word_type>
-Optional<Selection>
-select_to_previous_word(const Context& context, const Selection& selection);
+Optional<Selection> select_to_previous_word(const Context& context,
+                                            const Selection& selection);
 
-Optional<Selection>
-select_line(const Context& context, const Selection& selection);
+Optional<Selection> select_line(const Context& context,
+                                const Selection& selection);
 
 template<bool forward>
-Optional<Selection>
-select_matching(const Context& context, const Selection& selection);
+Optional<Selection> select_matching(const Context& context,
+                                    const Selection& selection);
 
-Optional<Selection>
-select_to(const Context& context, const Selection& selection,
-                    Codepoint c, int count, bool inclusive);
-Optional<Selection>
-select_to_reverse(const Context& context, const Selection& selection,
-                  Codepoint c, int count, bool inclusive);
-
-template<bool only_move>
-Optional<Selection>
-select_to_line_end(const Context& context, const Selection& selection);
+Optional<Selection> select_to(const Context& context,
+                              const Selection& selection, Codepoint c,
+                              int count, bool inclusive);
+Optional<Selection> select_to_reverse(const Context& context,
+                                      const Selection& selection, Codepoint c,
+                                      int count, bool inclusive);
 
 template<bool only_move>
-Optional<Selection>
-select_to_line_begin(const Context& context, const Selection& selection);
+Optional<Selection> select_to_line_end(const Context& context,
+                                       const Selection& selection);
 
-Optional<Selection>
-select_to_first_non_blank(const Context& context, const Selection& selection);
+template<bool only_move>
+Optional<Selection> select_to_line_begin(const Context& context,
+                                         const Selection& selection);
+
+Optional<Selection> select_to_first_non_blank(const Context& context,
+                                              const Selection& selection);
 
 enum class ObjectFlags
 {
@@ -63,39 +63,39 @@ enum class ObjectFlags
 constexpr bool with_bit_ops(Meta::Type<ObjectFlags>) { return true; }
 
 template<WordType word_type>
-Optional<Selection>
-select_word(const Context& context, const Selection& selection,
-            int count, ObjectFlags flags);
+Optional<Selection> select_word(const Context& context,
+                                const Selection& selection, int count,
+                                ObjectFlags flags);
 
-Optional<Selection>
-select_number(const Context& context, const Selection& selection,
-              int count, ObjectFlags flags);
+Optional<Selection> select_number(const Context& context,
+                                  const Selection& selection, int count,
+                                  ObjectFlags flags);
 
-Optional<Selection>
-select_sentence(const Context& context, const Selection& selection,
-                int count, ObjectFlags flags);
+Optional<Selection> select_sentence(const Context& context,
+                                    const Selection& selection, int count,
+                                    ObjectFlags flags);
 
-Optional<Selection>
-select_paragraph(const Context& context, const Selection& selection,
-                 int count, ObjectFlags flags);
+Optional<Selection> select_paragraph(const Context& context,
+                                     const Selection& selection, int count,
+                                     ObjectFlags flags);
 
-Optional<Selection>
-select_whitespaces(const Context& context, const Selection& selection,
-                   int count, ObjectFlags flags);
+Optional<Selection> select_whitespaces(const Context& context,
+                                       const Selection& selection, int count,
+                                       ObjectFlags flags);
 
-Optional<Selection>
-select_indent(const Context& context, const Selection& selection,
-              int count, ObjectFlags flags);
+Optional<Selection> select_indent(const Context& context,
+                                  const Selection& selection, int count,
+                                  ObjectFlags flags);
 
-Optional<Selection>
-select_argument(const Context& context, const Selection& selection,
-                int level, ObjectFlags flags);
+Optional<Selection> select_argument(const Context& context,
+                                    const Selection& selection, int level,
+                                    ObjectFlags flags);
 
-Optional<Selection>
-select_lines(const Context& context, const Selection& selection);
+Optional<Selection> select_lines(const Context& context,
+                                 const Selection& selection);
 
-Optional<Selection>
-trim_partial_lines(const Context& context, const Selection& selection);
+Optional<Selection> trim_partial_lines(const Context& context,
+                                       const Selection& selection);
 
 void select_buffer(SelectionList& selections);
 
@@ -105,13 +105,16 @@ template<MatchDirection direction>
 Selection find_next_match(const Context& context, const Selection& sel,
                           const Regex& regex, bool& wrapped);
 
-void select_all_matches(SelectionList& selections, const Regex& regex, int capture = 0);
-void split_selections(SelectionList& selections, const Regex& regex, int capture = 0);
+void select_all_matches(SelectionList& selections, const Regex& regex,
+                        int capture = 0);
+void split_selections(SelectionList& selections, const Regex& regex,
+                      int capture = 0);
 
-Optional<Selection>
-select_surrounding(const Context& context, const Selection& selection,
-                   const Regex& opening, const Regex& closing, int level,
-                   ObjectFlags flags);
+Optional<Selection> select_surrounding(const Context& context,
+                                       const Selection& selection,
+                                       const Regex& opening,
+                                       const Regex& closing, int level,
+                                       ObjectFlags flags);
 
 }
 

--- a/src/shared_string.cc
+++ b/src/shared_string.cc
@@ -8,11 +8,10 @@ namespace Kakoune
 
 StringDataPtr StringData::create(ArrayView<const StringView> strs)
 {
-    const int len = accumulate(strs, 0, [](int l, StringView s) {
-                        return l + (int)s.length();
-                    });
-    void* ptr = StringData::operator new(sizeof(StringData) + len + 1);
-    auto* res = new (ptr) StringData(len);
+    const int len = accumulate(
+        strs, 0, [](int l, StringView s) { return l + (int)s.length(); });
+    void* ptr  = StringData::operator new(sizeof(StringData) + len + 1);
+    auto* res  = new (ptr) StringData(len);
     auto* data = reinterpret_cast<char*>(res + 1);
     for (auto& str : strs)
     {
@@ -45,15 +44,17 @@ void StringData::Registry::debug_stats() const
 {
     write_to_debug_buffer("Shared Strings stats:");
     size_t total_refcount = 0;
-    size_t total_size = 0;
-    size_t count = m_strings.size();
+    size_t total_size     = 0;
+    size_t count          = m_strings.size();
     for (auto& st : m_strings)
     {
         total_refcount += (st.value->refcount & refcount_mask) - 1;
         total_size += (int)st.value->length;
     }
-    write_to_debug_buffer(format("  data size: {}, mean: {}", total_size, (float)total_size/count));
-    write_to_debug_buffer(format("  refcounts: {}, mean: {}", total_refcount, (float)total_refcount/count));
+    write_to_debug_buffer(format("  data size: {}, mean: {}", total_size,
+                                 (float)total_size / count));
+    write_to_debug_buffer(format("  refcounts: {}, mean: {}", total_refcount,
+                                 (float)total_refcount / count));
 }
 
 }

--- a/src/shared_string.hh
+++ b/src/shared_string.hh
@@ -16,10 +16,14 @@ struct StringData : UseMemoryDomain<MemoryDomain::SharedString>
     uint32_t refcount;
     const int length;
 
-    [[gnu::always_inline]]
-    const char* data() const { return reinterpret_cast<const char*>(this + 1); }
-    [[gnu::always_inline]]
-    StringView strview() const { return {data(), length}; }
+    [[gnu::always_inline]] const char* data() const
+    {
+        return reinterpret_cast<const char*>(this + 1);
+    }
+    [[gnu::always_inline]] StringView strview() const
+    {
+        return {data(), length};
+    }
 
 private:
     StringData(int len) : refcount(0), length(len) {}
@@ -36,7 +40,8 @@ private:
             {
                 if (r->refcount & interned_flag)
                     Registry::instance().remove(r->strview());
-                StringData::operator delete(r, sizeof(StringData) + r->length + 1);
+                StringData::operator delete(r,
+                                            sizeof(StringData) + r->length + 1);
             }
         }
         static void ptr_moved(StringData*, void*, void*) noexcept {}
@@ -59,7 +64,7 @@ public:
     static Ptr create(ArrayView<const StringView> strs);
 };
 
-using StringDataPtr = StringData::Ptr;
+using StringDataPtr  = StringData::Ptr;
 using StringRegistry = StringData::Registry;
 
 inline StringDataPtr intern(StringView str)

--- a/src/shell_manager.cc
+++ b/src/shell_manager.cc
@@ -20,7 +20,7 @@
 #include <fcntl.h>
 #include <cstdlib>
 
-extern char **environ;
+extern char** environ;
 
 namespace Kakoune
 {
@@ -33,22 +33,23 @@ ShellManager::ShellManager(ConstArrayView<EnvVarDesc> builtin_env_vars)
         if (stat(path.zstr(), &st))
             return false;
 
-        bool executable = (st.st_mode & S_IXUSR)
-                        | (st.st_mode & S_IXGRP)
-                        | (st.st_mode & S_IXOTH);
+        bool executable = (st.st_mode & S_IXUSR) | (st.st_mode & S_IXGRP)
+                          | (st.st_mode & S_IXOTH);
         return S_ISREG(st.st_mode) and executable;
     };
 
     if (const char* shell = getenv("KAKOUNE_POSIX_SHELL"))
     {
         if (not is_executable(shell))
-            throw runtime_error{format("KAKOUNE_POSIX_SHELL '{}' is not executable", shell)};
+            throw runtime_error{
+                format("KAKOUNE_POSIX_SHELL '{}' is not executable", shell)};
         m_shell = shell;
     }
     else // Get a guaranteed to be POSIX shell binary
     {
         auto size = confstr(_CS_PATH, nullptr, 0);
-        String path; path.resize(size-1, 0);
+        String path;
+        path.resize(size - 1, 0);
         confstr(_CS_PATH, path.data(), size);
         for (auto dir : StringView{path} | split<StringView>(':'))
         {
@@ -60,14 +61,16 @@ ShellManager::ShellManager(ConstArrayView<EnvVarDesc> builtin_env_vars)
             }
         }
         if (m_shell.empty())
-            throw runtime_error{format("unable to find a posix shell in {}", path)};
+            throw runtime_error{
+                format("unable to find a posix shell in {}", path)};
     }
 
     // Add Kakoune binary location to the path to guarantee that %sh{ ... }
     // have access to the kak command regardless of if the user installed it
     {
         const char* path = getenv("PATH");
-        auto new_path = format("{}:{}", path, split_path(get_kak_binary_path()).first);
+        auto new_path
+            = format("{}:{}", path, split_path(get_kak_binary_path()).first);
         setenv("PATH", new_path.c_str(), 1);
     }
 }
@@ -77,13 +80,18 @@ namespace
 
 struct Pipe
 {
-    Pipe(bool create = true)
-        : m_fd{-1, -1}
+    Pipe(bool create = true) : m_fd{-1, -1}
     {
         if (create and ::pipe(m_fd) < 0)
-            throw runtime_error(format("unable to create pipe (fds: {}/{}; errno: {})", m_fd[0], m_fd[1], ::strerror(errno)));
+            throw runtime_error(
+                format("unable to create pipe (fds: {}/{}; errno: {})", m_fd[0],
+                       m_fd[1], ::strerror(errno)));
     }
-    ~Pipe() { close_read_fd(); close_write_fd(); }
+    ~Pipe()
+    {
+        close_read_fd();
+        close_write_fd();
+    }
 
     int read_fd() const { return m_fd[0]; }
     int write_fd() const { return m_fd[1]; }
@@ -92,14 +100,20 @@ struct Pipe
     void close_write_fd() { close_fd(m_fd[1]); }
 
 private:
-    void close_fd(int& fd) { if (fd != -1) { close(fd); fd = -1; } }
+    void close_fd(int& fd)
+    {
+        if (fd != -1)
+        {
+            close(fd);
+            fd = -1;
+        }
+    }
     int m_fd[2];
 };
 
 template<typename Func>
 pid_t spawn_shell(const char* shell, StringView cmdline,
-                  ConstArrayView<String> params,
-                  ConstArrayView<String> kak_env,
+                  ConstArrayView<String> params, ConstArrayView<String> kak_env,
                   Func setup_child)
 {
     Vector<const char*> envptrs;
@@ -109,8 +123,8 @@ pid_t spawn_shell(const char* shell, StringView cmdline,
         envptrs.push_back(env.c_str());
     envptrs.push_back(nullptr);
 
-    auto cmdlinezstr = cmdline.zstr();
-    Vector<const char*> execparams = { "sh", "-c", cmdlinezstr };
+    auto cmdlinezstr               = cmdline.zstr();
+    Vector<const char*> execparams = {"sh", "-c", cmdlinezstr};
     if (not params.empty())
         execparams.push_back(shell);
     for (auto& param : params)
@@ -122,12 +136,14 @@ pid_t spawn_shell(const char* shell, StringView cmdline,
 
     setup_child();
 
-    execve(shell, (char* const*)execparams.data(), (char* const*)envptrs.data());
+    execve(shell, (char* const*)execparams.data(),
+           (char* const*)envptrs.data());
     exit(-1);
     return -1;
 }
 
-Vector<String> generate_env(StringView cmdline, const Context& context, const ShellContext& shell_context)
+Vector<String> generate_env(StringView cmdline, const Context& context,
+                            const ShellContext& shell_context)
 {
     static const Regex re(R"(\bkak_(\w+)\b)");
 
@@ -138,8 +154,8 @@ Vector<String> generate_env(StringView cmdline, const Context& context, const Sh
         StringView name{(*it)[1].first, (*it)[1].second};
 
         auto match_name = [&](const String& s) {
-            return s.substr(0_byte, name.length()) == name and
-                   s.substr(name.length(), 1_byte) == "=";
+            return s.substr(0_byte, name.length()) == name
+                   and s.substr(name.length(), 1_byte) == "=";
         };
         if (any_of(kak_env, match_name))
             continue;
@@ -147,11 +163,15 @@ Vector<String> generate_env(StringView cmdline, const Context& context, const Sh
         auto var_it = shell_context.env_vars.find(name);
         try
         {
-            const String& value = var_it != shell_context.env_vars.end() ?
-                var_it->value : ShellManager::instance().get_val(name, context, Quoting::Shell);
+            const String& value = var_it != shell_context.env_vars.end()
+                                      ? var_it->value
+                                      : ShellManager::instance().get_val(
+                                            name, context, Quoting::Shell);
 
             kak_env.push_back(format("kak_{}={}", name, value));
-        } catch (runtime_error&) {}
+        }
+        catch (runtime_error&)
+        {}
     }
 
     return kak_env;
@@ -159,12 +179,13 @@ Vector<String> generate_env(StringView cmdline, const Context& context, const Sh
 
 }
 
-std::pair<String, int> ShellManager::eval(
-    StringView cmdline, const Context& context, StringView input,
-    Flags flags, const ShellContext& shell_context)
+std::pair<String, int> ShellManager::eval(StringView cmdline,
+                                          const Context& context,
+                                          StringView input, Flags flags,
+                                          const ShellContext& shell_context)
 {
     const DebugFlags debug_flags = context.options()["debug"].get<DebugFlags>();
-    const bool profile = debug_flags & DebugFlags::Profile;
+    const bool profile           = debug_flags & DebugFlags::Profile;
     if (debug_flags & DebugFlags::Shell)
         write_to_debug_buffer(format("shell:\n{}\n----\n", cmdline));
 
@@ -175,30 +196,31 @@ std::pair<String, int> ShellManager::eval(
     auto spawn_time = profile ? Clock::now() : Clock::time_point{};
 
     Pipe child_stdin{not input.empty()}, child_stdout, child_stderr;
-    pid_t pid = spawn_shell(m_shell.c_str(), cmdline, shell_context.params, kak_env,
-                            [&child_stdin, &child_stdout, &child_stderr] {
-        set_signal_handler(SIGPIPE, SIG_DFL);
-        auto move = [](int oldfd, int newfd)
-        {
-            if (oldfd == newfd)
-                return;
-            dup2(oldfd, newfd); close(oldfd);
-        };
+    pid_t pid
+        = spawn_shell(m_shell.c_str(), cmdline, shell_context.params, kak_env,
+                      [&child_stdin, &child_stdout, &child_stderr] {
+                          set_signal_handler(SIGPIPE, SIG_DFL);
+                          auto move = [](int oldfd, int newfd) {
+                              if (oldfd == newfd)
+                                  return;
+                              dup2(oldfd, newfd);
+                              close(oldfd);
+                          };
 
-        if (child_stdin.read_fd() != -1)
-        {
-            close(child_stdin.write_fd());
-            move(child_stdin.read_fd(), 0);
-        }
-        else
-            move(open("/dev/null", O_RDONLY), 0);
+                          if (child_stdin.read_fd() != -1)
+                          {
+                              close(child_stdin.write_fd());
+                              move(child_stdin.read_fd(), 0);
+                          }
+                          else
+                              move(open("/dev/null", O_RDONLY), 0);
 
-        close(child_stdout.read_fd());
-        move(child_stdout.write_fd(), 1);
+                          close(child_stdout.read_fd());
+                          move(child_stdout.write_fd(), 1);
 
-        close(child_stderr.read_fd());
-        move(child_stderr.write_fd(), 2);
-    });
+                          close(child_stderr.read_fd());
+                          move(child_stderr.write_fd(), 2);
+                      });
 
     child_stdin.close_read_fd();
     child_stdout.close_write_fd();
@@ -209,45 +231,50 @@ std::pair<String, int> ShellManager::eval(
     struct PipeReader : FDWatcher
     {
         PipeReader(Pipe& pipe, String& contents)
-            : FDWatcher(pipe.read_fd(), FdEvents::Read,
-                        [&contents, &pipe](FDWatcher& watcher, FdEvents, EventMode) {
-                            char buffer[1024];
-                            while (fd_readable(pipe.read_fd()))
-                            {
-                                size_t size = ::read(pipe.read_fd(), buffer, 1024);
-                                if (size <= 0)
-                                {
-                                    pipe.close_read_fd();
-                                    watcher.disable();
-                                    return;
-                                }
-                                contents += StringView{buffer, buffer+size};
-                            }
-                        })
+            : FDWatcher(
+                  pipe.read_fd(), FdEvents::Read,
+                  [&contents, &pipe](FDWatcher& watcher, FdEvents, EventMode) {
+                      char buffer[1024];
+                      while (fd_readable(pipe.read_fd()))
+                      {
+                          size_t size = ::read(pipe.read_fd(), buffer, 1024);
+                          if (size <= 0)
+                          {
+                              pipe.close_read_fd();
+                              watcher.disable();
+                              return;
+                          }
+                          contents += StringView{buffer, buffer + size};
+                      }
+                  })
         {}
     };
 
     struct PipeWriter : FDWatcher
     {
         PipeWriter(Pipe& pipe, StringView contents)
-            : FDWatcher(pipe.write_fd(), FdEvents::Write,
-                        [contents, &pipe](FDWatcher& watcher, FdEvents, EventMode) mutable {
-                            while (fd_writable(pipe.write_fd()))
-                            {
-                                ssize_t size = ::write(pipe.write_fd(), contents.begin(),
-                                                       (size_t)contents.length());
-                                if (size > 0)
-                                    contents = contents.substr(ByteCount{(int)size});
-                                if (size == -1 and (errno == EAGAIN or errno == EWOULDBLOCK))
-                                    return;
-                                if (size < 0 or contents.empty())
-                                {
-                                    pipe.close_write_fd();
-                                    watcher.disable();
-                                    return;
-                                }
-                            }
-                        })
+            : FDWatcher(
+                  pipe.write_fd(), FdEvents::Write,
+                  [contents, &pipe](FDWatcher& watcher, FdEvents,
+                                    EventMode) mutable {
+                      while (fd_writable(pipe.write_fd()))
+                      {
+                          ssize_t size
+                              = ::write(pipe.write_fd(), contents.begin(),
+                                        (size_t)contents.length());
+                          if (size > 0)
+                              contents = contents.substr(ByteCount{(int)size});
+                          if (size == -1
+                              and (errno == EAGAIN or errno == EWOULDBLOCK))
+                              return;
+                          if (size < 0 or contents.empty())
+                          {
+                              pipe.close_write_fd();
+                              watcher.disable();
+                              return;
+                          }
+                      }
+                  })
         {
             int flags = fcntl(pipe.write_fd(), F_GETFL, 0);
             fcntl(pipe.write_fd(), F_SETFL, flags | O_NONBLOCK);
@@ -265,7 +292,8 @@ std::pair<String, int> ShellManager::eval(
     sigemptyset(&mask);
     sigaddset(&mask, SIGCHLD);
     sigprocmask(SIG_BLOCK, &mask, &orig_mask);
-    auto restore_mask = on_scope_end([&] { sigprocmask(SIG_SETMASK, &orig_mask, nullptr); });
+    auto restore_mask
+        = on_scope_end([&] { sigprocmask(SIG_SETMASK, &orig_mask, nullptr); });
 
     int status = 0;
     // check for termination now that SIGCHLD is blocked
@@ -274,43 +302,50 @@ std::pair<String, int> ShellManager::eval(
     using namespace std::chrono;
     static constexpr seconds wait_timeout{1};
     Optional<DisplayLine> previous_status;
-    Timer wait_timer{wait_time + wait_timeout, [&](Timer& timer)
-    {
-        auto wait_duration = Clock::now() - wait_time;
-        if (context.has_client())
-        {
-            auto& client = context.client();
-            if (not previous_status)
-                previous_status = client.current_status();
+    Timer wait_timer{
+        wait_time + wait_timeout,
+        [&](Timer& timer) {
+            auto wait_duration = Clock::now() - wait_time;
+            if (context.has_client())
+            {
+                auto& client = context.client();
+                if (not previous_status)
+                    previous_status = client.current_status();
 
-            client.print_status({ format("waiting for shell command to finish ({}s)",
-                                          duration_cast<seconds>(wait_duration).count()),
-                                    context.faces()["Information"] });
-            client.redraw_ifn();
-        }
-        timer.set_next_date(Clock::now() + wait_timeout);
-    }, EventMode::Urgent};
+                client.print_status(
+                    {format("waiting for shell command to finish ({}s)",
+                            duration_cast<seconds>(wait_duration).count()),
+                     context.faces()["Information"]});
+                client.redraw_ifn();
+            }
+            timer.set_next_date(Clock::now() + wait_timeout);
+        },
+        EventMode::Urgent};
 
-    while (not terminated or child_stdin.write_fd() != -1 or
-           ((flags & Flags::WaitForStdout) and
-            (child_stdout.read_fd() != -1 or child_stderr.read_fd() != -1)))
+    while (
+        not terminated or child_stdin.write_fd() != -1
+        or ((flags & Flags::WaitForStdout)
+            and (child_stdout.read_fd() != -1 or child_stderr.read_fd() != -1)))
     {
-        EventManager::instance().handle_next_events(EventMode::Urgent, &orig_mask);
+        EventManager::instance().handle_next_events(EventMode::Urgent,
+                                                    &orig_mask);
         if (not terminated)
             terminated = waitpid(pid, &status, WNOHANG) != 0;
     }
 
     if (not stderr_contents.empty())
-        write_to_debug_buffer(format("shell stderr: <<<\n{}>>>", stderr_contents));
+        write_to_debug_buffer(
+            format("shell stderr: <<<\n{}>>>", stderr_contents));
 
     if (profile)
     {
         auto end_time = Clock::now();
-        auto full = duration_cast<microseconds>(end_time - start_time);
-        auto spawn = duration_cast<microseconds>(wait_time - spawn_time);
-        auto wait = duration_cast<microseconds>(end_time - wait_time);
-        write_to_debug_buffer(format("shell execution took {} us (spawn: {}, wait: {})",
-                                     (size_t)full.count(), (size_t)spawn.count(), (size_t)wait.count()));
+        auto full     = duration_cast<microseconds>(end_time - start_time);
+        auto spawn    = duration_cast<microseconds>(wait_time - spawn_time);
+        auto wait     = duration_cast<microseconds>(end_time - wait_time);
+        write_to_debug_buffer(format(
+            "shell execution took {} us (spawn: {}, wait: {})",
+            (size_t)full.count(), (size_t)spawn.count(), (size_t)wait.count()));
     }
 
     if (previous_status) // restore the status line
@@ -319,10 +354,12 @@ std::pair<String, int> ShellManager::eval(
         context.client().redraw_ifn();
     }
 
-    return { std::move(stdout_contents), WIFEXITED(status) ? WEXITSTATUS(status) : -1 };
+    return {std::move(stdout_contents),
+            WIFEXITED(status) ? WEXITSTATUS(status) : -1};
 }
 
-String ShellManager::get_val(StringView name, const Context& context, Quoting quoting) const
+String ShellManager::get_val(StringView name, const Context& context,
+                             Quoting quoting) const
 {
     auto env_var = find_if(m_env_vars, [name](const EnvVarDesc& desc) {
         return desc.prefix ? prefix_match(name, desc.str) : name == desc.str;

--- a/src/shell_manager.hh
+++ b/src/shell_manager.hh
@@ -22,7 +22,8 @@ enum class Quoting;
 
 struct EnvVarDesc
 {
-    using Retriever = String (*)(StringView name, const Context&, Quoting quoting);
+    using Retriever
+        = String (*)(StringView name, const Context&, Quoting quoting);
 
     StringView str;
     bool prefix;
@@ -36,19 +37,21 @@ public:
 
     enum class Flags
     {
-        None = 0,
+        None          = 0,
         WaitForStdout = 1
     };
     friend constexpr bool with_bit_ops(Meta::Type<Flags>) { return true; }
 
     std::pair<String, int> eval(StringView cmdline, const Context& context,
                                 StringView input = {},
-                                Flags flags = Flags::WaitForStdout,
+                                Flags flags      = Flags::WaitForStdout,
                                 const ShellContext& shell_context = {});
 
-    String get_val(StringView name, const Context& context, Quoting quoting) const;
+    String get_val(StringView name, const Context& context,
+                   Quoting quoting) const;
 
-    CandidateList complete_env_var(StringView prefix, ByteCount cursor_pos) const;
+    CandidateList complete_env_var(StringView prefix,
+                                   ByteCount cursor_pos) const;
 
 private:
     String m_shell;

--- a/src/string.cc
+++ b/src/string.cc
@@ -14,8 +14,8 @@ String::Data::Data(const char* data, size_t size, size_t capacity)
             ++capacity;
 
         kak_assert(capacity < Long::max_capacity);
-        l.ptr = Alloc{}.allocate(capacity+1);
-        l.size = size;
+        l.ptr      = Alloc{}.allocate(capacity + 1);
+        l.size     = size;
         l.capacity = capacity;
 
         if (data != nullptr)
@@ -44,7 +44,7 @@ String::Data& String::Data::operator=(const Data& other)
 
     const size_t new_size = other.size();
     reserve<false>(new_size);
-    memcpy(data(), other.data(), new_size+1);
+    memcpy(data(), other.data(), new_size + 1);
     set_size(new_size);
 
     return *this;
@@ -81,15 +81,15 @@ void String::Data::reserve(size_t new_capacity)
         ++new_capacity;
 
     kak_assert(new_capacity < Long::max_capacity);
-    char* new_ptr = Alloc{}.allocate(new_capacity+1);
+    char* new_ptr = Alloc{}.allocate(new_capacity + 1);
     if (copy)
     {
-        memcpy(new_ptr, data(), size()+1);
+        memcpy(new_ptr, data(), size() + 1);
         l.size = size();
     }
     release();
 
-    l.ptr = new_ptr;
+    l.ptr      = new_ptr;
     l.capacity = new_capacity;
 }
 
@@ -124,12 +124,12 @@ void String::Data::clear()
 void String::Data::release()
 {
     if (is_long())
-        Alloc{}.deallocate(l.ptr, l.capacity+1);
+        Alloc{}.deallocate(l.ptr, l.capacity + 1);
 }
 
 void String::resize(ByteCount size, char c)
 {
-    const size_t target_size = (size_t)size;
+    const size_t target_size  = (size_t)size;
     const size_t current_size = m_data.size();
     if (target_size < current_size)
         m_data.set_size(target_size);

--- a/src/string.hh
+++ b/src/string.hh
@@ -24,70 +24,104 @@ public:
         return hash_data(str.data(), (int)str.length());
     }
 
-    using iterator = CharType*;
-    using const_iterator = const CharType*;
-    using reverse_iterator = std::reverse_iterator<iterator>;
+    using iterator               = CharType*;
+    using const_iterator         = const CharType*;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-    [[gnu::always_inline]]
-    iterator begin() { return type().data(); }
+    [[gnu::always_inline]] iterator begin() { return type().data(); }
 
-    [[gnu::always_inline]]
-    const_iterator begin() const { return type().data(); }
+    [[gnu::always_inline]] const_iterator begin() const
+    {
+        return type().data();
+    }
 
-    [[gnu::always_inline]]
-    iterator end() { return type().data() + (int)type().length(); }
+    [[gnu::always_inline]] iterator end()
+    {
+        return type().data() + (int)type().length();
+    }
 
-    [[gnu::always_inline]]
-    const_iterator end() const { return type().data() + (int)type().length(); }
+    [[gnu::always_inline]] const_iterator end() const
+    {
+        return type().data() + (int)type().length();
+    }
 
     reverse_iterator rbegin() { return reverse_iterator{end()}; }
-    const_reverse_iterator rbegin() const { return const_reverse_iterator{end()}; }
+    const_reverse_iterator rbegin() const
+    {
+        return const_reverse_iterator{end()};
+    }
 
     reverse_iterator rend() { return reverse_iterator{begin()}; }
-    const_reverse_iterator rend() const { return const_reverse_iterator{begin()}; }
+    const_reverse_iterator rend() const
+    {
+        return const_reverse_iterator{begin()};
+    }
 
     CharType& front() { return *type().data(); }
     const CharType& front() const { return *type().data(); }
     CharType& back() { return type().data()[(int)type().length() - 1]; }
-    const CharType& back() const { return type().data()[(int)type().length() - 1]; }
+    const CharType& back() const
+    {
+        return type().data()[(int)type().length() - 1];
+    }
 
-    [[gnu::always_inline]]
-    CharType& operator[](ByteCount pos) { return type().data()[(int)pos]; }
+    [[gnu::always_inline]] CharType& operator[](ByteCount pos)
+    {
+        return type().data()[(int)pos];
+    }
 
-    [[gnu::always_inline]]
-    const CharType& operator[](ByteCount pos) const { return type().data()[(int)pos]; }
+    [[gnu::always_inline]] const CharType& operator[](ByteCount pos) const
+    {
+        return type().data()[(int)pos];
+    }
 
     Codepoint operator[](CharCount pos) const
-    { return utf8::codepoint(utf8::advance(begin(), end(), pos), end()); }
+    {
+        return utf8::codepoint(utf8::advance(begin(), end(), pos), end());
+    }
 
     CharCount char_length() const { return utf8::distance(begin(), end()); }
-    ColumnCount column_length() const { return utf8::column_distance(begin(), end()); }
+    ColumnCount column_length() const
+    {
+        return utf8::column_distance(begin(), end());
+    }
 
-    [[gnu::always_inline]]
-    bool empty() const { return type().length() == 0_byte; }
+    [[gnu::always_inline]] bool empty() const
+    {
+        return type().length() == 0_byte;
+    }
 
     ByteCount byte_count_to(CharCount count) const
-    { return utf8::advance(begin(), end(), count) - begin(); }
+    {
+        return utf8::advance(begin(), end(), count) - begin();
+    }
 
     ByteCount byte_count_to(ColumnCount count) const
-    { return utf8::advance(begin(), end(), count) - begin(); }
+    {
+        return utf8::advance(begin(), end(), count) - begin();
+    }
 
     CharCount char_count_to(ByteCount count) const
-    { return utf8::distance(begin(), begin() + (int)count); }
+    {
+        return utf8::distance(begin(), begin() + (int)count);
+    }
 
     ColumnCount column_count_to(ByteCount count) const
-    { return utf8::column_distance(begin(), begin() + (int)count); }
+    {
+        return utf8::column_distance(begin(), begin() + (int)count);
+    }
 
     StringView substr(ByteCount from, ByteCount length = INT_MAX) const;
     StringView substr(CharCount from, CharCount length = INT_MAX) const;
     StringView substr(ColumnCount from, ColumnCount length = INT_MAX) const;
 
 private:
-    [[gnu::always_inline]]
-    Type& type() { return *static_cast<Type*>(this); }
-    [[gnu::always_inline]]
-    const Type& type() const { return *static_cast<const Type*>(this); }
+    [[gnu::always_inline]] Type& type() { return *static_cast<Type*>(this); }
+    [[gnu::always_inline]] const Type& type() const
+    {
+        return *static_cast<const Type*>(this);
+    }
 };
 
 constexpr ByteCount strlen(const char* s)
@@ -117,24 +151,22 @@ public:
         while (cp_count-- > 0)
             utf8::dump(std::back_inserter(*this), cp);
     }
-    String(const char* begin, const char* end) : m_data(begin, end-begin) {}
+    String(const char* begin, const char* end) : m_data(begin, end - begin) {}
 
     explicit String(StringView str);
 
-    [[gnu::always_inline]]
-    char* data() { return m_data.data(); }
+    [[gnu::always_inline]] char* data() { return m_data.data(); }
 
-    [[gnu::always_inline]]
-    const char* data() const { return m_data.data(); }
+    [[gnu::always_inline]] const char* data() const { return m_data.data(); }
 
-    [[gnu::always_inline]]
-    ByteCount length() const { return m_data.size(); }
+    [[gnu::always_inline]] ByteCount length() const { return m_data.size(); }
 
-    [[gnu::always_inline]]
-    const char* c_str() const { return m_data.data(); }
+    [[gnu::always_inline]] const char* c_str() const { return m_data.data(); }
 
-    [[gnu::always_inline]]
-    void append(const char* data, ByteCount count) { m_data.append(data, (size_t)count); }
+    [[gnu::always_inline]] void append(const char* data, ByteCount count)
+    {
+        m_data.append(data, (size_t)count);
+    }
 
     void clear() { m_data.clear(); }
 
@@ -159,8 +191,8 @@ public:
 
         struct Long
         {
-            static constexpr size_t max_capacity =
-                (size_t)1 << 8 * (sizeof(size_t) - 1);
+            static constexpr size_t max_capacity = (size_t)1
+                                                   << 8 * (sizeof(size_t) - 1);
 
             char* ptr;
             size_t size;
@@ -170,7 +202,7 @@ public:
         struct Short
         {
             static constexpr size_t capacity = sizeof(Long) - 2;
-            char string[capacity+1];
+            char string[capacity + 1];
             unsigned char size;
         } s;
 
@@ -186,7 +218,10 @@ public:
 
         bool is_long() const { return (s.size & 1) == 0; }
         size_t size() const { return is_long() ? l.size : (s.size >> 1); }
-        size_t capacity() const { return is_long() ? l.capacity : Short::capacity; }
+        size_t capacity() const
+        {
+            return is_long() ? l.capacity : Short::capacity;
+        }
 
         const char* data() const { return is_long() ? l.ptr : s.string; }
         char* data() { return is_long() ? l.ptr : s.string; }
@@ -213,19 +248,27 @@ class StringView : public StringOps<StringView, const char>
 public:
     StringView() = default;
     constexpr StringView(const char* data, ByteCount length)
-        : m_data{data}, m_length{length} {}
-    constexpr StringView(const char* data) : m_data{data}, m_length{data ? strlen(data) : 0} {}
-    constexpr StringView(const char* begin, const char* end) : m_data{begin}, m_length{(int)(end - begin)} {}
-    StringView(const String& str) : m_data{str.data()}, m_length{(int)str.length()} {}
+        : m_data{data}, m_length{length}
+    {}
+    constexpr StringView(const char* data)
+        : m_data{data}, m_length{data ? strlen(data) : 0}
+    {}
+    constexpr StringView(const char* begin, const char* end)
+        : m_data{begin}, m_length{(int)(end - begin)}
+    {}
+    StringView(const String& str)
+        : m_data{str.data()}, m_length{(int)str.length()}
+    {}
     StringView(const char& c) : m_data(&c), m_length(1) {}
-    StringView(int c) = delete;
+    StringView(int c)       = delete;
     StringView(Codepoint c) = delete;
 
-    [[gnu::always_inline]]
-    constexpr const char* data() const { return m_data; }
+    [[gnu::always_inline]] constexpr const char* data() const { return m_data; }
 
-    [[gnu::always_inline]]
-    constexpr ByteCount length() const { return m_length; }
+    [[gnu::always_inline]] constexpr ByteCount length() const
+    {
+        return m_length;
+    }
 
     String str() const { return {m_data, m_length}; }
 
@@ -238,7 +281,10 @@ public:
             else
                 owned = String::Data(begin, end - begin);
         }
-        operator const char*() const { return unowned ? unowned : owned.data(); }
+        operator const char*() const
+        {
+            return unowned ? unowned : owned.data();
+        }
 
     private:
         String::Data owned;
@@ -253,37 +299,45 @@ private:
 
 static_assert(std::is_trivial<StringView>::value, "");
 
-template<> struct HashCompatible<String, StringView> : std::true_type {};
-template<> struct HashCompatible<StringView, String> : std::true_type {};
+template<>
+struct HashCompatible<String, StringView> : std::true_type
+{};
+template<>
+struct HashCompatible<StringView, String> : std::true_type
+{};
 
 inline String::String(StringView str) : String{str.begin(), str.length()} {}
 
 template<typename Type, typename CharType>
-inline StringView StringOps<Type, CharType>::substr(ByteCount from, ByteCount length) const
+inline StringView StringOps<Type, CharType>::substr(ByteCount from,
+                                                    ByteCount length) const
 {
     if (length < 0)
         length = INT_MAX;
     const auto str_len = type().length();
     kak_assert(from >= 0 and from <= str_len);
-    return StringView{ type().data() + (int)from, std::min(str_len - from, length) };
+    return StringView{type().data() + (int)from,
+                      std::min(str_len - from, length)};
 }
 
 template<typename Type, typename CharType>
-inline StringView StringOps<Type, CharType>::substr(CharCount from, CharCount length) const
+inline StringView StringOps<Type, CharType>::substr(CharCount from,
+                                                    CharCount length) const
 {
     if (length < 0)
         length = INT_MAX;
     auto beg = utf8::advance(begin(), end(), from);
-    return StringView{ beg, utf8::advance(beg, end(), length) };
+    return StringView{beg, utf8::advance(beg, end(), length)};
 }
 
 template<typename Type, typename CharType>
-inline StringView StringOps<Type, CharType>::substr(ColumnCount from, ColumnCount length) const
+inline StringView StringOps<Type, CharType>::substr(ColumnCount from,
+                                                    ColumnCount length) const
 {
     if (length < 0)
         length = INT_MAX;
     auto beg = utf8::advance(begin(), end(), from);
-    return StringView{ beg, utf8::advance(beg, end(), length) };
+    return StringView{beg, utf8::advance(beg, end(), length)};
 }
 
 inline String& operator+=(String& lhs, StringView rhs)
@@ -301,27 +355,26 @@ inline String operator+(StringView lhs, StringView rhs)
     return res;
 }
 
-[[gnu::always_inline]]
-inline bool operator==(const StringView& lhs, const StringView& rhs)
+[[gnu::always_inline]] inline bool operator==(const StringView& lhs,
+                                              const StringView& rhs)
 {
-    return lhs.length() == rhs.length() and
-       std::equal(lhs.begin(), lhs.end(), rhs.begin());
+    return lhs.length() == rhs.length()
+           and std::equal(lhs.begin(), lhs.end(), rhs.begin());
 }
 
-[[gnu::always_inline]]
-inline bool operator!=(const StringView& lhs, const StringView& rhs)
-{ return not (lhs == rhs); }
+[[gnu::always_inline]] inline bool operator!=(const StringView& lhs,
+                                              const StringView& rhs)
+{
+    return not(lhs == rhs);
+}
 
 inline bool operator<(const StringView& lhs, const StringView& rhs)
 {
-    return std::lexicographical_compare(lhs.begin(), lhs.end(),
-                                        rhs.begin(), rhs.end());
+    return std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(),
+                                        rhs.end());
 }
 
-inline String operator"" _str(const char* str, size_t)
-{
-    return String(str);
-}
+inline String operator"" _str(const char* str, size_t) { return String(str); }
 
 inline StringView operator"" _sv(const char* str, size_t)
 {

--- a/src/string_utils.hh
+++ b/src/string_utils.hh
@@ -16,7 +16,7 @@ String unescape(StringView str, StringView characters, char escape);
 template<char character, char escape>
 String unescape(StringView str)
 {
-    const char to_escape[2] = { character, escape };
+    const char to_escape[2] = {character, escape};
     return unescape(str, {to_escape, 2}, escape);
 }
 
@@ -27,7 +27,7 @@ String replace(StringView str, StringView substr, StringView replacement);
 template<typename Container>
 String join(const Container& container, char joiner, bool esc_joiner = true)
 {
-    const char to_escape[2] = { joiner, '\\' };
+    const char to_escape[2] = {joiner, '\\'};
     String res;
     for (const auto& str : container)
     {
@@ -66,22 +66,35 @@ int str_to_int(StringView str); // throws on error
 Optional<int> str_to_int_ifp(StringView str);
 
 inline String option_to_string(StringView opt) { return opt.str(); }
-inline String option_from_string(Meta::Type<String>, StringView str) { return str.str(); }
-inline bool option_add(String& opt, StringView val) { opt += val; return not val.empty(); }
+inline String option_from_string(Meta::Type<String>, StringView str)
+{
+    return str.str();
+}
+inline bool option_add(String& opt, StringView val)
+{
+    opt += val;
+    return not val.empty();
+}
 
 template<size_t N>
 struct InplaceString
 {
     static_assert(N < 256, "InplaceString cannot handle sizes >= 256");
 
-    constexpr operator StringView() const { return {m_data, ByteCount{m_length}}; }
+    constexpr operator StringView() const
+    {
+        return {m_data, ByteCount{m_length}};
+    }
     operator String() const { return {m_data, ByteCount{m_length}}; }
 
     unsigned char m_length;
     char m_data[N];
 };
 
-struct Hex { size_t val; };
+struct Hex
+{
+    size_t val;
+};
 constexpr Hex hex(size_t val) { return {val}; }
 
 InplaceString<15> to_string(int val);
@@ -91,7 +104,7 @@ InplaceString<23> to_string(unsigned long val);
 InplaceString<23> to_string(long long int val);
 InplaceString<23> to_string(Hex val);
 InplaceString<23> to_string(float val);
-InplaceString<7>  to_string(Codepoint c);
+InplaceString<7> to_string(Codepoint c);
 
 template<typename RealType, typename ValueType>
 decltype(auto) to_string(const StronglyTypedNumber<RealType, ValueType>& val)
@@ -102,13 +115,20 @@ decltype(auto) to_string(const StronglyTypedNumber<RealType, ValueType>& val)
 namespace detail
 {
 
-template<typename T> constexpr bool is_string = std::is_convertible<T, StringView>::value;
+template<typename T>
+constexpr bool is_string = std::is_convertible<T, StringView>::value;
 
 template<typename T, class = std::enable_if_t<not is_string<T>>>
-decltype(auto) format_param(const T& val) { return to_string(val); }
+decltype(auto) format_param(const T& val)
+{
+    return to_string(val);
+}
 
 template<typename T, class = std::enable_if_t<is_string<T>>>
-StringView format_param(const T& val) { return val; }
+StringView format_param(const T& val)
+{
+    return val;
+}
 
 }
 
@@ -117,23 +137,24 @@ String format(StringView fmt, ArrayView<const StringView> params);
 template<typename... Types>
 String format(StringView fmt, Types&&... params)
 {
-    return format(fmt, ArrayView<const StringView>{detail::format_param(std::forward<Types>(params))...});
+    return format(fmt, ArrayView<const StringView>{detail::format_param(
+                           std::forward<Types>(params))...});
 }
 
-StringView format_to(ArrayView<char> buffer, StringView fmt, ArrayView<const StringView> params);
+StringView format_to(ArrayView<char> buffer, StringView fmt,
+                     ArrayView<const StringView> params);
 
 template<typename... Types>
 StringView format_to(ArrayView<char> buffer, StringView fmt, Types&&... params)
 {
-    return format_to(buffer, fmt, ArrayView<const StringView>{detail::format_param(std::forward<Types>(params))...});
+    return format_to(buffer, fmt,
+                     ArrayView<const StringView>{
+                         detail::format_param(std::forward<Types>(params))...});
 }
 
 String double_up(StringView s, StringView characters);
 
-inline String quote(StringView s)
-{
-    return format("'{}'", double_up(s, "'"));
-}
+inline String quote(StringView s) { return format("'{}'", double_up(s, "'")); }
 
 inline String shell_quote(StringView s)
 {
@@ -150,7 +171,6 @@ inline auto quoter(Quoting quoting)
 {
     return quoting == Quoting::Kakoune ? &quote : &shell_quote;
 }
-
 
 }
 

--- a/src/unicode.hh
+++ b/src/unicode.hh
@@ -14,10 +14,7 @@ namespace Kakoune
 
 using Codepoint = char32_t;
 
-inline bool is_eol(Codepoint c) noexcept
-{
-    return c == '\n';
-}
+inline bool is_eol(Codepoint c) noexcept { return c == '\n'; }
 
 inline bool is_horizontal_blank(Codepoint c) noexcept
 {
@@ -29,10 +26,15 @@ inline bool is_blank(Codepoint c) noexcept
     return c == ' ' or c == '\t' or c == '\n';
 }
 
-enum WordType { Word, WORD };
+enum WordType
+{
+    Word,
+    WORD
+};
 
 template<WordType word_type = Word>
-inline bool is_word(Codepoint c, ConstArrayView<Codepoint> extra_word_chars = {'_'}) noexcept
+inline bool is_word(Codepoint c,
+                    ConstArrayView<Codepoint> extra_word_chars = {'_'}) noexcept
 {
     return iswalnum((wchar_t)c) or contains(extra_word_chars, c);
 }
@@ -43,9 +45,11 @@ inline bool is_word<WORD>(Codepoint c, ConstArrayView<Codepoint>) noexcept
     return not is_blank(c);
 }
 
-inline bool is_punctuation(Codepoint c, ConstArrayView<Codepoint> extra_word_chars = {'_'}) noexcept
+inline bool is_punctuation(Codepoint c,
+                           ConstArrayView<Codepoint> extra_word_chars
+                           = {'_'}) noexcept
 {
-    return not (is_word(c, extra_word_chars) or is_blank(c));
+    return not(is_word(c, extra_word_chars) or is_blank(c));
 }
 
 inline bool is_basic_alpha(Codepoint c) noexcept
@@ -60,8 +64,7 @@ inline bool is_basic_digit(Codepoint c) noexcept
 
 inline bool is_identifier(Codepoint c) noexcept
 {
-    return is_basic_alpha(c) or is_basic_digit(c) or
-           c == '_' or c == '-';
+    return is_basic_alpha(c) or is_basic_digit(c) or c == '_' or c == '-';
 }
 
 inline ColumnCount codepoint_width(Codepoint c) noexcept
@@ -81,7 +84,8 @@ enum class CharCategories
 };
 
 template<WordType word_type = Word>
-inline CharCategories categorize(Codepoint c, ConstArrayView<Codepoint> extra_word_chars) noexcept
+inline CharCategories categorize(
+    Codepoint c, ConstArrayView<Codepoint> extra_word_chars) noexcept
 {
     if (is_eol(c))
         return CharCategories::EndOfLine;
@@ -92,14 +96,26 @@ inline CharCategories categorize(Codepoint c, ConstArrayView<Codepoint> extra_wo
     return CharCategories::Punctuation;
 }
 
-inline Codepoint to_lower(Codepoint cp) noexcept { return towlower((wchar_t)cp); }
-inline Codepoint to_upper(Codepoint cp) noexcept { return towupper((wchar_t)cp); }
+inline Codepoint to_lower(Codepoint cp) noexcept
+{
+    return towlower((wchar_t)cp);
+}
+inline Codepoint to_upper(Codepoint cp) noexcept
+{
+    return towupper((wchar_t)cp);
+}
 
 inline bool is_lower(Codepoint cp) noexcept { return iswlower((wchar_t)cp); }
 inline bool is_upper(Codepoint cp) noexcept { return iswupper((wchar_t)cp); }
 
-inline char to_lower(char c) noexcept { return c >= 'A' and c <= 'Z' ? c - 'A' + 'a' : c; }
-inline char to_upper(char c) noexcept { return c >= 'a' and c <= 'z' ? c - 'a' + 'A' : c; }
+inline char to_lower(char c) noexcept
+{
+    return c >= 'A' and c <= 'Z' ? c - 'A' + 'a' : c;
+}
+inline char to_upper(char c) noexcept
+{
+    return c >= 'a' and c <= 'z' ? c - 'a' + 'A' : c;
+}
 
 inline bool is_lower(char c) noexcept { return c >= 'a' and c <= 'z'; }
 inline bool is_upper(char c) noexcept { return c >= 'A' and c <= 'Z'; }

--- a/src/unit_tests.cc
+++ b/src/unit_tests.cc
@@ -8,48 +8,45 @@
 namespace Kakoune
 {
 
-UnitTest test_utf8{[]()
-{
+UnitTest test_utf8{[]() {
     StringView str = "maïs mélange bientôt";
     kak_assert(utf8::distance(std::begin(str), std::end(str)) == 20);
     kak_assert(utf8::codepoint(std::begin(str) + 2, std::end(str)) == 0x00EF);
 }};
 
-UnitTest test_diff{[]()
-{
+UnitTest test_diff{[]() {
     auto eq = [](const Diff& lhs, const Diff& rhs) {
-        return lhs.mode == rhs.mode and lhs.len == rhs.len and lhs.posB == rhs.posB;
+        return lhs.mode == rhs.mode and lhs.len == rhs.len
+               and lhs.posB == rhs.posB;
     };
 
     {
         auto diff = find_diff("a?", 2, "!", 1);
-        kak_assert(diff.size() == 3 and
-                   eq(diff[0], {Diff::Remove, 1, 0}) and
-                   eq(diff[1], {Diff::Add, 1, 0}) and
-                   eq(diff[2], {Diff::Remove, 1, 0}));
+        kak_assert(diff.size() == 3 and eq(diff[0], {Diff::Remove, 1, 0})
+                   and eq(diff[1], {Diff::Add, 1, 0})
+                   and eq(diff[2], {Diff::Remove, 1, 0}));
     }
 
     {
         auto diff = find_diff("abcde", 5, "cd", 2);
-        kak_assert(diff.size() == 3 and
-                   eq(diff[0], {Diff::Remove, 2, 0}) and
-                   eq(diff[1], {Diff::Keep, 2, 0}) and
-                   eq(diff[2], {Diff::Remove, 1, 0}));
+        kak_assert(diff.size() == 3 and eq(diff[0], {Diff::Remove, 2, 0})
+                   and eq(diff[1], {Diff::Keep, 2, 0})
+                   and eq(diff[2], {Diff::Remove, 1, 0}));
     }
 
     {
         auto diff = find_diff("abcd", 4, "cdef", 4);
-        kak_assert(diff.size() == 3 and
-                   eq(diff[0], {Diff::Remove, 2, 0}) and
-                   eq(diff[1], {Diff::Keep, 2, 0}) and
-                   eq(diff[2], {Diff::Add, 2, 2}));
+        kak_assert(diff.size() == 3 and eq(diff[0], {Diff::Remove, 2, 0})
+                   and eq(diff[1], {Diff::Keep, 2, 0})
+                   and eq(diff[2], {Diff::Add, 2, 2}));
     }
 
     {
         StringView s1 = "mais que fais la police";
         StringView s2 = "mais ou va la police";
 
-        auto diff = find_diff(s1.begin(), (int)s1.length(), s2.begin(), (int)s2.length());
+        auto diff = find_diff(s1.begin(), (int)s1.length(), s2.begin(),
+                              (int)s2.length());
         kak_assert(diff.size() == 11);
     }
 }};

--- a/src/units.hh
+++ b/src/units.hh
@@ -15,110 +15,169 @@ class StronglyTypedNumber
 public:
     StronglyTypedNumber() = default;
 
-    [[gnu::always_inline]]
-    explicit constexpr StronglyTypedNumber(ValueType value)
+    [[gnu::always_inline]] explicit constexpr StronglyTypedNumber(
+        ValueType value)
         : m_value(value)
     {
         static_assert(std::is_base_of<StronglyTypedNumber, RealType>::value,
-                     "RealType is not derived from StronglyTypedNumber");
+                      "RealType is not derived from StronglyTypedNumber");
     }
 
-    [[gnu::always_inline]]
-    constexpr friend RealType operator+(RealType lhs, RealType rhs)
-    { return RealType(lhs.m_value + rhs.m_value); }
+    [[gnu::always_inline]] constexpr friend RealType operator+(RealType lhs,
+                                                               RealType rhs)
+    {
+        return RealType(lhs.m_value + rhs.m_value);
+    }
 
-    [[gnu::always_inline]]
-    constexpr friend RealType operator-(RealType lhs, RealType rhs)
-    { return RealType(lhs.m_value - rhs.m_value); }
+    [[gnu::always_inline]] constexpr friend RealType operator-(RealType lhs,
+                                                               RealType rhs)
+    {
+        return RealType(lhs.m_value - rhs.m_value);
+    }
 
-    [[gnu::always_inline]]
-    constexpr friend RealType operator*(RealType lhs, RealType rhs)
-    { return RealType(lhs.m_value * rhs.m_value); }
+    [[gnu::always_inline]] constexpr friend RealType operator*(RealType lhs,
+                                                               RealType rhs)
+    {
+        return RealType(lhs.m_value * rhs.m_value);
+    }
 
-    [[gnu::always_inline]]
-    constexpr friend RealType operator/(RealType lhs, RealType rhs)
-    { return RealType(lhs.m_value / rhs.m_value); }
+    [[gnu::always_inline]] constexpr friend RealType operator/(RealType lhs,
+                                                               RealType rhs)
+    {
+        return RealType(lhs.m_value / rhs.m_value);
+    }
 
-    [[gnu::always_inline]]
-    RealType& operator+=(RealType other)
-    { m_value += other.m_value; return static_cast<RealType&>(*this); }
+    [[gnu::always_inline]] RealType& operator+=(RealType other)
+    {
+        m_value += other.m_value;
+        return static_cast<RealType&>(*this);
+    }
 
-    [[gnu::always_inline]]
-    RealType& operator-=(RealType other)
-    { m_value -= other.m_value; return static_cast<RealType&>(*this); }
+    [[gnu::always_inline]] RealType& operator-=(RealType other)
+    {
+        m_value -= other.m_value;
+        return static_cast<RealType&>(*this);
+    }
 
-    [[gnu::always_inline]]
-    RealType& operator*=(RealType other)
-    { m_value *= other.m_value; return static_cast<RealType&>(*this); }
+    [[gnu::always_inline]] RealType& operator*=(RealType other)
+    {
+        m_value *= other.m_value;
+        return static_cast<RealType&>(*this);
+    }
 
-    [[gnu::always_inline]]
-    RealType& operator/=(RealType other)
-    { m_value /= other.m_value; return static_cast<RealType&>(*this); }
+    [[gnu::always_inline]] RealType& operator/=(RealType other)
+    {
+        m_value /= other.m_value;
+        return static_cast<RealType&>(*this);
+    }
 
-    [[gnu::always_inline]]
-    RealType& operator++()
-    { ++m_value; return static_cast<RealType&>(*this); }
+    [[gnu::always_inline]] RealType& operator++()
+    {
+        ++m_value;
+        return static_cast<RealType&>(*this);
+    }
 
-    [[gnu::always_inline]]
-    RealType& operator--()
-    { --m_value; return static_cast<RealType&>(*this); }
+    [[gnu::always_inline]] RealType& operator--()
+    {
+        --m_value;
+        return static_cast<RealType&>(*this);
+    }
 
-    [[gnu::always_inline]]
-    RealType operator++(int)
-    { RealType backup(static_cast<RealType&>(*this)); ++m_value; return backup; }
+    [[gnu::always_inline]] RealType operator++(int)
+    {
+        RealType backup(static_cast<RealType&>(*this));
+        ++m_value;
+        return backup;
+    }
 
-    [[gnu::always_inline]]
-    RealType operator--(int)
-    { RealType backup(static_cast<RealType&>(*this)); --m_value; return backup; }
+    [[gnu::always_inline]] RealType operator--(int)
+    {
+        RealType backup(static_cast<RealType&>(*this));
+        --m_value;
+        return backup;
+    }
 
-    [[gnu::always_inline]]
-    constexpr RealType operator-() const { return RealType(-m_value); }
+    [[gnu::always_inline]] constexpr RealType operator-() const
+    {
+        return RealType(-m_value);
+    }
 
-    [[gnu::always_inline]]
-    constexpr friend RealType operator%(RealType lhs, RealType rhs)
-    { return RealType(lhs.m_value % rhs.m_value); }
+    [[gnu::always_inline]] constexpr friend RealType operator%(RealType lhs,
+                                                               RealType rhs)
+    {
+        return RealType(lhs.m_value % rhs.m_value);
+    }
 
-    [[gnu::always_inline]]
-    RealType& operator%=(RealType other)
-    { m_value %= other.m_value; return static_cast<RealType&>(*this); }
+    [[gnu::always_inline]] RealType& operator%=(RealType other)
+    {
+        m_value %= other.m_value;
+        return static_cast<RealType&>(*this);
+    }
 
-    [[gnu::always_inline]]
-    constexpr friend bool operator==(RealType lhs, RealType rhs)
-    { return lhs.m_value == rhs.m_value; }
+    [[gnu::always_inline]] constexpr friend bool operator==(RealType lhs,
+                                                            RealType rhs)
+    {
+        return lhs.m_value == rhs.m_value;
+    }
 
-    [[gnu::always_inline]]
-    constexpr friend bool operator!=(RealType lhs, RealType rhs)
-    { return lhs.m_value != rhs.m_value; }
+    [[gnu::always_inline]] constexpr friend bool operator!=(RealType lhs,
+                                                            RealType rhs)
+    {
+        return lhs.m_value != rhs.m_value;
+    }
 
-    [[gnu::always_inline]]
-    constexpr friend bool operator<(RealType lhs, RealType rhs)
-    { return lhs.m_value < rhs.m_value; }
+    [[gnu::always_inline]] constexpr friend bool operator<(RealType lhs,
+                                                           RealType rhs)
+    {
+        return lhs.m_value < rhs.m_value;
+    }
 
-    [[gnu::always_inline]]
-    constexpr friend bool operator<=(RealType lhs, RealType rhs)
-    { return lhs.m_value <= rhs.m_value; }
+    [[gnu::always_inline]] constexpr friend bool operator<=(RealType lhs,
+                                                            RealType rhs)
+    {
+        return lhs.m_value <= rhs.m_value;
+    }
 
-    [[gnu::always_inline]]
-    constexpr friend bool operator>(RealType lhs, RealType rhs)
-    { return lhs.m_value > rhs.m_value; }
+    [[gnu::always_inline]] constexpr friend bool operator>(RealType lhs,
+                                                           RealType rhs)
+    {
+        return lhs.m_value > rhs.m_value;
+    }
 
-    [[gnu::always_inline]]
-    constexpr friend bool operator>=(RealType lhs, RealType rhs)
-    { return lhs.m_value >= rhs.m_value; }
+    [[gnu::always_inline]] constexpr friend bool operator>=(RealType lhs,
+                                                            RealType rhs)
+    {
+        return lhs.m_value >= rhs.m_value;
+    }
 
-    [[gnu::always_inline]]
-    constexpr bool operator!() const
-    { return not m_value; }
+    [[gnu::always_inline]] constexpr bool operator!() const
+    {
+        return not m_value;
+    }
 
-    [[gnu::always_inline]]
-    explicit constexpr operator ValueType() const { return m_value; }
-    [[gnu::always_inline]]
-    explicit constexpr operator bool() const { return m_value; }
+    [[gnu::always_inline]] explicit constexpr operator ValueType() const
+    {
+        return m_value;
+    }
+    [[gnu::always_inline]] explicit constexpr operator bool() const
+    {
+        return m_value;
+    }
 
-    friend constexpr size_t hash_value(RealType val) { return hash_value(val.m_value); }
-    friend constexpr size_t abs(RealType val) { return val.m_value < ValueType(0) ? -val.m_value : val.m_value; }
+    friend constexpr size_t hash_value(RealType val)
+    {
+        return hash_value(val.m_value);
+    }
+    friend constexpr size_t abs(RealType val)
+    {
+        return val.m_value < ValueType(0) ? -val.m_value : val.m_value;
+    }
 
-    explicit operator size_t() { kak_assert(m_value >= 0); return (size_t)m_value; }
+    explicit operator size_t()
+    {
+        kak_assert(m_value >= 0);
+        return (size_t)m_value;
+    }
 
 protected:
     ValueType m_value;
@@ -128,12 +187,13 @@ struct LineCount : public StronglyTypedNumber<LineCount, int>
 {
     LineCount() = default;
 
-    [[gnu::always_inline]]
-    constexpr LineCount(int value) : StronglyTypedNumber<LineCount>(value) {}
+    [[gnu::always_inline]] constexpr LineCount(int value)
+        : StronglyTypedNumber<LineCount>(value)
+    {}
 };
 
-[[gnu::always_inline]]
-inline constexpr LineCount operator"" _line(unsigned long long int value)
+[[gnu::always_inline]] inline constexpr LineCount operator"" _line(
+    unsigned long long int value)
 {
     return LineCount(value);
 }
@@ -142,12 +202,13 @@ struct ByteCount : public StronglyTypedNumber<ByteCount, int>
 {
     ByteCount() = default;
 
-    [[gnu::always_inline]]
-    constexpr ByteCount(int value) : StronglyTypedNumber<ByteCount>(value) {}
+    [[gnu::always_inline]] constexpr ByteCount(int value)
+        : StronglyTypedNumber<ByteCount>(value)
+    {}
 };
 
-[[gnu::always_inline]]
-inline constexpr ByteCount operator"" _byte(unsigned long long int value)
+[[gnu::always_inline]] inline constexpr ByteCount operator"" _byte(
+    unsigned long long int value)
 {
     return ByteCount(value);
 }
@@ -156,12 +217,13 @@ struct CharCount : public StronglyTypedNumber<CharCount, int>
 {
     CharCount() = default;
 
-    [[gnu::always_inline]]
-    constexpr CharCount(int value) : StronglyTypedNumber<CharCount>(value) {}
+    [[gnu::always_inline]] constexpr CharCount(int value)
+        : StronglyTypedNumber<CharCount>(value)
+    {}
 };
 
-[[gnu::always_inline]]
-inline constexpr CharCount operator"" _char(unsigned long long int value)
+[[gnu::always_inline]] inline constexpr CharCount operator"" _char(
+    unsigned long long int value)
 {
     return CharCount(value);
 }
@@ -170,12 +232,13 @@ struct ColumnCount : public StronglyTypedNumber<ColumnCount, int>
 {
     ColumnCount() = default;
 
-    [[gnu::always_inline]]
-    constexpr ColumnCount(int value) : StronglyTypedNumber<ColumnCount>(value) {}
+    [[gnu::always_inline]] constexpr ColumnCount(int value)
+        : StronglyTypedNumber<ColumnCount>(value)
+    {}
 };
 
-[[gnu::always_inline]]
-inline constexpr ColumnCount operator"" _col(unsigned long long int value)
+[[gnu::always_inline]] inline constexpr ColumnCount operator"" _col(
+    unsigned long long int value)
 {
     return ColumnCount(value);
 }

--- a/src/user_interface.hh
+++ b/src/user_interface.hh
@@ -52,22 +52,24 @@ public:
 
     virtual void menu_show(ConstArrayView<DisplayLine> choices,
                            DisplayCoord anchor, Face fg, Face bg,
-                           MenuStyle style) = 0;
+                           MenuStyle style)
+        = 0;
     virtual void menu_select(int selected) = 0;
-    virtual void menu_hide() = 0;
+    virtual void menu_hide()               = 0;
 
     virtual void info_show(StringView title, StringView content,
-                           DisplayCoord anchor, Face face,
-                           InfoStyle style) = 0;
+                           DisplayCoord anchor, Face face, InfoStyle style)
+        = 0;
     virtual void info_hide() = 0;
 
     virtual void draw(const DisplayBuffer& display_buffer,
-                      const Face& default_face,
-                      const Face& padding_face) = 0;
+                      const Face& default_face, const Face& padding_face)
+        = 0;
 
     virtual void draw_status(const DisplayLine& status_line,
                              const DisplayLine& mode_line,
-                             const Face& default_face) = 0;
+                             const Face& default_face)
+        = 0;
 
     virtual DisplayCoord dimensions() = 0;
 

--- a/src/utf8.hh
+++ b/src/utf8.hh
@@ -14,13 +14,16 @@ namespace utf8
 {
 
 template<typename Iterator>
-[[gnu::always_inline]]
-inline char read(Iterator& it) noexcept { char c = *it; ++it; return c; }
+[[gnu::always_inline]] inline char read(Iterator& it) noexcept
+{
+    char c = *it;
+    ++it;
+    return c;
+}
 
 // return true if it points to the first byte of a (either single or
 // multibyte) character
-[[gnu::always_inline]]
-inline bool is_character_start(char c) noexcept
+[[gnu::always_inline]] inline bool is_character_start(char c) noexcept
 {
     return (c & 0xC0) != 0x80;
 }
@@ -30,7 +33,11 @@ namespace InvalidPolicy
 
 struct Assert
 {
-    Codepoint operator()(Codepoint cp) const { kak_assert(false); return cp; }
+    Codepoint operator()(Codepoint cp) const
+    {
+        kak_assert(false);
+        return cp;
+    }
 };
 
 struct Pass
@@ -42,10 +49,10 @@ struct Pass
 
 // returns the codepoint of the character whose first byte
 // is pointed by it
-template<typename InvalidPolicy = utf8::InvalidPolicy::Pass,
-         typename Iterator, typename Sentinel>
-Codepoint read_codepoint(Iterator& it, const Sentinel& end)
-    noexcept(noexcept(InvalidPolicy{}(0)))
+template<typename InvalidPolicy = utf8::InvalidPolicy::Pass, typename Iterator,
+         typename Sentinel>
+Codepoint read_codepoint(Iterator& it, const Sentinel& end) noexcept(
+    noexcept(InvalidPolicy{}(0)))
 {
     if (it == end)
         return InvalidPolicy{}(-1);
@@ -82,17 +89,16 @@ Codepoint read_codepoint(Iterator& it, const Sentinel& end)
     return InvalidPolicy{}(byte);
 }
 
-template<typename InvalidPolicy = utf8::InvalidPolicy::Pass,
-         typename Iterator, typename Sentinel>
-Codepoint codepoint(Iterator it, const Sentinel& end)
-    noexcept(noexcept(read_codepoint<InvalidPolicy>(it, end)))
+template<typename InvalidPolicy = utf8::InvalidPolicy::Pass, typename Iterator,
+         typename Sentinel>
+Codepoint codepoint(Iterator it, const Sentinel& end) noexcept(
+    noexcept(read_codepoint<InvalidPolicy>(it, end)))
 {
     return read_codepoint<InvalidPolicy>(it, end);
 }
 
 template<typename InvalidPolicy = utf8::InvalidPolicy::Pass>
-ByteCount codepoint_size(char byte)
-    noexcept(noexcept(InvalidPolicy{}(0)))
+ByteCount codepoint_size(char byte) noexcept(noexcept(InvalidPolicy{}(0)))
 {
     if ((byte & 0x80) == 0) // 0xxxxxxx
         return 1;
@@ -109,7 +115,8 @@ ByteCount codepoint_size(char byte)
     }
 }
 
-struct invalid_codepoint{};
+struct invalid_codepoint
+{};
 
 inline ByteCount codepoint_size(Codepoint cp)
 {
@@ -147,7 +154,7 @@ Iterator next(Iterator it, const Sentinel& end) noexcept
 template<typename Iterator, typename Sentinel>
 Iterator finish(Iterator it, const Sentinel& end) noexcept
 {
-    while (it != end and (*(it) & 0xC0) == 0x80)
+    while (it != end and (*(it)&0xC0) == 0x80)
         ++it;
     return it;
 }
@@ -275,7 +282,7 @@ void dump(OutputIterator&& it, Codepoint cp)
     {
         *it++ = 0xF0 | (cp >> 18);
         *it++ = 0x80 | ((cp >> 12) & 0x3F);
-        *it++ = 0x80 | ((cp >> 6)  & 0x3F);
+        *it++ = 0x80 | ((cp >> 6) & 0x3F);
         *it++ = 0x80 | (cp & 0x3F);
     }
     else

--- a/src/utf8_iterator.hh
+++ b/src/utf8_iterator.hh
@@ -13,17 +13,16 @@ namespace utf8
 
 // adapter for an iterator on bytes which permits to iterate
 // on unicode codepoints instead.
-template<typename BaseIt,
-         typename Sentinel = BaseIt,
-         typename CodepointType = Codepoint,
+template<typename BaseIt, typename Sentinel = BaseIt,
+         typename CodepointType  = Codepoint,
          typename DifferenceType = CharCount,
-         typename InvalidPolicy = utf8::InvalidPolicy::Pass>
-class iterator : public std::iterator<std::bidirectional_iterator_tag,
-                                      CodepointType, DifferenceType,
-                                      CodepointType*, CodepointType>
+         typename InvalidPolicy  = utf8::InvalidPolicy::Pass>
+class iterator
+    : public std::iterator<std::bidirectional_iterator_tag, CodepointType,
+                           DifferenceType, CodepointType*, CodepointType>
 {
 public:
-    iterator() = default;
+    iterator()                            = default;
     constexpr static bool noexcept_policy = noexcept(InvalidPolicy{}(0));
 
     iterator(BaseIt it, Sentinel begin, Sentinel end) noexcept
@@ -95,30 +94,65 @@ public:
         return *this;
     }
 
-    bool operator==(const iterator& other) const noexcept { return m_it == other.m_it; }
-    bool operator!=(const iterator& other) const noexcept { return m_it != other.m_it; }
+    bool operator==(const iterator& other) const noexcept
+    {
+        return m_it == other.m_it;
+    }
+    bool operator!=(const iterator& other) const noexcept
+    {
+        return m_it != other.m_it;
+    }
 
-    bool operator< (const iterator& other) const noexcept { return m_it < other.m_it; }
-    bool operator<= (const iterator& other) const noexcept { return m_it <= other.m_it; }
+    bool operator<(const iterator& other) const noexcept
+    {
+        return m_it < other.m_it;
+    }
+    bool operator<=(const iterator& other) const noexcept
+    {
+        return m_it <= other.m_it;
+    }
 
-    bool operator> (const iterator& other) const noexcept { return m_it > other.m_it; }
-    bool operator>= (const iterator& other) const noexcept { return m_it >= other.m_it; }
+    bool operator>(const iterator& other) const noexcept
+    {
+        return m_it > other.m_it;
+    }
+    bool operator>=(const iterator& other) const noexcept
+    {
+        return m_it >= other.m_it;
+    }
 
     template<typename T>
-    std::enable_if_t<std::is_same<T, BaseIt>::value or std::is_same<T, Sentinel>::value, bool>
-    operator==(const T& other) const noexcept { return m_it == other; }
+    std::enable_if_t<std::is_same<T, BaseIt>::value
+                         or std::is_same<T, Sentinel>::value,
+                     bool>
+    operator==(const T& other) const noexcept
+    {
+        return m_it == other;
+    }
 
     template<typename T>
-    std::enable_if_t<std::is_same<T, BaseIt>::value or std::is_same<T, Sentinel>::value, bool>
-    operator!=(const T& other) const noexcept { return m_it != other; }
+    std::enable_if_t<std::is_same<T, BaseIt>::value
+                         or std::is_same<T, Sentinel>::value,
+                     bool>
+    operator!=(const T& other) const noexcept
+    {
+        return m_it != other;
+    }
 
-    bool operator< (const BaseIt& other) const noexcept { return m_it < other; }
-    bool operator<= (const BaseIt& other) const noexcept { return m_it <= other; }
+    bool operator<(const BaseIt& other) const noexcept { return m_it < other; }
+    bool operator<=(const BaseIt& other) const noexcept
+    {
+        return m_it <= other;
+    }
 
-    bool operator> (const BaseIt& other) const noexcept { return m_it > other; }
-    bool operator>= (const BaseIt& other) const noexcept { return m_it >= other; }
+    bool operator>(const BaseIt& other) const noexcept { return m_it > other; }
+    bool operator>=(const BaseIt& other) const noexcept
+    {
+        return m_it >= other;
+    }
 
-    DifferenceType operator-(const iterator& other) const noexcept(noexcept_policy)
+    DifferenceType operator-(const iterator& other) const
+        noexcept(noexcept_policy)
     {
         return (DifferenceType)utf8::distance<InvalidPolicy>(other.m_it, m_it);
     }

--- a/src/utils.hh
+++ b/src/utils.hh
@@ -25,10 +25,7 @@ public:
         return *static_cast<T*>(ms_instance);
     }
 
-    static bool has_instance()
-    {
-        return ms_instance != nullptr;
-    }
+    static bool has_instance() { return ms_instance != nullptr; }
 
 protected:
     Singleton()
@@ -64,16 +61,21 @@ template<typename T>
 class OnScopeEnd
 {
 public:
-    [[gnu::always_inline]]
-    OnScopeEnd(T func) : m_func{std::move(func)}, m_valid{true} {}
+    [[gnu::always_inline]] OnScopeEnd(T func)
+        : m_func{std::move(func)}, m_valid{true}
+    {}
 
-    [[gnu::always_inline]]
-    OnScopeEnd(OnScopeEnd&& other)
-      : m_func{std::move(other.m_func)}, m_valid{other.m_valid}
-    { other.m_valid = false; }
+    [[gnu::always_inline]] OnScopeEnd(OnScopeEnd&& other)
+        : m_func{std::move(other.m_func)}, m_valid{other.m_valid}
+    {
+        other.m_valid = false;
+    }
 
-    [[gnu::always_inline]]
-    ~OnScopeEnd() noexcept(noexcept(std::declval<T>()())) { if (m_valid) m_func(); }
+    [[gnu::always_inline]] ~OnScopeEnd() noexcept(noexcept(std::declval<T>()()))
+    {
+        if (m_valid)
+            m_func();
+    }
 
 private:
     bool m_valid;
@@ -91,9 +93,14 @@ OnScopeEnd<T> on_scope_end(T t)
 struct NestedBool
 {
     void set() { m_count++; }
-    void unset() { kak_assert(m_count > 0); m_count--; }
+    void unset()
+    {
+        kak_assert(m_count > 0);
+        m_count--;
+    }
 
     operator bool() const { return m_count > 0; }
+
 private:
     int m_count = 0;
 };
@@ -121,7 +128,7 @@ private:
 // *** Misc helper functions ***
 
 template<typename T>
-bool operator== (const std::unique_ptr<T>& lhs, T* rhs)
+bool operator==(const std::unique_ptr<T>& lhs, T* rhs)
 {
     return lhs.get() == rhs;
 }

--- a/src/value.hh
+++ b/src/value.hh
@@ -10,7 +10,8 @@
 namespace Kakoune
 {
 
-struct bad_value_cast {};
+struct bad_value_cast
+{};
 
 struct Value
 {
@@ -18,11 +19,11 @@ struct Value
 
     template<typename T,
              typename = std::enable_if_t<not std::is_same<Value, T>::value>>
-    Value(T&& val)
-        : m_value{new Model<std::decay_t<T>>{std::forward<T>(val)}} {}
+    Value(T&& val) : m_value{new Model<std::decay_t<T>>{std::forward<T>(val)}}
+    {}
 
     Value(const Value& val) = delete;
-    Value(Value&&) = default;
+    Value(Value&&)          = default;
 
     Value& operator=(const Value& val) = delete;
     Value& operator=(Value&& val) = default;
@@ -52,7 +53,7 @@ struct Value
 private:
     struct Concept
     {
-        virtual ~Concept() = default;
+        virtual ~Concept()                         = default;
         virtual const std::type_info& type() const = 0;
     };
 
@@ -68,7 +69,9 @@ private:
     std::unique_ptr<Concept> m_value;
 };
 
-enum class ValueId : int {};
+enum class ValueId : int
+{
+};
 
 inline ValueId get_free_value_id()
 {

--- a/src/window.cc
+++ b/src/window.cc
@@ -21,9 +21,7 @@ namespace Kakoune
 void setup_builtin_highlighters(HighlighterGroup& group);
 
 Window::Window(Buffer& buffer)
-    : Scope(buffer),
-      m_buffer(&buffer),
-      m_builtin_highlighters{highlighters()}
+    : Scope(buffer), m_buffer(&buffer), m_builtin_highlighters{highlighters()}
 {
     run_hook_in_own_context(Hook::WinCreate, buffer.name());
 
@@ -32,9 +30,9 @@ Window::Window(Buffer& buffer)
     setup_builtin_highlighters(m_builtin_highlighters.group());
 
     // gather as on_option_changed can mutate the option managers
-    for (auto& option : options().flatten_options()
-                      | transform([](auto& ptr) { return ptr.get(); })
-                      | gather<Vector<const Option*>>())
+    for (auto& option : options().flatten_options() | transform([](auto& ptr) {
+                            return ptr.get();
+                        }) | gather<Vector<const Option*>>())
         on_option_changed(*option);
 }
 
@@ -57,7 +55,7 @@ void Window::display_line_at(LineCount buffer_line, LineCount display_line)
 
 void Window::center_line(LineCount buffer_line)
 {
-    display_line_at(buffer_line, m_dimensions.line/2_line);
+    display_line_at(buffer_line, m_dimensions.line / 2_line);
 }
 
 void Window::scroll(ColumnCount offset)
@@ -65,7 +63,8 @@ void Window::scroll(ColumnCount offset)
     m_position.column = std::max(0_col, m_position.column + offset);
 }
 
-void Window::display_column_at(ColumnCount buffer_column, ColumnCount display_column)
+void Window::display_column_at(ColumnCount buffer_column,
+                               ColumnCount display_column)
 {
     if (display_column >= 0 or display_column < m_dimensions.column)
         m_position.column = std::max(0_col, buffer_column - display_column);
@@ -73,14 +72,16 @@ void Window::display_column_at(ColumnCount buffer_column, ColumnCount display_co
 
 void Window::center_column(ColumnCount buffer_column)
 {
-    display_column_at(buffer_column, m_dimensions.column/2_col);
+    display_column_at(buffer_column, m_dimensions.column / 2_col);
 }
 
 static uint32_t compute_faces_hash(const FaceRegistry& faces)
 {
     uint32_t hash = 0;
-    for (auto&& face : faces.flatten_faces() | transform(&FaceRegistry::FaceMap::Item::value))
-        hash = combine_hash(hash, face.alias.empty() ? hash_value(face.face) : hash_value(face.alias));
+    for (auto&& face :
+         faces.flatten_faces() | transform(&FaceRegistry::FaceMap::Item::value))
+        hash = combine_hash(hash, face.alias.empty() ? hash_value(face.face)
+                                                     : hash_value(face.alias));
     return hash;
 }
 
@@ -90,29 +91,30 @@ Window::Setup Window::build_setup(const Context& context) const
     for (auto& sel : context.selections())
         selections.push_back({sel.cursor(), sel.anchor()});
 
-    return { m_position, m_dimensions,
-             context.buffer().timestamp(),
-             compute_faces_hash(context.faces()),
-             context.selections().main_index(),
-             std::move(selections) };
+    return {m_position,
+            m_dimensions,
+            context.buffer().timestamp(),
+            compute_faces_hash(context.faces()),
+            context.selections().main_index(),
+            std::move(selections)};
 }
 
 bool Window::needs_redraw(const Context& context) const
 {
     auto& selections = context.selections();
 
-    if (m_position != m_last_setup.position or
-        m_dimensions != m_last_setup.dimensions or
-        context.buffer().timestamp() != m_last_setup.timestamp or
-        selections.main_index() != m_last_setup.main_selection or
-        selections.size() != m_last_setup.selections.size() or
-        compute_faces_hash(context.faces()) != m_last_setup.faces_hash)
+    if (m_position != m_last_setup.position
+        or m_dimensions != m_last_setup.dimensions
+        or context.buffer().timestamp() != m_last_setup.timestamp
+        or selections.main_index() != m_last_setup.main_selection
+        or selections.size() != m_last_setup.selections.size()
+        or compute_faces_hash(context.faces()) != m_last_setup.faces_hash)
         return true;
 
     for (int i = 0; i < selections.size(); ++i)
     {
-        if (selections[i].cursor() != m_last_setup.selections[i].begin or
-            selections[i].anchor() != m_last_setup.selections[i].end)
+        if (selections[i].cursor() != m_last_setup.selections[i].begin
+            or selections[i].anchor() != m_last_setup.selections[i].end)
             return true;
     }
 
@@ -121,19 +123,24 @@ bool Window::needs_redraw(const Context& context) const
 
 const DisplayBuffer& Window::update_display_buffer(const Context& context)
 {
-    const bool profile = context.options()["debug"].get<DebugFlags>() &
-                        DebugFlags::Profile;
+    const bool profile
+        = context.options()["debug"].get<DebugFlags>() & DebugFlags::Profile;
 
     auto start_time = profile ? Clock::now() : Clock::time_point{};
 
     if (m_display_buffer.timestamp() != -1)
     {
-        for (auto&& change : buffer().changes_since(m_display_buffer.timestamp()))
+        for (auto&& change :
+             buffer().changes_since(m_display_buffer.timestamp()))
         {
-            if (change.type == Buffer::Change::Insert and change.begin.line < m_position.line)
+            if (change.type == Buffer::Change::Insert
+                and change.begin.line < m_position.line)
                 m_position.line += change.end.line - change.begin.line;
-            if (change.type == Buffer::Change::Erase and change.begin.line < m_position.line)
-                m_position.line = std::max(m_position.line - (change.end.line - change.begin.line), change.begin.line);
+            if (change.type == Buffer::Change::Erase
+                and change.begin.line < m_position.line)
+                m_position.line = std::max(
+                    m_position.line - (change.end.line - change.begin.line),
+                    change.begin.line);
         }
     }
 
@@ -141,7 +148,7 @@ const DisplayBuffer& Window::update_display_buffer(const Context& context)
     m_display_buffer.set_timestamp(buffer().timestamp());
     lines.clear();
 
-    if (m_dimensions == DisplayCoord{0,0})
+    if (m_dimensions == DisplayCoord{0, 0})
         return m_display_buffer;
 
     kak_assert(&buffer() == &context.buffer());
@@ -153,32 +160,41 @@ const DisplayBuffer& Window::update_display_buffer(const Context& context)
         LineCount buffer_line = setup.window_pos.line + line;
         if (buffer_line >= buffer().line_count())
             break;
-        auto beg_byte = get_byte_to_column(buffer(), tabstop, {buffer_line, setup.window_pos.column});
-        auto end_byte = setup.full_lines ?
-            buffer()[buffer_line].length()
-          : get_byte_to_column(buffer(), tabstop, {buffer_line, setup.window_pos.column + setup.window_range.column});
+        auto beg_byte = get_byte_to_column(
+            buffer(), tabstop, {buffer_line, setup.window_pos.column});
+        auto end_byte
+            = setup.full_lines
+                  ? buffer()[buffer_line].length()
+                  : get_byte_to_column(
+                        buffer(), tabstop,
+                        {buffer_line,
+                         setup.window_pos.column + setup.window_range.column});
 
-        // The display buffer always has at least one buffer atom, which might be empty if
-        // beg_byte == end_byte
-        lines.emplace_back(AtomList{ {buffer(), {buffer_line, beg_byte}, {buffer_line, end_byte}} });
+        // The display buffer always has at least one buffer atom, which might
+        // be empty if beg_byte == end_byte
+        lines.emplace_back(AtomList{
+            {buffer(), {buffer_line, beg_byte}, {buffer_line, end_byte}}});
     }
 
     m_display_buffer.compute_range();
-    const BufferRange range{{0,0}, buffer().end_coord()};
-    for (auto pass : { HighlightPass::Wrap, HighlightPass::Move, HighlightPass::Colorize })
-        m_builtin_highlighters.highlight({context, setup, pass, {}}, m_display_buffer, range);
+    const BufferRange range{{0, 0}, buffer().end_coord()};
+    for (auto pass :
+         {HighlightPass::Wrap, HighlightPass::Move, HighlightPass::Colorize})
+        m_builtin_highlighters.highlight({context, setup, pass, {}},
+                                         m_display_buffer, range);
 
     m_display_buffer.optimize();
 
     set_position(setup.window_pos);
     m_last_setup = build_setup(context);
 
-    if (profile and not (buffer().flags() & Buffer::Flags::Debug))
+    if (profile and not(buffer().flags() & Buffer::Flags::Debug))
     {
         using namespace std::chrono;
         auto duration = duration_cast<microseconds>(Clock::now() - start_time);
-        write_to_debug_buffer(format("window display update for '{}' took {} us",
-                                     buffer().display_name(), (size_t)duration.count()));
+        write_to_debug_buffer(
+            format("window display update for '{}' took {} us",
+                   buffer().display_name(), (size_t)duration.count()));
     }
 
     return m_display_buffer;
@@ -186,7 +202,7 @@ const DisplayBuffer& Window::update_display_buffer(const Context& context)
 
 void Window::set_position(DisplayCoord position)
 {
-    m_position.line = clamp(position.line, 0_line, buffer().line_count()-1);
+    m_position.line   = clamp(position.line, 0_line, buffer().line_count() - 1);
     m_position.column = std::max(0_col, position.column);
 }
 
@@ -195,14 +211,16 @@ void Window::set_dimensions(DisplayCoord dimensions)
     if (m_dimensions != dimensions)
     {
         m_dimensions = dimensions;
-        run_hook_in_own_context(Hook::WinResize, format("{}.{}", dimensions.line,
-                                                    dimensions.column));
+        run_hook_in_own_context(
+            Hook::WinResize,
+            format("{}.{}", dimensions.line, dimensions.column));
     }
 }
 
 static void check_display_setup(const DisplaySetup& setup, const Window& window)
 {
-    kak_assert(setup.window_pos.line >= 0 and setup.window_pos.line < window.buffer().line_count());
+    kak_assert(setup.window_pos.line >= 0
+               and setup.window_pos.line < window.buffer().line_count());
     kak_assert(setup.window_pos.column >= 0);
     kak_assert(setup.window_range.column >= 0);
     kak_assert(setup.window_range.line >= 0);
@@ -213,40 +231,43 @@ DisplaySetup Window::compute_display_setup(const Context& context) const
     auto win_pos = m_position;
 
     DisplayCoord offset = options()["scrolloff"].get<DisplayCoord>();
-    offset.line = std::min(offset.line, (m_dimensions.line + 1) / 2);
+    offset.line         = std::min(offset.line, (m_dimensions.line + 1) / 2);
     offset.column = std::min(offset.column, (m_dimensions.column + 1) / 2);
 
-    const int tabstop = context.options()["tabstop"].get<int>();
+    const int tabstop  = context.options()["tabstop"].get<int>();
     const auto& cursor = context.selections().main().cursor();
 
     // Ensure cursor line is visible
     if (cursor.line - offset.line < win_pos.line)
         win_pos.line = std::max(0_line, cursor.line - offset.line);
     if (cursor.line + offset.line >= win_pos.line + m_dimensions.line)
-        win_pos.line = std::min(buffer().line_count()-1, cursor.line + offset.line - m_dimensions.line + 1);
+        win_pos.line
+            = std::min(buffer().line_count() - 1,
+                       cursor.line + offset.line - m_dimensions.line + 1);
 
-    DisplaySetup setup{
-        win_pos,
-        m_dimensions,
-        {cursor.line - win_pos.line,
-         get_column(buffer(), tabstop, cursor) - win_pos.column},
-        offset,
-        false
-    };
-    for (auto pass : { HighlightPass::Move, HighlightPass::Wrap })
-        m_builtin_highlighters.compute_display_setup({context, setup, pass, {}}, setup);
+    DisplaySetup setup{win_pos,
+                       m_dimensions,
+                       {cursor.line - win_pos.line,
+                        get_column(buffer(), tabstop, cursor) - win_pos.column},
+                       offset,
+                       false};
+    for (auto pass : {HighlightPass::Move, HighlightPass::Wrap})
+        m_builtin_highlighters.compute_display_setup({context, setup, pass, {}},
+                                                     setup);
     check_display_setup(setup, *this);
 
     // now ensure the cursor column is visible
     {
-        auto underflow = std::max(-setup.window_pos.column,
-                                  setup.cursor_pos.column - setup.scroll_offset.column);
+        auto underflow
+            = std::max(-setup.window_pos.column,
+                       setup.cursor_pos.column - setup.scroll_offset.column);
         if (underflow < 0)
         {
             setup.window_pos.column += underflow;
             setup.cursor_pos.column -= underflow;
         }
-        auto overflow = setup.cursor_pos.column + setup.scroll_offset.column - setup.window_range.column + 1;
+        auto overflow = setup.cursor_pos.column + setup.scroll_offset.column
+                        - setup.window_range.column + 1;
         if (overflow > 0)
         {
             setup.window_pos.column += overflow;
@@ -266,12 +287,13 @@ ColumnCount find_display_column(const DisplayLine& line, const Buffer& buffer,
     ColumnCount column = 0;
     for (auto& atom : line)
     {
-        if (atom.has_buffer_range() and
-            coord >= atom.begin() and coord < atom.end())
+        if (atom.has_buffer_range() and coord >= atom.begin()
+            and coord < atom.end())
         {
             if (atom.type() == DisplayAtom::Range)
-                column += utf8::column_distance(get_iterator(buffer, atom.begin()),
-                                                get_iterator(buffer, coord));
+                column
+                    += utf8::column_distance(get_iterator(buffer, atom.begin()),
+                                             get_iterator(buffer, coord));
             return column;
         }
         column += atom.length();
@@ -292,13 +314,13 @@ BufferCoord find_buffer_coord(const DisplayLine& line, const Buffer& buffer,
                 return buffer.clamp(
                     utf8::advance(get_iterator(buffer, atom.begin()),
                                   get_iterator(buffer, range.end),
-                                  std::max(0_col, column)).coord());
-             return buffer.clamp(atom.begin());
+                                  std::max(0_col, column))
+                        .coord());
+            return buffer.clamp(atom.begin());
         }
         column -= len;
     }
-    return range.end == BufferCoord{0,0} ?
-        range.end : buffer.prev(range.end);
+    return range.end == BufferCoord{0, 0} ? range.end : buffer.prev(range.end);
 }
 }
 
@@ -320,38 +342,36 @@ Optional<DisplayCoord> Window::display_position(BufferCoord coord) const
 
 BufferCoord Window::buffer_coord(DisplayCoord coord) const
 {
-    if (m_display_buffer.timestamp() != buffer().timestamp() or
-        m_display_buffer.lines().empty())
+    if (m_display_buffer.timestamp() != buffer().timestamp()
+        or m_display_buffer.lines().empty())
         return {0, 0};
     if (coord <= 0_line)
-        coord = {0,0};
+        coord = {0, 0};
     if ((size_t)coord.line >= m_display_buffer.lines().size())
-        coord = DisplayCoord{(int)m_display_buffer.lines().size()-1, INT_MAX};
+        coord = DisplayCoord{(int)m_display_buffer.lines().size() - 1, INT_MAX};
 
     return find_buffer_coord(m_display_buffer.lines()[(int)coord.line],
                              buffer(), coord.column);
 }
 
-void Window::clear_display_buffer()
-{
-    m_display_buffer = DisplayBuffer{};
-}
+void Window::clear_display_buffer() { m_display_buffer = DisplayBuffer{}; }
 
 void Window::on_option_changed(const Option& option)
 {
-    run_hook_in_own_context(Hook::WinSetOption, format("{}={}", option.name(),
-                                                   option.get_as_string(Quoting::Kakoune)));
+    run_hook_in_own_context(
+        Hook::WinSetOption,
+        format("{}={}", option.name(), option.get_as_string(Quoting::Kakoune)));
     // an highlighter might depend on the option, so we need to redraw
     force_redraw();
 }
 
-
-void Window::run_hook_in_own_context(Hook hook, StringView param, String client_name)
+void Window::run_hook_in_own_context(Hook hook, StringView param,
+                                     String client_name)
 {
     if (m_buffer->flags() & Buffer::Flags::NoHooks)
         return;
 
-    InputHandler hook_handler{{ *m_buffer, Selection{} },
+    InputHandler hook_handler{{*m_buffer, Selection{}},
                               Context::Flags::Draft,
                               std::move(client_name)};
     hook_handler.context().set_window(*this);

--- a/src/window.hh
+++ b/src/window.hh
@@ -15,7 +15,9 @@ namespace Kakoune
 enum class Hook;
 
 // A Window is a view onto a Buffer
-class Window final : public SafeCountable, public Scope, private OptionManagerWatcher
+class Window final : public SafeCountable,
+                     public Scope,
+                     private OptionManagerWatcher
 {
 public:
     Window(Buffer& buffer);
@@ -33,7 +35,8 @@ public:
 
     void scroll(ColumnCount offset);
     void center_column(ColumnCount buffer_column);
-    void display_column_at(ColumnCount buffer_column, ColumnCount display_column);
+    void display_column_at(ColumnCount buffer_column,
+                           ColumnCount display_column);
 
     const DisplayBuffer& update_display_buffer(const Context& context);
 
@@ -48,6 +51,7 @@ public:
     void set_client(Client* client) { m_client = client; }
 
     void clear_display_buffer();
+
 private:
     Window(const Window&) = delete;
 

--- a/src/word_db.hh
+++ b/src/word_db.hh
@@ -24,6 +24,7 @@ public:
     RankedMatchList find_matching(StringView str);
 
     int get_word_occurences(StringView word) const;
+
 private:
     void update_db();
     void add_words(StringView line);
@@ -40,7 +41,7 @@ private:
         int refcount;
     };
     using WordToInfo = HashMap<StringView, WordInfo, MemoryDomain::WordDB>;
-    using Lines = Vector<StringDataPtr, MemoryDomain::WordDB>;
+    using Lines      = Vector<StringDataPtr, MemoryDomain::WordDB>;
 
     SafePtr<const Buffer> m_buffer;
     size_t m_timestamp;


### PR DESCRIPTION
Formatting all the C++ code in the `src` directory can be done by
using the `format` target implemented in the Makefile:

```
$ make format
```

Please note that `clang-format` doesn't allow -yet- granularity not every single piece of code, so some patterns change (e.g. spaces around binary operators, empty braces after constructors).

Comment directly on the cosmetics commit, if needed.