### PR TITLE
Fix tools using fifos for OpenBSD

### DIFF
--- a/rc/tools/clang.kak
+++ b/rc/tools/clang.kak
@@ -36,7 +36,7 @@ The syntaxic errors detected during parsing are shown when auto-diagnostics are 
         # not hang while clang is running. As completions references a cursor
         # position and a buffer timestamp, only valid completions should be
         # displayed.
-        {(
+        ((
             case ${kak_opt_filetype} in
                 c) ft=c ;;
                 cpp) ft=c++ ;;
@@ -100,7 +100,7 @@ The syntaxic errors detected during parsing are shown when auto-diagnostics are 
 
             printf %s\\n "set-option 'buffer=${kak_buffile}' clang_flags ${kak_timestamp} ${flags}
                   set-option 'buffer=${kak_buffile}' clang_errors ${kak_timestamp} ${errors}" | kak -p ${kak_session}
-        ) & } > /dev/null 2>&1 < /dev/null
+        ) & ) > /dev/null 2>&1 < /dev/null
     }
 }
 

--- a/rc/tools/clang.kak
+++ b/rc/tools/clang.kak
@@ -36,7 +36,7 @@ The syntaxic errors detected during parsing are shown when auto-diagnostics are 
         # not hang while clang is running. As completions references a cursor
         # position and a buffer timestamp, only valid completions should be
         # displayed.
-        {(
+        {{
             case ${kak_opt_filetype} in
                 c) ft=c ;;
                 cpp) ft=c++ ;;
@@ -100,7 +100,7 @@ The syntaxic errors detected during parsing are shown when auto-diagnostics are 
 
             printf %s\\n "set-option 'buffer=${kak_buffile}' clang_flags ${kak_timestamp} ${flags}
                   set-option 'buffer=${kak_buffile}' clang_errors ${kak_timestamp} ${errors}" | kak -p ${kak_session}
-        ) & } > /dev/null 2>&1 < /dev/null
+        } & } > /dev/null 2>&1 < /dev/null
     }
 }
 

--- a/rc/tools/clang.kak
+++ b/rc/tools/clang.kak
@@ -36,7 +36,7 @@ The syntaxic errors detected during parsing are shown when auto-diagnostics are 
         # not hang while clang is running. As completions references a cursor
         # position and a buffer timestamp, only valid completions should be
         # displayed.
-        (
+        {(
             case ${kak_opt_filetype} in
                 c) ft=c ;;
                 cpp) ft=c++ ;;
@@ -100,7 +100,7 @@ The syntaxic errors detected during parsing are shown when auto-diagnostics are 
 
             printf %s\\n "set-option 'buffer=${kak_buffile}' clang_flags ${kak_timestamp} ${flags}
                   set-option 'buffer=${kak_buffile}' clang_errors ${kak_timestamp} ${errors}" | kak -p ${kak_session}
-        ) > /dev/null 2>&1 < /dev/null &
+        ) & } > /dev/null 2>&1 < /dev/null
     }
 }
 

--- a/rc/tools/clang.kak
+++ b/rc/tools/clang.kak
@@ -36,7 +36,7 @@ The syntaxic errors detected during parsing are shown when auto-diagnostics are 
         # not hang while clang is running. As completions references a cursor
         # position and a buffer timestamp, only valid completions should be
         # displayed.
-        {{
+        {(
             case ${kak_opt_filetype} in
                 c) ft=c ;;
                 cpp) ft=c++ ;;
@@ -100,7 +100,7 @@ The syntaxic errors detected during parsing are shown when auto-diagnostics are 
 
             printf %s\\n "set-option 'buffer=${kak_buffile}' clang_flags ${kak_timestamp} ${flags}
                   set-option 'buffer=${kak_buffile}' clang_errors ${kak_timestamp} ${errors}" | kak -p ${kak_session}
-        } & } > /dev/null 2>&1 < /dev/null
+        ) & } > /dev/null 2>&1 < /dev/null
     }
 }
 

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -45,7 +45,7 @@ Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-
         esac
         output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-git.XXXXXXXX)/fifo
         mkfifo ${output}
-        ( git "$@" > ${output} 2>&1 ) > /dev/null 2>&1 < /dev/null &
+        ( git "$@" > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
 
         printf %s "evaluate-commands -try-client '$kak_opt_docsclient' %{
                   edit! -fifo ${output} *git*

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -45,7 +45,7 @@ Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-
         esac
         output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-git.XXXXXXXX)/fifo
         mkfifo ${output}
-        { git "$@" > ${output} 2>&1 & } > /dev/null 2>&1 < /dev/null
+        ( git "$@" > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
 
         printf %s "evaluate-commands -try-client '$kak_opt_docsclient' %{
                   edit! -fifo ${output} *git*

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -45,7 +45,7 @@ Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-
         esac
         output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-git.XXXXXXXX)/fifo
         mkfifo ${output}
-        ( git "$@" > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
+        { git "$@" > ${output} 2>&1 & } > /dev/null 2>&1 < /dev/null
 
         printf %s "evaluate-commands -try-client '$kak_opt_docsclient' %{
                   edit! -fifo ${output} *git*

--- a/rc/tools/grep.kak
+++ b/rc/tools/grep.kak
@@ -11,9 +11,9 @@ All the optional arguments are forwarded to the grep utility} \
      output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-grep.XXXXXXXX)/fifo
      mkfifo ${output}
      if [ $# -gt 0 ]; then
-         ( ${kak_opt_grepcmd} "$@" | tr -d '\r' > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
+         { ${kak_opt_grepcmd} "$@" | tr -d '\r' > ${output} 2>&1 & } > /dev/null 2>&1 < /dev/null
      else
-         ( ${kak_opt_grepcmd} "${kak_selection}" | tr -d '\r' > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
+         { ${kak_opt_grepcmd} "${kak_selection}" | tr -d '\r' > ${output} 2>&1 & } > /dev/null 2>&1 < /dev/null
      fi
 
      printf %s\\n "evaluate-commands -try-client '$kak_opt_toolsclient' %{

--- a/rc/tools/grep.kak
+++ b/rc/tools/grep.kak
@@ -11,9 +11,9 @@ All the optional arguments are forwarded to the grep utility} \
      output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-grep.XXXXXXXX)/fifo
      mkfifo ${output}
      if [ $# -gt 0 ]; then
-         { ${kak_opt_grepcmd} "$@" | tr -d '\r' > ${output} 2>&1 & } > /dev/null 2>&1 < /dev/null
+         ( ${kak_opt_grepcmd} "$@" | tr -d '\r' > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
      else
-         { ${kak_opt_grepcmd} "${kak_selection}" | tr -d '\r' > ${output} 2>&1 & } > /dev/null 2>&1 < /dev/null
+         ( ${kak_opt_grepcmd} "${kak_selection}" | tr -d '\r' > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
      fi
 
      printf %s\\n "evaluate-commands -try-client '$kak_opt_toolsclient' %{

--- a/rc/tools/grep.kak
+++ b/rc/tools/grep.kak
@@ -11,9 +11,9 @@ All the optional arguments are forwarded to the grep utility} \
      output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-grep.XXXXXXXX)/fifo
      mkfifo ${output}
      if [ $# -gt 0 ]; then
-         ( ${kak_opt_grepcmd} "$@" | tr -d '\r' > ${output} 2>&1 ) > /dev/null 2>&1 < /dev/null &
+         ( ${kak_opt_grepcmd} "$@" | tr -d '\r' > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
      else
-         ( ${kak_opt_grepcmd} "${kak_selection}" | tr -d '\r' > ${output} 2>&1 ) > /dev/null 2>&1 < /dev/null &
+         ( ${kak_opt_grepcmd} "${kak_selection}" | tr -d '\r' > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
      fi
 
      printf %s\\n "evaluate-commands -try-client '$kak_opt_toolsclient' %{

--- a/rc/tools/lint.kak
+++ b/rc/tools/lint.kak
@@ -28,7 +28,7 @@ define-command lint -docstring 'Parse the current buffer with a linter' %{
                   hook -always -once buffer BufCloseFifo .* %{ nop %sh{ rm -r '$dir' } }
               }"
 
-        { # do the parsing in the background and when ready send to the session
+        {{ # do the parsing in the background and when ready send to the session
 
         eval "$kak_opt_lintcmd '$dir'/${filename}" | sort -t: -k2,2 -n > "$dir"/stderr
 
@@ -78,7 +78,7 @@ define-command lint -docstring 'Parse the current buffer with a linter' %{
             }
             ' > "$dir"/fifo
 
-        } >/dev/null 2>&1 </dev/null &
+        } & } >/dev/null 2>&1 </dev/null
     }
 }
 

--- a/rc/tools/lint.kak
+++ b/rc/tools/lint.kak
@@ -28,7 +28,7 @@ define-command lint -docstring 'Parse the current buffer with a linter' %{
                   hook -always -once buffer BufCloseFifo .* %{ nop %sh{ rm -r '$dir' } }
               }"
 
-        {{ # do the parsing in the background and when ready send to the session
+        ({ # do the parsing in the background and when ready send to the session
 
         eval "$kak_opt_lintcmd '$dir'/${filename}" | sort -t: -k2,2 -n > "$dir"/stderr
 
@@ -78,7 +78,7 @@ define-command lint -docstring 'Parse the current buffer with a linter' %{
             }
             ' > "$dir"/fifo
 
-        } & } >/dev/null 2>&1 </dev/null
+        } & ) >/dev/null 2>&1 </dev/null
     }
 }
 

--- a/rc/tools/make.kak
+++ b/rc/tools/make.kak
@@ -13,7 +13,7 @@ All the optional arguments are forwarded to the make utility} \
     make %{ evaluate-commands %sh{
      output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-make.XXXXXXXX)/fifo
      mkfifo ${output}
-     ( eval ${kak_opt_makecmd} "$@" > ${output} 2>&1 ) > /dev/null 2>&1 < /dev/null &
+     ( eval ${kak_opt_makecmd} "$@" > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
 
      printf %s\\n "evaluate-commands -try-client '$kak_opt_toolsclient' %{
                edit! -fifo ${output} -scroll *make*

--- a/rc/tools/make.kak
+++ b/rc/tools/make.kak
@@ -13,7 +13,7 @@ All the optional arguments are forwarded to the make utility} \
     make %{ evaluate-commands %sh{
      output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-make.XXXXXXXX)/fifo
      mkfifo ${output}
-     { eval ${kak_opt_makecmd} "$@" > ${output} 2>&1 & } > /dev/null 2>&1 < /dev/null
+     ( eval ${kak_opt_makecmd} "$@" > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
 
      printf %s\\n "evaluate-commands -try-client '$kak_opt_toolsclient' %{
                edit! -fifo ${output} -scroll *make*

--- a/rc/tools/make.kak
+++ b/rc/tools/make.kak
@@ -13,7 +13,7 @@ All the optional arguments are forwarded to the make utility} \
     make %{ evaluate-commands %sh{
      output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-make.XXXXXXXX)/fifo
      mkfifo ${output}
-     ( eval ${kak_opt_makecmd} "$@" > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
+     { eval ${kak_opt_makecmd} "$@" > ${output} 2>&1 & } > /dev/null 2>&1 < /dev/null
 
      printf %s\\n "evaluate-commands -try-client '$kak_opt_toolsclient' %{
                edit! -fifo ${output} -scroll *make*

--- a/rc/tools/python/jedi.kak
+++ b/rc/tools/python/jedi.kak
@@ -19,7 +19,7 @@ define-command jedi-complete -docstring "Complete the current selection" %{
     evaluate-commands %sh{
         dir=${kak_opt_jedi_tmp_dir}
         printf %s\\n "evaluate-commands -draft %{ edit! -fifo ${dir}/fifo *jedi-output* }"
-        (
+        {(
             cd $(dirname ${kak_buffile})
             header="${kak_cursor_line}.${kak_cursor_column}@${kak_timestamp}"
 
@@ -32,7 +32,7 @@ define-command jedi-complete -docstring "Complete the current selection" %{
             )
             printf %s\\n "evaluate-commands -client ${kak_client} %~echo completed; set-option %{buffer=${kak_buffile}} jedi_completions ${header} ${compl}~" | kak -p ${kak_session}
             rm -r ${dir}
-        ) > /dev/null 2>&1 < /dev/null &
+        ) & } > /dev/null 2>&1 < /dev/null
     }
 }
 

--- a/rc/tools/python/jedi.kak
+++ b/rc/tools/python/jedi.kak
@@ -19,7 +19,7 @@ define-command jedi-complete -docstring "Complete the current selection" %{
     evaluate-commands %sh{
         dir=${kak_opt_jedi_tmp_dir}
         printf %s\\n "evaluate-commands -draft %{ edit! -fifo ${dir}/fifo *jedi-output* }"
-        {(
+        ((
             cd $(dirname ${kak_buffile})
             header="${kak_cursor_line}.${kak_cursor_column}@${kak_timestamp}"
 
@@ -32,7 +32,7 @@ define-command jedi-complete -docstring "Complete the current selection" %{
             )
             printf %s\\n "evaluate-commands -client ${kak_client} %~echo completed; set-option %{buffer=${kak_buffile}} jedi_completions ${header} ${compl}~" | kak -p ${kak_session}
             rm -r ${dir}
-        ) & } > /dev/null 2>&1 < /dev/null
+        ) & ) > /dev/null 2>&1 < /dev/null
     }
 }
 


### PR DESCRIPTION
Without these changes, kak would hang on the corresponding commands, displaying a 'waiting for shell command to finish' message.

I guess OpenBSD's `sh` behaves differently with the `&` control operator. The man pages for `sh` on OpenBSD and Linux don't really talk about putting whole command lists into the background, so I'd say there is no right or wrong here.

I tested the proposed solution on OpenBSD 6.5 and Xubuntu 18.04. I did not test the `clang`, `lint` and `jedi` commands in depth, because I did't yet set up the tools for it, but the commands don't block kak anymore.

I'm not sure if the `(...)  > /dev/null 2>&1 < /dev/null &` pattern should be adapted in all other places as well. The tools using fifos were just the first time I experienced problems with it.