### PR TITLE
doc: fix example about shared highlighter group

### DIFF
--- a/doc/pages/highlighters.asciidoc
+++ b/doc/pages/highlighters.asciidoc
@@ -275,8 +275,8 @@ The common case would be to create a named shared group, or regions and then
 fill it with highlighters:
 
 ---------------------------------------
-add-highlighter shared/ group <name>
-add-highlighter shared/<name> regex ...
+add-highlighter shared/<name> group
+add-highlighter shared/<name>/ regex ...
 ---------------------------------------
 
 It can then be referenced in a window using the ref highlighter.


### PR DESCRIPTION
Hi

It looks like this section of the doc was not updated with the rest in https://github.com/mawww/kakoune/commit/7976f8