### PR TITLE
[rc] Use 'fail' when the alternative file cannot be found

### DIFF
--- a/rc/filetype/c-family.kak
+++ b/rc/filetype/c-family.kak
@@ -428,11 +428,11 @@ define-command -hidden c-family-alternative-file %{
                 done
             ;;
             *)
-                echo "echo -markup '{Error}extension not recognized'"
+                echo "fail 'extension not recognized'"
                 exit
             ;;
         esac
-        echo "echo -markup '{Error}alternative file not found'"
+        echo "fail 'alternative file not found'"
     }
 }
 

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -54,7 +54,7 @@ define-command lua-alternative-file -docstring 'Jump to the alternate file (impl
     case $kak_buffile in
         *spec/*_spec.lua)
             altfile=$(eval printf %s\\n $(printf %s\\n $kak_buffile | sed s+spec/+'*'/+';'s/_spec//))
-            [ ! -f $altfile ] && echo "echo -markup '{Error}implementation file not found'" && exit
+            [ ! -f $altfile ] && echo "fail 'implementation file not found'" && exit
         ;;
         *.lua)
             path=$kak_buffile
@@ -66,10 +66,10 @@ define-command lua-alternative-file -docstring 'Jump to the alternate file (impl
                     break
                 fi
             done
-            [ ! -d $altdir ] && echo "echo -markup '{Error}spec/ not found'" && exit
+            [ ! -d $altdir ] && echo "fail 'spec/ not found'" && exit
         ;;
         *)
-            echo "echo -markup '{Error}alternative file not found'" && exit
+            echo "fail 'alternative file not found'" && exit
         ;;
     esac
     printf %s\\n "edit $altfile"

--- a/rc/filetype/moon.kak
+++ b/rc/filetype/moon.kak
@@ -56,7 +56,7 @@ define-command moon-alternative-file -docstring 'Jump to the alternate file (imp
     case $kak_buffile in
         *spec/*_spec.moon)
             altfile=$(eval printf %s\\n $(printf %s\\n $kak_buffile | sed s+spec/+'*'/+';'s/_spec//))
-            [ ! -f $altfile ] && echo "echo -markup '{Error}implementation file not found'" && exit
+            [ ! -f $altfile ] && echo "fail 'implementation file not found'" && exit
         ;;
         *.moon)
             path=$kak_buffile
@@ -68,10 +68,10 @@ define-command moon-alternative-file -docstring 'Jump to the alternate file (imp
                     break
                 fi
             done
-            [ ! -d $altdir ] && echo "echo -markup '{Error}spec/ not found'" && exit
+            [ ! -d $altdir ] && echo "fail 'spec/ not found'" && exit
         ;;
         *)
-            echo "echo -markup '{Error}alternative file not found'" && exit
+            echo "fail 'alternative file not found'" && exit
         ;;
     esac
     printf %s\\n "edit $altfile"

--- a/rc/filetype/ruby.kak
+++ b/rc/filetype/ruby.kak
@@ -102,11 +102,11 @@ define-command ruby-alternative-file -docstring 'Jump to the alternate file (imp
     case $kak_buffile in
         *spec/*_spec.rb)
             altfile=$(eval echo $(echo $kak_buffile | sed s+spec/+'*'/+';'s/_spec//))
-            [ ! -f $altfile ] && echo "echo -markup '{Error}implementation file not found'" && exit
+            [ ! -f $altfile ] && echo "fail 'implementation file not found'" && exit
         ;;
         *test/*_test.rb)
             altfile=$(eval echo $(echo $kak_buffile | sed s+test/+'*'/+';'s/_test//))
-            [ ! -f $altfile ] && echo "echo -markup '{Error}implementation file not found'" && exit
+            [ ! -f $altfile ] && echo "fail 'implementation file not found'" && exit
         ;;
         *.rb)
             path=$kak_buffile
@@ -119,10 +119,10 @@ define-command ruby-alternative-file -docstring 'Jump to the alternate file (imp
                     break
                 fi
             done
-            [ ! -d $altdir ] && echo "echo -markup '{Error}spec/ and test/ not found'" && exit
+            [ ! -d $altdir ] && echo "fail 'spec/ and test/ not found'" && exit
         ;;
         *)
-            echo "echo -markup '{Error}alternative file not found'" && exit
+            echo "fail 'alternative file not found'" && exit
         ;;
     esac
     echo "edit $altfile"


### PR DESCRIPTION
This makes it possible to implement a fallback strategy using 'try .. catch',
for cases where the alternative file is not stored in a subdirectory