### PR TITLE
adding simple color scheme

### DIFF
--- a/colors/plain.kak
+++ b/colors/plain.kak
@@ -1,0 +1,49 @@
+# Kakoune simple colors, mostly default
+
+# For default
+face global value default
+face global type default
+face global identifier default
+face global string blue
+face global keyword default
+face global operator default
+face global attribute default
+face global comment blue
+face global meta default
+face global builtin default
+
+
+# For default
+face global title default
+face global header default
+face global bold default
+face global italic default
+face global mono default
+face global block default
+face global link blue
+face global bullet default
+face global list default
+
+# builtin default
+face global Default default,default
+face global PrimarySelection white,blue
+face global SecondarySelection black,blue
+face global PrimaryCursor black,white
+face global SecondaryCursor white,blue
+face global PrimaryCursorEol default
+face global SecondaryCursorEol default
+face global LineNumbers default
+face global LineNumberCursor default
+face global MenuForeground default
+face global MenuBackground default
+face global MenuInfo default
+face global Information default
+face global Error default
+face global StatusLine default
+face global StatusLineMode default
+face global StatusLineInfo default
+face global StatusLineValue default
+face global StatusCursor default+r
+face global Prompt default
+face global MatchingChar default
+face global BufferPadding default


### PR DESCRIPTION
This adds a color scheme that makes almost everything use the terminal's defaults. It is intended to be minimal, so that users can override individual settings in their personal configuration.