### PR TITLE
src: De-indent docstrings passed to command/option/mapping definitions

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1163,9 +1163,9 @@ void define_command(const ParametersParser& parser, Context& context, const Shel
         };
     }
 
-    auto docstring = trim_whitespaces(parser.get_switch("docstring").value_or(StringView{}));
+    auto docstring = trim_indent(parser.get_switch("docstring").value_or(StringView{}));
 
-    cm.register_command(cmd_name, cmd, docstring.str(), desc, flags, CommandHelper{}, completer);
+    cm.register_command(cmd_name, cmd, docstring, desc, flags, CommandHelper{}, completer);
 }
 
 const CommandDesc define_command_cmd = {
@@ -1590,7 +1590,7 @@ const CommandDesc declare_option_cmd = {
         if (parser.get_switch("hidden"))
             flags = OptionFlags::Hidden;
 
-        auto docstring = trim_whitespaces(parser.get_switch("docstring").value_or(StringView{})).str();
+        auto docstring = trim_indent(parser.get_switch("docstring").value_or(StringView{}));
         OptionsRegistry& reg = GlobalScope::instance().option_registry();
 
 
@@ -1672,7 +1672,7 @@ const CommandDesc map_key_cmd = {
 
         KeyList mapping = parse_keys(parser[3]);
         keymaps.map_key(key[0], keymap_mode, std::move(mapping),
-                        trim_whitespaces(parser.get_switch("docstring").value_or("")).str());
+                        trim_indent(parser.get_switch("docstring").value_or("")));
     }
 };
 

--- a/src/string_utils.hh
+++ b/src/string_utils.hh
@@ -10,6 +10,7 @@ namespace Kakoune
 {
 
 StringView trim_whitespaces(StringView str);
+String trim_indent(StringView str);
 
 String escape(StringView str, StringView characters, char escape);
 String unescape(StringView str, StringView characters, char escape);


### PR DESCRIPTION
This commit implements formatting behaviour when the first character of a
docstring is a newline. In that case, the exact indentation level of the
next line will be removed from that line and all subsequent non-empty lines.

An error will be returned if a subsequent non-empty line does not have the
same indentation level.

The docstrings are always trimmed (surrounding whitespaces) whether the
first character is a newline or not, as was the case prior to this commit.

Example: the following declaration

```
define-command test -docstring %{
    test: do something

    Nothing really.
        More
            indented
                lines.
} nop
```

would be rendered as

```
test: do something

Nothing really.
    More
        indented
            lines.
```

Related to #2405