### PR TITLE
Various fixes to iterm.kak

### DIFF
--- a/rc/extra/iterm.kak
+++ b/rc/extra/iterm.kak
@@ -1,12 +1,13 @@
 # https://www.iterm2.com
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-## The default behaviour for the `new` command is to open an vertical pane in
+## The default behaviour for the `terminal` command is to open a vertical pane in
 ## an iTerm session if not in a tmux session.
 hook global KakBegin .* %sh{
     if [ "$TERM_PROGRAM" = "iTerm.app" ] && [ -z "$TMUX" ]; then
         echo "
             alias global focus iterm-focus
+            alias global terminal iterm-terminal-vertical
         "
     fi
 }
@@ -28,7 +29,7 @@ define-command -hidden -params 2.. iterm-terminal-split-impl %{
         # go through another round of escaping for osascript
         # \ -> \\
         # " -> \"
-        escaped=$(printf %s "$args" | sed -e 's|\|\\\\|g; s|"|\\"|g')
+        escaped=$(printf %s "$args" | sed -e 's|\\|\\\\|g; s|"|\\"|g')
         cmd="env PATH='${PATH}' TMPDIR='${TMPDIR}' $escaped"
         osascript                                                                             \
         -e "tell application \"iTerm\""                                                       \
@@ -41,14 +42,14 @@ define-command -hidden -params 2.. iterm-terminal-split-impl %{
 
 define-command iterm-terminal-vertical -params 1.. -shell-completion -docstring '
 iterm-terminal-vertical <program> [<arguments>]: create a new terminal as an iterm pane
-The current pane is split into two, top and bottom
+The current pane is split into two, left and right
 The program passed as argument will be executed in the new terminal'\
 %{
     iterm-terminal-split-impl 'vertically' %arg{@}
 }
 define-command iterm-terminal-horizontal -params 1.. -shell-completion -docstring '
 iterm-terminal-horizontal <program> [<arguments>]: create a new terminal as an iterm pane
-The current pane is split into two, left and right
+The current pane is split into two, top and bottom
 The program passed as argument will be executed in the new terminal'\
 %{
     iterm-terminal-split-impl 'horizontally' %arg{@}
@@ -69,7 +70,7 @@ The program passed as argument will be executed in the new terminal'\
                 fi
             done
         )
-        escaped=$(printf %s "$args" | sed -e 's|\|\\\\|g; s|"|\\"|g')
+        escaped=$(printf %s "$args" | sed -e 's|\\|\\\\|g; s|"|\\"|g')
         cmd="env PATH='${PATH}' TMPDIR='${TMPDIR}' $escaped"
         osascript                                                       \
         -e "tell application \"iTerm\""                                 \
@@ -95,7 +96,7 @@ The program passed as argument will be executed in the new terminal'\
                 fi
             done
         )
-        escaped=$(printf %s "$args" | sed -e 's|\|\\\\|g; s|"|\\"|g')
+        escaped=$(printf %s "$args" | sed -e 's|\\|\\\\|g; s|"|\\"|g')
         cmd="env PATH='${PATH}' TMPDIR='${TMPDIR}' $escaped"
         osascript                                                      \
         -e "tell application \"iTerm\""                                \


### PR DESCRIPTION
The 'terminal' alias wasn't automatically setup
Missing `\` in sed calls
Descriptions of vertical and horizontal split was swapped around

Thanks @grtlr for testing