### PR TITLE
Automatically open a file buffer when saving a scratch buffer

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -470,15 +470,15 @@ const CommandDesc force_edit_cmd = {
 
 void convert_scratch_to_file_buffer(Context& context, String filename)
 {
-    const auto flags = context.hooks_disabled() ? Buffer::Flags::NoHooks : Buffer::Flags::None;
     auto& buffer_manager = BufferManager::instance();
     Buffer* file_buffer = buffer_manager.get_buffer_ifp(filename);
-    if (not file_buffer)
+    if (file_buffer)
+        reload_file_buffer(*file_buffer);
+    else
     {
+        const auto flags = context.hooks_disabled() ? Buffer::Flags::NoHooks : Buffer::Flags::None;
         file_buffer = get_file_buffer(context, filename, flags, false);
     }
-    else
-        reload_file_buffer(*file_buffer);
     buffer_manager.delete_buffer(context.buffer());
     context.change_buffer(*file_buffer);
 }


### PR DESCRIPTION
I often find myself opening Kakoune to quickly take some notes and then decide to save them in a file.

With this pull request, Kakoune will automatically delete the scratch buffer and open the file in a buffer.  This seems convenient to me and also ensures that I won't accidentally quit Kakoune with unsaved changes.

**EDIT 2019-12-07:** `:rename-buffer -file /tmp/foo.txt` followed by `:write` can now be used, but I think this is still less convenient than simply using `:write /tmp/foo.txt`. Also, path auto-completion will only work with the latter.