### PR TITLE
Accept tmux pre-release versions

### DIFF
--- a/rc/windowing/repl/tmux.kak
+++ b/rc/windowing/repl/tmux.kak
@@ -53,7 +53,10 @@ define-command -hidden tmux-repl-disabled %{ evaluate-commands %sh{
 } }
 
 evaluate-commands %sh{
-    VERSION_TMUX=$(tmux -V | cut -d' ' -f2)
+    VERSION_TMUX=$(tmux -V)
+    VERSION_TMUX=${VERSION_TMUX##* }
+    VERSION_TMUX=${VERSION_TMUX#next-}
+    VERSION_TMUX=${VERSION_TMUX%-rc*}
     VERSION_TMUX=${VERSION_TMUX%%.*}
 
     if [ "${VERSION_TMUX}" = "master" ] \


### PR DESCRIPTION
Currently, the master branch of tmux reports `tmux next-3.1`, which fails the version check logic.

This also removes one fork during boot.