### PR TITLE
rc, doc: set extra_word_chars on buffer, not window

### DIFF
--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -235,7 +235,8 @@ are exclusively available to built-in options.
 
 *extra_word_chars* `codepoint-list`::
     a list of all additional codepoints that should be considered
-    as word character.
+    as word character. This must be set on the buffer, not the window,
+    for word completion to offer words containing these codepoints.
 
 *matching_pairs* `codepoint-list`::
     _default_ ( ) { } [ ] < > +

--- a/rc/filetype/clojure.kak
+++ b/rc/filetype/clojure.kak
@@ -10,16 +10,10 @@ hook global BufCreate .*[.](clj|cljc|cljs|cljx|edn) %{
 
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
-hook global WinSetOption filetype=clojure %[
+hook global WinSetOption filetype=clojure %{
     require-module clojure
-
-    set-option window static_words %opt{clojure_static_words}
-
-    hook window ModeChange insert:.* -group clojure-trim-indent  clojure-trim-indent
-    hook window InsertChar \n -group clojure-indent clojure-indent-on-new-line
-
-    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window clojure-.+ }
-]
+    clojure-configure-window
+}
 
 hook -group clojure-highlight global WinSetOption filetype=clojure %{
     add-highlighter window/clojure ref clojure
@@ -47,10 +41,6 @@ add-highlighter shared/clojure/string  region '(?<!\\)(?:\\\\)*\K"' '(?<!\\)(?:\
 add-highlighter shared/clojure/code/ regex \b(nil|true|false)\b 0:value
 add-highlighter shared/clojure/code/ regex \
     \\(?:space|tab|newline|return|backspace|formfeed|u[0-9a-fA-F]{4}|o[0-3]?[0-7]{1,2}|.)\b 0:string
-
-hook global WinSetOption filetype=clojure %{
-    set-option window extra_word_chars '_' . / * ? + - < > ! : "'"
-}
 
 evaluate-commands %sh{
     exec awk -f - <<'EOF'
@@ -187,6 +177,16 @@ EOF
 
 # Commands
 # ‾‾‾‾‾‾‾‾
+
+define-command -hidden clojure-configure-window %{
+    set-option window static_words %opt{clojure_static_words}
+
+    hook window ModeChange insert:.* -group clojure-trim-indent  clojure-trim-indent
+    hook window InsertChar \n -group clojure-indent clojure-indent-on-new-line
+
+    set-option buffer extra_word_chars '_' . / * ? + - < > ! : "'"
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window clojure-.+ }
+}
 
 define-command -hidden clojure-trim-indent lisp-trim-indent
 

--- a/rc/filetype/haskell.kak
+++ b/rc/filetype/haskell.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](hs) %{
 hook global WinSetOption filetype=haskell %{
     require-module haskell
 
-    set-option window extra_word_chars '_' "'"
+    set-option buffer extra_word_chars '_' "'"
     hook window ModeChange insert:.* -group haskell-trim-indent  haskell-trim-indent
     hook window InsertChar \n -group haskell-indent haskell-indent-on-new-line
 


### PR DESCRIPTION
For clojure.kak and haskell.kak, set extra_word_chars on the buffer
and not the window, so that the buffer's word db is updated correctly
for word completion.

Also, minor refactor of clojure.kak.

Closes #3108