### PR TITLE
Make autoscroll behavior of grep buffer configurable via option

### DIFF
--- a/rc/tools/grep.kak
+++ b/rc/tools/grep.kak
@@ -2,6 +2,8 @@ declare-option -docstring "shell command run to search for subtext in a file/dir
     str grepcmd 'grep -RHn'
 declare-option -docstring "name of the client in which utilities display information" \
     str toolsclient
+declare-option -docstring "scroll to bottom of results buffer each time grep is run" \
+	bool grepscroll true
 declare-option -hidden int grep_current_line 0
 
 define-command -params .. -file-completion \
@@ -16,8 +18,14 @@ All the optional arguments are forwarded to the grep utility} \
          ( ${kak_opt_grepcmd} "${kak_selection}" | tr -d '\r' > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
      fi
 
+     if [ $kak_opt_grepscroll = "true" ]; then
+     	scroll="-scroll"
+     else
+     	scroll=""
+ 	fi
+
      printf %s\\n "evaluate-commands -try-client '$kak_opt_toolsclient' %{
-               edit! -fifo ${output} -scroll *grep*
+               edit! -fifo ${output} ${scroll} *grep*
                set-option buffer filetype grep
                set-option buffer grep_current_line 0
                hook -always -once buffer BufCloseFifo .* %{ nop %sh{ rm -r $(dirname ${output}) } }


### PR DESCRIPTION
This declares a new option named 'grepscroll'.  It defaults to the existing
behavior of always scrolling the grep fifo buffer to the end when new content
comes in.  However, when disabled (set to no/false), the selection will stay on
the first line.

I personally prefer to read my grep results starting at the top and working my way down.  [@alexherbo2 suggested this method of disabling scrolling of the grep buffer.](https://discuss.kakoune.com/t/goto-top-of-grep-buffer-after-each-run-of-grep/727/2) 