### PR TITLE
Add object command submode

### DIFF
--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -681,6 +681,10 @@ in order to specify the wanted object:
 *c*::
     select user defined object, will prompt for open and close text
 
+*<a-;>*::
+    run a command in object context.  The expansions `%val{count}` and
+    `%val{register}` are available here.
+
 == Prompt commands
 
 When pressing `:` in normal mode, Kakoune will open a prompt to enter

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1252,12 +1252,12 @@ void select_object(Context& context, NormalParams params)
                       whole ? "" : (flags & ObjectFlags::ToBegin ? " begin" : " end"));
     };
 
-    const int count = params.count <= 0 ? 0 : params.count - 1;
     on_next_key_with_autoinfo(context, KeymapMode::Object,
-                             [count](Key key, Context& context) {
+                             [params](Key key, Context& context) {
         if (key == Key::Escape)
             return;
 
+        const int count = params.count <= 0 ? 0 : params.count - 1;
         static constexpr struct ObjectType
         {
             Key key;
@@ -1308,6 +1308,12 @@ void select_object(Context& context, NormalParams params)
                                            Regex{params[1], RegexCompileFlags::Backward},
                                            count, flags));
                 });
+            return;
+        }
+
+        if (key == alt(';'))
+        {
+            command(context, params);
             return;
         }
 
@@ -1365,7 +1371,8 @@ void select_object(Context& context, NormalParams params)
          {{'i'},         "indent"},
          {{'u'},         "argument"},
          {{'n'},         "number"},
-         {{'c'},         "custom object desc"}}));
+         {{'c'},         "custom object desc"},
+         {{alt(';')},    "run command in object context"}}));
 }
 
 enum Direction { Backward = -1, Forward = 1 };


### PR DESCRIPTION
Closes #2735

In addition, we *could* add additional expansions to tell the command what
kind of object it is (e.g. `<a-a>` vs. `]`), resolving part of #1299 and part
of #2669.