### PR TITLE
Remove unused history timepoint field

### DIFF
--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -63,7 +63,7 @@ static void apply_options(OptionManager& options, const ParsedLines& parsed_line
 }
 
 Buffer::HistoryNode::HistoryNode(HistoryId parent)
-    : parent{parent}, timepoint{Clock::now()}
+    : parent{parent}
 {}
 
 Buffer::Buffer(String name, Flags flags, StringView data,

--- a/src/buffer.hh
+++ b/src/buffer.hh
@@ -268,7 +268,6 @@ private:
 
         HistoryId parent;
         HistoryId redo_child = HistoryId::Invalid;
-        TimePoint timepoint;
         UndoGroup undo_group;
     };
 


### PR DESCRIPTION
I noticed this while trying to work out a text format for #2021.