### PR TITLE
Add -Og for debug builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ ifneq ($(gzip_man),yes)
 endif
 
 ifeq ($(debug),yes)
-    CPPFLAGS += -DKAK_DEBUG
+    CPPFLAGS += -DKAK_DEBUG -Og
     suffix := .debug
 else
     ifeq ($(debug),no)


### PR DESCRIPTION
On my system, some optimizations are on by default (NixOS), resulting in
variables being optimized out on debug builds.  It *seems to be*
something about a "_FORTIFY_SOURCE" feature?  In any case, `-Og` is
documented as "Optimize debugging experience".