### PR TITLE
Add KDE Konsole terminal to termcmd

### DIFF
--- a/rc/base/x11.kak
+++ b/rc/base/x11.kak
@@ -13,7 +13,8 @@ A shell command is appended to the one set in this option at runtime} \
                    'mintty         -e sh -c' \
                    'sakura         -x      ' \
                    'gnome-terminal -e      ' \
-                   'xfce4-terminal -e      ' ; do
+                   'xfce4-terminal -e      ' \
+                   'konsole        -e      '; do
         terminal=${termcmd%% *}
         if command -v $terminal >/dev/null 2>&1; then
             printf %s\\n "$termcmd"


### PR DESCRIPTION
Konsole doesn't work well with non-default Kakoune themes, so I've put it last in the list, but in case when no other terminal is available it's good to have it in the list for launching non-kakoune things, like tig