### PR TITLE
man: Factorize the documentation about autoloading

### DIFF
--- a/doc/kak.1
+++ b/doc/kak.1
@@ -145,20 +145,75 @@ line of the file
 .BR file
 one or more \fIfile\fRs to edit
 
-.PP
-At  startup, if \fB\-n\fR is not specified, Kakoune will try to source the file
-\fI../share/kak/kakrc\fR relative to the kak binary. This kak file will then
-try to recursively source any files in \fI$KAKOUNE_CONFIG_DIR/autoload\fR
-(with \fI$KAKOUNE_CONFIG_DIR\fR defaulting to \fI$XDG_CONFIG_HOME/kak\fR
-if \fI$XDG_CONFIG_HOME\fR is set, \fI$HOME/.config/kak\fR if it is not,
-and falling back to \fI../share/kak/autoload\fR if that autoload directory
-does not exist), and finally \fI$XDG_CONFIG_HOME/kak/kakrc\fR.
+.SH ENVIRONMENT
 
-That leads to the following behaviour: by default, with no user autoload
-directory, the system wide autoload directory is used, once the user wants
-control on autoloading, they can create an autoload directory and eventually
-symlink individual scripts, or the whole system wide autoload directory. They
-can as well add any new scripts not provided with Kakoune.
+.TP
+.BR KAKOUNE_POSIX_SHELL
+Overrides the posix shell binary path to use for \fI%sh{...}\fR expansion.
+
+.TP
+.BR KAKOUNE_CONFIG_DIR
+Overrides the location of the directory containing kakoune user configuration,
+defaults to \fI$XDG_CONFIG_HOME/kak\fR if unset.
+
+.TP
+.BR XDG_CONFIG_HOME
+Path to the user configuration directory, defaults to \fI$HOME/.config/kak\fR
+if unset.
+
+.TP
+.BR XDG_RUNTIME_DIR
+Path to the user session sockets, defaults to \fI$TMPDIR/kakoune\fR if unset.
+
+.SH FILES
+
+In the paths documented below, \fI<rtdir>\fR refers to the runtime directory,
+whose value is determined in relation to the path to the \fBkak\fR binary:
+\fI<rtdir>\fR = \fI<path_to_kak_binary>/../share/kak\fR.
+
+If not started with the \fB\-n\fR switch, Kakoune will first load
+\fI<rtdir>/kakrc\fR, which will in turn load the following additional files:
+
+.nf
+.RS
+if the \fI$KAKOUNE_CONFIG_DIR/kak/autoload\fR directory exists, recursively load every
+\fI*.kak\fR files in it and its sub-directories
+.RE
+.fi
+
+.nf
+.RS
+if it does not exist, fall back to the system\-wide autoload directory
+in \fI<rtdir>/autoload\fR, and recursively load all files in a similar way
+.RE
+.fi
+
+.nf
+.RS
+\fI<rtdir>/kakrc.local\fR, if it exists; this is a user\-defined system\-wide
+configuration
+.RE
+.fi
+
+.nf
+.RS
+\fI$KAKOUNE_CONFIG_DIR/kak/kakrc\fR, if it exists; this is the user configuration
+.RE
+.fi
+
+Consequently, if the \fI$KAKOUNE_CONFIG_DIR/kak/autoload\fR directory exists,
+only scripts stored within that directory will be loaded \- the built-in
+\fI*.kak\fR files \fBwill not be\fR.
+
+Users who still want to have the built\-in scripts loaded along their own
+can create a symbolic link to \fI<rtdir>/autoload\fR (or to individual
+scripts in it) in their user\-configuration directory:
+
+.nf
+.RS
+ln -s \fI<rtdir>\fR/autoload "${XDG_CONFIG_HOME:-$HOME/.config}"/kak/autoload
+.RE
+.fi
 
 .SH EXAMPLES
 
@@ -189,40 +244,6 @@ source code files:
 kak \-f "ggO// kak: tabstop=8<esc>" *.c
 .RE
 .fi
-
-.SH ENVIRONMENT
-
-.TP
-.BR KAKOUNE_POSIX_SHELL
-Overrides the posix shell binary path to use for \fI%sh{...}\fR expansion.
-
-.TP
-.BR KAKOUNE_CONFIG_DIR
-Overrides the location of the directory containing kakoune user configuration.
-
-.SH FILES
-
-If not started with the \fB\-n\fR switch, Kakoune will source the \fI../share/kak/kakrc\fR file relative to the kak binary,
-which will source additional files:
-
-.nf
-.RS
-if the \fI$XDG_CONFIG_HOME/kak/autoload\fR directory exists, load every
-\fI*.kak\fR files in it, and load recursively any subdirectory
-.RE
-.fi
-
-.nf
-.RS
-if it does not exist, fall back to the system wide autoload directory
-in \fI../share/kak/autoload\fR
-.RE
-.fi
-
-After that, if it exists, source the \fI$XDG_CONFIG_HOME/kak/kakrc\fR file
-which should be used for user configuration. In order to continue autoloading
-site\-wide files with a local autoload directory, just add a symbolic link
-to \fI../share/kak/autoload\fR into your local autoload directory.
 
 .SH SEE ALSO
 


### PR DESCRIPTION
Hi,

There was redundant documentation about the autoloading process in the man page, so I factorized it and documented the process in the relevant section.

`kakrc.local` is now documented.

I've also added the two XDG environment variables that Kakoune respects to the environment section.

Here's a text rendering of the manpage after modification:

```
KAK(1)                                  General Commands Manual                                  KAK(1)

NAME
       kak - a vim inspired, selection oriented code editor

SYNOPSIS
       kak -help

       kak -version

       kak -l

       kak -clear

       kak -f keys [-q] [-i] file...

       kak -p session_id

       kak -s session_id -d [-n] [-ro] [-E command] [+line[:column]|+:] file...

       kak   [-c  session_id|-s  session_id]  [-n]  [-ro]  [-ui  ui_type]  [-e  command]  [-E  command]
       [+line[:column]|+:] file...

DESCRIPTION
       Kakoune is a code editor heavily inspired by Vim, as such most of its commands  are  similar  to
       Vi's ones, and it shares Vi's "keystrokes as a text editing language" model.

       Kakoune can operate in two modes, normal and insertion. In insertion mode, keys are directly in‐
       serted into the current buffer. In normal mode, keys are used to manipulate the  current  selec‐
       tion and to enter insertion mode.

       Kakoune has a strong focus on interactivity, most commands provide immediate and incremental re‐
       sults, while still being competitive (as in keystroke count) with Vim.

       Kakoune works on selections, which are oriented, inclusive range of characters, selections  have
       an  anchor and a cursor character. Most commands move both of them, except when extending selec‐
       tion where the anchor character stays fixed and the cursor one moves around.

       For more information, use  the  :doc  command  after  starting  Kakoune,  the  Kakoune  wiki  at
       https://github.com/mawww/kakoune/wiki or the main Kakoune web site: https://kakoune.org/

OPTIONS
       -help  display a help message and quit

       -version
              display kakoune version and quit

       -n     do not load resource files on startup (kakrc, autoload, rc etc)

       -l     list existing sessions

       -d     run as a headless session (requires -s)

       -e command
              execute command after the client initialization phase

       -E command
              execute command after the server initialization phase

       -f keys
              enter in filter mode: select the whole file, then execute keys

       -i suffix
              backup the files on which a filter is applied using the given suffix

       -q     when in filter mode, don't print any errors

       -p session_id
              send the commands written on the standard input to session session_id

       -c session_id
              connect to the given session

       -s session_id
              set the current session name to session_id

       -ui type
              select the user interface, can be one of ncurses, dummy or json

       -clear remove sessions that terminated in an incorrect state (e.g. after a crash)

       -ro    enter in readonly mode, all the buffers opened will not be written to disk

       +line[:column]
              specify  a  target  line and column for the first file; when the plus sign is followed by
              only a colon, then the cursor is sent to the last line of the file

       file   one or more files to edit

ENVIRONMENT
       KAKOUNE_POSIX_SHELL
              Overrides the posix shell binary path to use for %sh{...} expansion.

       KAKOUNE_CONFIG_DIR
              Overrides the location of the directory containing kakoune user  configuration,  defaults
              to $XDG_CONFIG_HOME/kak if unset.

       XDG_CONFIG_HOME
              Path to the user configuration directory, defaults to $HOME/.config/kak if unset.

       XDG_RUNTIME_DIR
              Path to the user session sockets, defaults to $TMPDIR/kakoune if unset.

FILES
       In  the  paths  documented below, <rtdir> refers to the runtime directory, whose value is deter‐
       mined in relation to the path to the kak binary: <rtdir> = <path_to_kak_binary>/../share/kak.

       If not started with the -n switch, Kakoune will first load <rtdir>/kakrc,  which  will  in  turn
       load the following additional files:

              if the $KAKOUNE_CONFIG_DIR/kak/autoload directory exists, recursively load every
              *.kak files in it and its sub-directories

              if it does not exist, fall back to the system-wide autoload directory
              in <rtdir>/autoload, and recursively load all files in a similar way

              <rtdir>/kakrc.local, if it exists; this is a user-defined system-wide
              configuration

              $KAKOUNE_CONFIG_DIR/kak/kakrc, if it exists; this is the user configuration

       Consequently,  if  the  $KAKOUNE_CONFIG_DIR/kak/autoload  directory  exists, only scripts stored
       within that directory will be loaded - the built-in *.kak files will not be.

       Users who still want to have the built-in scripts loaded along their own can create  a  symbolic
       link to <rtdir>/autoload (or to individual scripts in it) in their user-configuration directory:

              ln -s <rtdir>/autoload "${XDG_CONFIG_HOME:-$HOME/.config}"/kak/autoload

EXAMPLES
       Edit a file:

              kak /path/to/file

       Edit multiple files (multiple buffers will be created):

              kak ./file1.txt /path/to/file2.c

       Insert a modeline that sets the tabstop variable at the beginning of several source code files:

              kak -f "ggO// kak: tabstop=8<esc>" *.c

SEE ALSO
       vi(1), vim(1), sam(1plan9)

                                                                                                 KAK(1)


```
Fixes #2510 