### PR TITLE
src: Use all selections to generate a pattern upon hitting `*`

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -939,12 +939,20 @@ template<bool smart>
 void use_selection_as_search_pattern(Context& context, NormalParams params)
 {
     const auto& buffer = context.buffer();
-    auto& sel = context.selections().main();
-    const auto beg = sel.min(), end = buffer.char_next(sel.max());
-    String pattern = format("{}{}{}",
-                            smart and is_bow(buffer, beg) ? "\\b" : "",
-                            escape(buffer.string(beg, end), "^$\\.*+?()[]{}|", '\\'),
-                            smart and is_eow(buffer, end) ? "\\b" : "");
+    String pattern;
+
+    for (auto& sel : context.selections())
+    {
+        const auto beg = sel.min(), end = buffer.char_next(sel.max());
+        const String sel_pattern = format("{}{}{}",
+                                          smart and is_bow(buffer, beg) ? "\\b" : "",
+                                          escape(buffer.string(beg, end), "^$\\.*+?()[]{}|", '\\'),
+                                          smart and is_eow(buffer, end) ? "\\b" : "");
+
+        if (not pattern.empty())
+            pattern += '|';
+        pattern += sel_pattern;
+    }
 
     const char reg = to_lower(params.reg ? params.reg : '/');
 


### PR DESCRIPTION
This commit makes the `*` and <a-*> primitives compose a search pattern
comprised of all the current selections, as opposed to only the main one.

All selections are OR'd into the default search register, which makes it
convenient to search for several identifiers already selected.

To retain the old behaviour, the following mappings can be used:

```
map global normal * ': exec -draft -save-regs "" %{<space>*}<ret>'
map global normal <a-*> ': exec -draft -save-regs "" %{<space><a-*>}<ret>'
```

Fixes #2994