### PR TITLE
Auto-indent scripts for LaTeX

### DIFF
--- a/rc/filetype/latex.kak
+++ b/rc/filetype/latex.kak
@@ -11,16 +11,21 @@ hook global BufCreate .*\.tex %{
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global WinSetOption filetype=latex %{
+hook global WinSetOption filetype=latex %(
     require-module latex
-}
+
+    hook window InsertChar \n -group latex-indent %{ latex-indent-newline }
+    hook window InsertChar \} -group latex-indent %{ latex-indent-closing-brace }
+    hook window ModeChange insert:.* -group latex-indent %{ latex-trim-indent }
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks latex-indent }
+)
 
 hook -group latex-highlight global WinSetOption filetype=latex %{
     add-highlighter window/latex ref latex
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/latex }
 }
 
-provide-module latex %(
+provide-module latex %~
 
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
@@ -40,4 +45,47 @@ add-highlighter shared/latex/content/ regex '\\(emph|textit)\{([^}]+)\}' 2:defau
 # Bold text
 add-highlighter shared/latex/content/ regex '\\textbf\{([^}]+)\}' 1:default+b
 
+
+# Indent
+# ------
+
+define-command -hidden latex-trim-indent %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        try %{ execute-keys <a-x> 1s^(\h+)$<ret> d }
+    }
+}
+
+define-command -hidden latex-indent-newline %(
+    evaluate-commands -no-hooks -draft -itersel %(
+        # copy '%' comment prefix and following white spaces
+        try %{ execute-keys -draft k<a-x> s^\h*%\h*<ret> y jgh P }
+        # preserve previous line indent
+        try %{ execute-keys -draft K<a-&> }
+        # cleanup trailing whitespaces from previous line
+        try %{ execute-keys -draft k<a-x> s\h+$<ret> d }
+        # indent after line ending with {
+        try %( execute-keys -draft k<a-x> <a-k>\{$<ret> j<a-gt> )
+        # indent after line ending with \begin{...}[...]{...}, with multiple
+        # sets of arguments possible
+        try %(
+            execute-keys -draft \
+                k<a-x> \
+                <a-k>\\begin\h*\{[^\}]+\}(\h|\[.*\]|\{.*\})*$<ret> \
+                j<a-gt>
+        )
+    )
 )
+
+define-command -hidden latex-indent-closing-brace %(
+    evaluate-commands -no-hooks -draft -itersel %(
+        # Align lone } with matching bracket
+        try %( execute-keys -draft <a-x>_ <a-k>\A\}\z<ret> m<a-S>1<a-&> )
+        # Align \end{...} with corresponding \begin{...}
+        try %(
+            execute-keys -draft h<a-h> 1s\\end\h*\{([^\}]+)\}\z<ret> \
+                <a-?>\\begin\s*\{<c-r>.\}<ret> <a-S>1<a-&>
+        )
+    )
+)
+
+~


### PR DESCRIPTION
* Indents after lines ending with `{` and `\begin{...}` (allows arguments to environments, but only on the same line)
* Aligns `}` and `\end{...}` with their matching openers
* Trims trailing whitespace from lines