### PR TITLE
Add built-in breakpoint function to python highlighting and completion

### DIFF
--- a/rc/filetype/python.kak
+++ b/rc/filetype/python.kak
@@ -86,7 +86,7 @@ evaluate-commands %sh{
     types="bool|buffer|bytearray|bytes|complex|dict|file|float|frozenset|int"
     types="${types}|list|long|memoryview|object|set|str|tuple|unicode|xrange"
 
-    functions="abs|all|any|ascii|bin|callable|chr|classmethod|compile|complex"
+    functions="abs|all|any|ascii|bin|breakpoint|callable|chr|classmethod|compile|complex"
     functions="${functions}|delattr|dict|dir|divmod|enumerate|eval|exec|filter"
     functions="${functions}|format|frozenset|getattr|globals|hasattr|hash|help"
     functions="${functions}|hex|id|__import__|input|isinstance|issubclass|iter"


### PR DESCRIPTION
Add the breakpoint function, as per [PEP 553](https://www.python.org/dev/peps/pep-0553/), to the automated highlightning and autocompletion.