### PR TITLE
A minor grammar fix

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -293,7 +293,7 @@ void edit(const ParametersParser& parser, Context& context, const ShellContext&)
 }
 
 ParameterDesc edit_params{
-    { { "existing", { false, "fail if the file does not exists, do not open a new file" } },
+    { { "existing", { false, "fail if the file does not exist, do not open a new file" } },
       { "scratch",  { false, "create a scratch buffer, not linked to a file" } },
       { "debug",    { false, "create buffer as debug output" } },
       { "fifo",     { true,  "create a buffer reading its content from a named fifo" } },


### PR DESCRIPTION
Probably, the extra «s» at the end of «exist» was added accidentally. A verb after «does not» in Present Simple definitely shouldn't have this extra «s».