### PR TITLE
Remove ' from comment in subshell

### DIFF
--- a/rc/windowing/x11.kak
+++ b/rc/windowing/x11.kak
@@ -54,7 +54,7 @@ The program passed as argument will be executed in the new terminal' \
         # would be nicer to do in a single sed/awk call but that's difficult
         args=$(
             for i in "$@"; do
-                # special case to preserve empty variables as sed won't touch these
+                # special case to preserve empty variables as sed will not touch these
                 if [ "$i" = '' ]; then
                     printf "'' "
                 else


### PR DESCRIPTION
I know this seems really weird and it's probably a bug in OpenBSD's `sh`, but having a `'` in a comment, within a subshell breaks things here.

On OpenBSD I got a "no closing quote" error in the `*debug*` buffer, when I tried executing `:new`.