### PR TITLE
rc python: Highlight indented decorators with `.`

### DIFF
--- a/rc/filetype/python.kak
+++ b/rc/filetype/python.kak
@@ -130,7 +130,7 @@ evaluate-commands %sh{
         add-highlighter shared/python/code/ regex '\b($(join "${keywords}" '|'))\b' 0:keyword
         add-highlighter shared/python/code/ regex '\b($(join "${functions}" '|'))\b\(' 1:builtin
         add-highlighter shared/python/code/ regex '\b($(join "${types}" '|'))\b' 0:type
-        add-highlighter shared/python/code/ regex '@[\w_]+\b' 0:attribute
+        add-highlighter shared/python/code/ regex '^\h*(@[\w_.]+))' 1:attribute
     "
 }
 


### PR DESCRIPTION
Make sure decorators are on their own line, and don't stop highlighting at
the first dot when they are imported, e.g.

```
import enum

@enum.unique
class A(enum.Enum):
    …
```

Ideally highlighting shouldn't stop at the first parenthesis either
(e.g. `@foo(['1'])`), but the current code somewhat highlights the contents
of the parens already, which is good enough in most cases.