### PR TITLE
Update OpenSUSE install instructions

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -168,17 +168,11 @@ cave resolve -x kakoune
 [TIP]
 .openSUSE
 ====
-kakoune can be found in the
-https://build.opensuse.org/package/show/editors/kakoune[editors] devel
-project.  Make sure to adjust the link below to point to the repository of
-your openSUSE version.
+kakoune can be found in the https://software.opensuse.org/package/kakoune[repositories].
 
----------------------------------------------------------------------------------------------------
-#Example for Tumbleweed:
-sudo zypper addrepo http://download.opensuse.org/repositories/editors/openSUSE_Factory/editors.repo
-sudo zypper refresh
+---------------------------
 sudo zypper install kakoune
----------------------------------------------------------------------------------------------------
+---------------------------
 ====
 
 [TIP]


### PR DESCRIPTION
Kakoune is now in the official OpenSUSE repositories so it is no-longer necessary to use the `editors` repo.

Overall this is just a simple README change.

OpenSUSE Tumbleweed ships the latest Kakoune version `2019.07.01`,
while OpenSUSE Leap 15.1 ships `2018.04.13`.

It may be worth leaving the instructions for the `editors` repo so that Leap users can get the latest version. However there is likely a reason that it has not been updated in the official repos, so I would recommend against it.