### PR TITLE
nix.kak: Highlight parenthesized paths

### DIFF
--- a/rc/filetype/nix.kak
+++ b/rc/filetype/nix.kak
@@ -26,7 +26,7 @@ hook -group nix-highlight global WinSetOption filetype=nix %{
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/nix }
 }
 
-provide-module nix %(
+provide-module nix %§
 
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
@@ -77,7 +77,7 @@ add-highlighter shared/nix/code/ regex \bor\b      0:operator
 
 # override any operators matched before
 # path:
-add-highlighter shared/nix/code/ regex '\s(\.?\.?/[-A-Za-z0-9/_+.]+)[;?]?' 1:meta
+add-highlighter shared/nix/code/ regex '\s\(*(\.?\.?/[-A-Za-z0-9/_+.]+)[;?]?' 1:meta
 # imported path:
 add-highlighter shared/nix/code/ regex <[-A-Za-z0-9/_+.]+> 0:meta
 # RFC 2396 URIs can be used without quoting. Strangely, "string" ends URL but ''indented'' one doesn't
@@ -112,4 +112,4 @@ define-command -hidden nix-indent-on-new-line %<
     >
 >
 
-)
+§


### PR DESCRIPTION
Hi, 

This will highlight paths correctly in nix expressions like
`import (../path/to + "${file}")`

Also change module quoting from %( ... ) to %§ ... § to fix cases of uneven parenthesis breaking the syntax highlighting.