### PR TITLE
rc: Don't hide errors produced by shell commands

### DIFF
--- a/rc/base/spell.kak
+++ b/rc/base/spell.kak
@@ -28,7 +28,7 @@ Formats of language supported:
         fi
 
         {
-            sed 's/^/^/' "$kak_opt_spell_tmp_file" | eval "aspell --byte-offsets -a $options" 2>&1 | {
+            sed 's/^/^/' "$kak_opt_spell_tmp_file" | eval "aspell --byte-offsets -a $options" | {
                 line_num=1
                 regions=$kak_timestamp
                 read line # drop the identification message

--- a/rc/base/tmux.kak
+++ b/rc/base/tmux.kak
@@ -22,7 +22,7 @@ define-command -hidden -params 1.. tmux-new-impl %{
         tmux_args="$1"
         shift
         if [ $# -ne 0 ]; then kakoune_params="-e '$@'"; fi
-        TMUX=$tmux tmux $tmux_args "env TMPDIR='${TMPDIR}' kak -c ${kak_session} ${kakoune_params}" < /dev/null > /dev/null 2>&1 &
+        TMUX=$tmux tmux $tmux_args "env TMPDIR='${TMPDIR}' kak -c ${kak_session} ${kakoune_params}" < /dev/null > /dev/null &
     }
 }
 

--- a/rc/base/x11.kak
+++ b/rc/base/x11.kak
@@ -15,7 +15,7 @@ A shell command is appended to the one set in this option at runtime} \
                    'gnome-terminal -e      ' \
                    'xfce4-terminal -e      ' ; do
         terminal=${termcmd%% *}
-        if command -v $terminal >/dev/null 2>&1; then
+        if command -v $terminal >/dev/null; then
             printf %s\\n "$termcmd"
             exit
         fi

--- a/rc/extra/editorconfig.kak
+++ b/rc/extra/editorconfig.kak
@@ -16,7 +16,7 @@ declare-option -hidden bool editorconfig_trim_trailing_whitespace false
 define-command editorconfig-load -params ..1 -docstring "editorconfig-load [file]: set formatting behavior according to editorconfig" %{
     remove-hooks buffer editorconfig-hooks
     evaluate-commands %sh{
-        command -v editorconfig >/dev/null 2>&1 || { echo 'echo -markup "{Error}editorconfig could not be found"'; exit 1; }
+        command -v editorconfig >/dev/null || { echo 'echo -markup "{Error}editorconfig could not be found"'; exit 1; }
         editorconfig "${1:-$kak_buffile}" | awk -F= -- '
             /indent_style=/            { indent_style = $2 }
             /indent_size=/             { indent_size = $2 == "tab" ? 4 : $2  }

--- a/rc/extra/go-tools.kak
+++ b/rc/extra/go-tools.kak
@@ -7,7 +7,7 @@
 
 evaluate-commands %sh{
     for dep in gocode goimports gogetdoc jq; do
-        if ! command -v $dep > /dev/null 2>&1; then
+        if ! command -v $dep > /dev/null; then
             echo "echo -debug %{Dependency unmet: $dep, please install it to use go-tools}"
         fi
     done

--- a/rc/extra/kitty.kak
+++ b/rc/extra/kitty.kak
@@ -46,7 +46,7 @@ All optional parameters are forwarded to the new window} \
     -shell-completion \
     kitty-repl %{ evaluate-commands %sh{
         if [ $# -eq 0 ]; then cmd="${SHELL:-/bin/sh}"; else cmd="$*"; fi
-        kitty @ new-window --no-response --window-type $kak_opt_kitty_window_type --title kak_repl_window --cwd "$PWD" $cmd < /dev/null > /dev/null 2>&1 &
+        kitty @ new-window --no-response --window-type $kak_opt_kitty_window_type --title kak_repl_window --cwd "$PWD" $cmd < /dev/null > /dev/null &
 }}
 
 define-command kitty-send-text -docstring "send the selected text to the repl window" %{


### PR DESCRIPTION
Errors returned by shell utilities will be printed in the *debug*
buffer, hiding them prevents users from figuring out what's wrong
if commands they're excecuting silently fail.