### PR TITLE
git should not ignore doc/kak.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ src/kak
 src/kak.debug
 src/kak.opt
 src/.version*
-doc/kak.1
 doc/kak.1.gz
 doc/manpages/*.gz
 tags


### PR DESCRIPTION
In the past, the 'make man' used a2x to generate doc/kak.1, and therefore, git ignored it. Later, a fix for #2504 changed the kak.1 nroff file to a source file, and therefore git should not ignore it.