### PR TITLE
src: Add support for right click events

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -92,9 +92,20 @@ struct MouseHandler
         Buffer& buffer = context.buffer();
         BufferCoord cursor;
         auto& selections = context.selections();
-        switch ((Key::Modifiers)(key.modifiers & Key::Modifiers::MouseEvent))
+        const auto key_modifier = (Key::Modifiers)(key.modifiers & Key::Modifiers::MouseEvent);
+        switch (key_modifier)
         {
-        case Key::Modifiers::MousePress:
+        case Key::Modifiers::MousePressRight:
+            m_dragging = false;
+            cursor = context.window().buffer_coord(key.coord());
+            if (key.modifiers & Key::Modifiers::Control)
+                selections = {{selections.begin()->anchor(), cursor}};
+            else
+                selections.main() = {selections.main().anchor(), cursor};
+            selections.sort_and_merge_overlapping();
+            return true;
+
+        case Key::Modifiers::MousePressLeft:
             m_dragging = true;
             m_anchor = context.window().buffer_coord(key.coord());
             if (not (key.modifiers & Key::Modifiers::Control))
@@ -108,7 +119,8 @@ struct MouseHandler
             }
             return true;
 
-        case Key::Modifiers::MouseRelease:
+        case Key::Modifiers::MouseReleaseLeft:
+        case Key::Modifiers::MouseReleaseRight:
             if (not m_dragging)
                 return true;
             m_dragging = false;

--- a/src/json_ui.cc
+++ b/src/json_ui.cc
@@ -424,10 +424,14 @@ void JsonUI::eval_json(const Value& json)
         const Codepoint coord = encode_coord({params[1].as<int>(), params[2].as<int>()});
         if (type == "move")
             m_on_key({Key::Modifiers::MousePos, coord});
-        else if (type == "press")
-            m_on_key({Key::Modifiers::MousePress, coord});
-        else if (type == "release")
-            m_on_key({Key::Modifiers::MouseRelease, coord});
+        else if (type == "press_left")
+            m_on_key({Key::Modifiers::MousePressLeft, coord});
+        else if (type == "press_right")
+            m_on_key({Key::Modifiers::MousePressRight, coord});
+        else if (type == "release_left")
+            m_on_key({Key::Modifiers::MouseReleaseLeft, coord});
+        else if (type == "release_right")
+            m_on_key({Key::Modifiers::MouseReleaseRight, coord});
         else if (type == "wheel_up")
             m_on_key({Key::Modifiers::MouseWheelUp, coord});
         else if (type == "wheel_down")

--- a/src/keys.cc
+++ b/src/keys.cc
@@ -152,10 +152,14 @@ String key_to_str(Key key)
         {
             case Key::Modifiers::MousePos:
                 return format("<mouse:move:{}.{}>", coord.line, coord.column);
-            case Key::Modifiers::MousePress:
-                return format("<mouse:press:{}.{}>", coord.line, coord.column);
-            case Key::Modifiers::MouseRelease:
-                return format("<mouse:release:{}.{}>", coord.line, coord.column);
+            case Key::Modifiers::MousePressLeft:
+                return format("<mouse:press_left:{}.{}>", coord.line, coord.column);
+            case Key::Modifiers::MousePressRight:
+                return format("<mouse:press_right:{}.{}>", coord.line, coord.column);
+            case Key::Modifiers::MouseReleaseLeft:
+                return format("<mouse:release_left:{}.{}>", coord.line, coord.column);
+            case Key::Modifiers::MouseReleaseRight:
+                return format("<mouse:release_right:{}.{}>", coord.line, coord.column);
             case Key::Modifiers::MouseWheelDown:
                 return "<mouse:wheel_down>";
             case Key::Modifiers::MouseWheelUp:

--- a/src/keys.hh
+++ b/src/keys.hh
@@ -21,16 +21,19 @@ struct Key
         Alt     = 1 << 1,
         Shift   = 1 << 2,
 
-        MousePress   = 1 << 3,
-        MouseRelease = 1 << 4,
-        MousePos     = 1 << 5,
-        MouseWheelDown = 1 << 6,
-        MouseWheelUp = 1 << 7,
-        MouseEvent = MousePress | MouseRelease | MousePos |
-                     MouseWheelDown | MouseWheelUp,
+        MousePressLeft    = 1 << 3,
+        MousePressRight   = 1 << 4,
+        MouseReleaseLeft  = 1 << 5,
+        MouseReleaseRight = 1 << 6,
+        MousePos          = 1 << 7,
+        MouseWheelDown    = 1 << 8,
+        MouseWheelUp      = 1 << 9,
+        MouseEvent        = MousePressLeft | MousePressRight |
+                            MouseReleaseLeft | MouseReleaseRight |
+                            MousePos | MouseWheelDown | MouseWheelUp,
 
-        Resize = 1 << 8,
-        MenuSelect = 1 << 10,
+        Resize     = 1 << 10,
+        MenuSelect = 1 << 11,
     };
     enum NamedKey : Codepoint
     {

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -565,9 +565,13 @@ Optional<Key> NCursesUI::get_next_key()
                     res |= Key::Modifiers::Alt;
 
                 if (BUTTON_PRESS(mask, 1))
-                    return res | Key::Modifiers::MousePress;
+                    return res | Key::Modifiers::MousePressLeft;
+                if (BUTTON_PRESS(mask, 3))
+                    return res | Key::Modifiers::MousePressRight;
                 if (BUTTON_RELEASE(mask, 1))
-                    return res | Key::Modifiers::MouseRelease;
+                    return res | Key::Modifiers::MouseReleaseLeft;
+                if (BUTTON_RELEASE(mask, 3))
+                    return res | Key::Modifiers::MouseReleaseRight;
                 if (BUTTON_PRESS(mask, m_wheel_down_button))
                     return res | Key::Modifiers::MouseWheelDown;
                 if (BUTTON_PRESS(mask, m_wheel_up_button))


### PR DESCRIPTION
The current implementation treats left mouse button clicks as a
generic "mouse press" modifier, this commit extends the list of
modifiers by adding a "right mouse click" one.

The proper way to implement this would be to ship the coordinates
of mouse key press events in each `Key` object, and pass whichever
button was clicked as a codepoint value (instead of coordinates
currently), but this would require more work.

This commit allows:

* right clicks to set the cursor of the main selection
* control-right clicks to merge all the selections, and then set
  its cursor

Fixes #843