### PR TITLE
Reimplemented ctags-search command

### DIFF
--- a/rc/tools/ctags.kak
+++ b/rc/tools/ctags.kak
@@ -25,27 +25,38 @@ If no symbol is passed then the current selection is used as symbol name} \
     ctags-search \
     %{ evaluate-commands %sh{
         realpath() { ( cd "$(dirname "$1")"; printf "%s/%s\n" "$(pwd -P)" "$(basename "$1")" ) }
-        export tagname=${1:-${kak_selection}}
+        export tagname="${1:-${kak_selection}}"
         eval "set -- $kak_opt_ctagsfiles"
         for candidate in "$@"; do
             [ -f "$candidate" ] && realpath "$candidate"
         done | awk '!x[$0]++' | # remove duplicates
         while read -r tags; do
             printf '!TAGROOT\t%s\n' "$(realpath "${tags%/*}")/"
-            readtags -t "$tags" $tagname
+            readtags -t "$tags" "$tagname"
         done | awk -F '\t|\n' '
-        /^!TAGROOT\t/ { tagroot=$2 }
-        /[^\t]+\t[^\t]+\t\/\^.*\$?\// {
-            re=$0;
-            sub(".*\t/\\^", "", re); sub("\\$?/$", "", re); gsub("(\\{|\\}|\\\\E).*$", "", re);
-            keys=re; gsub(/</, "<lt>", keys); gsub(/\t/, "<c-v><c-i>", keys);
-            out = out " %{" $2 " {MenuInfo}" re "} %{evaluate-commands %{ try %{ edit %{" path($2) "}; execute-keys %{/\\Q" keys "<ret>vc} } catch %{ echo %{unable to find tag} } } }"
-        }
-        /[^\t]+\t[^\t]+\t[0-9]+/ { out = out " %{" $2 ":" $3 "} %{evaluate-commands %{ edit %{" path($2) "} %{" $3 "}}}" }
-        END { print ( length(out) == 0 ? "echo -markup %{{Error}no such tag " ENVIRON["tagname"] "}" : "menu -markup -auto-single " out ) }
-
-        # Ensure x is an absolute file path, by prepending with tagroot
-        function path(x) { return x ~/^\// ? x : tagroot x }'
+            /^!TAGROOT\t/ { tagroot=$2 }
+            /[^\t]+\t[^\t]+\t\/\^.*\$?\// {
+                opener = "\\{"; closer = "\\}"
+                line = $0; sub(".*\t/\\^", "", line); sub("\\$?/$", "", line);
+                menu_info = line; gsub("!", "!!", menu_info); gsub(/^[\t+ ]+/, "", menu_info); gsub(opener, "\\"opener, menu_info); gsub(/\t/, " ", menu_info);
+                keys = line; gsub(/</, "<lt>", keys); gsub(/\t/, "<c-v><c-i>", keys); gsub("!", "!!", keys); gsub("&", "&&", keys); gsub("#", "##", keys); gsub("\\|", "||", keys); gsub("\\\\/", "/", keys);
+                menu_item = $2; gsub("!", "!!", menu_item);
+                edit_path = path($2); gsub("&", "&&", edit_path); gsub("#", "##", edit_path); gsub("\\|", "||", edit_path);
+                select = $1; gsub(/</, "<lt>", select); gsub(/\t/, "<c-v><c-i>", select); gsub("!", "!!", select); gsub("&", "&&", select); gsub("#", "##", select); gsub("\\|", "||", select);
+                out = out "%!" menu_item ": {MenuInfo}" menu_info "! %!evaluate-commands %# try %& edit -existing %|" edit_path "|; execute-keys %|/\\Q" keys "<ret>vc| & catch %& echo -markup %|{Error}unable to find tag| &; try %& execute-keys %|s\\Q" select "<ret>| & # !"
+            }
+            /[^\t]+\t[^\t]+\t[0-9]+/ {
+                opener = "{"; closer = "}"
+                menu_item = $2; gsub("!", "!!", menu_item);
+                select = $1; gsub(/</, "<lt>", select); gsub(/\t/, "<c-v><c-i>", select); gsub("!", "!!", select); gsub("&", "&&", select); gsub("#", "##", select); gsub("\\|", "||", select);
+                menu_info = $3; gsub("!", "!!", menu_info); gsub(opener, "\\"opener, menu_info);
+                edit_path = path($2); gsub("!", "!!", edit_path); gsub("#", "##", edit_path); gsub("&", "&&", edit_path); gsub("\\|", "||", edit_path);
+                line_number = $3;
+                out = out "%!" menu_item ": {MenuInfo}" menu_info "! %!evaluate-commands %# try %& edit -existing %|" edit_path "|; execute-keys %|" line_number "gx| & catch %& echo -markup %|{Error}unable to find tag| &; try %& execute-keys %|s\\Q" select "<ret>| & # !"
+            }
+            END { print ( length(out) == 0 ? "echo -markup %{{Error}no such tag " ENVIRON["tagname"] "}" : "menu -markup -auto-single " out ) }
+            # Ensure x is an absolute file path, by prepending with tagroot
+            function path(x) { return x ~/^\// ? x : tagroot x }'
     }}
 
 define-command ctags-complete -docstring "Insert completion candidates for the current selection into the buffer's local variables" %{ evaluate-commands -draft %{


### PR DESCRIPTION
Conversation: #662 
Fixes: #2787
I have reimplemented `ctags-search` command so it could search for any arbitrary sequence of symbols within the opened file, thus making this command more reliable. Current awk-based implementation fails to find many tags in non-C files. For example in `asciidoc` files:

![image](https://user-images.githubusercontent.com/19470159/49688064-d6baf480-fb1d-11e8-8f5d-dab519584c08.png)
We search for `Scratch Buffers` tag, and jump to it's location, but end up on `= Buffers` tag for some reason.

My implementation doesn't have this bug, but more importantly, it handles this:
![image](https://user-images.githubusercontent.com/19470159/49688045-85ab0080-fb1d-11e8-9b04-d0dc9ef810d0.png)
So there's no need to truncate tag when we find first opening curly brace, like it is done in current `awk` command.

~~The downside of this implementation is that it is slower when we have lots of files with identical tag names, e.g. searching for `Kakoune` tag in Kakoune sources will take around 2 seconds to build menu on my machine. I think that this part can be optimized, but I don't see a way of doing it.~~