### PR TITLE
Check if file exists before loading editorconfig settings

### DIFF
--- a/rc/detection/editorconfig.kak
+++ b/rc/detection/editorconfig.kak
@@ -11,53 +11,51 @@ hook global BufCreate .*[.](editorconfig) %{
     latin1 utf-8 utf-8-bom utf-16be utf-16le lf cr crlf unset space tab max_line_length
 }
 
-declare-option -hidden bool editorconfig_trim_trailing_whitespace false
-
 define-command editorconfig-load -params ..1 -docstring "editorconfig-load [file]: set formatting behavior according to editorconfig" %{
-    remove-hooks buffer editorconfig-hooks
     evaluate-commands %sh{
-        command -v editorconfig >/dev/null 2>&1 || { echo 'echo -markup "{Error}editorconfig could not be found"'; exit 1; }
-        editorconfig "${1:-$kak_buffile}" | awk -F= -- '
-            /indent_style=/             { indent_style = $2 }
-            /indent_size=/              { indent_size = $2 == "tab" ? 4 : $2  }
-            /tab_width=/                { tab_width = $2 }
-            /end_of_line=/              { end_of_line = $2 }
-            /charset=/                  { charset = $2 }
-            /trim_trailing_whitespace=/ { trim_trailing_whitespace = $2 }
-            /max_line_length=/          { max_line_length = $2 }
+        command -v editorconfig >/dev/null 2>&1 || { printf %s\\n 'echo -markup "{Error}editorconfig could not be found"'; exit 1; }
 
-            END {
-                if (indent_style == "tab") {
-                    print "set-option buffer indentwidth 0"
-                    print "set-option buffer aligntab true"
-                }
-                if (indent_style == "space") {
-                    print "set-option buffer indentwidth " (indent_size == "tab" ? 4 : indent_size)
-                    print "set-option buffer aligntab false"
-                }
-                if (indent_size || tab_width) {
-                    print "set-option buffer tabstop " (tab_width ? tab_width : indent_size)
-                }
-                if (end_of_line == "lf" || end_of_line == "crlf") {
-                    print "set-option buffer eolformat " end_of_line
-                }
-                if (charset == "utf-8-bom") {
-                    print "set-option buffer BOM utf8"
-                }
-                if (trim_trailing_whitespace == "true") {
-                    print "set-option buffer editorconfig_trim_trailing_whitespace true"
-                }
-                if (max_line_length && max_line_length != "off") {
-                    print "set window autowrap_column " max_line_length
-                    print "autowrap-enable"
-                    print "add-highlighter window/ column %sh{ echo $((" max_line_length "+1)) } default,bright-black"
-                }
-            }
-        '
+        file="${1:-$kak_buffile}"
+        case $file in
+            /*) # $kak_buffile is a full path that starts with a '/'
+                printf %s\\n "remove-hooks buffer editorconfig-hooks"
+                editorconfig "$file" | awk -v file="$file" -F= -- '
+                    /indent_style=/             { indent_style = $2 }
+                    /indent_size=/              { indent_size = $2 == "tab" ? 4 : $2  }
+                    /tab_width=/                { tab_width = $2 }
+                    /end_of_line=/              { end_of_line = $2 }
+                    /charset=/                  { charset = $2 }
+                    /trim_trailing_whitespace=/ { trim_trailing_whitespace = $2 }
+                    /max_line_length=/          { max_line_length = $2 }
+
+                    END {
+                        if (indent_style == "tab") {
+                            print "set-option buffer indentwidth 0"
+                            print "set-option buffer aligntab true"
+                        }
+                        if (indent_style == "space") {
+                            print "set-option buffer indentwidth " (indent_size == "tab" ? 4 : indent_size)
+                            print "set-option buffer aligntab false"
+                        }
+                        if (indent_size || tab_width) {
+                            print "set-option buffer tabstop " (tab_width ? tab_width : indent_size)
+                        }
+                        if (end_of_line == "lf" || end_of_line == "crlf") {
+                            print "set-option buffer eolformat " end_of_line
+                        }
+                        if (charset == "utf-8-bom") {
+                            print "set-option buffer BOM utf8"
+                        }
+                        if (trim_trailing_whitespace == "true") {
+                            print "hook buffer BufWritePre \"" file "\" -group editorconfig-hooks %{ try %{ execute-keys -draft %{ %s\\h+$<ret>d } } }"
+                        }
+                        if (max_line_length && max_line_length != "off") {
+                            print "set window autowrap_column " max_line_length
+                            print "autowrap-enable"
+                            print "add-highlighter window/ column %sh{ echo $((" max_line_length "+1)) } default,bright-black"
+                        }
+                    }
+                ' ;;
+        esac
     }
-    hook buffer BufWritePre %val{buffile} -group editorconfig-hooks %{ evaluate-commands %sh{
-        if [ ${kak_opt_editorconfig_trim_trailing_whitespace} = "true" ]; then
-            printf %s\\n "try %{ execute-keys -draft %{ %s\h+$<ret>d } }"
-        fi
-    } }
 }


### PR DESCRIPTION
I noticed when using the recommended [editorconfig hook](https://github.com/mawww/kakoune/wiki/EditorConfig) from the Wiki, that the editorconfig.kak script failed for buffers that were not real files. For example `*scratch*`, `*debug*`, `*make*`, `*grep*`, etc.

This PR adds a check in the `editorcofig-load` command to see if a file exists before calling the external `editorconfig` utility.

It also moves the `remove-hooks` line to after the valid file check and directly prints the command to add a remove trailing whitespace hook from awk (if necessary). This prevents an invalid file from clearing a hook and removes the need to store an option and reference it from a spawned shell in the later hook.