### PR TITLE
 src: Add a `window_range` default expansion

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -355,6 +355,12 @@ The following expansions are supported (with required context _in italics_):
     _in window scope_ +
     width of the current Kakoune window
 
+*%val{window_range}*::
+    _in window scope_ +
+    list of coordinates and dimensions of the buffer-space
+    available on the current window, in the following format:
+    `<coord_x> <coord_y> <width> <height>`
+
 Values in the above list that do not mention a context are available
 everywhere.
 

--- a/rc/tools/man.kak
+++ b/rc/tools/man.kak
@@ -33,7 +33,7 @@ define-command -hidden -params 2..3 man-impl %{ evaluate-commands %sh{
     manout=$(mktemp "${TMPDIR:-/tmp}"/kak-man-XXXXXX)
     manerr=$(mktemp "${TMPDIR:-/tmp}"/kak-man-XXXXXX)
     colout=$(mktemp "${TMPDIR:-/tmp}"/kak-man-XXXXXX)
-    MANWIDTH=${kak_window_width} man "$@" > "$manout" 2> "$manerr"
+    env MANWIDTH=${kak_window_range##* } man "$@" > "$manout" 2> "$manerr"
     retval=$?
     col -b -x > ${colout} < ${manout}
     rm ${manout}

--- a/src/main.cc
+++ b/src/main.cc
@@ -280,6 +280,17 @@ static const EnvVarDesc builtin_env_vars[] = { {
         "user_modes", false,
         [](StringView name, const Context& context, Quoting quoting) -> String
         { return join(context.keymaps().user_modes(), ' ', false); }
+    }, {
+        "window_range", false,
+        [](StringView name, const Context& context, Quoting quoting) -> String
+        {
+            const auto top_left = context.window().display_position({0, 0});
+            const auto window_dim = context.window().dimensions();
+
+            return format("{} {} {} {}", top_left->line, top_left->column,
+                                         window_dim.line - top_left->line,
+                                         window_dim.column - top_left->column);
+        }
     }
 };
 


### PR DESCRIPTION
This commit adds a `window_range` default expansion that holds the
coordinates and size of the buffer-space on the window.

Fixes #675