### PR TITLE
doc: add precision about -buffer switch on eval/exec

### DIFF
--- a/doc/pages/execeval.asciidoc
+++ b/doc/pages/execeval.asciidoc
@@ -42,7 +42,8 @@ when the commands have been executed: */*, *"*, *|*, *^*, *@*.
 
 *-buffer* <names>::
     execute in the context of each buffers in the comma separated list
-    *names*. `*` as a name can be used to iterate on all buffers
+    *names*. `*` as a name can be used to iterate on all non-debug buffers
+    (See <<buffers#debug-buffers, `:doc buffers`>>)
 
 *-save-regs* <regs>::
     regs is a string of registers to be restored after execution (overwrites


### PR DESCRIPTION
Hello

Relevant filter in the code:
```
if (*bufnames == "*")
{
    for (auto&& buffer : BufferManager::instance()
                       | transform(&std::unique_ptr<Buffer>::get)
                       | filter([](Buffer* buf) { return not (buf->flags() & Buffer::Flags::Debug); })
                       | gather<Vector<SafePtr<Buffer>>>()) // gather as we might be mutating the buffer list in the loop.
        context_wrap_for_buffer(*buffer);
}
```