### PR TITLE
Better elm syntax highlighting

### DIFF
--- a/rc/filetype/elm.kak
+++ b/rc/filetype/elm.kak
@@ -36,15 +36,13 @@ add-highlighter shared/elm/string        region         '"'     (?<!\\)(\\\\)*" 
 add-highlighter shared/elm/line_comment  region         (--) $                        fill comment
 add-highlighter shared/elm/comment       region         -recurse \{- \{-   -\}        fill comment
 
-add-highlighter shared/elm/code/ regex (\b)+([A-Z]+[^\s]*)                                               0:type 
-add-highlighter shared/elm/code/ regex (\b)+([a-z]+[^\s]*)                                               0:variable
-add-highlighter shared/elm/code/ regex (^[a-z]+[^\s]*)                                                   0:function
-add-highlighter shared/elm/code/ regex "-?\b[0-9]*\.?[0-9]+"                                             0:value
-add-highlighter shared/elm/code/ regex \B(\+|\+\+|/|//|-|\*|=|==|&&|\|\||<\||\|>|->)\B                   0:operator
-add-highlighter shared/elm/code/ regex \b(import|exposing|as|module|where)\b                             0:meta
-add-highlighter shared/elm/code/ regex (\b(type|alias|if|then|else|case|of|let|in|infix|->)\b)|(\B(:)\B) 0:keyword
-
-
+add-highlighter shared/elm/code/ regex \b([A-Z]+[^\s]*)\b                                                  0:type 
+add-highlighter shared/elm/code/ regex \b([a-z]+[^\s]*)\b                                                  0:variable
+add-highlighter shared/elm/code/ regex \b(^[a-z]+[^\s]*)\b                                                 0:function
+add-highlighter shared/elm/code/ regex "-?\b[0-9]*\.?[0-9]+"                                               0:value
+add-highlighter shared/elm/code/ regex \B(\+|\+\+|\*|/|//|-|=|==|&&|\|\||<\||\|>)\B                        0:operator
+add-highlighter shared/elm/code/ regex \b(import|exposing|as|module|where)\b                               0:meta
+add-highlighter shared/elm/code/ regex (\b(type|alias|if|then|else|case|of|let|in|infix|_)\b)|(\B(->|:)\B) 0:keyword
 
 # Commands
 # ‾‾‾‾‾‾‾‾

--- a/rc/filetype/elm.kak
+++ b/rc/filetype/elm.kak
@@ -30,16 +30,21 @@ provide-module elm %[
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
-add-highlighter shared/elm regions
-add-highlighter shared/elm/code default-region group
-add-highlighter shared/elm/string        region '"'     (?<!\\)(\\\\)*"       fill string
-add-highlighter shared/elm/line_comment  region (--) $                        fill comment
-add-highlighter shared/elm/comment       region -recurse \{- \{-   -\}        fill comment
+add-highlighter shared/elm               regions
+add-highlighter shared/elm/code          default-region group
+add-highlighter shared/elm/string        region         '"'     (?<!\\)(\\\\)*"       fill string
+add-highlighter shared/elm/line_comment  region         (--) $                        fill comment
+add-highlighter shared/elm/comment       region         -recurse \{- \{-   -\}        fill comment
 
-add-highlighter shared/elm/code/ regex \b(import|exposing|as|module|where)\b 0:meta
-add-highlighter shared/elm/code/ regex \b(True|False)\b 0:value
-add-highlighter shared/elm/code/ regex \b(if|then|else|case|of|let|in|type|port|alias)\b 0:keyword
-add-highlighter shared/elm/code/ regex \b(Array|Bool|Char|Float|Int|String)\b 0:type
+add-highlighter shared/elm/code/ regex (\b)+([A-Z]+[^\s]*)                                               0:type 
+add-highlighter shared/elm/code/ regex (\b)+([a-z]+[^\s]*)                                               0:variable
+add-highlighter shared/elm/code/ regex (^[a-z]+[^\s]*)                                                   0:function
+add-highlighter shared/elm/code/ regex "-?\b[0-9]*\.?[0-9]+"                                             0:value
+add-highlighter shared/elm/code/ regex \B(\+|\+\+|/|//|-|\*|=|==|&&|\|\||<\||\|>|->)\B                   0:operator
+add-highlighter shared/elm/code/ regex \b(import|exposing|as|module|where)\b                             0:meta
+add-highlighter shared/elm/code/ regex (\b(type|alias|if|then|else|case|of|let|in|infix|->)\b)|(\B(:)\B) 0:keyword
+
+
 
 # Commands
 # ‾‾‾‾‾‾‾‾


### PR DESCRIPTION
this will only highlight elm 0.19 (latest) properly
very close to how https://ellie-app.com/ highlights
- anything that starts with an upper case letter is a type
- anything that starts with a lower case letter is a function
- function declaration is just a function at the start of a line

note: the default color scheme looks too colorful