### PR TITLE
src: Run and display the time taken by unit tests to run in debug mode

### DIFF
--- a/src/clock.hh
+++ b/src/clock.hh
@@ -8,6 +8,7 @@ namespace Kakoune
 
 using Clock = std::chrono::steady_clock;
 using TimePoint = Clock::time_point;
+using DurationMs = std::chrono::milliseconds;
 
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -26,6 +26,7 @@
 #include "string.hh"
 #include "unit_tests.hh"
 #include "window.hh"
+#include "clock.hh"
 
 #include <fcntl.h>
 #include <locale>
@@ -651,9 +652,14 @@ int run_server(StringView session, StringView server_init,
 
     global_scope.options()["debug"].set(debug_flags);
 
+    write_to_debug_buffer("*** This is the debug buffer, where debug info will be written ***");
+
+    const auto start_time = Clock::now();
     UnitTest::run_all_tests();
 
-    write_to_debug_buffer("*** This is the debug buffer, where debug info will be written ***");
+    if (debug_flags & DebugFlags::Profile)
+        write_to_debug_buffer(format("running the unit tests took {} ms",
+            std::chrono::duration_cast<DurationMs>(Clock::now() - start_time).count()));
 
     GlobalScope::instance().options().get_local_option("readonly").set<bool>(flags & ServerFlags::ReadOnly);
 


### PR DESCRIPTION
Knowing how much time the editor took to run unit tests gives users
a notion of how fast it's performing on a given system.