### PR TITLE
src: Allow renaming the current session with an already used name

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -2359,6 +2359,13 @@ const CommandDesc change_directory_cmd = {
     }
 };
 
+template<bool force>
+static void rename_session(const ParametersParser& parser, Context& context, const ShellContext&)
+{
+    if (not Server::instance().rename_session(parser[0], force))
+        throw runtime_error(format("unable to rename current session: '{}' may be already in use", parser[0]));
+}
+
 const CommandDesc rename_session_cmd = {
     "rename-session",
     nullptr,
@@ -2367,11 +2374,18 @@ const CommandDesc rename_session_cmd = {
     CommandFlags::None,
     CommandHelper{},
     make_single_word_completer([](const Context&){ return Server::instance().session(); }),
-    [](const ParametersParser& parser, Context&, const ShellContext&)
-    {
-        if (not Server::instance().rename_session(parser[0]))
-            throw runtime_error(format("unable to rename current session: '{}' may be already in use", parser[0]));
-    }
+    rename_session<false>,
+};
+
+const CommandDesc force_rename_session_cmd = {
+    "rename-session!",
+    nullptr,
+    "rename-session! <name>: change remote session name, ignore errors",
+    single_param,
+    CommandFlags::None,
+    CommandHelper{},
+    make_single_word_completer([](const Context&){ return Server::instance().session(); }),
+    rename_session<true>,
 };
 
 const CommandDesc fail_cmd = {
@@ -2560,6 +2574,7 @@ void register_commands()
     register_command(select_cmd);
     register_command(change_directory_cmd);
     register_command(rename_session_cmd);
+    register_command(force_rename_session_cmd);
     register_command(fail_cmd);
     register_command(declare_user_mode_cmd);
     register_command(enter_user_mode_cmd);

--- a/src/remote.cc
+++ b/src/remote.cc
@@ -832,7 +832,7 @@ Server::Server(String session_name)
     m_listener.reset(new FDWatcher{listen_sock, FdEvents::Read, accepter});
 }
 
-bool Server::rename_session(StringView name)
+bool Server::rename_session(StringView name, bool force)
 {
     if (not all_of(name, is_identifier))
         throw runtime_error{format("invalid session name: '{}'", name)};
@@ -840,10 +840,9 @@ bool Server::rename_session(StringView name)
     String old_socket_file = session_path(m_session);
     String new_socket_file = session_path(name);
 
-    if (file_exists(new_socket_file))
-        return false;
-
-    if (rename(old_socket_file.c_str(), new_socket_file.c_str()) != 0)
+    if ((file_exists(new_socket_file) or
+         rename(old_socket_file.c_str(), new_socket_file.c_str()) != 0)
+         and not force)
         return false;
 
     m_session = name.str();

--- a/src/remote.hh
+++ b/src/remote.hh
@@ -54,7 +54,7 @@ struct Server : public Singleton<Server>
     ~Server();
     const String& session() const { return m_session; }
 
-    bool rename_session(StringView name);
+    bool rename_session(StringView name, bool force = false);
     void close_session(bool do_unlink = true);
 
     bool negotiating() const { return not m_accepters.empty(); }


### PR DESCRIPTION
This commit allows clients to make sure they are part of a given session
by implementing the `:rename-session!` command.

The `:rename-session` command will error out if the given name is already in
use, the new `:rename-session!` command will merely remove the old session
socket and join the new session seamlessly.