### PR TITLE
Use indentwidth for lisp, scheme, and Clojure

### DIFF
--- a/rc/base/clojure.kak
+++ b/rc/base/clojure.kak
@@ -179,8 +179,9 @@ define-command -hidden clojure-indent-on-new-line %{
             execute-keys -draft '[bl"i<a-Z><gt>"wZ'
 
             try %{
-                # If a special form, indent another space
-                execute-keys -draft '"wze<a-k>\A' %opt{clojure_special_indent_forms} '\z<ret><a-L>s.\K.*<ret><a-;>;"i<a-Z><gt>'
+                # If a special form, indent another (indentwidth - 1) spaces
+                execute-keys -draft '"wze<a-k>\A' %opt{clojure_special_indent_forms} '\z<ret>'
+                execute-keys -draft '"wze<a-L>s.{' %sh{printf $(( kak_opt_indentwidth - 1 ))} '}\K.*<ret><a-;>;"i<a-Z><gt>'
             } catch %{
                 # If not special and parameter appears on line 1, indent to parameter
                 execute-keys -draft '"wze<a-l>s\h\K[^\s].*<ret><a-;>;"i<a-Z><gt>'

--- a/rc/base/lisp.kak
+++ b/rc/base/lisp.kak
@@ -43,10 +43,14 @@ define-command -hidden lisp-indent-on-new-line %{
         try %{
             execute-keys -draft '[bl"i<a-Z><gt>"wZ'
 
-            try %{ execute-keys -draft '"wz<a-l>s.\K.*<ret><a-;>;"i<a-Z><gt>' }
-
-            # If not "special" form and parameter appears on line 1, indent to parameter
-            execute-keys -draft '"wze<a-K>\A' %opt{lisp_special_indent_forms} '\z<ret>' '<a-l>s\h\K[^\s].*<ret><a-;>;"i<a-Z><gt>'
+            try %{
+                # If a special form, indent another (indentwidth - 1) spaces
+                execute-keys -draft '"wze<a-k>\A' %opt{lisp_special_indent_forms} '\z<ret>'
+                execute-keys -draft '"wze<a-L>s.{' %sh{printf $(( kak_opt_indentwidth - 1 ))} '}\K.*<ret><a-;>;"i<a-Z><gt>'
+            } catch %{
+                # If not "special" form and parameter appears on line 1, indent to parameter
+                execute-keys -draft '"wze<a-l>s\h\K[^\s].*<ret><a-;>;"i<a-Z><gt>'
+            }
         }
         try %{ execute-keys -draft '[rl"i<a-Z><gt>' }
         try %{ execute-keys -draft '[Bl"i<a-Z><gt>' }


### PR DESCRIPTION
Previously, indenting two spaces (which is usual) was assumed for special
forms.  We might as well use indentwidth here, so users can configure this.