### PR TITLE
Adding allow-empty command to contributing

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -12,3 +12,9 @@ your name or nickname):
   large and to the detriment of my heirs and successors.  I intend this
   dedication to be an overt act of relinquishment in perpetuity of all
   present and future rights to this software under copyright law.
+  
+  
+  
+The command to create an empty commit from the command line is 
+
+  git commit --allow-empty


### PR DESCRIPTION
Many people will not know about the `allow-empty` flag, and will instead 
lose time googling the "nothing to commit, working tree clean" error message.