### PR TITLE
Escape '(' in shell parameter expansion in man.kak

### DIFF
--- a/rc/tools/man.kak
+++ b/rc/tools/man.kak
@@ -58,9 +58,9 @@ The page can be a word, or a word directly followed by a section number between 
     ## The completion suggestions display the page number, strip them if present
     case "${subject}" in
         *\([1-8]*\))
-            pagenum="${subject##*(}"
-            pagenum="${pagenum%)}"
-            subject="${subject%%(*}"
+            pagenum="${subject##*\(}"
+            pagenum="${pagenum%\)}"
+            subject="${subject%%\(*}"
             ;;
     esac
 


### PR DESCRIPTION
Not escaping '(' here led to a 'no closing quote' error on OpenBSD.