### PR TITLE
Fix kak file recognition

### DIFF
--- a/rc/filetype/kakrc.kak
+++ b/rc/filetype/kakrc.kak
@@ -4,7 +4,7 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate (.*/)?(kakrc|.*.kak) %{
+hook global BufCreate (.*/)?(kakrc|.*\.kak) %{
     set-option buffer filetype kak
 }
 


### PR DESCRIPTION
I adjusted the regex to match kak scripts so that the file needs an explicit `.kak` file extension to trigger a match (unless it's kakrc, of course). The current behavior is to match a file name like `abckak` without a period separating the final 'kak'.