### PR TITLE
[Rust] Highlight strings in meta attributes

### DIFF
--- a/rc/filetype/rust.kak
+++ b/rc/filetype/rust.kak
@@ -47,7 +47,8 @@ add-highlighter shared/rust/line_comment     region "//" "$"                    
 
 add-highlighter shared/rust/macro_attributes region -recurse "\[" "#!?\[" "\]" regions
 add-highlighter shared/rust/macro_attributes/ default-region fill meta
-add-highlighter shared/rust/macro_attributes/inner region %{(?<!')"} (?<!\\)(\\\\)*" fill string
+add-highlighter shared/rust/macro_attributes/string region %{(?<!')"} (?<!\\)(\\\\)*" fill string
+add-highlighter shared/rust/macro_attributes/raw_string region -match-capture %{(?<!')r(#*)"} %{"(#*)} fill string
 
 add-highlighter shared/rust/code/byte_literal         regex "'\\\\?.'" 0:value
 add-highlighter shared/rust/code/long_quoted          regex "('\w+)[^']" 1:meta

--- a/rc/filetype/rust.kak
+++ b/rc/filetype/rust.kak
@@ -44,7 +44,10 @@ add-highlighter shared/rust/string           region %{(?<!')"} (?<!\\)(\\\\)*"  
 add-highlighter shared/rust/raw_string       region -match-capture %{(?<!')r(#*)"} %{"(#*)} fill string
 add-highlighter shared/rust/comment          region -recurse "/\*" "/\*" "\*/"              fill comment
 add-highlighter shared/rust/line_comment     region "//" "$"                                fill comment
-add-highlighter shared/rust/macro_attributes region "#!?\[" "\]"                            fill meta
+
+add-highlighter shared/rust/macro_attributes region -recurse "\[" "#!?\[" "\]" regions
+add-highlighter shared/rust/macro_attributes/ default-region fill meta
+add-highlighter shared/rust/macro_attributes/inner region %{(?<!')"} (?<!\\)(\\\\)*" fill string
 
 add-highlighter shared/rust/code/byte_literal         regex "'\\\\?.'" 0:value
 add-highlighter shared/rust/code/long_quoted          regex "('\w+)[^']" 1:meta


### PR DESCRIPTION
fix #3043

Before:
![image](https://user-images.githubusercontent.com/19470159/62546711-a8d4ae00-b86c-11e9-8685-870df38dc7c4.png)

After:
![image](https://user-images.githubusercontent.com/19470159/62546657-8fcbfd00-b86c-11e9-8b0a-e783a9d4086e.png)

@daboross does this syntax supports raw strings?

---

Added raw strings:
![image](https://user-images.githubusercontent.com/19470159/62608156-01a55480-b908-11e9-90e5-a2d37136ede6.png)