### PR TITLE
Add ClientClosePre hook

### DIFF
--- a/doc/pages/hooks.asciidoc
+++ b/doc/pages/hooks.asciidoc
@@ -143,7 +143,10 @@ name. Hooks with no description will always use an empty string.
 *ClientCreate* `client name`::
     executed when a new client is created.
 
-*ClientClose* `client name`::
+*ClientClosePre* `client name`::
+    executed before a client is closed
+
+*ClientClosePost* `client name`::
     executed when a client is closed, after it was removed from the client
     list.
 

--- a/src/client_manager.cc
+++ b/src/client_manager.cc
@@ -111,6 +111,8 @@ bool ClientManager::has_pending_inputs() const
 
 void ClientManager::remove_client(Client& client, bool graceful, int status)
 {
+    auto& context = client.context();
+    context.hooks().run_hook(Hook::ClientClosePre, context.name(), context);
     auto it = find(m_clients, &client);
     if (it == m_clients.end())
     {
@@ -122,8 +124,7 @@ void ClientManager::remove_client(Client& client, bool graceful, int status)
     m_client_trash.push_back(std::move(*it));
     m_clients.erase(it);
 
-    auto& context = client.context();
-    context.hooks().run_hook(Hook::ClientClose, context.name(), context);
+    context.hooks().run_hook(Hook::ClientClosePost, context.name(), context);
 
     if (not graceful and m_clients.empty())
         BufferManager::instance().backup_modified_buffers();

--- a/src/hook_manager.hh
+++ b/src/hook_manager.hh
@@ -29,7 +29,8 @@ enum class Hook
     BufReadFifo,
     BufSetOption,
     ClientCreate,
-    ClientClose,
+    ClientClosePre,
+    ClientClosePost,
     InsertBegin,
     InsertChar,
     InsertDelete,
@@ -62,7 +63,7 @@ enum class Hook
 
 constexpr auto enum_desc(Meta::Type<Hook>)
 {
-    return make_array<EnumDesc<Hook>, 41>({
+    return make_array<EnumDesc<Hook>, 42>({
         {Hook::BufCreate, "BufCreate"},
         {Hook::BufNewFile, "BufNewFile"},
         {Hook::BufOpenFile, "BufOpenFile"},
@@ -75,7 +76,8 @@ constexpr auto enum_desc(Meta::Type<Hook>)
         {Hook::BufReadFifo, "BufReadFifo"},
         {Hook::BufSetOption, "BufSetOption"},
         {Hook::ClientCreate, "ClientCreate"},
-        {Hook::ClientClose, "ClientClose"},
+        {Hook::ClientClosePre, "ClientClosePre"},
+        {Hook::ClientClosePost, "ClientClosePost"},
         {Hook::InsertBegin, "InsertBegin"},
         {Hook::InsertChar, "InsertChar"},
         {Hook::InsertDelete, "InsertDelete"},


### PR DESCRIPTION
This extra hook can be used to handle stuff in the client that is about to be closed, such as closing the current buffer

I will update the documentation if this is going to be merged
Edit: updated it already