### PR TITLE
Trim whitespace from spell check word length variable

### DIFF
--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -41,7 +41,8 @@ Formats of language supported:
                                pos=$(printf %s\\n "$line" | cut -d ' ' -f 3)
                             fi
                             word=$(printf %s\\n "$line" | cut -d ' ' -f 2)
-                            len=$(printf %s "$word" | wc -c)
+                            # trim whitespace to make `wc` output consistent across implementations
+                            len=$(($(printf %s "$word" | wc -c)))
                             regions="$regions $line_num.$pos+${len}|Error"
                             ;;
                         '') line_num=$((line_num + 1));;


### PR DESCRIPTION
Due to ambiguity in the POSIX standard, GNU and BSD versions of the `wc` utility use slightly [different whitespace conventions](https://unix.stackexchange.com/questions/205906/extra-space-with-counted-line-number) when formatting their output. When limiting the output to just counting the number of bytes (as is done by Kakoune when calculating the length of words for spell check highlighting), the BSD version of `wc -c` has some additional leading whitespace:

    gnu$ printf %s "test" | wc -c
    4
    bsd$ printf %s "test" | wc -c
           4

This leading whitespace needs to be removed before defining the "region" to highlight, or `set-option` will not be able to parse the given `spell_regions` and will complain that there are "not enough elements in tuple." In other words, the region on Linux is fine, but is invalid on macOS:

```
Linux: 1.21+8|Error
macOS: 1.21+       8|Error
```

Removing the whitespace could be accomplished in a number of ways, but using [arithmetic expansion](https://mywiki.wooledge.org/ArithmeticExpression) is POSIX compliant and does not require shelling out to another process.
