### PR TITLE
Set the REPL window title using xdotool

### DIFF
--- a/rc/windowing/repl/x11.kak
+++ b/rc/windowing/repl/x11.kak
@@ -15,9 +15,8 @@ All optional parameters are forwarded to the new window} \
            exit
         fi
         if [ $# -eq 0 ]; then cmd="${SHELL:-sh}"; else cmd="$@"; fi
-        setsid ${kak_opt_termcmd} \
-               "xdotool getactivewindow set_window --name kak_repl_window \
-                && exec \"${cmd}\"" < /dev/null > /dev/null 2>&1 &
+        setsid ${kak_opt_termcmd} "printf '\e]2;kak_repl_window\a' \
+                && ${cmd}" < /dev/null > /dev/null 2>&1 &
 }}
 
 define-command x11-send-text -docstring "send the selected text to the repl window" %{

--- a/rc/windowing/repl/x11.kak
+++ b/rc/windowing/repl/x11.kak
@@ -15,6 +15,7 @@ All optional parameters are forwarded to the new window} \
            exit
         fi
         if [ $# -eq 0 ]; then cmd="${SHELL:-sh}"; else cmd="$@"; fi
+        # The escape sequence in the printf command sets the terminal's title:
         setsid ${kak_opt_termcmd} "printf '\e]2;kak_repl_window\a' \
                 && ${cmd}" < /dev/null > /dev/null 2>&1 &
 }}

--- a/rc/windowing/repl/x11.kak
+++ b/rc/windowing/repl/x11.kak
@@ -15,7 +15,9 @@ All optional parameters are forwarded to the new window} \
            exit
         fi
         if [ $# -eq 0 ]; then cmd="${SHELL:-sh}"; else cmd="$@"; fi
-        setsid ${kak_opt_termcmd} ${cmd} -t kak_repl_window < /dev/null > /dev/null 2>&1 &
+        setsid ${kak_opt_termcmd} \
+               "xdotool getactivewindow set_window --name kak_repl_window \
+                && exec \"${cmd}\"" < /dev/null > /dev/null 2>&1 &
 }}
 
 define-command x11-send-text -docstring "send the selected text to the repl window" %{


### PR DESCRIPTION
As mentioned in issue #2973, the -t argument for setting the terminal title was not very portable.

This relies on the window manager to 'activate' the newly created window, but I haven't met one that doesn't.