### PR TITLE
src: Send the stop signal to the entire process group

### DIFF
--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -622,7 +622,7 @@ Optional<Key> NCursesUI::get_next_key()
                 bool mouse_enabled = m_mouse_enabled;
                 enable_mouse(false);
 
-                raise(SIGTSTP); // We suspend at this line
+                kill(0, SIGTSTP); // We suspend at this line
 
                 check_resize(true);
                 enable_mouse(mouse_enabled);


### PR DESCRIPTION
Whenever a tool spawns the editor (e.g. Git), suspending it with ^Z is not
enough to be sent back to the calling shell - another ^Z is necessary.

Fixes #3061