### PR TITLE
Properly quote input arguments for tmux splits

### DIFF
--- a/rc/windowing/tmux.kak
+++ b/rc/windowing/tmux.kak
@@ -18,9 +18,13 @@ define-command -hidden -params 2.. tmux-terminal-impl %{
         fi
         tmux_args="$1"
         shift
-        # ideally we should escape single ';' to stop tmux from interpreting it as a new command
-        # but that's probably too rare to care
-        TMUX=$tmux tmux $tmux_args env TMPDIR="$TMPDIR" "$@" < /dev/null > /dev/null 2>&1 &
+        (
+            TMUX=$tmux tmux $tmux_args "env TMPDIR="$TMPDIR" ${*@Q}" < /dev/null 2>&1
+        ) | (
+            wihle read line; do
+                echo "echo -debug TMUX: ${line@Q}"
+            done
+        )
     }
 }
 


### PR DESCRIPTION
Properly quote input arguments

Also, print any tmux output to the debug buffer to make debugging easier. At one point in my debugging Tmux was printing "create pane failed: pane too small", but I couldn't see it.

This allows the following to actually work:
```
define-command -hidden skim-edit %{
  tmux-terminal-vertical sh -c "echo eval -client %val{client} \""edit $(sk --reverse -c 'fd -t f')\"" | kak -p %val{session}"
}
```