### PR TITLE
Caching shell token expansion proof of concept

### DIFF
--- a/rc/base/clojure.kak
+++ b/rc/base/clojure.kak
@@ -27,7 +27,7 @@ hook global WinSetOption filetype=clojure %{
     set-option window extra_word_chars '_' . / * ? + - < > ! : "'"
 }
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     symbol_char='[^\s()\[\]{}"\;@^`~\\%/]'
     in_core='(clojure\.core/|(?<!/))'
     keywords="

--- a/rc/base/d.kak
+++ b/rc/base/d.kak
@@ -32,7 +32,7 @@ add-highlighter shared/d/code/ regex "\b(this)\b\s*[^(]" 1:value
 add-highlighter shared/d/code/ regex "((?:~|\b)this)\b\s*\(" 1:function
 add-highlighter shared/d/code/ regex '#\s*line\b.*' 0:meta
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
 
     keywords="abstract|alias|align|asm|assert|auto|body|break|case|cast"

--- a/rc/base/go.kak
+++ b/rc/base/go.kak
@@ -21,7 +21,7 @@ add-highlighter shared/go/comment_line region '//' $ fill comment
 
 add-highlighter shared/go/code/ regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9]+|0[xX][0-9a-fA-F]+)\.?([eE][+-]?[0-9]+)?i?\b} 0:value
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     keywords="break|default|func|interface|select|case|defer|go|map|struct"
     keywords="${keywords}|chan|else|goto|package|switch|const|fallthrough|if|range|type"

--- a/rc/base/markdown.kak
+++ b/rc/base/markdown.kak
@@ -15,7 +15,7 @@ add-highlighter shared/markdown regions
 add-highlighter shared/markdown/inline default-region regions
 add-highlighter shared/markdown/inline/text default-region group
 
-evaluate-commands %sh{
+evaluate-commands %cached{
   languages="
     c cabal clojure coffee cpp css cucumber d diff dockerfile fish gas go
     haml haskell html ini java javascript json julia kak kickstart latex

--- a/rc/base/ocaml.kak
+++ b/rc/base/ocaml.kak
@@ -27,7 +27,7 @@ hook -group ocaml-highlight global WinSetOption filetype=ocaml %{
 # Macro
 # ‾‾‾‾‾
 
-evaluate-commands %sh{
+evaluate-commands %cached{
   keywords=and:as:asr:assert:begin:class:constraint:do:done:downto:else:end:exception:external:false:for:fun:function:functor:if:in:include:inherit:initializer:land:lazy:let:lor:lsl:lsr:lxor:match:method:mod:module:mutable:new:nonrec:object:of:open:or:private:rec:sig:struct:then:to:true:try:type:val:virtual:when:while:with
   echo "
     add-highlighter shared/ocaml/code/ regex \b($(printf $keywords | tr : '|'))\b 0:keyword

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -18,7 +18,7 @@ add-highlighter shared/perl/double_string region (?<!\$)(?<!\\)"   (?<!\\)(\\\\)
 add-highlighter shared/perl/single_string region (?<!\$)(?<!\\\\)' (?<!\\)(\\\\)*' fill string
 add-highlighter shared/perl/comment       region (?<!\$)(?<!\\)#   $               fill comment
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     keywords="else|lock|qw|elsif|lt|qx|eq|exp|ne|sub|for|no|my|not|tr|goto|and|foreach|or|break|exit|unless|cmp|ge|package|until|continue|gt|while|if|qq|xor|do|le|qr|return"
     attributes="END|AUTOLOAD|BEGIN|CHECK|UNITCHECK|INIT|DESTROY"

--- a/rc/base/restructuredtext.kak
+++ b/rc/base/restructuredtext.kak
@@ -12,7 +12,7 @@ add-highlighter shared/restructuredtext regions
 add-highlighter shared/restructuredtext/content default-region group
 add-highlighter shared/restructuredtext/code region ::\h*\n ^[^\s]  fill meta
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     for ft in c cabal clojure coffee cpp css cucumber ddiff dockerfile \
               fish gas go haml haskell html ini java javascript json \
               julia kak kickstart latex lisp lua makefile moon objc \

--- a/rc/base/ruby.kak
+++ b/rc/base/ruby.kak
@@ -40,7 +40,7 @@ add-highlighter shared/ruby/regex/interpolation region -recurse \{ \Q#{ \} fill 
 
 add-highlighter shared/ruby/code/ regex \b([A-Za-z]\w*:(?!:))|([$@][A-Za-z]\w*)|((?<!:):(([A-Za-z]\w*[=?!]?)|(\[\]=?)))|([A-Z]\w*|^|\h)\K::(?=[A-Z]) 0:variable
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     # Keywords are collected searching for keywords at
     # https://github.com/ruby/ruby/blob/trunk/parse.y

--- a/rc/base/sql.kak
+++ b/rc/base/sql.kak
@@ -19,7 +19,7 @@ add-highlighter shared/sql/comment1 region '--' '$' fill comment
 add-highlighter shared/sql/comment2 region '#' '$' fill comment
 add-highlighter shared/sql/comment3 region '/\*' '\*/' fill comment
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Keywords
     keywords="ALTER|AS|ASC|AUTO_INCREMENT|CHECK|CONSTRAINT|CREATE|DATABASE|DEFAULT|DELETE|DESC|DISTINCT|DROP"
     keywords="${keywords}|EXISTS|FOREIGN KEY|FROM|FULL JOIN|FULL OUTER JOIN|GROUP BY|HAVING|INDEX|INNER JOIN"

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -129,7 +129,7 @@ define-command -hidden c-family-insert-on-newline %[ evaluate-commands -itersel 
 ] ]
 
 # Regions definition are the same between c++ and objective-c
-evaluate-commands %sh{
+evaluate-commands %cached{
     for ft in c cpp objc; do
         if [ "${ft}" = "objc" ]; then
             maybe_at='@?'
@@ -156,7 +156,7 @@ evaluate-commands %sh{
 
 # c specific
 add-highlighter shared/c/code/numbers regex %{\b-?(0x[0-9a-fA-F]+|\d+)([uU][lL]{0,2}|[lL]{1,2}[uU]?|[fFdDiI])?|'((\\.)?|[^'\\])'} 0:value
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     keywords="asm break case continue default do else for goto if return
               sizeof switch while offsetof alignas alignof"
@@ -244,7 +244,7 @@ add-highlighter shared/cpp/code/ regex %{(?i)(?<!\.)\b0x([\da-f]('?[\da-f]+)*)?\
 # character literals (no multi-character literals)
 add-highlighter shared/cpp/code/char regex %{(\b(u8|u|U|L)|\B)'((\\.)|[^'\\])'\B} 0:value
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     keywords="alignas alignof and and_eq asm bitand bitor break case catch
               compl const_cast continue decltype delete do dynamic_cast
@@ -278,7 +278,7 @@ evaluate-commands %sh{
 }
 
 # c and c++ compiler macros
-evaluate-commands %sh{
+evaluate-commands %cached{
     builtin_macros="__cplusplus|__STDC_HOSTED__|__FILE__|__LINE__|__DATE__|__TIME__|__STDCPP_DEFAULT_NEW_ALIGNMENT__"
 
     printf %s "
@@ -290,7 +290,7 @@ evaluate-commands %sh{
 # objective-c specific
 add-highlighter shared/objc/code/number regex %{\b-?\d+[fdiu]?|'((\\.)?|[^'\\])'} 0:value
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     keywords="break case continue default do else for goto if return switch
               while"

--- a/rc/core/kakrc.kak
+++ b/rc/core/kakrc.kak
@@ -24,8 +24,12 @@ add-highlighter shared/kakrc/shell5 region -recurse '\{' '(^|\h)\K-shell-script-
 add-highlighter shared/kakrc/shell6 region -recurse '\(' '(^|\h)\K-shell-script-(completion|candidates)\h+%\(' '\)' ref sh
 add-highlighter shared/kakrc/shell7 region -recurse '\[' '(^|\h)\K-shell-script-(completion|candidates)\h+%\[' '\]' ref sh
 add-highlighter shared/kakrc/shell8 region -recurse '<'  '(^|\h)\K-shell-script-(completion|candidates)\h+%<'  '>'  ref sh
+add-highlighter shared/kakrc/shell9 region -recurse '\{' '(^|\h)\K%?%cached\{' '\}' ref sh
+add-highlighter shared/kakrc/shell10 region -recurse '\(' '(^|\h)\K%?%cached\(' '\)' ref sh
+add-highlighter shared/kakrc/shell11 region -recurse '\[' '(^|\h)\K%?%cached\[' '\]' ref sh
+add-highlighter shared/kakrc/shell12 region -recurse '<'  '(^|\h)\K%?%cached<'  '>'  ref sh
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     keywords="edit write write-all kill quit write-quit write-all-quit map unmap alias unalias
               buffer buffer-next buffer-previous delete-buffer add-highlighter remove-highlighter

--- a/rc/core/makefile.kak
+++ b/rc/core/makefile.kak
@@ -17,7 +17,7 @@ add-highlighter shared/makefile/evaluate-commands region -recurse '\(' '\$\(' '\
 add-highlighter shared/makefile/content/ regex ^[\w.%-]+\h*:\s 0:variable
 add-highlighter shared/makefile/content/ regex [+?:]= 0:operator
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     keywords="ifeq|ifneq|ifdef|ifndef|else|endif|define|endef"
 

--- a/rc/core/python.kak
+++ b/rc/core/python.kak
@@ -34,7 +34,7 @@ add-highlighter shared/python/docstring/ default-region fill string
 add-highlighter shared/python/docstring/ region '>>> \K'    '\z' ref python
 add-highlighter shared/python/docstring/ region '\.\.\. \K'    '\z' ref python
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     values="True|False|None|self|inf"
     meta="import|from"

--- a/rc/core/sh.kak
+++ b/rc/core/sh.kak
@@ -11,7 +11,7 @@ add-highlighter shared/sh/heredoc region -match-capture '<<-?(\w+)' '^\t*(\w+)$'
 
 add-highlighter shared/sh/double_string/fill fill string
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     keywords="alias bind builtin caller case cd command coproc declare do done
               echo elif else enable esac exit fi for function help

--- a/rc/extra/dart.kak
+++ b/rc/extra/dart.kak
@@ -21,7 +21,7 @@ add-highlighter shared/dart/comment_line region '//' $ fill comment
 
 add-highlighter shared/dart/code/ regex %{-?([0-9]*\.(?!0[xX]))?\b([0-9]+|0[xX][0-9a-fA-F]+)\.?([eE][+-]?[0-9]+)?i?\b} 0:value
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     keywords="abstract|do|import|super|as|in|switch|assert|else|interface|async"
     keywords="${keywords}|enum|is|this|export|library|throw|await|external|mixin|break|extends"

--- a/rc/extra/dockerfile.kak
+++ b/rc/extra/dockerfile.kak
@@ -19,7 +19,7 @@ add-highlighter shared/dockerfile/double_string region '"' '(?<!\\)(\\\\)*"' fil
 add-highlighter shared/dockerfile/single_string region "'" "'"               fill string
 add-highlighter shared/dockerfile/comment region '#' $ fill comment
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     keywords="ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL"
     keywords="${keywords}|MAINTAINER|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR"

--- a/rc/extra/nim.kak
+++ b/rc/extra/nim.kak
@@ -18,7 +18,7 @@ add-highlighter shared/nim/raw_string region [A-Za-z](_?[A-Za-z])*" (?<!")"(?!")
 add-highlighter shared/nim/string region (?<!'\\)"(?!') (?<!\\)(\\\\)*" fill string
 add-highlighter shared/nim/comment region '#?#\[' '\]##?' fill comment
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     opchars='[=+-/<>@$~&%|!?^.:\\*]'
     opnocol='[=+-/<>@$~&%|!?^.\\*]'

--- a/rc/extra/pony.kak
+++ b/rc/extra/pony.kak
@@ -18,7 +18,7 @@ add-highlighter shared/pony/double_string region '"'   (?<!\\)(\\\\)*"  fill str
 add-highlighter shared/pony/comment       region '/\*'   '\*/'          fill comment
 add-highlighter shared/pony/line_comment  region '//'   '$'             fill comment
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammar
     values="true|false|None|this"
     meta='use'

--- a/rc/extra/protobuf.kak
+++ b/rc/extra/protobuf.kak
@@ -18,7 +18,7 @@ add-highlighter shared/protobuf/comment_line region '//' $ fill comment
 
 add-highlighter shared/protobuf/code/ regex %{(0x)?[0-9]+\b} 0:value
 
-evaluate-commands %sh{
+evaluate-commands %cached{
     # Grammer
     keywords="default|deprecated|enum|extend|import|message|oneof|option"
     keywords="${keywords}|package|service|syntax"

--- a/rc/extra/scheme.kak
+++ b/rc/extra/scheme.kak
@@ -25,7 +25,7 @@ add-highlighter shared/scheme/quoted-form region -recurse "\(" "'\(" "\)" fill v
 add-highlighter shared/scheme/code/ regex (#t|#f) 0:value
 add-highlighter shared/scheme/code/ regex \b[0-9]+\.[0-9]*\b 0:value
 
-evaluate-commands %sh{
+evaluate-commands %cached{
 
 	# Primitive expressions that cannot be derived.
 	keywords='define do let let* letrec if cond case and or begin lambda delay delay-force set!'

--- a/src/Makefile
+++ b/src/Makefile
@@ -149,6 +149,7 @@ installdirs:
 		$(sharedir)/rc/extra \
 		$(sharedir)/colors \
 		$(sharedir)/doc \
+		$(sharedir)/shell_tokens \
 		$(docdir) \
 		$(mandir)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -149,7 +149,6 @@ installdirs:
 		$(sharedir)/rc/extra \
 		$(sharedir)/colors \
 		$(sharedir)/doc \
-		$(sharedir)/shell_tokens \
 		$(docdir) \
 		$(mandir)
 

--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -13,7 +13,6 @@
 #include "utils.hh"
 #include "unit_tests.hh"
 #include "file.hh"
-#include "hash.hh"
 
 #include <algorithm>
 #include <fcntl.h>
@@ -319,7 +318,7 @@ expand_token(const Token& token, const Context& context, const ShellContext& she
         String path;
         if(token.type == Token::Type::ShellExpandCached)
         {
-            auto hash = hash_data(content.data(), (size_t)content.length());
+            auto hash = hash_value(content);
             path = real_path(parse_filename(format("{}/{}", cache_directory(), hash)));
             if(file_exists(path))
             {

--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -69,8 +69,6 @@ Reader& Reader::operator++()
     return *this;
 }
 
-String runtime_directory();
-
 namespace
 {
 
@@ -166,8 +164,8 @@ Token::Type token_type(StringView type_name, bool throw_on_invalid)
         return Token::Type::RawQuoted;
     else if (type_name == "sh")
         return Token::Type::ShellExpand;
-    else if (type_name == "shi")
-        return Token::Type::ShellExpandImmediate;
+    else if (type_name == "cached")
+        return Token::Type::ShellExpandCached;
     else if (type_name == "reg")
         return Token::Type::RegisterExpand;
     else if (type_name == "opt")
@@ -304,6 +302,22 @@ static uint16_t Fletcher16( const uint8_t* data, size_t count ) {
    return (sum2 << 8) | sum1;
 }
 
+String cache_directory()
+{
+    String cache_home;
+
+    StringView env = getenv("XDG_CACHE_HOME");
+    if (env.empty())
+        cache_home = format("{}/.cache/kak", homedir());
+    else
+        cache_home = format("{}/kak", env);
+
+    if (!file_exists(cache_home))
+        make_directory(cache_home, 01777);
+
+    return cache_home;
+}
+
 template<bool single>
 std::conditional_t<single, String, Vector<String>>
 expand_token(const Token& token, const Context& context, const ShellContext& shell_context)
@@ -313,29 +327,37 @@ expand_token(const Token& token, const Context& context, const ShellContext& she
     switch (token.type)
     {
     case Token::Type::ShellExpand:
-    case Token::Type::ShellExpandImmediate:
+    case Token::Type::ShellExpandCached:
     {
         String str;
-        auto hash = Fletcher16((const uint8_t *)content.data(), (size_t)content.length());
-        String path = real_path(parse_filename(format("{}/shell_tokens/{}", runtime_directory(), hash)));
-        if(token.type != Token::Type::ShellExpandImmediate and file_exists(path))
+        String path;
+        if(token.type == Token::Type::ShellExpandCached)
         {
-            MappedFile cached_content{path};
-            str = String(cached_content);
+            auto hash = Fletcher16((const uint8_t *)content.data(), (size_t)content.length());
+            path = real_path(parse_filename(format("{}/{}", cache_directory(), hash)));
+            if(file_exists(path))
+            {
+                MappedFile cached_content{path};
+                str = String(cached_content);
+            }
         }
-        else
+
+        if(str.empty())
         {
             str = ShellManager::instance().eval(
                 content, context, {}, ShellManager::Flags::WaitForStdout,
                 shell_context).first;
 
-            int fd = open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
-            if (fd == -1)
-                throw file_access_error(path, strerror(errno));
-
+            if(token.type == Token::Type::ShellExpandCached)
             {
-                auto close_fd = on_scope_end([fd]{ close(fd); });
-                write(fd, str);
+                int fd = open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+                if (fd == -1)
+                    throw file_access_error(path, strerror(errno));
+
+                {
+                    auto close_fd = on_scope_end([fd]{ close(fd); });
+                    write(fd, str);
+                }
             }
         }
 

--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -12,8 +12,12 @@
 #include "shell_manager.hh"
 #include "utils.hh"
 #include "unit_tests.hh"
+#include "file.hh"
 
 #include <algorithm>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
 
 namespace Kakoune
 {
@@ -64,6 +68,8 @@ Reader& Reader::operator++()
     utf8::to_next(pos, str.end());
     return *this;
 }
+
+String runtime_directory();
 
 namespace
 {
@@ -160,6 +166,8 @@ Token::Type token_type(StringView type_name, bool throw_on_invalid)
         return Token::Type::RawQuoted;
     else if (type_name == "sh")
         return Token::Type::ShellExpand;
+    else if (type_name == "shi")
+        return Token::Type::ShellExpandImmediate;
     else if (type_name == "reg")
         return Token::Type::RegisterExpand;
     else if (type_name == "opt")
@@ -281,6 +289,21 @@ Vector<String> expand_arobase(ConstArrayView<String> params, std::false_type)
     return {params.begin(), params.end()};
 }
 
+// Fletcher, J. G. (January 1982). "An Arithmetic Checksum for Serial Transmissions". IEEE Transactions on Communications COM-30 (1): 247-252.
+static uint16_t Fletcher16( const uint8_t* data, size_t count ) {
+   uint16_t sum1 = 0;
+   uint16_t sum2 = 0;
+   size_t index;
+
+   for( index = 0; index < count; ++index )
+   {
+      sum1 = (sum1 + data[index]) % 255;
+      sum2 = (sum2 + sum1) % 255;
+   }
+
+   return (sum2 << 8) | sum1;
+}
+
 template<bool single>
 std::conditional_t<single, String, Vector<String>>
 expand_token(const Token& token, const Context& context, const ShellContext& shell_context)
@@ -290,10 +313,31 @@ expand_token(const Token& token, const Context& context, const ShellContext& she
     switch (token.type)
     {
     case Token::Type::ShellExpand:
+    case Token::Type::ShellExpandImmediate:
     {
-        auto str = ShellManager::instance().eval(
-            content, context, {}, ShellManager::Flags::WaitForStdout,
-            shell_context).first;
+        String str;
+        auto hash = Fletcher16((const uint8_t *)content.data(), (size_t)content.length());
+        String path = real_path(parse_filename(format("{}/shell_tokens/{}", runtime_directory(), hash)));
+        if(token.type != Token::Type::ShellExpandImmediate and file_exists(path))
+        {
+            MappedFile cached_content{path};
+            str = String(cached_content);
+        }
+        else
+        {
+            str = ShellManager::instance().eval(
+                content, context, {}, ShellManager::Flags::WaitForStdout,
+                shell_context).first;
+
+            int fd = open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+            if (fd == -1)
+                throw file_access_error(path, strerror(errno));
+
+            {
+                auto close_fd = on_scope_end([fd]{ close(fd); });
+                write(fd, str);
+            }
+        }
 
         int trailing_eol_count = 0;
         for (auto c : str | reverse())

--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -13,6 +13,7 @@
 #include "utils.hh"
 #include "unit_tests.hh"
 #include "file.hh"
+#include "hash.hh"
 
 #include <algorithm>
 #include <fcntl.h>
@@ -287,21 +288,6 @@ Vector<String> expand_arobase(ConstArrayView<String> params, std::false_type)
     return {params.begin(), params.end()};
 }
 
-// Fletcher, J. G. (January 1982). "An Arithmetic Checksum for Serial Transmissions". IEEE Transactions on Communications COM-30 (1): 247-252.
-static uint16_t Fletcher16( const uint8_t* data, size_t count ) {
-   uint16_t sum1 = 0;
-   uint16_t sum2 = 0;
-   size_t index;
-
-   for( index = 0; index < count; ++index )
-   {
-      sum1 = (sum1 + data[index]) % 255;
-      sum2 = (sum2 + sum1) % 255;
-   }
-
-   return (sum2 << 8) | sum1;
-}
-
 String cache_directory()
 {
     String cache_home;
@@ -333,7 +319,7 @@ expand_token(const Token& token, const Context& context, const ShellContext& she
         String path;
         if(token.type == Token::Type::ShellExpandCached)
         {
-            auto hash = Fletcher16((const uint8_t *)content.data(), (size_t)content.length());
+            auto hash = hash_data(content.data(), (size_t)content.length());
             path = real_path(parse_filename(format("{}/{}", cache_directory(), hash)));
             if(file_exists(path))
             {

--- a/src/command_manager.hh
+++ b/src/command_manager.hh
@@ -47,6 +47,7 @@ struct Token
         RawQuoted,
         RawEval,
         ShellExpand,
+        ShellExpandImmediate,
         RegisterExpand,
         OptionExpand,
         ValExpand,

--- a/src/command_manager.hh
+++ b/src/command_manager.hh
@@ -47,7 +47,7 @@ struct Token
         RawQuoted,
         RawEval,
         ShellExpand,
-        ShellExpandImmediate,
+        ShellExpandCached,
         RegisterExpand,
         OptionExpand,
         ValExpand,

--- a/src/file.cc
+++ b/src/file.cc
@@ -2,7 +2,6 @@
 
 #include "assert.hh"
 #include "buffer.hh"
-#include "exception.hh"
 #include "flags.hh"
 #include "option_types.hh"
 #include "ranked_match.hh"
@@ -37,17 +36,6 @@
 
 namespace Kakoune
 {
-
-struct file_access_error : runtime_error
-{
-public:
-    file_access_error(StringView filename,
-                      StringView error_desc)
-        : runtime_error(format("{}: {}", filename, error_desc)) {}
-
-    file_access_error(int fd, StringView error_desc)
-        : runtime_error(format("fd {}: {}", fd, error_desc)) {}
-};
 
 String parse_filename(StringView filename, StringView buf_dir)
 {

--- a/src/file.hh
+++ b/src/file.hh
@@ -6,6 +6,8 @@
 #include "string.hh"
 #include "units.hh"
 #include "vector.hh"
+#include "exception.hh"
+#include "string_utils.hh"
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -18,6 +20,18 @@ class String;
 class Regex;
 
 using CandidateList = Vector<String, MemoryDomain::Completion>;
+
+struct file_access_error : runtime_error
+{
+public:
+    file_access_error(StringView filename,
+                      StringView error_desc)
+        : runtime_error(format("{}: {}", filename, error_desc)) {}
+
+    file_access_error(int fd, StringView error_desc)
+        : runtime_error(format("fd {}: {}", fd, error_desc)) {}
+};
+
 
 // parse ~/ and %/ in filename and returns the translated filename
 String parse_filename(StringView filename, StringView buf_dir = {});


### PR DESCRIPTION
This will almost completely eliminate startup time after the first launch.  Most of the startup time is taken by running shell scripts to generate the same content each startup.  I added a second shell token to bypass the caching if needed, for situations where the script depends on the current environment.

This is a proof of concept and I am happy to make any changes to bring it up to the standards needed to be merged in.