### PR TITLE
Run default shell if terminal is given no arguments

### DIFF
--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -12,7 +12,7 @@ hook -group kitty-hooks global KakBegin .* %sh{
     fi
 }
 
-define-command kitty-terminal -params 1.. -shell-completion -docstring '
+define-command kitty-terminal -params .. -shell-completion -docstring '
 kitty-terminal <program> [<arguments>]: create a new terminal as a kitty window
 The program passed as argument will be executed in the new terminal' \
 %{
@@ -21,7 +21,7 @@ The program passed as argument will be executed in the new terminal' \
     }
 }
 
-define-command kitty-terminal-tab -params 1.. -shell-completion -docstring '
+define-command kitty-terminal-tab -params .. -shell-completion -docstring '
 kitty-terminal-tab <program> [<arguments>]: create a new terminal as kitty tab
 The program passed as argument will be executed in the new terminal' \
 %{

--- a/rc/windowing/screen.kak
+++ b/rc/windowing/screen.kak
@@ -9,11 +9,18 @@ hook -group GNUscreen global KakBegin .* %sh{
     "
 }
 
-define-command screen-terminal-impl -hidden -params 3.. %{
+define-command screen-terminal-impl -hidden -params 2.. %{
     nop %sh{
         tty="$(ps -o tty ${kak_client_pid} | tail -n 1)"
         screen -X eval "$1" "$2"
         shift 2
+
+        # run default shell if no arguments
+        if [ $# -eq 0 ]; then
+            screen -X screen sh -c "$SHELL ; screen -X remove" < "/dev/$tty"
+            exit
+        fi
+
         # see x11.kak for what this achieves
         args=$(
             for i in "$@"; do
@@ -28,21 +35,21 @@ define-command screen-terminal-impl -hidden -params 3.. %{
     }
 }
 
-define-command screen-terminal-vertical -params 1.. -shell-completion -docstring '
+define-command screen-terminal-vertical -params .. -shell-completion -docstring '
 screen-terminal-vertical <program> [<arguments>] [<arguments>]: create a new terminal as a screen pane
 The current pane is split into two, left and right
 The program passed as argument will be executed in the new terminal' \
 %{
     screen-terminal-impl 'split -v' 'focus right' %arg{@}
 }
-define-command screen-terminal-horizontal -params 1.. -shell-completion -docstring '
+define-command screen-terminal-horizontal -params .. -shell-completion -docstring '
 screen-terminal-horizontal <program> [<arguments>]: create a new terminal as a screen pane
 The current pane is split into two, top and bottom
 The program passed as argument will be executed in the new terminal' \
 %{
     screen-terminal-impl 'split -h' 'focus down' %arg{@}
 }
-define-command screen-terminal-window -params 1.. -shell-completion -docstring '
+define-command screen-terminal-window -params .. -shell-completion -docstring '
 screen-terminal-window <program> [<arguments>]: create a new terminal as a screen window
 The program passed as argument will be executed in the new terminal' \
 %{

--- a/rc/windowing/tmux.kak
+++ b/rc/windowing/tmux.kak
@@ -11,7 +11,7 @@ hook global KakBegin .* %sh{
     fi
 }
 
-define-command -hidden -params 2.. tmux-terminal-impl %{
+define-command -hidden -params 1.. tmux-terminal-impl %{
     evaluate-commands %sh{
         tmux=${kak_client_env_TMUX:-$TMUX}
         if [ -z "$tmux" ]; then
@@ -20,27 +20,33 @@ define-command -hidden -params 2.. tmux-terminal-impl %{
         fi
         tmux_args="$1"
         shift
+
+        # run default shell if no arguments
+        if [ $# -eq 0 ]; then
+            TMUX=$tmux tmux $tmux_args < /dev/null > /dev/null 2>&1 &
+            exit
+        fi
         # ideally we should escape single ';' to stop tmux from interpreting it as a new command
         # but that's probably too rare to care
         TMUX=$tmux tmux $tmux_args env TMPDIR="$TMPDIR" "$@" < /dev/null > /dev/null 2>&1 &
     }
 }
 
-define-command tmux-terminal-vertical -params 1.. -shell-completion -docstring '
+define-command tmux-terminal-vertical -params .. -shell-completion -docstring '
 tmux-terminal-vertical <program> [<arguments>]: create a new terminal as a tmux pane
 The current pane is split into two, top and bottom
 The program passed as argument will be executed in the new terminal' \
 %{
     tmux-terminal-impl 'split-window -v' %arg{@}
 }
-define-command tmux-terminal-horizontal -params 1.. -shell-completion -docstring '
+define-command tmux-terminal-horizontal -params .. -shell-completion -docstring '
 tmux-terminal-horizontal <program> [<arguments>]: create a new terminal as a tmux pane
 The current pane is split into two, left and right
 The program passed as argument will be executed in the new terminal' \
 %{
     tmux-terminal-impl 'split-window -h' %arg{@}
 }
-define-command tmux-terminal-window -params 1.. -shell-completion -docstring '
+define-command tmux-terminal-window -params .. -shell-completion -docstring '
 tmux-terminal-window <program> [<arguments>] [<arguments>]: create a new terminal as a tmux window
 The program passed as argument will be executed in the new terminal' \
 %{

--- a/rc/windowing/x11.kak
+++ b/rc/windowing/x11.kak
@@ -23,7 +23,7 @@ A shell command is appended to the one set in this option at runtime} \
     done
 }
 
-define-command x11-terminal -params 1.. -shell-completion -docstring '
+define-command x11-terminal -params .. -shell-completion -docstring '
 x11-terminal <program> [<arguments>]: create a new terminal as an x11 window
 The program passed as argument will be executed in the new terminal' \
 %{
@@ -32,6 +32,13 @@ The program passed as argument will be executed in the new terminal' \
            echo "fail 'termcmd option is not set'"
            exit
         fi
+
+        # run default shell if no arguments
+        if [ $# -eq 0 ]; then
+            setsid ${kak_opt_termcmd%% *} < /dev/null > /dev/null 2>&1 &
+            exit
+        fi
+
         # join arguments into a single string, in which they're delimited
         # by single quotes, and with single quotes inside transformed to '\''
         # so that sh -c "$args" will re-split the arguments properly


### PR DESCRIPTION
Modify the `terminal` alias to run the user's shell if `terminal` is called with no arguments.

This is incomplete as I am unfamiliar with macos, so I don't know how to change or test the iterm support.