### PR TITLE
Add `select_mode` and `object_flags` expansions

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -215,7 +215,7 @@ The following expansions are supported (with required context _in italics_):
     directory containing the user configuration
 
 *%val{count}*::
-    _in `map` command <keys> parameter_ +
+    _in `map` command <keys> parameter and `<a-;>` from object menu_ +
     current count when the mapping was triggered, defaults to 0 if no
     count given
 
@@ -262,13 +262,24 @@ The following expansions are supported (with required context _in italics_):
     _in buffer, window scope_ +
     `true` if the buffer has modifications not saved, otherwise `false`
 
+*%val{object_flags}*::
+    _for commands executed from the object menu's `<a-;>` only_ +
+    a pipe-separted list of words including `inner` if the user wants
+    an inner selection, `to_begin` if the user wants to select to the
+    beginning, and `to_end` if the user wants to select to the end
+
 *%val{register}*::
-    _in `map` command <keys> parameter_ +
+    _in `map` command <keys> parameter and `<a-;>` from the object menu_ +
     current register when the mapping was triggered
 
 *%val{runtime}*::
     directory containing the kak support files, determined from Kakoune's
     binary location
+
+*%val{select_mode}*::
+    _for commands executed from the object menu's `<a-;>` only_ +
+    `replace` if the new selection should replace the existing, `extend`
+    otherwise
 
 *%val{selection}*::
     _in window scope_ +

--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -682,8 +682,8 @@ in order to specify the wanted object:
     select user defined object, will prompt for open and close text
 
 *<a-;>*::
-    run a command in object context.  The expansions `%val{count}` and
-    `%val{register}` are available here.
+    run a command with additional expansions describing the selection
+    context (See <<expansions#,`:doc expansions`>>)
 
 == Prompt commands
 

--- a/src/selectors.hh
+++ b/src/selectors.hh
@@ -1,6 +1,7 @@
 #ifndef selectors_hh_INCLUDED
 #define selectors_hh_INCLUDED
 
+#include "enum.hh"
 #include "optional.hh"
 #include "meta.hh"
 #include "unicode.hh"
@@ -61,6 +62,15 @@ enum class ObjectFlags
 };
 
 constexpr bool with_bit_ops(Meta::Type<ObjectFlags>) { return true; }
+
+constexpr auto enum_desc(Meta::Type<ObjectFlags>)
+{
+    return make_array<EnumDesc<ObjectFlags>, 3>({
+        { ObjectFlags::ToBegin, "to_begin" },
+        { ObjectFlags::ToEnd, "to_end" },
+        { ObjectFlags::Inner, "inner" },
+    });
+}
 
 template<WordType word_type>
 Optional<Selection>


### PR DESCRIPTION
This is built on top of #2736, but is here for separate consideration.

Adds `select_mode` and `object_flags` expansions for the command-line
invoked from the object menu's `<a-;>`.