### PR TITLE
clojure: Fix indentation for lists with 1-character heads

### DIFF
--- a/rc/filetype/clojure.kak
+++ b/rc/filetype/clojure.kak
@@ -199,11 +199,11 @@ define-command -hidden clojure-indent-on-new-line %{
 
             try %{
                 # If a special form, indent another (indentwidth - 1) spaces
-                execute-keys -draft '"wze<a-k>\A' %opt{clojure_special_indent_forms} '\z<ret>'
+                execute-keys -draft '"wze<a-K>[\s()\[\]\{\}]<ret><a-k>\A' %opt{clojure_special_indent_forms} '\z<ret>'
                 execute-keys -draft '"wze<a-L>s.{' %sh{printf $(( kak_opt_indentwidth - 1 ))} '}\K.*<ret><a-;>;"i<a-Z><gt>'
             } catch %{
                 # If not special and parameter appears on line 1, indent to parameter
-                execute-keys -draft '"wze<a-l>s\h\K[^\s].*<ret><a-;>;"i<a-Z><gt>'
+                execute-keys -draft '"wze<a-K>[\s()\[\]\{\}]<ret><a-l>s\h\K[^\s].*<ret><a-;>;"i<a-Z><gt>'
             }
         }
         try %{ execute-keys -draft '[rl"i<a-Z><gt>' }


### PR DESCRIPTION
Indentation can be different depending on the first word of list forms.  The
indent hook uses `e` from inside the parent to select the first word for
testing whether it is a special word; however, in the case of a one-character
symbol, this selects to the end of the *next* word.

This rejects such selections.