### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,6 +1,6 @@
 = image:{logo}[K,30,30,link="{website}",title="Kakoune logo by p0nce"] Kakoune image:{travis-img}[link="{travis-url}"] image:{irc-img}[link="{irc-url}"]
 ifdef::env-github,env-browser[:outfilesuffix: .asciidoc]
-:logo: https://rawgit.com/mawww/kakoune/master/doc/kakoune_logo.svg
+:logo: https://combinatronics.com/mawww/kakoune/master/doc/kakoune_logo.svg
 :website: http://kakoune.org
 :travis-img: https://travis-ci.org/mawww/kakoune.svg?branch=master
 :travis-url: https://travis-ci.org/mawww/kakoune


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.