### PR TITLE
[WIP] Markdown code highlighting fix

### DIFF
--- a/rc/filetype/c-family.kak
+++ b/rc/filetype/c-family.kak
@@ -1,3 +1,4 @@
+# Detection
 hook global BufCreate .*\.(cc|cpp|cxx|C|hh|hpp|hxx|H)$ %{
     set-option buffer filetype cpp
 }
@@ -57,6 +58,11 @@ hook -group objc-highlight global WinSetOption filetype=objc %{
     add-highlighter window/objc ref objc
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/objc }
 }
+
+# Module aliases
+provide-module c %{ require-module c-family }
+provide-module cpp %{ require-module c-family }
+provide-module objc %{ require-module c-family }
 
 
 provide-module c-family %§

--- a/rc/filetype/c-family.kak
+++ b/rc/filetype/c-family.kak
@@ -59,11 +59,6 @@ hook -group objc-highlight global WinSetOption filetype=objc %{
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/objc }
 }
 
-# Module aliases
-provide-module c %{ require-module c-family }
-provide-module cpp %{ require-module c-family }
-provide-module objc %{ require-module c-family }
-
 
 provide-module c-family %§
 
@@ -450,3 +445,8 @@ define-command objc-alternative-file -docstring "Jump to the alternate objc file
 }
 
 §
+
+# Module aliases
+provide-module c %{ require-module c-family }
+provide-module cpp %{ require-module c-family }
+provide-module objc %{ require-module c-family }

--- a/rc/filetype/javascript.kak
+++ b/rc/filetype/javascript.kak
@@ -34,6 +34,9 @@ hook -group typescript-highlight global WinSetOption filetype=typescript %{
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/typescript }
 }
 
+# Aliases
+# ‾‾‾‾‾‾‾
+provide-module typescript %{ require-module javascript }
 
 provide-module javascript %§
 

--- a/rc/filetype/javascript.kak
+++ b/rc/filetype/javascript.kak
@@ -34,9 +34,6 @@ hook -group typescript-highlight global WinSetOption filetype=typescript %{
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/typescript }
 }
 
-# Aliases
-# ‾‾‾‾‾‾‾
-provide-module typescript %{ require-module javascript }
 
 provide-module javascript %§
 
@@ -133,3 +130,7 @@ add-highlighter shared/typescript/code/ regex \b(array|boolean|date|number|objec
 add-highlighter shared/typescript/code/ regex \b(as|constructor|declare|enum|from|implements|interface|module|namespace|package|private|protected|public|readonly|static|type)\b 0:keyword
 
 §
+
+# Aliases
+# ‾‾‾‾‾‾‾
+provide-module typescript %{ require-module javascript }

--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -16,6 +16,11 @@ hook global WinSetOption filetype=markdown %{
 
     hook window InsertChar \n -group markdown-indent markdown-indent-on-new-line
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window markdown-.+ }
+
+    hook -group markdown-load buffer NormalIdle .* %{ try %{ evaluate-commands -draft %{
+        execute-keys '%s^\h*```\h*\K[^\n]+$<ret>'
+        evaluate-commands -itersel %{ require-module %val{selection} }
+    }}}
 }
 
 hook -group markdown-highlight global WinSetOption filetype=markdown %{

--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -19,8 +19,8 @@ hook global WinSetOption filetype=markdown %{
 }
 
 hook -group markdown-load-languages global WinSetOption filetype=markdown %{
-    hook window NormalIdle .* markdown-load-languages
-    hook window InsertIdle .* markdown-load-languages
+    hook -group markdown-load-languages window NormalIdle .* markdown-load-languages
+    hook -group markdown-load-languages window InsertIdle .* markdown-load-languages
 }
 
 

--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -16,12 +16,13 @@ hook global WinSetOption filetype=markdown %{
 
     hook window InsertChar \n -group markdown-indent markdown-indent-on-new-line
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window markdown-.+ }
-
-    hook -group markdown-load buffer NormalIdle .* %{ try %{ evaluate-commands -draft %{
-        execute-keys '%s^\h*```\h*\K[^\n]+$<ret>'
-        evaluate-commands -itersel %{ require-module %val{selection} }
-    }}}
 }
+
+hook -group markdown-load-languages global WinSetOption filetype=markdown %{
+    hook window NormalIdle .* markdown-load-languages
+    hook window InsertIdle .* markdown-load-languages
+}
+
 
 hook -group markdown-highlight global WinSetOption filetype=markdown %{
     add-highlighter window/markdown ref markdown
@@ -92,6 +93,13 @@ define-command -hidden markdown-indent-on-new-line %{
         # remove trailing white spaces
         try %{ execute-keys -draft -itersel %{ k<a-x> s \h+$ <ret> d } }
     }
+}
+
+define-command -hidden markdown-load-languages %{
+    evaluate-commands -draft %{ try %{
+        execute-keys 'gtGbGls```\h*\K[^\s]+<ret>'
+        evaluate-commands -itersel %{ require-module %val{selection} }
+    }}
 }
 
 }


### PR DESCRIPTION
WIP fix of #2920. reStructuredText is also broken, but it's syntax is more complicated.

Added a hook that detects if the buffer contains a code block, then attempts to load the highlighting for that code block. Currently works for most languages, but not the ones where the module is named differently from the markdown name. Notably C, C++, ObjC, and Typescript. 

I can think of three ways to fix this. Create a mapping of language names to module names in Markdown/reStructuredText/Org-mode, ensure there's only one language defined per module (though we wouldn't be able to do things like accept both 'c++' and 'cpp'), or add a kind of module alias system.