### PR TITLE
Be explicit about ordering when autoloading

### DIFF
--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -28,6 +28,7 @@ def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
 evaluate-commands %sh{
     autoload_directory() {
         find -L "$1" -type f -name '*\.kak' \
+            | sort \
             | sed 's/.*/try %{ source "&" } catch %{ echo -debug Autoload: could not load "&" }/'
     }
 


### PR DESCRIPTION
Some autoloads may depend on another. Right now, the autoload ordering depends on the filesystem, so the ordering may change depending on what happens on the file system (`find` does not list the files in any given order).

This sorts the files before `source`ing them, thus making the ordering explicit.