### PR TITLE
src: The `test` build target depends on `kak`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -102,7 +102,7 @@ man: ../doc/kak.1
 endif
 
 check: test
-test:
+test: kak
 	cd ../test && ./run
 
 TAGS: tags


### PR DESCRIPTION
Not having the `test` target (in the Makefile) depend on the `kak` one
prevents users from running commands that make use of parallelism, e.g.:

$ make -j all test

The above command sometimes results in the test suite running before
the binary has been compiled and symlinked, resulting in failures.