### PR TITLE
Treat '-' as an word character in lisp

### DIFF
--- a/rc/filetype/lisp.kak
+++ b/rc/filetype/lisp.kak
@@ -16,6 +16,7 @@ hook global WinSetOption filetype=lisp %{
 
     hook window ModeChange insert:.* -group lisp-trim-indent  lisp-trim-indent
     hook window InsertChar \n -group lisp-indent lisp-indent-on-new-line
+    set-option buffer extra_word_chars '_' '-' 
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window lisp-.+ }
 }

--- a/rc/filetype/lisp.kak
+++ b/rc/filetype/lisp.kak
@@ -16,7 +16,7 @@ hook global WinSetOption filetype=lisp %{
 
     hook window ModeChange insert:.* -group lisp-trim-indent  lisp-trim-indent
     hook window InsertChar \n -group lisp-indent lisp-indent-on-new-line
-    set-option buffer extra_word_chars '_' '-' 
+    set-option buffer extra_word_chars '_' '+' '-' '*' '/' '@' '$' '%' '^' '&' '_' '=' '<' '>' '~' '.'
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window lisp-.+ }
 }


### PR DESCRIPTION
I've run into this using the lisp mode (albiet not for common lisp). In most lisps, identifiers include `-`, and I don't know of any lisps which don't count it as a separator.

The code itself is directly copied from `scss.kak`: https://github.com/mawww/kakoune/blob/2ff9fd8d9262e9fd1361dd2c0e873277aabad663/rc/filetype/scss.kak#L14-L23