### PR TITLE
doc: swap `q` and `Q` in TRAMPOLINE

### DIFF
--- a/contrib/TRAMPOLINE
+++ b/contrib/TRAMPOLINE
@@ -453,10 +453,10 @@ using the built-in `:doc` command.
         `---'       non-interactively. The middle ground between the two
         .---,       solutions is to record the modifications made to one
         | Q |       chunk interactively, and replay the sequence of keys
-        `---'       at will. The sequence in question is a macro: the `q`
+        `---'       at will. The sequence in question is a macro: the `Q`
                     primitive will create a new one (i.e. record all the keys
 .---, .---,         hit henceforth until the escape key `<esc>` is hit), and
-|ctl|+| r |_.       the `Q` primitive will replay the keys saved in the macro.
+|ctl|+| r |_.       the `q` primitive will replay the keys saved in the macro.
 `---' `---'  `.---,
               | @ | Notes: macros can easily be translated into a proper
               `---' script, as they are saved in the `@` register, which you


### PR DESCRIPTION
The TRAMPOLINE is incorrect about macros. This PR fixes it by swapping `q` and `Q`.

Yang Tang Copyright Waiver

I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.