### PR TITLE
Use KAK_BIN_PATH as portable fallback.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -84,6 +84,7 @@ else
     endif
 
     LIBS += $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --libs ncursesw)
+    CPPFLAGS += -D'KAK_BIN_PATH="$(bindir)/kak"'
     NCURSES_CFLAGS += $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --cflags ncursesw)
     LDFLAGS += -rdynamic
 endif

--- a/src/file.cc
+++ b/src/file.cc
@@ -642,10 +642,8 @@ String get_kak_binary_path()
     kak_assert(res != -1);
     buffer[res] = '\0';
     return buffer;
-#elif defined(__OpenBSD__)
-    return KAK_BIN_PATH;
 #else
-# error "finding executable path is not implemented on this platform"
+    return KAK_BIN_PATH;
 #endif
 }
 


### PR DESCRIPTION
Instead of just using KAK_BIN_PATH on OpenBSD, use it on any OS that doesn't have platform-specific code, instead of erroring.

Fixes build on NetBSD, probably illumos too.