### PR TITLE
Fix *-trim-indent commands showing up in history

### DIFF
--- a/rc/filetype/cabal.kak
+++ b/rc/filetype/cabal.kak
@@ -57,7 +57,7 @@ define-command -hidden cabal-indent-on-new-line %[
         # preserve previous line indent
         try %[ execute-keys -draft \; K <a-&> ]
         # filter previous line
-        try %[ execute-keys -draft k : cabal-trim-indent <ret> ]
+        try %[ execute-keys -draft k : ' cabal-trim-indent' <ret> ]
         # indent after lines ending with { or :
         try %[ execute-keys -draft <space> k <a-x> <a-k> [:{]$ <ret> j <a-gt> ]
     ]

--- a/rc/filetype/cabal.kak
+++ b/rc/filetype/cabal.kak
@@ -57,7 +57,7 @@ define-command -hidden cabal-indent-on-new-line %[
         # preserve previous line indent
         try %[ execute-keys -draft \; K <a-&> ]
         # filter previous line
-        try %[ execute-keys -draft k : ' cabal-trim-indent' <ret> ]
+        try %[ execute-keys -draft k ": cabal-trim-indent<ret>" ]
         # indent after lines ending with { or :
         try %[ execute-keys -draft <space> k <a-x> <a-k> [:{]$ <ret> j <a-gt> ]
     ]

--- a/rc/filetype/coffee.kak
+++ b/rc/filetype/coffee.kak
@@ -77,7 +77,7 @@ define-command -hidden coffee-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : coffee-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' coffee-trim-indent' <ret> }
         # indent after start structure
         try %{ execute-keys -draft k <a-x> <a-k> ^ \h * (case|catch|class|else|finally|for|function|if|switch|try|while|with) \b | (=|->) $ <ret> j <a-gt> }
     }

--- a/rc/filetype/coffee.kak
+++ b/rc/filetype/coffee.kak
@@ -77,7 +77,7 @@ define-command -hidden coffee-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' coffee-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": coffee-trim-indent<ret>" }
         # indent after start structure
         try %{ execute-keys -draft k <a-x> <a-k> ^ \h * (case|catch|class|else|finally|for|function|if|switch|try|while|with) \b | (=|->) $ <ret> j <a-gt> }
     }

--- a/rc/filetype/css.kak
+++ b/rc/filetype/css.kak
@@ -67,7 +67,7 @@ define-command -hidden css-indent-on-new-line %[
         # preserve previous line indent
         try %[ execute-keys -draft \; K <a-&> ]
         # filter previous line
-        try %[ execute-keys -draft k : css-trim-indent <ret> ]
+        try %[ execute-keys -draft k : ' css-trim-indent' <ret> ]
         # indent after lines ending with with {
         try %[ execute-keys -draft k <a-x> <a-k> \{$ <ret> j <a-gt> ]
     ]

--- a/rc/filetype/css.kak
+++ b/rc/filetype/css.kak
@@ -67,7 +67,7 @@ define-command -hidden css-indent-on-new-line %[
         # preserve previous line indent
         try %[ execute-keys -draft \; K <a-&> ]
         # filter previous line
-        try %[ execute-keys -draft k : ' css-trim-indent' <ret> ]
+        try %[ execute-keys -draft k ": css-trim-indent<ret>" ]
         # indent after lines ending with with {
         try %[ execute-keys -draft k <a-x> <a-k> \{$ <ret> j <a-gt> ]
     ]

--- a/rc/filetype/cucumber.kak
+++ b/rc/filetype/cucumber.kak
@@ -87,7 +87,7 @@ define-command -hidden cucumber-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' cucumber-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": cucumber-trim-indent<ret>" }
         # indent after lines containing :
         try %{ execute-keys -draft <space> k x <a-k> : <ret> j <a-gt> }
     }

--- a/rc/filetype/cucumber.kak
+++ b/rc/filetype/cucumber.kak
@@ -87,7 +87,7 @@ define-command -hidden cucumber-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : cucumber-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' cucumber-trim-indent' <ret> }
         # indent after lines containing :
         try %{ execute-keys -draft <space> k x <a-k> : <ret> j <a-gt> }
     }

--- a/rc/filetype/elixir.kak
+++ b/rc/filetype/elixir.kak
@@ -74,7 +74,7 @@ define-command -hidden elixir-indent-on-new-line %{
         # indent after line ending with:
 	# try %{ execute-keys -draft k x <a-k> (do|else|->)$ <ret> & }
 	# filter previous line
-        try %{ execute-keys -draft k : elixir-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' elixir-trim-indent' <ret> }
         # indent after lines ending with do or ->
         try %{ execute-keys -draft \\; k x <a-k> ^.+(do|->)$ <ret> j <a-gt> }
     }

--- a/rc/filetype/elixir.kak
+++ b/rc/filetype/elixir.kak
@@ -74,7 +74,7 @@ define-command -hidden elixir-indent-on-new-line %{
         # indent after line ending with:
 	# try %{ execute-keys -draft k x <a-k> (do|else|->)$ <ret> & }
 	# filter previous line
-        try %{ execute-keys -draft k : ' elixir-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": elixir-trim-indent<ret>" }
         # indent after lines ending with do or ->
         try %{ execute-keys -draft \\; k x <a-k> ^.+(do|->)$ <ret> j <a-gt> }
     }

--- a/rc/filetype/elm.kak
+++ b/rc/filetype/elm.kak
@@ -64,7 +64,7 @@ define-command -hidden elm-indent-on-new-line %{
         # align to first clause
         try %{ execute-keys -draft \; k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|let)\h+\K.* <ret> s \A|.\z <ret> & }
         # filter previous line
-        try %{ execute-keys -draft k : ' elm-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": elm-trim-indent<ret>" }
         # indent after lines beginning with condition or ending with expression or =(
         try %{ elm-indent-after }
     }

--- a/rc/filetype/elm.kak
+++ b/rc/filetype/elm.kak
@@ -64,7 +64,7 @@ define-command -hidden elm-indent-on-new-line %{
         # align to first clause
         try %{ execute-keys -draft \; k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|let)\h+\K.* <ret> s \A|.\z <ret> & }
         # filter previous line
-        try %{ execute-keys -draft k : elm-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' elm-trim-indent' <ret> }
         # indent after lines beginning with condition or ending with expression or =(
         try %{ elm-indent-after }
     }

--- a/rc/filetype/gas.kak
+++ b/rc/filetype/gas.kak
@@ -89,7 +89,7 @@ define-command -hidden gas-indent-on-new-line %~
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : gas-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' gas-trim-indent' <ret> }
         # indent after label
         try %[ execute-keys -draft k <a-x> <a-k> :$ <ret> j <a-gt> ]
     >

--- a/rc/filetype/gas.kak
+++ b/rc/filetype/gas.kak
@@ -89,7 +89,7 @@ define-command -hidden gas-indent-on-new-line %~
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' gas-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": gas-trim-indent<ret>" }
         # indent after label
         try %[ execute-keys -draft k <a-x> <a-k> :$ <ret> j <a-gt> ]
     >

--- a/rc/filetype/haml.kak
+++ b/rc/filetype/haml.kak
@@ -63,7 +63,7 @@ define-command -hidden haml-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' haml-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": haml-trim-indent<ret>" }
         # indent after lines beginning with : or -
         try %{ execute-keys -draft k <a-x> <a-k> ^\h*[:-] <ret> j <a-gt> }
     }

--- a/rc/filetype/haml.kak
+++ b/rc/filetype/haml.kak
@@ -63,7 +63,7 @@ define-command -hidden haml-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : haml-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' haml-trim-indent' <ret> }
         # indent after lines beginning with : or -
         try %{ execute-keys -draft k <a-x> <a-k> ^\h*[:-] <ret> j <a-gt> }
     }

--- a/rc/filetype/haskell.kak
+++ b/rc/filetype/haskell.kak
@@ -103,7 +103,7 @@ define-command -hidden haskell-indent-on-new-line %{
         # align to first clause
         try %{ execute-keys -draft \; k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|do|let|where)\h+\K.* <ret> s \A|.\z <ret> & }
         # filter previous line
-        try %{ execute-keys -draft k : ' haskell-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": haskell-trim-indent<ret>" }
         # indent after lines beginning with condition or ending with expression or =(
         try %{ execute-keys -draft \; k x <a-k> ^\h*(if)|(case\h+[\w']+\h+of|do|let|where|[=(])$ <ret> j <a-gt> }
     }

--- a/rc/filetype/haskell.kak
+++ b/rc/filetype/haskell.kak
@@ -103,7 +103,7 @@ define-command -hidden haskell-indent-on-new-line %{
         # align to first clause
         try %{ execute-keys -draft \; k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|do|let|where)\h+\K.* <ret> s \A|.\z <ret> & }
         # filter previous line
-        try %{ execute-keys -draft k : haskell-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' haskell-trim-indent' <ret> }
         # indent after lines beginning with condition or ending with expression or =(
         try %{ execute-keys -draft \; k x <a-k> ^\h*(if)|(case\h+[\w']+\h+of|do|let|where|[=(])$ <ret> j <a-gt> }
     }

--- a/rc/filetype/hbs.kak
+++ b/rc/filetype/hbs.kak
@@ -80,7 +80,7 @@ define-command -hidden hbs-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : hbs-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' hbs-trim-indent' <ret> }
         # indent after lines beginning with : or -
         try %{ execute-keys -draft k <a-x> <a-k> ^\h*[:-] <ret> j <a-gt> }
     }

--- a/rc/filetype/hbs.kak
+++ b/rc/filetype/hbs.kak
@@ -80,7 +80,7 @@ define-command -hidden hbs-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' hbs-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": hbs-trim-indent<ret>" }
         # indent after lines beginning with : or -
         try %{ execute-keys -draft k <a-x> <a-k> ^\h*[:-] <ret> j <a-gt> }
     }

--- a/rc/filetype/html.kak
+++ b/rc/filetype/html.kak
@@ -79,7 +79,7 @@ define-command -hidden html-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : html-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' html-trim-indent' <ret> }
         # indent after lines ending with opening tag
         try %{ execute-keys -draft k <a-x> <a-k> <lt>(?!area)(?!base)(?!br)(?!col)(?!command)(?!embed)(?!hr)(?!img)(?!input)(?!keygen)(?!link)(?!menuitem)(?!meta)(?!param)(?!source)(?!track)(?!wbr)(?!/)(?!>)[a-zA-Z0-9_-]+[^>]*?>$ <ret> j <a-gt> } }
 }

--- a/rc/filetype/html.kak
+++ b/rc/filetype/html.kak
@@ -79,7 +79,7 @@ define-command -hidden html-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' html-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": html-trim-indent<ret>" }
         # indent after lines ending with opening tag
         try %{ execute-keys -draft k <a-x> <a-k> <lt>(?!area)(?!base)(?!br)(?!col)(?!command)(?!embed)(?!hr)(?!img)(?!input)(?!keygen)(?!link)(?!menuitem)(?!meta)(?!param)(?!source)(?!track)(?!wbr)(?!/)(?!>)[a-zA-Z0-9_-]+[^>]*?>$ <ret> j <a-gt> } }
 }

--- a/rc/filetype/javascript.kak
+++ b/rc/filetype/javascript.kak
@@ -59,7 +59,7 @@ define-command -hidden javascript-indent-on-new-line %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : javascript-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' javascript-trim-indent' <ret> }
         # indent after lines beginning / ending with opener token
         try %_ execute-keys -draft k <a-x> <a-k> ^\h*[[{]|[[{]$ <ret> j <a-gt> _
     >

--- a/rc/filetype/javascript.kak
+++ b/rc/filetype/javascript.kak
@@ -59,7 +59,7 @@ define-command -hidden javascript-indent-on-new-line %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' javascript-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": javascript-trim-indent<ret>" }
         # indent after lines beginning / ending with opener token
         try %_ execute-keys -draft k <a-x> <a-k> ^\h*[[{]|[[{]$ <ret> j <a-gt> _
     >

--- a/rc/filetype/json.kak
+++ b/rc/filetype/json.kak
@@ -58,7 +58,7 @@ define-command -hidden json-indent-on-new-line %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' json-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": json-trim-indent<ret>" }
         # indent after lines beginning with opener token
         try %< execute-keys -draft k <a-x> <a-k> ^\h*[[{] <ret> j <a-gt> >
     >

--- a/rc/filetype/json.kak
+++ b/rc/filetype/json.kak
@@ -58,7 +58,7 @@ define-command -hidden json-indent-on-new-line %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : json-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' json-trim-indent' <ret> }
         # indent after lines beginning with opener token
         try %< execute-keys -draft k <a-x> <a-k> ^\h*[[{] <ret> j <a-gt> >
     >

--- a/rc/filetype/moon.kak
+++ b/rc/filetype/moon.kak
@@ -103,7 +103,7 @@ define-command -hidden moon-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : moon-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' moon-trim-indent' <ret> }
         # indent after start structure
         try %{ execute-keys -draft k <a-x> <a-k> ^ \h * (class|else(if)?|for|if|switch|unless|when|while|with) \b | ([:=]|[-=]>) $ <ret> j <a-gt> }
         # deindent after return statements

--- a/rc/filetype/moon.kak
+++ b/rc/filetype/moon.kak
@@ -103,7 +103,7 @@ define-command -hidden moon-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' moon-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": moon-trim-indent<ret>" }
         # indent after start structure
         try %{ execute-keys -draft k <a-x> <a-k> ^ \h * (class|else(if)?|for|if|switch|unless|when|while|with) \b | ([:=]|[-=]>) $ <ret> j <a-gt> }
         # deindent after return statements

--- a/rc/filetype/php.kak
+++ b/rc/filetype/php.kak
@@ -88,7 +88,7 @@ define-command -hidden php-indent-on-new-line %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : php-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' php-trim-indent' <ret> }
         # indent after lines beginning / ending with opener token
         try %_ execute-keys -draft k <a-x> <a-k> ^\h*[[{]|[[{]$ <ret> j <a-gt> _
         # append " * " on lines starting a multiline /** or /* comment

--- a/rc/filetype/php.kak
+++ b/rc/filetype/php.kak
@@ -88,7 +88,7 @@ define-command -hidden php-indent-on-new-line %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' php-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": php-trim-indent<ret>" }
         # indent after lines beginning / ending with opener token
         try %_ execute-keys -draft k <a-x> <a-k> ^\h*[[{]|[[{]$ <ret> j <a-gt> _
         # append " * " on lines starting a multiline /** or /* comment

--- a/rc/filetype/pug.kak
+++ b/rc/filetype/pug.kak
@@ -70,7 +70,7 @@ define-command -hidden pug-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : pug-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' pug-trim-indent' <ret> }
         # copy '//', '|', '-' or '(!)=' prefix and following whitespace
         try %{ execute-keys -draft k <a-x> s ^\h*\K[/|!=-]{1,2}\h* <ret> y gh j P }
         # indent unless we copied something above

--- a/rc/filetype/pug.kak
+++ b/rc/filetype/pug.kak
@@ -70,7 +70,7 @@ define-command -hidden pug-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' pug-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": pug-trim-indent<ret>" }
         # copy '//', '|', '-' or '(!)=' prefix and following whitespace
         try %{ execute-keys -draft k <a-x> s ^\h*\K[/|!=-]{1,2}\h* <ret> y gh j P }
         # indent unless we copied something above

--- a/rc/filetype/ragel.kak
+++ b/rc/filetype/ragel.kak
@@ -67,7 +67,7 @@ define-command -hidden ragel-indent-on-new-line %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ragel-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' ragel-trim-indent' <ret> }
         # indent after lines ending with opener token
         try %< execute-keys -draft k <a-x> <a-k> [[{(*]$ <ret> j <a-gt> >
     >

--- a/rc/filetype/ragel.kak
+++ b/rc/filetype/ragel.kak
@@ -67,7 +67,7 @@ define-command -hidden ragel-indent-on-new-line %<
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' ragel-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": ragel-trim-indent<ret>" }
         # indent after lines ending with opener token
         try %< execute-keys -draft k <a-x> <a-k> [[{(*]$ <ret> j <a-gt> >
     >

--- a/rc/filetype/ruby.kak
+++ b/rc/filetype/ruby.kak
@@ -151,7 +151,7 @@ define-command -hidden ruby-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ruby-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' ruby-trim-indent' <ret> }
         # indent after start structure
         try %{ execute-keys -draft k <a-x> <a-k> ^ \h * (begin|case|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|.+\bdo$|.+\bdo\h\|.+(?=\|)) \b <ret> j <a-gt> }
     }

--- a/rc/filetype/ruby.kak
+++ b/rc/filetype/ruby.kak
@@ -151,7 +151,7 @@ define-command -hidden ruby-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' ruby-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": ruby-trim-indent<ret>" }
         # indent after start structure
         try %{ execute-keys -draft k <a-x> <a-k> ^ \h * (begin|case|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|.+\bdo$|.+\bdo\h\|.+(?=\|)) \b <ret> j <a-gt> }
     }

--- a/rc/filetype/rust.kak
+++ b/rc/filetype/rust.kak
@@ -77,7 +77,7 @@ define-command -hidden rust-indent-on-new-line %~
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' rust-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": rust-trim-indent<ret>" }
         # indent after lines ending with { or (
         try %[ execute-keys -draft k <a-x> <a-k> [{(]\h*$ <ret> j <a-gt> ]
         # indent after lines ending with [{(].+ and move first parameter to own line

--- a/rc/filetype/rust.kak
+++ b/rc/filetype/rust.kak
@@ -77,7 +77,7 @@ define-command -hidden rust-indent-on-new-line %~
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : rust-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' rust-trim-indent' <ret> }
         # indent after lines ending with { or (
         try %[ execute-keys -draft k <a-x> <a-k> [{(]\h*$ <ret> j <a-gt> ]
         # indent after lines ending with [{(].+ and move first parameter to own line

--- a/rc/filetype/sass.kak
+++ b/rc/filetype/sass.kak
@@ -60,7 +60,7 @@ define-command -hidden sass-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : sass-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' sass-trim-indent' <ret> }
         # avoid indent after properties and comments
         try %{ execute-keys -draft k <a-x> <a-K> [:/] <ret> j <a-gt> }
     }

--- a/rc/filetype/sass.kak
+++ b/rc/filetype/sass.kak
@@ -60,7 +60,7 @@ define-command -hidden sass-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' sass-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": sass-trim-indent<ret>" }
         # avoid indent after properties and comments
         try %{ execute-keys -draft k <a-x> <a-K> [:/] <ret> j <a-gt> }
     }

--- a/rc/filetype/scala.kak
+++ b/rc/filetype/scala.kak
@@ -66,7 +66,7 @@ define-command -hidden scala-indent-on-new-line %[
         # preserve previous line indent
         try %[ execute-keys -draft \; K <a-&> ]
         # filter previous line
-        try %[ execute-keys -draft k : ' scala-trim-indent' <ret> ]
+        try %[ execute-keys -draft k ": scala-trim-indent<ret>" ]
         # indent after lines ending with {
         try %[ execute-keys -draft k <a-x> <a-k> \{$ <ret> j <a-gt> ]
     ]

--- a/rc/filetype/scala.kak
+++ b/rc/filetype/scala.kak
@@ -66,7 +66,7 @@ define-command -hidden scala-indent-on-new-line %[
         # preserve previous line indent
         try %[ execute-keys -draft \; K <a-&> ]
         # filter previous line
-        try %[ execute-keys -draft k : scala-trim-indent <ret> ]
+        try %[ execute-keys -draft k : ' scala-trim-indent' <ret> ]
         # indent after lines ending with {
         try %[ execute-keys -draft k <a-x> <a-k> \{$ <ret> j <a-gt> ]
     ]

--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -75,7 +75,7 @@ define-command -hidden sh-indent-on-new-line %[
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : sh-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' sh-trim-indent' <ret> }
 
         # Indent loop syntax, e.g.:
         # for foo in bar; do

--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -75,7 +75,7 @@ define-command -hidden sh-indent-on-new-line %[
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' sh-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": sh-trim-indent<ret>" }
 
         # Indent loop syntax, e.g.:
         # for foo in bar; do

--- a/rc/filetype/toml.kak
+++ b/rc/filetype/toml.kak
@@ -63,7 +63,7 @@ define-command -hidden toml-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' toml-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": toml-trim-indent<ret>" }
     }
 }
 

--- a/rc/filetype/toml.kak
+++ b/rc/filetype/toml.kak
@@ -63,7 +63,7 @@ define-command -hidden toml-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : toml-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' toml-trim-indent' <ret> }
     }
 }
 

--- a/rc/filetype/yaml.kak
+++ b/rc/filetype/yaml.kak
@@ -56,7 +56,7 @@ define-command -hidden yaml-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : yaml-trim-indent <ret> }
+        try %{ execute-keys -draft k : ' yaml-trim-indent' <ret> }
         # indent after :
         try %{ execute-keys -draft <space> k x <a-k> :$ <ret> j <a-gt> }
     }

--- a/rc/filetype/yaml.kak
+++ b/rc/filetype/yaml.kak
@@ -56,7 +56,7 @@ define-command -hidden yaml-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line
-        try %{ execute-keys -draft k : ' yaml-trim-indent' <ret> }
+        try %{ execute-keys -draft k ": yaml-trim-indent <ret>" }
         # indent after :
         try %{ execute-keys -draft <space> k x <a-k> :$ <ret> j <a-gt> }
     }


### PR DESCRIPTION
This adds an explicit space when executing all `*-trim-indent` commands in `execute-keys`, so that the commands don't show up in history.

I chose using quotes here of `<space>` since it seemed simpler. Perhaps it's less obvious what the purpose is though?

I'm assuming that it's unintentional that these show up in history. If it is, then this could be closed.

Fixes #3013.