### PR TITLE
doc: Mention that commands requiring a client context do nothing in a draft context.

### DIFF
--- a/doc/pages/commands.asciidoc
+++ b/doc/pages/commands.asciidoc
@@ -284,10 +284,19 @@ but not really useful in that context.
     prompt content will be passed as a single token. In other words,
     word splitting does not take place.
 
+    NOTE: The prompt is displayed in and receives input from the
+    current client context, so inside a draft context like
+    `evaluate-commands -draft`, it is invisible and only responds to
+    an `execute-keys` command in the same context.
+
 *on-key* <command>::
     wait for next key from user, then execute <command>, the key is
     available through the `key` value, accessible through `$kak_key`
     in shells, or `%val{key}` in commands.
+
+    NOTE: The key press must come from the current client context,
+    so inside a draft context like `evaluate-commands -draft`, it only
+    responds to an `execute-keys` command in the same context.
 
 *menu* [<switches>] <label1> <commands1> <label2> <commands2> ...::
     display a menu using labels, the selected label’s commands are
@@ -296,6 +305,11 @@ but not really useful in that context.
     argument, in which case menu takes three argument per item, the
     last one being a command to execute when the item is selected (but
     not validated)
+
+    NOTE: The menu is displayed in and receives input from the
+    current client context, so inside a draft context like
+    `evaluate-commands -draft`, it is invisible and only responds to
+    an `execute-keys` command in the same context.
 
 *info* [<switches>] <text>::
     display text in an information box with the following *switches*:
@@ -328,6 +342,9 @@ but not really useful in that context.
     *-markup*:::
         parse markup in both title (if provided) and text. (See
         <<faces#markup-strings,`:doc faces markup-strings`>>)
+
+    NOTE: The info box is displayed in the current client context,
+    so inside a draft context like `eval -draft`, it is invisible.
 
 *try* <commands> [catch <on_error_commands>]...::
     prevent an error in *commands* from aborting the whole command


### PR DESCRIPTION
Fixes #2618.