### PR TITLE
Change regular expression for git blame to one more supported

### DIFF
--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -76,7 +76,7 @@ Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-
                       print "set-option -add buffer=" ENVIRON["kak_bufname"] " git_blame_flags " flag | cmd
                       close(cmd)
                   }
-                  /^([0-9a-f]{40}) ([0-9]+) ([0-9]+) ([0-9]+)/ {
+                  /^([0-9a-f]+) ([0-9]+) ([0-9]+) ([0-9]+)/ {
                       send_flags()
                       sha=$1
                       line=$3


### PR DESCRIPTION
Hi. Some awk engines doesn't support braces. I propose change the regular expression in git blame to support them out of the box.

You can see the discussion in: https://www.reddit.com/r/kakoune/comments/bjjf3s/git_blame_not_showing_results_inside_kakoune/

Change regular expression in git blame, removing braces. New expression is supported on various awk engines used in some distributions as default ones. As trade-off, the new expression accepts more input character sequences.