### PR TITLE
Rename ModuleLoad hook

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -28,8 +28,8 @@ released versions.
   `require-module` commands that allows for lazily loading language
   support files with dependency resolution.
 
-* Added a new hook `ModuleLoad` which is run when a module is loaded,
-  allowing for module specific configuration.
+* Added a new hook `ModuleLoaded` which is run after a module is
+  loaded, allowing for module specific configuration.
 
 * Shell quoting of lists is not automatic anymore, `$kak_quoted_...`
   makes it opt-in, and works for all option types.

--- a/doc/pages/hooks.asciidoc
+++ b/doc/pages/hooks.asciidoc
@@ -176,8 +176,8 @@ name. Hooks with no description will always use an empty string.
 *RawKey* `key`::
     Triggered whenever a key is pressed by the user
 
-*ModuleLoad* `module`::
-    Triggered when a module is evaluated by the first `require-module` call
+*ModuleLoaded* `module`::
+    Triggered after a module is evaluated by the first `require-module` call
 
 Note that some hooks will not consider underlying scopes depending on what
 context they are bound to be run into, e.g. the `BufWritePost` hook is a buffer

--- a/rc/windowing/repl/tmux.kak
+++ b/rc/windowing/repl/tmux.kak
@@ -1,7 +1,7 @@
 # http://tmux.github.io/
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global ModuleLoad tmux %{
+hook global ModuleLoaded tmux %{
     require-module tmux-repl
 }
 

--- a/rc/windowing/repl/x11.kak
+++ b/rc/windowing/repl/x11.kak
@@ -1,4 +1,4 @@
-hook global ModuleLoad x11 %{
+hook global ModuleLoaded x11 %{
     require-module x11-repl
 }
 

--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -67,7 +67,7 @@ void CommandManager::load_module(StringView module_name, Context& context)
     execute(module->value.commands, empty_context);
     module->value.commands.clear();
 
-    context.hooks().run_hook(Hook::ModuleLoad, module_name, context);
+    context.hooks().run_hook(Hook::ModuleLoaded, module_name, context);
 }
 
 struct parse_error : runtime_error

--- a/src/hook_manager.hh
+++ b/src/hook_manager.hh
@@ -57,7 +57,7 @@ enum class Hook
     WinDisplay,
     WinResize,
     WinSetOption,
-    ModuleLoad
+    ModuleLoaded
 };
 
 constexpr auto enum_desc(Meta::Type<Hook>)
@@ -103,7 +103,7 @@ constexpr auto enum_desc(Meta::Type<Hook>)
         {Hook::WinDisplay, "WinDisplay"},
         {Hook::WinResize, "WinResize"},
         {Hook::WinSetOption, "WinSetOption"},
-        {Hook::ModuleLoad, "ModuleLoad"}
+        {Hook::ModuleLoaded, "ModuleLoaded"}
     });
 }
 


### PR DESCRIPTION
With this pull request I intend to clarify the exact time, when the hook is executed. When I first encountered the hook it was unclear to me, whether it's run before or after a module is loaded.

See #2991.