### PR TITLE
Strip all trailing slashes in real_path and compact_path

### DIFF
--- a/src/file.cc
+++ b/src/file.cc
@@ -86,7 +86,7 @@ String real_path(StringView filename)
                 return res;
 
             StringView dir = res;
-            if (dir.substr(dir.length()-1_byte, 1_byte) == "/")
+            while (dir.substr(dir.length()-1_byte, 1_byte) == "/")
                 dir = dir.substr(0_byte, dir.length()-1_byte);
             return format("{}/{}", dir, non_existing);
         }
@@ -115,7 +115,10 @@ String compact_path(StringView filename)
     if (prefix_match(real_filename, real_cwd))
         return real_filename.substr(real_cwd.length()).str();
 
-    const StringView home = homedir();
+    StringView home = homedir();
+    while (home.substr(home.length()-1_byte, 1_byte) == "/")
+        home = home.substr(0_byte, home.length()-1_byte);
+
     if (not home.empty())
     {
         ByteCount home_len = home.length();


### PR DESCRIPTION
Small patch to deal with multiple slashes and other less common circumstances (like home ending with a /), in response to this thread: https://discuss.kakoune.com/t/is-the-error-1-1-no-such-buffer-message-an-invalid-issue/565.