### PR TITLE
rc: Use builtin faces

### DIFF
--- a/rc/base/d.kak
+++ b/rc/base/d.kak
@@ -14,15 +14,15 @@ hook global BufCreate .*\.di? %{
 add-highlighter shared/d regions
 add-highlighter shared/d/code default-region group
 add-highlighter shared/d/string region %{(?<!')(?<!'\\)"} %{(?<!\\)(?:\\\\)*"} group
-add-highlighter shared/d/verbatim_string1 region ` ` fill magenta
-add-highlighter shared/d/verbatim_string2 region %{(?<!')(?<!'\\)`} %{(?<!\\)(?:\\\\)*`} fill magenta
-add-highlighter shared/d/verbatim_string_prefixed region %{r`([^(]*)\(} %{\)([^)]*)`} fill magenta
-add-highlighter shared/d/disabled region '/\+[^+]?' '\+/' fill rgb:777777
+add-highlighter shared/d/verbatim_string1 region ` ` fill meta
+add-highlighter shared/d/verbatim_string2 region %{(?<!')(?<!'\\)`} %{(?<!\\)(?:\\\\)*`} fill meta
+add-highlighter shared/d/verbatim_string_prefixed region %{r`([^(]*)\(} %{\)([^)]*)`} fill meta
+add-highlighter shared/d/disabled region '/\+[^+]?' '\+/' fill comment
 add-highlighter shared/d/comment1 region '/\*[^*]?' '\*/' fill comment
 add-highlighter shared/d/comment2 region '//[^/]?' $ fill comment
-add-highlighter shared/d/docstring1 region '/\+\+' '\+/' fill blue
-add-highlighter shared/d/docstring2 region '/\*\*' '\*/' fill blue
-add-highlighter shared/d/docstring3 region /// $ fill blue
+add-highlighter shared/d/docstring1 region '/\+\+' '\+/' fill comment
+add-highlighter shared/d/docstring2 region '/\*\*' '\*/' fill comment
+add-highlighter shared/d/docstring3 region /// $ fill comment
 
 add-highlighter shared/d/string/ fill string
 add-highlighter shared/d/string/ regex %{\\(x[0-9a-fA-F]{2}|[0-7]{1,3}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})\b} 0:value

--- a/rc/base/git.kak
+++ b/rc/base/git.kak
@@ -14,14 +14,14 @@ hook -group git-commit-highlight global WinSetOption filetype=git-commit %{
     add-highlighter window/git-commit-highlight regions
     add-highlighter window/git-commit-highlight/diff region '^diff --git' '^(?=diff --git)' ref diff # highlight potential diffs from the -v option
     add-highlighter window/git-commit-highlight/comments region '^\h*#' '$' group
-    add-highlighter window/git-commit-highlight/comments/ fill cyan,default
+    add-highlighter window/git-commit-highlight/comments/ fill comment
     add-highlighter window/git-commit-highlight/comments/ regex "\b(?:(modified)|(deleted)|(new file)|(renamed|copied)):([^\n]*)$" 1:yellow 2:red 3:green 4:blue 5:magenta
 
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-commit-highlight }
 }
 
 hook -group git-commit-highlight global WinSetOption filetype=git-notes %{
-    add-highlighter window/git-notes-highlight regex '^\h*#[^\n]*$' 0:cyan
+    add-highlighter window/git-notes-highlight regex '^\h*#[^\n]*$' 0:comment
 
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-notes-highlight }
 }
@@ -33,8 +33,8 @@ hook global BufCreate .*git-rebase-todo %{
 
 hook -group git-rebase-highlight global WinSetOption filetype=git-rebase %{
     add-highlighter window/git-rebase-highlight group
-    add-highlighter window/git-rebase-highlight/ regex "#[^\n]*\n" 0:cyan,default
-    add-highlighter window/git-rebase-highlight/ regex "^(pick|edit|reword|squash|fixup|exec|break|drop|label|reset|merge|[persfxbdltm]) (\w+)" 1:green 2:magenta
+    add-highlighter window/git-rebase-highlight/ regex "#[^\n]*\n" 0:comment
+    add-highlighter window/git-rebase-highlight/ regex "^(pick|edit|reword|squash|fixup|exec|break|drop|label|reset|merge|[persfxbdltm]) (\w+)" 1:keyword 2:meta
 
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-rebase-highlight }
 }

--- a/rc/base/mercurial.kak
+++ b/rc/base/mercurial.kak
@@ -1,11 +1,6 @@
 # https://www.mercurial-scm.org/
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-# Faces
-# ‾‾‾‾‾
-
-set-face global MercurialCommitComment cyan
-
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
@@ -18,6 +13,6 @@ hook global BufCreate .*hg-editor-\w+\.txt$ %{
 
 hook -group hg-commit-highlight global WinSetOption filetype=hg-commit %{
     add-highlighter window/ group hg-commit-highlight
-    add-highlighter window/hg-commit-highlight regex '^HG:[^\n]*' 0:MercurialCommitComment
+    add-highlighter window/hg-commit-highlight regex '^HG:[^\n]*' 0:comment
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/hg-commit-highlight }
 }

--- a/rc/base/perl.kak
+++ b/rc/base/perl.kak
@@ -13,7 +13,7 @@ hook global BufCreate .*\.(t|p[lm])$ %{
 
 add-highlighter shared/perl regions
 add-highlighter shared/perl/code default-region group
-add-highlighter shared/perl/command       region (?<!\$)(?<!\\)`   (?<!\\)(\\\\)*` fill magenta
+add-highlighter shared/perl/command       region (?<!\$)(?<!\\)`   (?<!\\)(\\\\)*` fill meta
 add-highlighter shared/perl/double_string region (?<!\$)(?<!\\)"   (?<!\\)(\\\\)*" fill string
 add-highlighter shared/perl/single_string region (?<!\$)(?<!\\\\)' (?<!\\)(\\\\)*' fill string
 add-highlighter shared/perl/comment       region (?<!\$)(?<!\\)#   $               fill comment

--- a/rc/core/c-family.kak
+++ b/rc/core/c-family.kak
@@ -153,7 +153,7 @@ evaluate-commands %sh{
             add-highlighter shared/$ft/raw_string region -match-capture %{R"([^(]*)\\(} %{\\)([^")]*)"} fill string
             add-highlighter shared/$ft/comment region /\\* \\*/ fill comment
             add-highlighter shared/$ft/line_comment region // (?<!\\\\)(?=\\n) fill comment
-            add-highlighter shared/$ft/disabled region -recurse "#\\h*if(?:def)?" ^\\h*?#\\h*if\\h+(?:0|FALSE)\\b "#\\h*(?:else|elif|endif)" fill rgb:666666
+            add-highlighter shared/$ft/disabled region -recurse "#\\h*if(?:def)?" ^\\h*?#\\h*if\\h+(?:0|FALSE)\\b "#\\h*(?:else|elif|endif)" fill comment
             add-highlighter shared/$ft/macro region %{^\\h*?\\K#} %{(?<!\\\\)(?=\\n)|(?=//)} group
 
             add-highlighter shared/$ft/macro/ fill meta

--- a/rc/core/man.kak
+++ b/rc/core/man.kak
@@ -6,13 +6,13 @@ declare-option -hidden str manpage
 hook -group man-highlight global WinSetOption filetype=man %{
     add-highlighter window/man-highlight group
     # Sections
-    add-highlighter window/man-highlight/ regex ^\S.*?$ 0:blue
+    add-highlighter window/man-highlight/ regex ^\S.*?$ 0:title
     # Subsections
     add-highlighter window/man-highlight/ regex '^ {3}\S.*?$' 0:default+b
     # Command line options
-    add-highlighter window/man-highlight/ regex '^ {7}-[^\s,]+(,\s+-[^\s,]+)*' 0:yellow
+    add-highlighter window/man-highlight/ regex '^ {7}-[^\s,]+(,\s+-[^\s,]+)*' 0:list
     # References to other manpages
-    add-highlighter window/man-highlight/ regex [-a-zA-Z0-9_.]+\([a-z0-9]+\) 0:green
+    add-highlighter window/man-highlight/ regex [-a-zA-Z0-9_.]+\([a-z0-9]+\) 0:header
 
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/man-highlight }
 }

--- a/rc/extra/git-tools.kak
+++ b/rc/extra/git-tools.kak
@@ -3,8 +3,8 @@ declare-option -docstring "name of the client in which documentation is to be di
 
 hook -group git-log-highlight global WinSetOption filetype=git-log %{
     add-highlighter window/git-log group
-    add-highlighter window/git-log/ regex '^(commit) ([0-9a-f]+)$' 1:yellow 2:red
-    add-highlighter window/git-log/ regex '^([a-zA-Z_-]+:) (.*?)$' 1:green 2:magenta
+    add-highlighter window/git-log/ regex '^(commit) ([0-9a-f]+)$' 1:keyword 2:meta
+    add-highlighter window/git-log/ regex '^([a-zA-Z_-]+:) (.*?)$' 1:variable 2:value
     add-highlighter window/git-log/ ref diff # highlight potential diffs from the -p option
 
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-log }
@@ -21,9 +21,6 @@ hook -group git-status-highlight global WinSetOption filetype=git-status %{
 
 declare-option -hidden line-specs git_blame_flags
 declare-option -hidden line-specs git_diff_flags
-
-set-face global GitBlame default,magenta
-set-face global GitDiffFlags default,black
 
 define-command -params 1.. \
   -docstring %sh{printf 'git [<arguments>]: git wrapping helper
@@ -62,7 +59,7 @@ Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-
     run_git_blame() {
         (
             printf %s "evaluate-commands -client '$kak_client' %{
-                      try %{ add-highlighter window/git-blame flag-lines GitBlame git_blame_flags }
+                      try %{ add-highlighter window/git-blame flag-lines Information git_blame_flags }
                       set-option buffer=$kak_bufname git_blame_flags '$kak_timestamp'
                   }" | kak -p ${kak_session}
                   git blame "$@" --incremental ${kak_buffile} | awk '
@@ -184,7 +181,7 @@ Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-
             }"
             ;;
        show-diff)
-           echo 'try %{ add-highlighter window/git-diff flag-lines GitDiffFlags git_diff_flags }'
+           echo 'try %{ add-highlighter window/git-diff flag-lines Default git_diff_flags }'
            update_diff
            ;;
        hide-diff)

--- a/rc/extra/latex.kak
+++ b/rc/extra/latex.kak
@@ -20,7 +20,7 @@ add-highlighter shared/latex/content/ regex '\\(?!_)\w+\b' 0:keyword
 # Options passed to scopes, between brackets
 add-highlighter shared/latex/content/ regex '\\(?!_)\w+\b\[([^\]]+)\]' 1:value
 # Content between dollar signs/pairs
-add-highlighter shared/latex/content/ regex '(\$(\\\$|[^$])+\$)|(\$\$(\\\$|[^$])+\$\$)' 0:magenta
+add-highlighter shared/latex/content/ regex '(\$(\\\$|[^$])+\$)|(\$\$(\\\$|[^$])+\$\$)' 0:meta
 # Emphasized text
 add-highlighter shared/latex/content/ regex '\\(emph|textit)\{([^}]+)\}' 2:default+i
 # Bold text


### PR DESCRIPTION
I took about five commits from PR #1560, rebased and squashed them.  I aimed
for the pieces that seemed "uncontroversial" to me.  I think I may have made
a minor change, but I kept @lenormf's authorship on the commit.

I didn't check to ensure this was _complete_.  New uses of non-semantic faces
may have been introduced since the PR was made.

(I like the diff stuff, but I think the face names warrant being defined in
`colors/default.kak`.)