### PR TITLE
 css.kak: Highlight comment inside declaration 

### DIFF
--- a/rc/filetype/css.kak
+++ b/rc/filetype/css.kak
@@ -41,6 +41,7 @@ add-highlighter shared/css/comment    region /[*] [*]/ fill comment
 add-highlighter shared/css/declaration/base default-region group
 add-highlighter shared/css/declaration/double_string region '"' (?<!\\)(\\\\)*" fill string
 add-highlighter shared/css/declaration/single_string region "'" "'"             fill string
+add-highlighter shared/css/declaration/comment region /[*] [*]/ fill comment
 
 # https://developer.mozilla.org/en-US/docs/Web/CSS/length
 add-highlighter shared/css/declaration/base/ regex (#[0-9A-Fa-f]+)|((\d*\.)?\d+(ch|cm|em|ex|mm|pc|pt|px|rem|vh|vmax|vmin|vw)) 0:value


### PR DESCRIPTION
Currently, Kakoune doesn't highlight CSS comments inside of declaration. This commit will fix it.

![before.png](https://user-images.githubusercontent.com/830515/61395799-d2299c00-a8b5-11e9-937f-a3398175df9e.png)
![after.png](https://user-images.githubusercontent.com/830515/61395806-d786e680-a8b5-11e9-8392-8dcdd878597a.png)

