### PR TITLE
Fix and simplify ctags-funcinfo command

### DIFF
--- a/rc/base/ctags.kak
+++ b/rc/base/ctags.kak
@@ -62,7 +62,10 @@ define-command ctags-funcinfo -docstring "Display ctags information about a sele
         try %{
             execute-keys '[(;B<a-k>[a-zA-Z_]+\(<ret><a-;>'
             evaluate-commands %sh{
-                sigs=$(readtags -e ${kak_selection%?} | grep kind:f | sed -re 's/^(\S+).*((class|struct|namespace):(\S+))?.*signature:(.*)$/\5 [\4::\1]/')
+                f=${kak_selection%?}
+                sig='\tsignature:(.*)'
+                csn='\t(class|struct|namespace):(\S+)'
+                sigs=$(readtags -e -Q '(eq? $kind "f")' "${f}" | sed -re "s/^.*${csn}.*${sig}$/\3 [\2::${f}]/ ;t ;s/^.*${sig}$/\1 [${f}]/")
                 if [ -n "$sigs" ]; then
                     printf %s\\n "evaluate-commands -client ${kak_client} %{info -anchor $kak_cursor_line.$kak_cursor_column -placement above '$sigs'}"
                 fi


### PR DESCRIPTION
1. ctags-funcinfo tries to show a fully-qualified name for a function if a class, struct, or namespace tag is available, in the form of, _eg_, `[classname::funcname]`. However, the prefix is always missing, `[::funcname]`. The problem is the use of an optional group in the sed regex. A simplify form is `s/^(a).*(b)?.*(c)$/\1 \2 \3/`, where `a` token is the funcname, `b` token is class/struct/namespace, and `c` token is the function signature. The optional `b` token is surrounded by greedy `.*` expressions, leading to a successful match if `b` is present but yielding no capture value in `\2`. The fix is to reconstruct the sed regex to have the form `s/^(a).*(b).*(c)$/\1 \2 \3/; t; s/^(a).*(c)$/\1 \2/`, where the 1st substitution is more specific than the 2nd; the 2nd will be tried only if the 1st fails.

1. We can simplify the above because the funcname is already known--it is the `kak_selection`--so we can omit it from the pattern matches, _eg_, `s/^.*(b).*(c)$/\1 \2/; t; s/^.*(c)$/\1/`

1. We can further simplify by using a readtag filter expression to replace a use of grep, _ie_, `readtags -e funcname | grep kind:f | ...` becomes `readtags -e -Q '(eq? $kind "f")' | ...`.

When tested with c++ code, fully qualified function names are nicely shown; when tested with c code, plain function names without the leading :: are shown.