### PR TITLE
Use _exit() after vfork()

### DIFF
--- a/src/shell_manager.cc
+++ b/src/shell_manager.cc
@@ -123,7 +123,7 @@ pid_t spawn_shell(const char* shell, StringView cmdline,
     setup_child();
 
     execve(shell, (char* const*)execparams.data(), (char* const*)envptrs.data());
-    exit(-1);
+    _exit(-1);
     return -1;
 }
 


### PR DESCRIPTION
Closes #2620

The docs for Mac OS X's vfork() requires it, and _exit() conforms to
POSIX.1-2008.

http://man7.org/linux/man-pages/man2/_exit.2.html

I suspect Mac OS X has some exit handlers that were being run twice
in the parent's address space.