### PR TITLE
Add quotes to expansions example

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -109,7 +109,7 @@ back the original values. For example, if you want to process the contents
 of each selection, you can do something like:
 
 ----
-eval set -- $kak_selections
+eval set -- "$kak_selections"
 while [ $# -gt 0 ]; do
     # ... do a thing with $1 ...
     shift


### PR DESCRIPTION
Without them, newlines are eaten.  I have no idea why, but to demonstrate:

```
[jfelice@C02X421DJHD4 kakoune(quote-eval-set)]$ foo="'hello 
> there                       
> again '"                    
[jfelice@C02X421DJHD4 kakoune(quote-eval-set)]$ eval set -- $foo                                                         
[jfelice@C02X421DJHD4 kakoune(quote-eval-set)]$ echo "$1"   
hello there again             
[jfelice@C02X421DJHD4 kakoune(quote-eval-set)]$ eval set -- "$foo"                                                       
[jfelice@C02X421DJHD4 kakoune(quote-eval-set)]$ echo "$1"   
hello                         
there                         
again                         
```

```
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin17)
Copyright (C) 2007 Free Software Foundation, Inc.
```