### PR TITLE
Support for JSON object key highlighting

### DIFF
--- a/rc/filetype/json.kak
+++ b/rc/filetype/json.kak
@@ -32,11 +32,10 @@ provide-module json %(
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
-add-highlighter shared/json regions
-add-highlighter shared/json/code default-region group
-add-highlighter shared/json/string region '"' (?<!\\)(\\\\)*" fill string
-
-add-highlighter shared/json/code/ regex \b(true|false|null|\d+(?:\.\d+)?(?:[eE][+-]?\d*)?)\b 0:value
+add-highlighter shared/json group
+add-highlighter shared/json/string regex (?<!\\)("(?:[^"\\]|\\\\|\\")*") 1:string
+add-highlighter shared/json/key regex (?<!\\)("(?:[^"\\]|\\\\|\\")*")\s*: 1:keyword
+add-highlighter shared/json/literal region '"' (?<!\\)(\\\\)*" regex \b(true|false|null|\d+(?:\.\d+)?(?:[eE][+-]?\d*)?)\b 0:value
 
 # Commands
 # ‾‾‾‾‾‾‾‾

--- a/rc/filetype/json.kak
+++ b/rc/filetype/json.kak
@@ -33,9 +33,10 @@ provide-module json %(
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
 add-highlighter shared/json group
-add-highlighter shared/json/string regex (?<!\\)("(?:[^"\\]|\\\\|\\")*") 1:string
+add-highlighter shared/json/value regions
+add-highlighter shared/json/value/string region '"' (?<!\\)(\\\\)*" fill string
+add-highlighter shared/json/value/ default-region regex \b(true|false|null|\d+(?:\.\d+)?(?:[eE][+-]?\d*)?)\b 0:value
 add-highlighter shared/json/key regex (?<!\\)("(?:[^"\\]|\\\\|\\")*")\s*: 1:keyword
-add-highlighter shared/json/literal region '"' (?<!\\)(\\\\)*" regex \b(true|false|null|\d+(?:\.\d+)?(?:[eE][+-]?\d*)?)\b 0:value
 
 # Commands
 # ‾‾‾‾‾‾‾‾


### PR DESCRIPTION
Since JSON object keys are just strings in specific context, they are highlighted same as literal JSON strings. This problem was originally brought up by @Delapouite in [kakoune forum thread](https://discuss.kakoune.com/t/json-highlighters-for-keys/758).

Following images are taken from previously mentioned discussion thread to demonstrate the desired effect:

![Current JSON highlighter](https://discuss.kakoune.com/uploads/default/original/1X/b5038f190e5d0e1fd997a3436dc045f57ab0cf2c.png)

![Desired JSON highlighter](https://discuss.kakoune.com/uploads/default/original/1X/b5c1a965f8c74ebff37d056417410e392949a87a.png)

I have tested the proposed highlighter using the following test JSON:
```json
{
    "test1": true,
    "test2\\" : ["a\"123:s true", "a\\\\bc\"defg\\"],
    "t\"est\\"
    :123
}
```
