### PR TITLE
Fix kak -l when $XDG_RUNTIME_DIR is set

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1018,21 +1018,13 @@ int main(int argc, char* argv[])
         const bool clear_sessions = (bool)parser.get_switch("clear");
         if (list_sessions or clear_sessions)
         {
-            const String username = get_user_name();
-            const StringView tmp_dir = tmpdir();
-            for (auto& session : list_files(format("{}/kakoune/{}/", tmp_dir,
-                                                   username)))
+            for (auto& session : list_files(session_directory()))
             {
                 const bool valid = check_session(session);
                 if (list_sessions)
                     write_stdout(format("{}{}\n", session, valid ? "" : " (dead)"));
                 if (not valid and clear_sessions)
-                {
-                    char socket_file[128];
-                    format_to(socket_file, "{}/kakoune/{}/{}", tmp_dir,
-                              username, session);
-                    unlink(socket_file);
-                }
+                    unlink(session_path(session).c_str());
             }
             return 0;
         }

--- a/src/remote.cc
+++ b/src/remote.cc
@@ -537,6 +537,15 @@ String get_user_name()
     return getenv("USER");
 }
 
+String session_directory()
+{
+    StringView xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
+    if (xdg_runtime_dir.empty())
+        return format("{}/kakoune/{}", tmpdir(), get_user_name());
+    else
+        return format("{}/kakoune", xdg_runtime_dir);
+}
+
 void make_session_directory()
 {
     StringView xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
@@ -544,21 +553,15 @@ void make_session_directory()
     {
         // set sticky bit on the shared kakoune directory
         make_directory(format("{}/kakoune", tmpdir()), 01777);
-        make_directory(format("{}/kakoune/{}", tmpdir(), get_user_name()), 0711);
     }
-    else
-        make_directory(format("{}/kakoune", xdg_runtime_dir), 0711);
+    make_directory(session_directory(), 0711);
 }
 
 String session_path(StringView session)
 {
     if (contains(session, '/'))
         throw runtime_error{"session names cannot have slashes"};
-    StringView xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
-    if (xdg_runtime_dir.empty())
-        return format("{}/kakoune/{}/{}", tmpdir(), get_user_name(), session);
-    else
-        return format("{}/kakoune/{}", xdg_runtime_dir, session);
+    return format("{}/{}", session_directory(), session);
 }
 
 static sockaddr_un session_addr(StringView session)

--- a/src/remote.hh
+++ b/src/remote.hh
@@ -45,6 +45,7 @@ private:
 
 void send_command(StringView session, StringView command);
 String get_user_name();
+String session_directory();
 String session_path(StringView session);
 
 struct Server : public Singleton<Server>


### PR DESCRIPTION
I missed this in the XDG_RUNTIME_DIR patch, oops. :(