### PR TITLE
Removed unneeded compilation warning suppression options

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -98,7 +98,7 @@ kak$(suffix) : $(objects) .version.o
 -include $(deps)
 
 .%$(suffix).o: %.cc
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -MD -MP -MF $(addprefix ., $(<:.cc=$(suffix).d)) -c -o $@ $<
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -MD -MF $(addprefix ., $(<:.cc=$(suffix).d)) -c -o $@ $<
 
 .version.o: .version.cc
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $<

--- a/src/Makefile
+++ b/src/Makefile
@@ -85,7 +85,7 @@ else
     LDFLAGS += -rdynamic
 endif
 
-CXXFLAGS += -pedantic -std=c++17 -g -Wall -Wextra -Wno-unused-parameter -Wno-reorder -Wno-sign-compare -Wno-address -Wno-noexcept-type -Wno-unknown-attributes -Wno-unknown-warning-option
+CXXFLAGS += -pedantic -std=c++17 -g -Wall -Wextra -Wno-unused-parameter -Wno-reorder -Wno-sign-compare -Wno-address
 
 all : kak
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -85,7 +85,7 @@ else
     LDFLAGS += -rdynamic
 endif
 
-CXXFLAGS += -pedantic -std=c++17 -g -Wall -Wextra -Wno-unused-parameter -Wno-reorder -Wno-sign-compare -Wno-address
+CXXFLAGS += -pedantic -std=c++17 -g -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-address
 
 all : kak
 

--- a/src/client.cc
+++ b/src/client.cc
@@ -32,9 +32,9 @@ Client::Client(std::unique_ptr<UserInterface>&& ui,
     : m_ui{std::move(ui)}, m_window{std::move(window)},
       m_pid{pid},
       m_on_exit{std::move(on_exit)},
+      m_env_vars(std::move(env_vars)),
       m_input_handler{std::move(selections), Context::Flags::None,
-                      std::move(name)},
-      m_env_vars(std::move(env_vars))
+                      std::move(name)}
 {
     m_window->set_client(this);
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -13,9 +13,9 @@ Context::~Context() = default;
 
 Context::Context(InputHandler& input_handler, SelectionList selections,
                  Flags flags, String name)
-    : m_input_handler{&input_handler},
+    : m_flags(flags),
+      m_input_handler{&input_handler},
       m_selections{std::move(selections)},
-      m_flags(flags),
       m_name(std::move(name))
 {}
 

--- a/src/display_buffer.hh
+++ b/src/display_buffer.hh
@@ -28,7 +28,7 @@ public:
         : m_type(Range), m_buffer(&buffer), m_range{begin, end} {}
 
     DisplayAtom(String str, Face face)
-        : m_type(Text), m_text(std::move(str)), face(face) {}
+        : face(face), m_type(Text), m_text(std::move(str)) {}
 
     StringView content() const;
     ColumnCount length() const;

--- a/src/event_manager.cc
+++ b/src/event_manager.cc
@@ -34,7 +34,7 @@ void FDWatcher::close_fd()
 }
 
 Timer::Timer(TimePoint date, Callback callback, EventMode mode)
-    : m_date{date}, m_callback{std::move(callback)}, m_mode(mode)
+    : m_date{date}, m_mode(mode), m_callback{std::move(callback)}
 {
     if (m_callback and EventManager::has_instance())
         EventManager::instance().m_timers.push_back(this);

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -633,8 +633,8 @@ std::unique_ptr<Highlighter> create_column_highlighter(HighlighterParameters par
 struct WrapHighlighter : Highlighter
 {
     WrapHighlighter(ColumnCount max_width, bool word_wrap, bool preserve_indent, String marker)
-        : Highlighter{HighlightPass::Wrap}, m_max_width{max_width},
-          m_word_wrap{word_wrap}, m_preserve_indent{preserve_indent},
+        : Highlighter{HighlightPass::Wrap}, m_word_wrap{word_wrap},
+          m_preserve_indent{preserve_indent}, m_max_width{max_width},
           m_marker{std::move(marker)} {}
 
     static constexpr StringView ms_id = "wrap";

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -250,7 +250,9 @@ default_colors = {
 };
 
 NCursesUI::NCursesUI()
-    : m_stdin_watcher{0, FdEvents::Read,
+    : m_colors{default_colors},
+      m_cursor{CursorMode::Buffer, {}},
+      m_stdin_watcher{0, FdEvents::Read,
                       [this](FDWatcher&, FdEvents, EventMode) {
         if (not m_on_key)
             return;
@@ -258,9 +260,7 @@ NCursesUI::NCursesUI()
         while (auto key = get_next_key())
             m_on_key(*key);
       }},
-      m_assistant(assistant_clippy),
-      m_colors{default_colors},
-      m_cursor{CursorMode::Buffer, {}}
+      m_assistant(assistant_clippy)
 {
     initscr();
     raw();

--- a/src/regex_impl.cc
+++ b/src/regex_impl.cc
@@ -672,7 +672,7 @@ constexpr RegexParser::ControlEscape RegexParser::control_escapes[];
 struct RegexCompiler
 {
     RegexCompiler(ParsedRegex&& parsed_regex, RegexCompileFlags flags)
-        : m_parsed_regex{parsed_regex}, m_flags(flags)
+        : m_flags(flags), m_parsed_regex{parsed_regex}
     {
         kak_assert(not (flags & RegexCompileFlags::NoForward) or flags & RegexCompileFlags::Backward);
         // Approximation of the number of instructions generated

--- a/src/selection.cc
+++ b/src/selection.cc
@@ -8,7 +8,7 @@ namespace Kakoune
 {
 
 SelectionList::SelectionList(Buffer& buffer, Selection s, size_t timestamp)
-    : m_buffer(&buffer), m_selections({ std::move(s) }), m_timestamp(timestamp)
+    : m_selections({ std::move(s) }), m_buffer(&buffer), m_timestamp(timestamp)
 {
     check_invariant();
 }
@@ -17,7 +17,7 @@ SelectionList::SelectionList(Buffer& buffer, Selection s)
     : SelectionList(buffer, std::move(s), buffer.timestamp()) {}
 
 SelectionList::SelectionList(Buffer& buffer, Vector<Selection> list, size_t timestamp)
-    : m_buffer(&buffer), m_selections(std::move(list)), m_timestamp(timestamp)
+    : m_selections(std::move(list)), m_buffer(&buffer), m_timestamp(timestamp)
 {
     kak_assert(size() > 0);
     m_main = size() - 1;
@@ -28,7 +28,7 @@ SelectionList::SelectionList(Buffer& buffer, Vector<Selection> list)
     : SelectionList(buffer, std::move(list), buffer.timestamp()) {}
 
 SelectionList::SelectionList(SelectionList::UnsortedTag, Buffer& buffer, Vector<Selection> list, size_t timestamp, size_t main)
-    : m_buffer(&buffer), m_selections(std::move(list)), m_timestamp(timestamp)
+    : m_selections(std::move(list)), m_buffer(&buffer), m_timestamp(timestamp)
 {
     sort_and_merge_overlapping();
     check_invariant();

--- a/src/selectors.hh
+++ b/src/selectors.hh
@@ -10,7 +10,7 @@
 namespace Kakoune
 {
 
-class Selection;
+struct Selection;
 class Buffer;
 class Regex;
 class Context;

--- a/src/utils.hh
+++ b/src/utils.hh
@@ -65,11 +65,11 @@ class OnScopeEnd
 {
 public:
     [[gnu::always_inline]]
-    OnScopeEnd(T func) : m_func{std::move(func)}, m_valid{true} {}
+    OnScopeEnd(T func) : m_valid{true}, m_func{std::move(func)} {}
 
     [[gnu::always_inline]]
     OnScopeEnd(OnScopeEnd&& other)
-      : m_func{std::move(other.m_func)}, m_valid{other.m_valid}
+      : m_valid{other.m_valid}, m_func{std::move(other.m_func)}
     { other.m_valid = false; }
 
     [[gnu::always_inline]]


### PR DESCRIPTION
Removed unneeded compilation warning suppression options from the makefile.
Reordered initialization lists so that the -Wno-reorder option is no longer needed
Slightly changed `option_manager.hh` to fixed address warnings.

The fix to address warnings is a bit hacky, so it might not be worth it just to remove a compilation option.

Why did I do this pointless work you ask? I'm not sure either.