### PR TITLE
src: Silently handle counts in locked-view mode

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -339,12 +339,16 @@ void view_commands(Context& context, NormalParams params)
         if (key == Key::Escape)
             return;
 
-        if (lock)
-            view_commands<true>(context, { count, 0 });
-
         auto cp = key.codepoint();
         if (not cp or not context.has_window())
             return;
+
+        if (lock and isdigit(*cp))
+        {
+            const long long new_count = (long long)count * 10 + *cp - '0';
+            if (new_count <= std::numeric_limits<int>::max())
+                return view_commands<true>(context, {(int)new_count, 0});
+        }
 
         const BufferCoord cursor = context.selections().main().cursor();
         Window& window = context.window();
@@ -377,6 +381,9 @@ void view_commands(Context& context, NormalParams params)
             window.scroll( std::max<ColumnCount>(1, count));
             break;
         }
+
+        if (lock)
+            view_commands<true>(context, {0, 0});
     }, lock ? "view (lock)" : "view",
     build_autoinfo_for_mapping(context, KeymapMode::View,
         {{{'v','c'}, "center cursor (vertically)"},


### PR DESCRIPTION
The locked-view mode only uses the count passed to `V` to execute
further commands, this commit allows using a separate count for each.

Ideally the count should be passed to the `Normal` input handler to
have it displayed in the mode line, but we can still handle digits
individually from the menu using tail recursive calls.

Fixes #996