### PR TITLE
Default to rustfmt for formatcmd in rust

### DIFF
--- a/rc/filetype/rust.kak
+++ b/rc/filetype/rust.kak
@@ -90,4 +90,6 @@ hook global WinSetOption filetype=rust %[
 # Configuration
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-set window formatcmd 'rustfmt'
+hook global WinSetOption filetype=rust %[
+    set window formatcmd 'rustfmt'
+]

--- a/rc/filetype/rust.kak
+++ b/rc/filetype/rust.kak
@@ -86,3 +86,8 @@ hook global WinSetOption filetype=rust %[
     hook window InsertChar \} -group rust-indent rust-indent-on-closing-curly-brace
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window rust-.+ }
 ]
+
+# Configuration
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+set window formatcmd 'rustfmt'


### PR DESCRIPTION
`rustfmt` is the de facto standard for formatting in rust so setting it by default would be nice.

https://github.com/mawww/kakoune/issues/2801