### PR TITLE
Paste youngest instead of oldest value of read-only history registers 

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1353,7 +1353,7 @@ public:
                     auto cp = key.codepoint();
                     if (not cp or key == Key::Escape)
                         return;
-                    insert(RegisterManager::instance()[*cp].get(context()));
+                    insert(RegisterManager::instance()[*cp].get_for_pasting(context()));
                 }, "enter register name", register_doc.str());
             update_completions = false;
         }

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -708,7 +708,7 @@ template<InsertMode mode>
 void paste(Context& context, NormalParams params)
 {
     const char reg = params.reg ? params.reg : '"';
-    auto strings = RegisterManager::instance()[reg].get(context);
+    auto strings = RegisterManager::instance()[reg].get_for_pasting(context);
     const bool linewise = any_of(strings, [](StringView str) {
         return not str.empty() and str.back() == '\n';
     });

--- a/src/register_manager.cc
+++ b/src/register_manager.cc
@@ -53,6 +53,16 @@ void HistoryRegister::set(Context& context, ConstArrayView<String> values, bool 
 
 const String& HistoryRegister::get_main(const Context&, size_t)
 {
+    return last_entry();
+}
+
+ConstArrayView<String> HistoryRegister::get_for_pasting(Context&)
+{
+    return last_entry();
+}
+
+const String& HistoryRegister::last_entry() const
+{
     return m_content.empty() ? String::ms_empty : m_content.back();
 }
 

--- a/src/register_manager.hh
+++ b/src/register_manager.hh
@@ -21,6 +21,7 @@ public:
 
     virtual void set(Context& context, ConstArrayView<String> values, bool restoring = false) = 0;
     virtual ConstArrayView<String> get(const Context& context) = 0;
+    virtual ConstArrayView<String> get_for_pasting(Context& context) { return this->get(context); }
     virtual const String& get_main(const Context& context, size_t main_index) = 0;
 
     using RestoreInfo = Vector<String, MemoryDomain::Registers>;
@@ -82,6 +83,8 @@ public:
 
     void set(Context& context, ConstArrayView<String> values, bool restoring) override;
     const String& get_main(const Context&, size_t) override;
+    ConstArrayView<String> get_for_pasting(Context&) override;
+    const String& last_entry() const;
 };
 
 template<typename Func>


### PR DESCRIPTION
The docs say that the register `:` contains the *last* entered command.
However, when typing `":p`, the *first* entered command is inserted.

This patch fixes this by always using the last entry for `:` and other history registers, for all selections.