### PR TITLE
Put ModeChange indent cleaning hooks into their own group

### DIFF
--- a/rc/base/clojure.kak
+++ b/rc/base/clojure.kak
@@ -157,7 +157,7 @@ evaluate-commands %sh{
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden clojure-filter-around-selections lisp-filter-around-selections
+define-command -hidden clojure-trim-indent lisp-trim-indent
 
 declare-option \
     -docstring 'regex matching the head of forms which have options *and* indented bodies' \
@@ -193,7 +193,7 @@ hook -group clojure-highlight global WinSetOption filetype=clojure %{
 }
 
 hook global WinSetOption filetype=clojure %[
-    hook window ModeChange insert:.* -group clojure-hooks  clojure-filter-around-selections
+    hook window ModeChange insert:.* -group clojure-trim-indent  clojure-trim-indent
     hook window InsertChar \n -group clojure-indent clojure-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window clojure-.+ }

--- a/rc/base/css.kak
+++ b/rc/base/css.kak
@@ -35,7 +35,7 @@ add-highlighter shared/css/selector/ regex [*]|[#.][A-Za-z][A-Za-z0-9_-]* 0:vari
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden css-filter-around-selections %{
+define-command -hidden css-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -45,7 +45,7 @@ define-command -hidden css-indent-on-new-line %[
         # preserve previous line indent
         try %[ execute-keys -draft \; K <a-&> ]
         # filter previous line
-        try %[ execute-keys -draft k : css-filter-around-selections <ret> ]
+        try %[ execute-keys -draft k : css-trim-indent <ret> ]
         # indent after lines ending with with {
         try %[ execute-keys -draft k <a-x> <a-k> \{$ <ret> j <a-gt> ]
     ]
@@ -67,7 +67,7 @@ hook -group css-highlight global WinSetOption filetype=css %{
 }
 
 hook global WinSetOption filetype=css %[
-    hook window ModeChange insert:.* -group css-hooks  css-filter-around-selections
+    hook window ModeChange insert:.* -group css-trim-indent  css-trim-indent
     hook window InsertChar \n -group css-indent css-indent-on-new-line
     hook window InsertChar \} -group css-indent css-indent-on-closing-curly-brace
     set-option buffer extra_word_chars '_' '-'

--- a/rc/base/d.kak
+++ b/rc/base/d.kak
@@ -123,7 +123,7 @@ hook -group d-highlight global WinSetOption filetype=d %{
 
 hook global WinSetOption filetype=d %{
     # cleanup trailing whitespaces when exiting insert mode
-    hook window ModeChange insert:.* -group d-hooks %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
+    hook window ModeChange insert:.* -group d-trim-indent %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group d-indent d-indent-on-new-line
     hook window InsertChar \{ -group d-indent d-indent-on-opening-curly-brace
     hook window InsertChar \} -group d-indent d-indent-on-closing-curly-brace

--- a/rc/base/fish.kak
+++ b/rc/base/fish.kak
@@ -28,7 +28,7 @@ add-highlighter shared/fish/code/ regex \b(and|begin|bg|bind|block|break|breakpo
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden fish-filter-around-selections %{
+define-command -hidden fish-trim-indent %{
     evaluate-commands -no-hooks -draft -itersel %{
         # remove trailing white spaces
         try %{ execute-keys -draft <a-x>s\h+$<ret>d }
@@ -49,7 +49,7 @@ define-command -hidden fish-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft <space>K<a-&> }
         # filter previous line
-        try %{ execute-keys -draft k:fish-filter-around-selections<ret> }
+        try %{ execute-keys -draft k:fish-trim-indent<ret> }
         # indent after start structure
         try %{ execute-keys -draft k<a-x><a-k>^\h*(begin|case|else|for|function|if|switch|while)\b<ret>j<a-gt> }
     }

--- a/rc/base/gas.kak
+++ b/rc/base/gas.kak
@@ -61,7 +61,7 @@ add-highlighter shared/gas/code/ regex \
 ^\h*(cvttp[ds]2dq|cvttp[ds]2pi|cvtts[ds]2si)\b|\
 ^\h*(vxorp[sd]|vandp[sd]|ucomis[sd])\b 0:keyword
 
-define-command -hidden gas-filter-around-selections %{
+define-command -hidden gas-trim-indent %{
     evaluate-commands -draft -itersel %{
         execute-keys <a-x>
         # remove trailing white spaces
@@ -74,7 +74,7 @@ define-command -hidden gas-indent-on-new-line %~
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : gas-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : gas-trim-indent <ret> }
         # indent after label
         try %[ execute-keys -draft k <a-x> <a-k> :$ <ret> j <a-gt> ]
     >

--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -88,7 +88,7 @@ hook -group go-highlight global WinSetOption filetype=go %{
 
 hook global WinSetOption filetype=go %{
     # cleanup trailing whitespaces when exiting insert mode
-    hook window ModeChange insert:.* -group go-hooks %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
+    hook window ModeChange insert:.* -group go-trim-indent %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group go-indent go-indent-on-new-line
     hook window InsertChar \{ -group go-indent go-indent-on-opening-curly-brace
     hook window InsertChar \} -group go-indent go-indent-on-closing-curly-brace

--- a/rc/base/haskell.kak
+++ b/rc/base/haskell.kak
@@ -68,7 +68,7 @@ add-highlighter shared/haskell/code/ regex \B'([^\\]|[\\]['"\w\d\\])' 0:string
 
 # http://en.wikibooks.org/wiki/Haskell/Indentation
 
-define-command -hidden haskell-filter-around-selections %{
+define-command -hidden haskell-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -82,7 +82,7 @@ define-command -hidden haskell-indent-on-new-line %{
         # align to first clause
         try %{ execute-keys -draft \; k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|do|let|where)\h+\K.* <ret> s \A|.\z <ret> & }
         # filter previous line
-        try %{ execute-keys -draft k : haskell-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : haskell-trim-indent <ret> }
         # indent after lines beginning with condition or ending with expression or =(
         try %{ execute-keys -draft \; k x <a-k> ^\h*(if)|(case\h+[\w']+\h+of|do|let|where|[=(])$ <ret> j <a-gt> }
     }
@@ -98,7 +98,7 @@ hook -group haskell-highlight global WinSetOption filetype=haskell %{
 
 hook global WinSetOption filetype=haskell %{
     set-option window extra_word_chars '_' "'"
-    hook window ModeChange insert:.* -group haskell-hooks  haskell-filter-around-selections
+    hook window ModeChange insert:.* -group haskell-trim-indent  haskell-trim-indent
     hook window InsertChar \n -group haskell-indent haskell-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window haskell-.+ }

--- a/rc/base/html.kak
+++ b/rc/base/html.kak
@@ -32,7 +32,7 @@ add-highlighter shared/html/tag/base/ regex <(!DOCTYPE(\h+\w+)+) 1:meta
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden html-filter-around-selections %{
+define-command -hidden html-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -49,7 +49,7 @@ define-command -hidden html-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : html-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : html-trim-indent <ret> }
         # indent after lines ending with opening tag
         try %{ execute-keys -draft k <a-x> <a-k> <lt>(?!area)(?!base)(?!br)(?!col)(?!command)(?!embed)(?!hr)(?!img)(?!input)(?!keygen)(?!link)(?!menuitem)(?!meta)(?!param)(?!source)(?!track)(?!wbr)(?!/)(?!>)[a-zA-Z0-9_-]+[^>]*?>$ <ret> j <a-gt> } }
 }
@@ -65,7 +65,7 @@ hook -group html-highlight global WinSetOption filetype=(html|xml) %{
 }
 
 hook global WinSetOption filetype=(html|xml) %{
-    hook window ModeChange insert:.* -group "%val{hook_param_capture_1}-hooks"  html-filter-around-selections
+    hook window ModeChange insert:.* -group "%val{hook_param_capture_1}-trim-indent"  html-trim-indent
     hook window InsertChar '>' -group "%val{hook_param_capture_1}-indent" html-indent-on-greater-than
     hook window InsertChar \n -group "%val{hook_param_capture_1}-indent" html-indent-on-new-line
 

--- a/rc/base/java.kak
+++ b/rc/base/java.kak
@@ -56,7 +56,7 @@ hook -group java-highlight global WinSetOption filetype=java %{
 
 hook global WinSetOption filetype=java %{
     # cleanup trailing whitespaces when exiting insert mode
-    hook window ModeChange insert:.* -group java-hooks %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
+    hook window ModeChange insert:.* -group java-trim-indent %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group java-indent java-indent-on-new-line
     hook window InsertChar \{ -group java-indent java-indent-on-opening-curly-brace
     hook window InsertChar \} -group java-indent java-indent-on-closing-curly-brace

--- a/rc/base/javascript.kak
+++ b/rc/base/javascript.kak
@@ -12,7 +12,7 @@ hook global BufCreate .*[.](ts)x? %{
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden javascript-filter-around-selections %{
+define-command -hidden javascript-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -31,7 +31,7 @@ define-command -hidden javascript-indent-on-new-line %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : javascript-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : javascript-trim-indent <ret> }
         # indent after lines beginning / ending with opener token
         try %_ execute-keys -draft k <a-x> <a-k> ^\h*[[{]|[[{]$ <ret> j <a-gt> _
     >
@@ -99,7 +99,7 @@ define-command -hidden init-javascript-filetype -params 1 %~
     "
 
     hook global WinSetOption "filetype=%arg{1}" "
-        hook window ModeChange insert:.* -group %arg{1}-hooks javascript-filter-around-selections
+        hook window ModeChange insert:.* -group %arg{1}-trim-indent javascript-trim-indent
         hook window InsertChar .* -group %arg{1}-indent javascript-indent-on-char
         hook window InsertChar \n -group %arg{1}-indent javascript-indent-on-new-line
 

--- a/rc/base/json.kak
+++ b/rc/base/json.kak
@@ -20,7 +20,7 @@ add-highlighter shared/json/code/ regex \b(true|false|null|\d+(?:\.\d+)?(?:[eE][
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden json-filter-around-selections %{
+define-command -hidden json-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -37,7 +37,7 @@ define-command -hidden json-indent-on-new-line %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : json-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : json-trim-indent <ret> }
         # indent after lines beginning with opener token
         try %< execute-keys -draft k <a-x> <a-k> ^\h*[[{] <ret> j <a-gt> >
     >
@@ -52,7 +52,7 @@ hook -group json-highlight global WinSetOption filetype=json %{
 }
 
 hook global WinSetOption filetype=json %{
-    hook window ModeChange insert:.* -group json-hooks  json-filter-around-selections
+    hook window ModeChange insert:.* -group json-trim-indent  json-trim-indent
     hook window InsertChar .* -group json-indent json-indent-on-char
     hook window InsertChar \n -group json-indent json-indent-on-new-line
 

--- a/rc/base/lisp.kak
+++ b/rc/base/lisp.kak
@@ -26,7 +26,7 @@ add-highlighter shared/lisp/code/ regex (\b\d+)?\.\d+([eEsSfFdDlL]\d+)?\b 0:valu
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden lisp-filter-around-selections %{
+define-command -hidden lisp-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -63,7 +63,7 @@ hook -group lisp-highlight global WinSetOption filetype=lisp %{
 }
 
 hook global WinSetOption filetype=lisp %{
-    hook window ModeChange insert:.* -group lisp-hooks  lisp-filter-around-selections
+    hook window ModeChange insert:.* -group lisp-trim-indent  lisp-trim-indent
     hook window InsertChar \n -group lisp-indent lisp-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window lisp-.+ }

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -105,7 +105,7 @@ hook -group perl-highlight global WinSetOption filetype=perl %{
 
 hook global WinSetOption filetype=perl %{
     # cleanup trailing whitespaces when exiting insert mode
-    hook window ModeChange insert:.* -group perl-hooks %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
+    hook window ModeChange insert:.* -group perl-trim-indent %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group perl-indent perl-indent-on-new-line
     hook window InsertChar \{ -group perl-indent perl-indent-on-opening-curly-brace
     hook window InsertChar \} -group perl-indent perl-indent-on-closing-curly-brace

--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -93,7 +93,7 @@ define-command ruby-alternative-file -docstring 'Jump to the alternate file (imp
     echo "edit $altfile"
 }}
 
-define-command -hidden ruby-filter-around-selections %{
+define-command -hidden ruby-trim-indent %{
     evaluate-commands -no-hooks -draft -itersel %{
         execute-keys <a-x>
         # remove trailing white spaces
@@ -116,7 +116,7 @@ define-command -hidden ruby-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ruby-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : ruby-trim-indent <ret> }
         # indent after start structure
         try %{ execute-keys -draft k <a-x> <a-k> ^ \h * (begin|case|class|def|do|else|elsif|ensure|for|if|module|rescue|unless|until|when|while) \b <ret> j <a-gt> }
     }

--- a/rc/base/rust.kak
+++ b/rc/base/rust.kak
@@ -37,7 +37,7 @@ add-highlighter shared/rust/code/ regex "('\w+)[^']" 1:meta
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden rust-filter-around-selections %{
+define-command -hidden rust-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -49,7 +49,7 @@ define-command -hidden rust-indent-on-new-line %~
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : rust-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : rust-trim-indent <ret> }
         # indent after lines ending with { or (
         try %[ execute-keys -draft k <a-x> <a-k> [{(]\h*$ <ret> j <a-gt> ]
         # align to opening paren of previous line
@@ -80,7 +80,7 @@ hook -group rust-highlight global WinSetOption filetype=rust %{
 }
 
 hook global WinSetOption filetype=rust %[
-    hook window ModeChange insert:.* -group rust-hooks  rust-filter-around-selections
+    hook window ModeChange insert:.* -group rust-trim-indent  rust-trim-indent
     hook window InsertChar \n -group rust-indent rust-indent-on-new-line
     hook window InsertChar \{ -group rust-indent rust-indent-on-opening-curly-brace
     hook window InsertChar \} -group rust-indent rust-indent-on-closing-curly-brace

--- a/rc/base/scala.kak
+++ b/rc/base/scala.kak
@@ -33,7 +33,7 @@ add-highlighter shared/scala/code/ regex (\[|\]|=>|<:|:>|=:=|::|&&|\|\|) 0:opera
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden scala-filter-around-selections %{
+define-command -hidden scala-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -45,7 +45,7 @@ define-command -hidden scala-indent-on-new-line %[
         # preserve previous line indent
         try %[ execute-keys -draft \; K <a-&> ]
         # filter previous line
-        try %[ execute-keys -draft k : scala-filter-around-selections <ret> ]
+        try %[ execute-keys -draft k : scala-trim-indent <ret> ]
         # indent after lines ending with {
         try %[ execute-keys -draft k <a-x> <a-k> \{$ <ret> j <a-gt> ]
     ]
@@ -67,7 +67,7 @@ hook -group scala-highlight global WinSetOption filetype=scala %{
 }
 
 hook global WinSetOption filetype=scala %[
-    hook window ModeChange insert:.* -group scala-hooks  scala-filter-around-selections
+    hook window ModeChange insert:.* -group scala-trim-indent  scala-trim-indent
     hook window InsertChar \n -group scala-indent scala-indent-on-new-line
     hook window InsertChar \} -group scala-indent scala-indent-on-closing-curly-brace
 

--- a/rc/base/yaml.kak
+++ b/rc/base/yaml.kak
@@ -25,7 +25,7 @@ add-highlighter shared/yaml/code/ regex ^\h*-?\h*(\S+): 1:attribute
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden yaml-filter-around-selections %{
+define-command -hidden yaml-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -37,7 +37,7 @@ define-command -hidden yaml-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : yaml-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : yaml-trim-indent <ret> }
         # indent after :
         try %{ execute-keys -draft <space> k x <a-k> :$ <ret> j <a-gt> }
     }
@@ -52,7 +52,7 @@ hook -group yaml-highlight global WinSetOption filetype=yaml %{
 }
 
 hook global WinSetOption filetype=yaml %{
-    hook window ModeChange insert:.* -group yaml-hooks  yaml-filter-around-selections
+    hook window ModeChange insert:.* -group yaml-trim-indent yaml-trim-indent
     hook window InsertChar \n -group yaml-indent yaml-indent-on-new-line
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window yaml-.+ }
 }

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -23,7 +23,7 @@ hook global BufCreate .*\.m %{
     set-option buffer filetype objc
 }
 
-define-command -hidden c-family-trim-autoindent %{
+define-command -hidden c-family-trim-indent %{
     # remove the line if it's empty when leaving the insert mode
     try %{ execute-keys -draft <a-x> 1s^(\h+)$<ret> d }
 }
@@ -321,7 +321,7 @@ hook global WinSetOption filetype=(c|cpp|objc) %[
     hook -group "%val{hook_param_capture_1}-indent" window InsertChar \n c-family-indent-on-newline
     hook -group "%val{hook_param_capture_1}-indent" window InsertChar \{ c-family-indent-on-opening-curly-brace
     hook -group "%val{hook_param_capture_1}-indent" window InsertChar \} c-family-indent-on-closing-curly-brace
-    hook -group "%val{hook_param_capture_1}-trim-indent" window ModeChange insert:.* c-family-trim-autoindent
+    hook -group "%val{hook_param_capture_1}-trim-indent" window ModeChange insert:.* c-family-trim-indent
     hook -group "%val{hook_param_capture_1}-insert" window InsertChar \n c-family-insert-on-newline
     hook -group "%val{hook_param_capture_1}-insert" window InsertChar \} c-family-insert-on-closing-curly-brace
 

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -318,17 +318,17 @@ evaluate-commands %sh{
 }
 
 hook global WinSetOption filetype=(c|cpp|objc) %[
-    hook -group "%val{hook_param_capture_1}-family-indent" window ModeChange insert:.* c-family-trim-autoindent
-    hook -group "%val{hook_param_capture_1}-family-insert" window InsertChar \n c-family-insert-on-newline
-    hook -group "%val{hook_param_capture_1}-family-indent" window InsertChar \n c-family-indent-on-newline
-    hook -group "%val{hook_param_capture_1}-family-indent" window InsertChar \{ c-family-indent-on-opening-curly-brace
-    hook -group "%val{hook_param_capture_1}-family-indent" window InsertChar \} c-family-indent-on-closing-curly-brace
-    hook -group "%val{hook_param_capture_1}-family-insert" window InsertChar \} c-family-insert-on-closing-curly-brace
+    hook -group "%val{hook_param_capture_1}-indent" window InsertChar \n c-family-indent-on-newline
+    hook -group "%val{hook_param_capture_1}-indent" window InsertChar \{ c-family-indent-on-opening-curly-brace
+    hook -group "%val{hook_param_capture_1}-indent" window InsertChar \} c-family-indent-on-closing-curly-brace
+    hook -group "%val{hook_param_capture_1}-trim-indent" window ModeChange insert:.* c-family-trim-autoindent
+    hook -group "%val{hook_param_capture_1}-insert" window InsertChar \n c-family-insert-on-newline
+    hook -group "%val{hook_param_capture_1}-insert" window InsertChar \} c-family-insert-on-closing-curly-brace
 
     alias window alt "%val{hook_param_capture_1}-alternative-file"
 
     hook -once -always window WinSetOption filetype=.* "
-        remove-hooks window %val{hook_param_capture_1}-family-.+
+        remove-hooks window %val{hook_param_capture_1}-.+
         unalias window alt %val{hook_param_capture_1}-alternative-file
     "
 ]

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -318,11 +318,11 @@ evaluate-commands %sh{
 }
 
 hook global WinSetOption filetype=(c|cpp|objc) %[
+    hook -group "%val{hook_param_capture_1}-trim-indent" window ModeChange insert:.* c-family-trim-indent
+    hook -group "%val{hook_param_capture_1}-insert" window InsertChar \n c-family-insert-on-newline
     hook -group "%val{hook_param_capture_1}-indent" window InsertChar \n c-family-indent-on-newline
     hook -group "%val{hook_param_capture_1}-indent" window InsertChar \{ c-family-indent-on-opening-curly-brace
     hook -group "%val{hook_param_capture_1}-indent" window InsertChar \} c-family-indent-on-closing-curly-brace
-    hook -group "%val{hook_param_capture_1}-trim-indent" window ModeChange insert:.* c-family-trim-indent
-    hook -group "%val{hook_param_capture_1}-insert" window InsertChar \n c-family-insert-on-newline
     hook -group "%val{hook_param_capture_1}-insert" window InsertChar \} c-family-insert-on-closing-curly-brace
 
     alias window alt "%val{hook_param_capture_1}-alternative-file"

--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -102,7 +102,7 @@ hook global WinSetOption filetype=kak %~
     hook window InsertChar [>)}\]] -group kak-indent kak-indent-on-closing-matching
     hook window InsertChar (?![[{(<>)}\]])[^\s\w] -group kak-indent kak-indent-on-closing-char
     # cleanup trailing whitespaces on current line insert end
-    hook window ModeChange insert:.* -group kak-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
+    hook window ModeChange insert:.* -group kak-trim-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
     set-option buffer extra_word_chars '_' '-'
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window kak-.+ }

--- a/rc/core/makefile.kak
+++ b/rc/core/makefile.kak
@@ -56,5 +56,5 @@ hook -group makefile-highlight global WinSetOption filetype=makefile %{
 
 hook global WinSetOption filetype=makefile %{
     hook window InsertChar \n -group makefile-indent makefile-indent-on-new-line
-	hook -once -always window WinSetOption filetype=.* %{ remove-hooks window makefile-.+ }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window makefile-.+ }
 }

--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -143,6 +143,6 @@ hook -group python-highlight global WinSetOption filetype=python %{
 hook global WinSetOption filetype=python %{
     hook window InsertChar \n -group python-indent python-indent-on-new-line
     # cleanup trailing whitespaces on current line insert end
-    hook window ModeChange insert:.* -group python-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
+    hook window ModeChange insert:.* -group python-trim-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window python-.+ }
 }

--- a/rc/extra/cabal.kak
+++ b/rc/extra/cabal.kak
@@ -23,7 +23,7 @@ add-highlighter shared/cabal/code/ regex ^\h*([A-Za-z][A-Za-z0-9_-]*)\h*: 1:vari
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden cabal-filter-around-selections %{
+define-command -hidden cabal-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -35,7 +35,7 @@ define-command -hidden cabal-indent-on-new-line %[
         # preserve previous line indent
         try %[ execute-keys -draft \; K <a-&> ]
         # filter previous line
-        try %[ execute-keys -draft k : cabal-filter-around-selections <ret> ]
+        try %[ execute-keys -draft k : cabal-trim-indent <ret> ]
         # indent after lines ending with { or :
         try %[ execute-keys -draft <space> k <a-x> <a-k> [:{]$ <ret> j <a-gt> ]
     ]
@@ -65,7 +65,7 @@ hook -group cabal-highlight global WinSetOption filetype=cabal %{
 }
 
 hook global WinSetOption filetype=cabal %[
-    hook window ModeChange insert:.* -group cabal-hooks  cabal-filter-around-selections
+    hook window ModeChange insert:.* -group cabal-trim-indent  cabal-trim-indent
     hook window InsertChar \n -group cabal-indent cabal-indent-on-new-line
     hook window InsertChar \{ -group cabal-indent cabal-indent-on-opening-curly-brace
     hook window InsertChar \} -group cabal-indent cabal-indent-on-closing-curly-brace

--- a/rc/extra/coffee.kak
+++ b/rc/extra/coffee.kak
@@ -42,7 +42,7 @@ add-highlighter shared/coffee/code/ regex \b(break|case|catch|class|const|contin
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden coffee-filter-around-selections %{
+define-command -hidden coffee-trim-indent %{
     evaluate-commands -draft -itersel %{
         execute-keys <a-x>
         # remove trailing white spaces
@@ -57,7 +57,7 @@ define-command -hidden coffee-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : coffee-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : coffee-trim-indent <ret> }
         # indent after start structure
         try %{ execute-keys -draft k <a-x> <a-k> ^ \h * (case|catch|class|else|finally|for|function|if|switch|try|while|with) \b | (=|->) $ <ret> j <a-gt> }
     }
@@ -72,7 +72,7 @@ hook -group coffee-highlight global WinSetOption filetype=coffee %{
 }
 
 hook global WinSetOption filetype=coffee %{
-    hook window ModeChange insert:.* -group coffee-hooks  coffee-filter-around-selections
+    hook window ModeChange insert:.* -group coffee-trim-indent  coffee-trim-indent
     hook window InsertChar \n -group coffee-indent coffee-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window coffee-.+ }

--- a/rc/extra/cucumber.kak
+++ b/rc/extra/cucumber.kak
@@ -55,7 +55,7 @@ add-highlighter shared/cucumber/code/ regex \b(Feature|Business\h+Need|Ability|B
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden cucumber-filter-around-selections %{
+define-command -hidden cucumber-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -67,7 +67,7 @@ define-command -hidden cucumber-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : cucumber-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : cucumber-trim-indent <ret> }
         # indent after lines containing :
         try %{ execute-keys -draft <space> k x <a-k> : <ret> j <a-gt> }
     }
@@ -82,7 +82,7 @@ hook -group cucumber-highlight global WinSetOption filetype=cucumber %{
 }
 
 hook global WinSetOption filetype=cucumber %{
-    hook window ModeChange insert:.* -group cucumber-hooks  cucumber-filter-around-selections
+    hook window ModeChange insert:.* -group cucumber-trim-indent  cucumber-trim-indent
     hook window InsertChar \n -group cucumber-indent cucumber-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window cucumber-.+ }

--- a/rc/extra/dart.kak
+++ b/rc/extra/dart.kak
@@ -97,7 +97,7 @@ hook -group dart-highlight global WinSetOption filetype=dart %{
 
 hook global WinSetOption filetype=dart %{
     # cleanup trailing whitespaces when exiting insert mode
-    hook window ModeChange insert:.* -group dart-hooks %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
+    hook window ModeChange insert:.* -group dart-trim-indent %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group dart-indent dart-indent-on-new-line
     hook window InsertChar \{ -group dart-indent dart-indent-on-opening-curly-brace
     hook window InsertChar \} -group dart-indent dart-indent-on-closing-curly-brace

--- a/rc/extra/elixir.kak
+++ b/rc/extra/elixir.kak
@@ -41,7 +41,7 @@ add-highlighter shared/elixir/code/ regex '\b\d+[\d_]*\b' 0:value
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden elixir-filter-around-selections %{
+define-command -hidden elixir-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -55,7 +55,7 @@ define-command -hidden elixir-indent-on-new-line %{
         # indent after line ending with: 
 	# try %{ execute-keys -draft k x <a-k> (do|else|->)$ <ret> & }
 	# filter previous line
-        try %{ execute-keys -draft k : elixir-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : elixir-trim-indent <ret> }
         # indent after lines ending with do or ->
         try %{ execute-keys -draft \\; k x <a-k> ^.+(do|->)$ <ret> j <a-gt> }
     }
@@ -70,7 +70,7 @@ hook -group elixir-highlight global WinSetOption filetype=elixir %{
 }
 
 hook global WinSetOption filetype=elixir %{
-    hook window ModeChange insert:.* -group elixir-hooks  elixir-filter-around-selections
+    hook window ModeChange insert:.* -group elixir-trim-indent  elixir-trim-indent
     hook window InsertChar \n -group elixir-indent elixir-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window elixir-.+ }

--- a/rc/extra/elm.kak
+++ b/rc/extra/elm.kak
@@ -27,7 +27,7 @@ add-highlighter shared/elm/code/ regex \b(Array|Bool|Char|Float|Int|String)\b 0:
 
 # http://elm-lang.org/docs/style-guide
 
-define-command -hidden elm-filter-around-selections %{
+define-command -hidden elm-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -45,7 +45,7 @@ define-command -hidden elm-indent-on-new-line %{
         # align to first clause
         try %{ execute-keys -draft \; k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|let)\h+\K.* <ret> s \A|.\z <ret> & }
         # filter previous line
-        try %{ execute-keys -draft k : elm-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : elm-trim-indent <ret> }
         # indent after lines beginning with condition or ending with expression or =(
         try %{ elm-indent-after }
     }
@@ -60,7 +60,7 @@ hook -group elm-highlight global WinSetOption filetype=elm %{
 }
 
 hook global WinSetOption filetype=elm %{
-    hook window ModeChange insert:.* -group elm-hooks  elm-filter-around-selections
+    hook window ModeChange insert:.* -group elm-trim-indent  elm-trim-indent
     hook window InsertChar \n -group elm-indent elm-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window elm-.+ }

--- a/rc/extra/haml.kak
+++ b/rc/extra/haml.kak
@@ -28,7 +28,7 @@ add-highlighter shared/haml/code/ regex ^\h*%([A-Za-z][A-Za-z0-9_-]*)([#.][A-Za-
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden haml-filter-around-selections %{
+define-command -hidden haml-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -40,7 +40,7 @@ define-command -hidden haml-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : haml-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : haml-trim-indent <ret> }
         # indent after lines beginning with : or -
         try %{ execute-keys -draft k <a-x> <a-k> ^\h*[:-] <ret> j <a-gt> }
     }
@@ -55,7 +55,7 @@ hook -group haml-highlight global WinSetOption filetype=haml %{
 }
 
 hook global WinSetOption filetype=haml %{
-    hook window ModeChange insert:.* -group haml-hooks  haml-filter-around-selections
+    hook window ModeChange insert:.* -group haml-trim-indent  haml-trim-indent
     hook window InsertChar \n -group haml-indent haml-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window haml-.+ }

--- a/rc/extra/hbs.kak
+++ b/rc/extra/hbs.kak
@@ -40,7 +40,7 @@ add-highlighter shared/hbs-file/html default-region ref html
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden hbs-filter-around-selections %{
+define-command -hidden hbs-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -59,7 +59,7 @@ define-command -hidden hbs-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : hbs-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : hbs-trim-indent <ret> }
         # indent after lines beginning with : or -
         try %{ execute-keys -draft k <a-x> <a-k> ^\h*[:-] <ret> j <a-gt> }
     }
@@ -87,10 +87,9 @@ hook -group hbs-highlight global WinSetOption filetype=hbs %{
 }
 
 hook global WinSetOption filetype=hbs %{
-    hook window ModeChange insert:.* -group hbs-hooks  hbs-filter-around-selections
+    hook window ModeChange insert:.* -group hbs-trim-indent hbs-trim-indent
     hook window InsertChar \n -group hbs-indent hbs-indent-on-new-line
-    hook window InsertChar .* -group hbs-ident hbs-indent-on-char
-    hook window ModeChange insert:.* -group hbs-hooks  html-filter-around-selections
+    hook window InsertChar .* -group hbs-indent hbs-indent-on-char
     hook window InsertChar '>' -group hbs-indent html-indent-on-greater-than
     hook window InsertChar \n -group hbs-indent html-indent-on-new-line
 

--- a/rc/extra/i3.kak
+++ b/rc/extra/i3.kak
@@ -73,7 +73,7 @@ hook -group i3-highlight global WinSetOption filetype=i3 %{
 
 hook global WinSetOption filetype=i3 %[
     # cleanup trailing whitespaces when exiting insert mode
-    hook window ModeChange insert:.* -group i3-hooks %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
+    hook window ModeChange insert:.* -group i3-trim-indent %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
     hook window InsertChar \n -group i3-indent i3-indent-on-new-line
     hook window InsertChar \} -group i3-indent i3-indent-on-closing-curly-brace
 

--- a/rc/extra/moon.kak
+++ b/rc/extra/moon.kak
@@ -51,7 +51,7 @@ define-command moon-alternative-file -docstring 'Jump to the alternate file (imp
     printf %s\\n "edit $altfile"
 }}
 
-define-command -hidden moon-filter-around-selections %{
+define-command -hidden moon-trim-indent %{
     evaluate-commands -draft -itersel %{
         execute-keys <a-x>
         # remove trailing white spaces
@@ -77,7 +77,7 @@ define-command -hidden moon-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : moon-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : moon-trim-indent <ret> }
         # indent after start structure
         try %{ execute-keys -draft k <a-x> <a-k> ^ \h * (class|else(if)?|for|if|switch|unless|when|while|with) \b | ([:=]|[-=]>) $ <ret> j <a-gt> }
         # deindent after return statements
@@ -94,7 +94,7 @@ hook -group moon-highlight global WinSetOption filetype=moon %{
 }
 
 hook global WinSetOption filetype=moon %{
-    hook window ModeChange insert:.* -group moon-hooks  moon-filter-around-selections
+    hook window ModeChange insert:.* -group moon-trim-indent  moon-trim-indent
     hook window InsertChar .* -group moon-indent moon-indent-on-char
     hook window InsertChar \n -group moon-indent moon-indent-on-new-line
 

--- a/rc/extra/nim.kak
+++ b/rc/extra/nim.kak
@@ -79,7 +79,7 @@ hook -group nim-highlight global WinSetOption filetype=nim %{
 hook global WinSetOption filetype=nim %{
     hook window InsertChar \n -group nim-indent nim-indent-on-new-line
     # cleanup trailing whitespaces on current line insert end
-    hook window ModeChange insert:.* -group nim-indent %{ try %{ exec -draft \; <a-x> s ^\h+$ <ret> d } }
+    hook window ModeChange insert:.* -group nim-trim-indent %{ try %{ exec -draft \; <a-x> s ^\h+$ <ret> d } }
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window nim-.+ }
 }

--- a/rc/extra/php.kak
+++ b/rc/extra/php.kak
@@ -48,7 +48,7 @@ add-highlighter shared/php-file/php  region '<\?(php)?'     '\?>'      ref php
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden php-filter-around-selections %{
+define-command -hidden php-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -67,7 +67,7 @@ define-command -hidden php-indent-on-new-line %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : php-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : php-trim-indent <ret> }
         # indent after lines beginning / ending with opener token
         try %_ execute-keys -draft k <a-x> <a-k> ^\h*[[{]|[[{]$ <ret> j <a-gt> _
     >
@@ -82,7 +82,7 @@ hook -group php-highlight global WinSetOption filetype=php %{
 }
 
 hook global WinSetOption filetype=php %{
-    hook window ModeChange insert:.* -group php-hooks  php-filter-around-selections
+    hook window ModeChange insert:.* -group php-trim-indent  php-trim-indent
     hook window InsertChar .* -group php-indent php-indent-on-char
     hook window InsertChar \n -group php-indent php-indent-on-new-line
 

--- a/rc/extra/pony.kak
+++ b/rc/extra/pony.kak
@@ -86,7 +86,7 @@ hook -group pony-highlight global WinSetOption filetype=pony %{
 hook global WinSetOption filetype=pony %{
     hook window InsertChar \n -group pony-indent pony-indent-on-new-line
     # cleanup trailing whitespaces on current line insert end
-    hook window ModeChange insert:.* -group pony-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
+    hook window ModeChange insert:.* -group pony-trim-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window pony-.+ }
 }

--- a/rc/extra/pug.kak
+++ b/rc/extra/pug.kak
@@ -40,7 +40,7 @@ add-highlighter shared/pug/code/            regex   ((?:\.[A-Za-z][A-Za-z0-9_-]*
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden pug-filter-around-selections %{
+define-command -hidden pug-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -50,7 +50,7 @@ define-command -hidden pug-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : pug-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : pug-trim-indent <ret> }
         # copy '//', '|', '-' or '(!)=' prefix and following whitespace
         try %{ execute-keys -draft k <a-x> s ^\h*\K[/|!=-]{1,2}\h* <ret> y gh j P }
         # indent unless we copied something above
@@ -67,7 +67,7 @@ hook -group pug-highlight global WinSetOption filetype=pug %{
 }
 
 hook global WinSetOption filetype=pug %{
-    hook window ModeChange insert:.* -group pug-hooks  pug-filter-around-selections
+    hook window ModeChange insert:.* -group pug-trim-indent  pug-trim-indent
     hook window InsertChar \n -group pug-indent pug-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window pug-.+ }

--- a/rc/extra/ragel.kak
+++ b/rc/extra/ragel.kak
@@ -27,7 +27,7 @@ add-highlighter shared/ragel/code/ regex \b(action|alnum|alpha|any|ascii|case|cn
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden ragel-filter-around-selections %{
+define-command -hidden ragel-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -47,7 +47,7 @@ define-command -hidden ragel-indent-on-new-line %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ragel-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : ragel-trim-indent <ret> }
         # indent after lines ending with opener token
         try %< execute-keys -draft k <a-x> <a-k> [[{(*]$ <ret> j <a-gt> >
     >
@@ -62,7 +62,7 @@ hook -group ragel-highlight global WinSetOption filetype=ragel %{
 }
 
 hook global WinSetOption filetype=ragel %{
-    hook window ModeChange insert:.* -group ragel-hooks  ragel-filter-around-selections
+    hook window ModeChange insert:.* -group ragel-trim-indent  ragel-trim-indent
     hook window InsertChar .* -group ragel-indent ragel-indent-on-char
     hook window InsertChar \n -group ragel-indent ragel-indent-on-new-line
 

--- a/rc/extra/sass.kak
+++ b/rc/extra/sass.kak
@@ -27,7 +27,7 @@ add-highlighter shared/sass/code/ regex !important 0:keyword
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden sass-filter-around-selections %{
+define-command -hidden sass-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -39,7 +39,7 @@ define-command -hidden sass-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : sass-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : sass-trim-indent <ret> }
         # avoid indent after properties and comments
         try %{ execute-keys -draft k <a-x> <a-K> [:/] <ret> j <a-gt> }
     }
@@ -54,7 +54,7 @@ hook -group sass-highlight global WinSetOption filetype=sass %{
 }
 
 hook global WinSetOption filetype=sass %{
-    hook window ModeChange insert:.* -group sass-hooks  sass-filter-around-selections
+    hook window ModeChange insert:.* -group sass-trim-indent  sass-trim-indent
     hook window InsertChar \n -group sass-indent sass-indent-on-new-line
     set-option buffer extra_word_chars '_' '-'
 

--- a/rc/extra/scheme.kak
+++ b/rc/extra/scheme.kak
@@ -120,7 +120,7 @@ hook -group scheme-highlight global WinSetOption filetype=scheme %{
 
 hook global WinSetOption filetype=scheme %{
     set-option buffer extra_word_chars '_' '-' '!' '%' '?' '<' '>' '='
-    hook window InsertEnd  .* -group scheme-hooks  lisp-filter-around-selections
+    hook window InsertEnd  .* -group scheme-trim-indent  lisp-trim-indent
     hook window InsertChar \n -group scheme-indent lisp-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window scheme-.+ }

--- a/rc/extra/scss.kak
+++ b/rc/extra/scss.kak
@@ -23,7 +23,7 @@ add-highlighter shared/scss/core/ regex @[A-Za-z][A-Za-z0-9_-]* 0:meta
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden scss-filter-around-selections      css-filter-around-selections
+define-command -hidden scss-trim-indent      css-trim-indent
 define-command -hidden scss-indent-on-new-line            css-indent-on-new-line
 define-command -hidden scss-indent-on-closing-curly-brace css-indent-on-closing-curly-brace
 
@@ -36,7 +36,7 @@ hook -group scss-highlight global WinSetOption filetype=scss %{
 }
 
 hook global WinSetOption filetype=scss %[
-    hook window ModeChange insert:.* -group scss-hooks  scss-filter-around-selections
+    hook window ModeChange insert:.* -group scss-trim-indent  scss-trim-indent
     hook window InsertChar \n -group scss-indent scss-indent-on-new-line
     hook window InsertChar \} -group scss-indent scss-indent-on-closing-curly-brace
     set-option buffer extra_word_chars '_' '-'

--- a/rc/extra/toml.kak
+++ b/rc/extra/toml.kak
@@ -31,7 +31,7 @@ add-highlighter shared/toml/code/ regex \
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden toml-filter-around-selections %{
+define-command -hidden toml-trim-indent %{
     # remove trailing white spaces
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
@@ -43,7 +43,7 @@ define-command -hidden toml-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : toml-filter-around-selections <ret> }
+        try %{ execute-keys -draft k : toml-trim-indent <ret> }
     }
 }
 
@@ -56,7 +56,7 @@ hook -group toml-highlight global WinSetOption filetype=toml %{
 }
 
 hook global WinSetOption filetype=toml %{
-    hook window ModeChange insert:.* -group toml-hooks toml-filter-around-selections
+    hook window ModeChange insert:.* -group toml-trim-indent toml-trim-indent
     hook window InsertChar \n -group toml-indent toml-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window toml-.+ }


### PR DESCRIPTION
* ModeChange hooks that remove indent now belong to *-trim-indent groups, instead of just -indent
* *-filter-around-selections hooks and commands have been renamed to trim-indent for clarity

This doesn't change anything regarding the status quo of indent removal, but this lets users opt out of the ModeChange hook (using disabled-hooks), which are too aggressive in my opinion.