### PR TITLE
rc latex: Highlight .cls files as LaTeX

### DIFF
--- a/rc/filetype/latex.kak
+++ b/rc/filetype/latex.kak
@@ -4,7 +4,7 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*\.tex %{
+hook global BufCreate .*\.(tex|cls) %{
     set-option buffer filetype latex
 }
 

--- a/rc/filetype/latex.kak
+++ b/rc/filetype/latex.kak
@@ -4,7 +4,7 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*\.(tex|cls) %{
+hook global BufCreate .*\.(tex|cls|sty|dtx) %{
     set-option buffer filetype latex
 }
 


### PR DESCRIPTION
When .cls files are opened, the local `filetype` option is automatically
set to `tex`, which isn't supported.