### PR TITLE
Add hyperlink support to man plugin

### DIFF
--- a/rc/tools/man.kak
+++ b/rc/tools/man.kak
@@ -14,7 +14,12 @@ hook -group man-highlight global WinSetOption filetype=man %{
     # References to other manpages
     add-highlighter window/man-highlight/ regex [-a-zA-Z0-9_.]+\([a-z0-9]+\) 0:header
 
-    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/man-highlight }
+    map window normal <ret> ': man-jump<ret>'
+
+    hook -once -always window WinSetOption filetype=.* %{
+      remove-highlighter window/man-highlight
+      unmap window normal <ret>
+    }
 }
 
 hook global WinSetOption filetype=man %{
@@ -74,3 +79,62 @@ The page can be a word, or a word directly followed by a section number between 
 
     printf %s\\n "evaluate-commands -try-client %opt{docsclient} man-impl man $pagenum $subject"
 } }
+
+
+
+# The following section of code enables a user
+# to go to next or previous man page links and to follow man page links,
+# for example, apropos(1), that would normally appear in SEE ALSO sections.
+# The user would position the cursor on any character of the link
+# and then press <ret> to change to a buffer showing the man page.
+
+# Regex pattern defining a man page link.
+# Used for determining if a selection, which may just be a link, is a link.
+declare-option -hidden regex man_link1 \
+  [\w_.:-]+\(\d[a-z]*\)
+
+# Same as above but with lookbehind and lookahead patterns.
+# Used for searching for a man page link.
+declare-option -hidden regex man_link2 \
+  "(?:^|(?<=\W))%opt{man_link1}(?=\W)"
+
+# Define a useful command sequence for searching a given regex
+# and a given sequence of search keys.
+define-command man-search -params 2 %{
+  set-register / %arg[1]
+  execute-keys %arg[2]
+}
+
+define-command -docstring 'Go to next man page link' \
+man-link-next %{ man-search %opt[man_link2] n }
+
+define-command -docstring 'Go to previous man page link' \
+man-link-prev %{ man-search %opt[man_link2] <a-n> }
+
+# Expand backward and forward, and then try to search for a man page link
+define-command man-link-here %{ evaluate-commands -save-regs / %{
+  man-search %opt[man_link2] '<a-?>\b\w<ret><a-;>?\)<ret>'
+}} -hidden
+
+# Search current selection for a man page link
+define-command man-link %{ evaluate-commands -save-regs / %{
+  man-search %opt[man_link1] s<ret>
+}} -hidden
+
+define-command -docstring 'Try to jump to a man page' \
+man-jump %{
+  try %{ man-link } catch %{ man-link-here } catch %{ fail 'Not a valid man page link' }
+  try %{ man } catch %{ fail 'No man page link to follow' }
+}
+
+# Suggested keymaps for a user mode
+declare-user-mode man-mode
+
+define-command man-mode-map -params 3 %{
+  map global man-mode %arg[1] %arg[2] -docstring %arg[3]
+} -hidden
+
+man-mode-map 'g' ': man-jump<ret>' 'Jump to a man page using selected man page link'
+man-mode-map 'j' ': try %{ man-link-next }<ret>' 'Go to next man page link'
+man-mode-map 'k' ': try %{ man-link-prev }<ret>' 'Go to previous man page link'
+man-mode-map 'm' ': man<space>' 'Look up a man page'

--- a/rc/tools/man.kak
+++ b/rc/tools/man.kak
@@ -1,7 +1,7 @@
 declare-option -docstring "name of the client in which documentation is to be displayed" \
     str docsclient
 
-declare-option -hidden str manpage
+declare-option -hidden str-list manpage
 
 hook -group man-highlight global WinSetOption filetype=man %{
     add-highlighter window/man-highlight group
@@ -18,7 +18,7 @@ hook -group man-highlight global WinSetOption filetype=man %{
 }
 
 hook global WinSetOption filetype=man %{
-    hook -group man-hooks window WinResize .* %{ man-impl %val{bufname} %opt{manpage} }
+    hook -group man-hooks window WinResize .* %{ man-impl %opt{manpage} }
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window man-hooks }
 }
 
@@ -33,11 +33,11 @@ define-command -hidden -params 2..3 man-impl %{ evaluate-commands %sh{
     rm ${manout}
     if [ "${retval}" -eq 0 ]; then
         printf %s\\n "
-                edit -scratch '$buffer_name'
+                edit -scratch %{*$buffer_name ${*}*}
                 execute-keys '%|cat<space>${colout}<ret>gk'
                 nop %sh{rm ${colout}}
                 set-option buffer filetype man
-                set-option window manpage '$@'
+                set-option window manpage $buffer_name $*
         "
     else
        printf %s\\n "echo -markup %{{Error}man '$@' failed: see *debug* buffer for details}"
@@ -64,5 +64,5 @@ The page can be a word, or a word directly followed by a section number between 
             ;;
     esac
 
-    printf %s\\n "evaluate-commands -try-client %opt{docsclient} man-impl *man* $pagenum $subject"
+    printf %s\\n "evaluate-commands -try-client %opt{docsclient} man-impl man $pagenum $subject"
 } }


### PR DESCRIPTION
This is a 2nd attempt at it. I've somehow made the first attempt disappear, when I meant to keep it and its discussion. Sorry.

I've organized the changes into three commits.

1. First, I re-implement PR #1927. The original PR lowered the arity of man-impl command, but I do not change it. But it achieves the same thing, which is to create a new buffer for each new man page. A buffer name will look like, for example, _\*man 1 apropos\*_.

1. The original `man` command did not show the stderr text, but I've exposed it as the error message, because sometimes the specific text, for example, _No manual entry for..._, is more informative than generic text.

1. The final commit is the one defining new commands for navigating between man page links and jumping to a man page. See the commit message for details.