### PR TITLE
Add highlight for operators in the c-family of languages

### DIFF
--- a/rc/filetype/c-family.kak
+++ b/rc/filetype/c-family.kak
@@ -163,6 +163,13 @@ evaluate-commands %sh{
     done
 }
 
+# Operators for c cpp objc
+evaluate-commands %sh{
+    for ft in c cpp objc; do
+        printf "%s\n" "add-highlighter shared/$ft/code/ regex %{\W} 0:operator"
+    done
+}
+
 # c specific
 add-highlighter shared/c/code/numbers regex %{\b-?(0x[0-9a-fA-F]+|\d+)([uU][lL]{0,2}|[lL]{1,2}[uU]?|[fFdDiI]|([eE][-+]?\d+))?|'((\\.)?|[^'\\])'} 0:value
 evaluate-commands %sh{


### PR DESCRIPTION
I found this useful. There are the comparison screens with example code.

Before:
![image](https://user-images.githubusercontent.com/14204812/54931294-621b9280-4f21-11e9-8c8e-1d0145a046c4.png)
After:
![image](https://user-images.githubusercontent.com/14204812/54931309-6a73cd80-4f21-11e9-9cc2-b6c761532c8e.png)
