### PR TITLE
Fix Dart highlighting of annotations

### DIFF
--- a/rc/filetype/dart.kak
+++ b/rc/filetype/dart.kak
@@ -73,7 +73,7 @@ evaluate-commands %sh{
         add-highlighter shared/dart/code/ regex \b(${types})\b 0:type
         add-highlighter shared/dart/code/ regex \b(${values})\b 0:value
         add-highlighter shared/dart/code/ regex \b(${functions}) 2:function
-        add-highlighter shared/dart/code/ regex \b(${annotations})\b 0:meta
+        add-highlighter shared/dart/code/ regex (${annotations})\b 0:meta
         add-highlighter shared/dart/code/ regex \b(${classes})\b 0:module
     "
 }


### PR DESCRIPTION
Annotations start with `@` sign so `\b` doesn't match the whole annotation.