### PR TITLE
unset-option: throw if option is not set in the scope

### DIFF
--- a/src/option_manager.cc
+++ b/src/option_manager.cc
@@ -91,6 +91,8 @@ void OptionManager::unset_option(StringView name)
         if (changed)
             on_option_changed(parent_option);
     }
+    else
+        throw runtime_error{format("option '{}' is not set in this scope", name)};
 }
 
 void OptionManager::on_option_changed(const Option& option)


### PR DESCRIPTION
This makes it possible to reset an option (in order to rerun hooks for example), by doing

```
try "
    unset buffer filetype
    set buffer %opt{filetype}
"
```