### PR TITLE
allow for mapping the Insert key

### DIFF
--- a/doc/pages/mapping.asciidoc
+++ b/doc/pages/mapping.asciidoc
@@ -135,7 +135,7 @@ be used:
 *<ins>*::
     The Insert key.
 
-*<f1>*, *<f2>*, ...*<f12>*::
+*<F1>*, *<F2>*, ...*<F12>*::
     Function keys.
 
 NOTE: Although Kakoune allows many key combinations to be mapped, not every

--- a/doc/pages/mapping.asciidoc
+++ b/doc/pages/mapping.asciidoc
@@ -132,6 +132,9 @@ be used:
 *<pageup>*, *<pagedown>*, *<home>*, *<end>*::
     The usual cursor-movement keys.
 
+*<ins>*::
+    The Insert key.
+
 *<f1>*, *<f2>*, ...*<f12>*::
     Function keys.
 

--- a/src/keys.cc
+++ b/src/keys.cc
@@ -74,6 +74,7 @@ static constexpr KeyAndName keynamemap[] = {
     { "pagedown", Key::PageDown },
     { "home", Key::Home },
     { "end", Key::End },
+    { "ins", Key::Insert },
     { "del", Key::Delete },
     { "plus", '+' },
     { "minus", '-' },

--- a/src/keys.hh
+++ b/src/keys.hh
@@ -50,6 +50,7 @@ struct Key
         PageDown,
         Home,
         End,
+        Insert,
         Tab,
         F1,
         F2,

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -606,6 +606,8 @@ Optional<Key> NCursesUI::get_next_key()
         case KEY_SHOME: return shift(Key::Home);
         case KEY_END: return {Key::End};
         case KEY_SEND: return shift(Key::End);
+        case KEY_IC: return {Key::Insert};
+        case KEY_SIC: return shift(Key::Insert);
         case KEY_BTAB: return shift(Key::Tab);
         case KEY_RESIZE: return resize(dimensions());
         }


### PR DESCRIPTION
enable the use of `<ins>` for custom bindings, e. g.:
```
:map global normal <ins> ';i'
```