### PR TITLE
Cache clojure highlighting info

### DIFF
--- a/rc/base/clojure.kak
+++ b/rc/base/clojure.kak
@@ -28,6 +28,14 @@ hook global WinSetOption filetype=clojure %{
 }
 
 evaluate-commands %sh{
+    cache_version=1 # Change when below code is changed
+    cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/kak"
+    cache_file="$cache_dir/clojure-v$cache_version.kak"
+    if [ -f "$cache_file" ]; then
+        printf 'source "%s"\n' "$cache_file"
+        exit 0
+    fi
+    mkdir -p "$cache_dir"
     symbol_char='[^\s()\[\]{}"\;@^`~\\%/]'
     in_core='(clojure\.core/|(?<!/))'
     keywords="
@@ -152,7 +160,8 @@ evaluate-commands %sh{
         hook global WinSetOption filetype=clojure %{
             set-option window static_words $static_words
         }
-    "
+    " >"$cache_file"
+    printf 'source "%s"\n' "$cache_file"
 }
 
 # Commands


### PR DESCRIPTION
Related to #2683, I thought, "What if shell expansions handled their own caching manually?  Would that be too bad?"

This is the result.  I think it isn't too bad, actually.  (`clojure.kak` was the second worst offender on startup script timings on some list I saw a while back.)

Before:
```
[jfelice@C02X421DJHD4 kakoune(master)]$ time for ((i = 0; i < 1000; i++)); do kak -n -e 'source rc/base/clojure.kak; quit'; done                                    

real    1m12.413s                        
user    0m37.475s                        
sys     0m35.105s                        
```

After:
```
[jfelice@C02X421DJHD4 kakoune(cache-clojure-highlighting)]$ time for ((i = 0; i < 1000; i++)); do kak -n -e 'source rc/base/clojure.kak; quit'; done                

real    0m20.221s                        
user    0m5.919s                         
sys     0m10.725s                        
```