### PR TITLE
write_buffer_to_fd():write file at once

### DIFF
--- a/src/file.cc
+++ b/src/file.cc
@@ -270,14 +270,10 @@ void write_buffer_to_fd(Buffer& buffer, int fd)
         if (::write(fd, "\xEF\xBB\xBF", 3) < 0)
             throw runtime_error(format("unable to write data to the buffer (fd: {}; errno: {})", fd, ::strerror(errno)));
 
-    for (LineCount i = 0; i < buffer.line_count(); ++i)
-    {
-        // end of lines are written according to eolformat but always
-        // stored as \n
-        StringView linedata = buffer[i];
-        write(fd, linedata.substr(0, linedata.length()-1));
-        write(fd, eoldata);
-    }
+   BufferCoord start {0, 0}; 
+   auto end = buffer.end_coord(); 
+   String contents = buffer.string(start, end); 
+   write(fd, contents); 
 }
 
 int open_temp_file(StringView filename, char (&buffer)[PATH_MAX])


### PR DESCRIPTION
this issue https://github.com/mawww/kakoune/issues/2036 never got resolved by https://github.com/mawww/kakoune/commit/4dae2c875bf70d87ace53d7b03c4a9289b2bb241

unfortunately the following commit https://github.com/dmerejkowsky/kakoune/commit/ea7f5d25c7b229042f994f7331bc1d8e96888c3c

can't be automatically merged as commits from both branches have occurred ever since.

Without this code implementation by https://github.com/dmerejkowsky static site generators such as hugo, jekyll, and I can only imagine a few more, do not reflect the changes by the traditional `write` operation by kakoune. 

With other editors, such as GNU/Emacs, neovim, vim, and many others, the changes are detected immediately. Not so with Kakoune. Please consider it. 