### PR TITLE
Indent and deindent c-family single line else properly

### DIFF
--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -49,11 +49,16 @@ define-command -hidden c-family-indent-on-newline %< evaluate-commands -draft -i
     try %< execute-keys -draft k <a-x> s[a-zA-Z0-9_-]+:\h*$<ret> j <a-gt> >
     # indent after a statement not followed by an opening brace
     try %< execute-keys -draft k <a-x> s\)\h*(?://[^\n]+)?\n\z<ret> \
-                               <a-\;>mB <a-k>\A\b(if|else|for|while)\b<ret> <a-\;>j <a-gt> >
+                               <a-\;>mB <a-k>\A\b(if|for|while)\b<ret> <a-\;>j <a-gt> >
+    try %< execute-keys -draft k <a-x> s \belse\b\h*(?://[^\n]+)?\n\z<ret> \
+                               j <a-gt> >
     # deindent after a single line statement end
     try %< execute-keys -draft K <a-x> <a-k>\;\h*(//[^\n]+)?$<ret> \
                                K <a-x> s\)(\h+\w+)*\h*(//[^\n]+)?\n([^\n]*\n){2}\z<ret> \
-                               MB <a-k>\A\b(if|else|for|while)\b<ret> <a-S>1<a-&> >
+                               MB <a-k>\A\b(if|for|while)\b<ret> <a-S>1<a-&> >
+    try %< execute-keys -draft K <a-x> <a-k>\;\h*(//[^\n]+)?$<ret> \
+                               K <a-x> s \belse\b\h*(?://[^\n]+)?\n([^\n]*\n){2}\z<ret> \
+                               <a-S>1<a-&> >
     # align to the opening parenthesis or opening brace (whichever is first)
     # on a previous line if its followed by text on the same line
     try %< evaluate-commands -draft %<

--- a/test/indent/c-family/deindent-if-body/in
+++ b/test/indent/c-family/deindent-if-body/in
@@ -8,3 +8,9 @@ if (bar(a, b,
 if (bar(a, b,
         c, d)) // comment
     foo();%( )
+
+else
+    bar();%( )
+
+else // comment
+    bar();%( )

--- a/test/indent/c-family/deindent-if-body/out
+++ b/test/indent/c-family/deindent-if-body/out
@@ -11,3 +11,11 @@ if (bar(a, b,
         c, d)) // comment
     foo();
 baz
+
+else
+    bar();
+baz
+
+else // comment
+    bar();
+baz

--- a/test/indent/c-family/indent-if-body/in
+++ b/test/indent/c-family/indent-if-body/in
@@ -5,3 +5,7 @@ if (bar(a, b,
 
 if (bar(a, b,
         c, d)) // comment%( )
+
+else%( )
+
+else // comment%( )

--- a/test/indent/c-family/indent-if-body/out
+++ b/test/indent/c-family/indent-if-body/out
@@ -8,3 +8,9 @@ if (bar(a, b,
 if (bar(a, b,
         c, d)) // comment
     foo
+
+else
+    foo
+
+else // comment
+    foo


### PR DESCRIPTION
Previous optimization only indented/deindented single line else cases if else had parentheses after it.