### PR TITLE
Goto next and previous buffer

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -184,7 +184,7 @@ sudo zypper install kakoune
 [TIP]
 .Ubuntu
 ====
-Building on Ubuntu 16.04.
+Building on Ubuntu 16.04 and 18.04.
 Make sure you have .local/bin in your path to make the kak binary available from your shell.
 
 ----------------------------------------------------------------

--- a/src/commands.hh
+++ b/src/commands.hh
@@ -1,6 +1,9 @@
 #ifndef commands_hh_INCLUDED
 #define commands_hh_INCLUDED
 
+#include "parameters_parser.hh"
+#include "shell_manager.hh"
+
 namespace Kakoune
 {
 
@@ -10,6 +13,9 @@ struct kill_session
 {
     int exit_status;
 };
+
+template<bool next>
+void cycle_buffer(const ParametersParser& parser, Context& context, const ShellContext&);
 
 }
 

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -280,6 +280,16 @@ void goto_commands(Context& context, NormalParams params)
                 context.change_buffer(*target);
                 break;
             }
+            case 'n':
+            {
+                cycle_buffer<true>(ParametersParser({}, {}), context, {});
+                break;
+            }
+            case 'p':
+            {
+                cycle_buffer<false>(ParametersParser({}, {}), context, {});
+                break;
+            }
             case 'f':
             {
                 auto filename = content(buffer, context.selections().main());
@@ -333,6 +343,8 @@ void goto_commands(Context& context, NormalParams params)
              {{'b'},    "window bottom"},
              {{'c'},    "window center"},
              {{'a'},    "last buffer"},
+             {{'n'},    "next buffer"},
+             {{'p'},    "previous buffer"},
              {{'f'},    "file"},
              {{'.'},    "last buffer change"}}));
     }


### PR DESCRIPTION
I know this can be done with scripting, but it just seem like it was missing from the goto command.  I'm sure there are better ways to do this.  I often work with a handful of files and this seems more natural than :bn and :bp.