### PR TITLE
Improve README: clarify the difference between 'alt-j' and 'alt-J' join commands.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -454,9 +454,12 @@ Changes
 
  * `r`: replace each character with the next entered one
 
- * `<a-j>`: join selected lines
- * `<a-J>`: join selected lines and select spaces inserted
-            in place of line breaks
+ * `<a-j>`: join selected lines, replacing the line break with
+            whitespace--joins lines containing words
+            to make a paragraph
+ * `<a-J>`: join selected lines, then select the inserted whitespace,
+            in case you want to delete it
+
  * `<a-m>`: merge contiguous selections together (works across lines as well)
 
  * `<gt> (>)`: indent selected lines


### PR DESCRIPTION
I'm not sure how much detail you want to put into the README compared to other documents. I don't know, for example, where to find a guide like "translating vim commands into kakoune commands". I'm trying to add to the README whenever I find something surprising, but I don't want to overdo it. Let me know if I should add these clarifications somewhere else.