### PR TITLE
src: Enforce case sensitivity when parsing function keys

### DIFF
--- a/src/keys.cc
+++ b/src/keys.cc
@@ -126,7 +126,7 @@ KeyList parse_keys(StringView str)
             result.push_back(canonicalize_ifn({ modifier, name_it->key }));
         else if (desc.char_length() == 1)
             result.push_back(canonicalize_ifn({ modifier, desc[0_char] }));
-        else if (to_lower(desc[0_byte]) == 'f' and desc.length() <= 3)
+        else if (desc[0_byte] == 'F' and desc.length() <= 3)
         {
             int val = str_to_int(desc.substr(1_byte));
             if (val >= 1 and val <= 12)


### PR DESCRIPTION
The `parse_keys()` function is case insensitive when parsing function keys,
while the `key_to_str()` function always returns a capitalized key
description.

When users hook on the lowercase name of a function key,
e.g. `NormalKey <f10>`, and later hit that same key in normal mode, the
`key_to_str()` will convert it to the uppercase description (`<F10>`).

This results into a hook with a lowercase regex predicate being unsuccessfully
matched against an uppercase key description by the hook manager, which
works on a case sensitive basis.

One solution could be to uppercase all function key descriptions passed as
hook filter upon declaration, but detecting that is not trivial as the
filter can contain more than just the simple `<f\d+>` data, e.g.

```
hook global InsertKey '<(?<name>\w+)>' %{…}
```

Another simpler solution that this commit implements is to allow only `<F\d+>`
descriptions in `parse_keys()`, and hope users will know not to use the
lowercase notation when declaring hooks.

Fixes #2907