### PR TITLE
src: Create a <semicolon> named key

### DIFF
--- a/rc/filetype/awk.kak
+++ b/rc/filetype/awk.kak
@@ -71,7 +71,7 @@ evaluate-commands %sh{
 define-command -hidden awk-indent-on-new-line %[
     evaluate-commands -draft -itersel %[
         # preserve previous line indent
-        try %[ execute-keys -draft \; K <a-&> ]
+        try %[ execute-keys -draft <semicolon> K <a-&> ]
         # cleanup trailing whitespaces from previous line
         try %[ execute-keys -draft k <a-x> s \h+$ <ret> d ]
         # indent after line ending in opening curly brace
@@ -80,7 +80,7 @@ define-command -hidden awk-indent-on-new-line %[
 ]
 
 define-command -hidden awk-trim-indent %{
-    try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d }
+    try %{ execute-keys -draft <semicolon> <a-x> s ^\h+$ <ret> d }
 }
 
 @

--- a/rc/filetype/c-family.kak
+++ b/rc/filetype/c-family.kak
@@ -68,14 +68,14 @@ define-command -hidden c-family-trim-indent %{
 }
 
 define-command -hidden c-family-indent-on-newline %< evaluate-commands -draft -itersel %<
-    execute-keys \;
+    execute-keys <semicolon>
     try %<
         # if previous line is part of a comment, do nothing
         execute-keys -draft <a-?>/\*<ret> <a-K>^\h*[^/*\h]<ret>
     > catch %<
         # else if previous line closed a paren (possibly followed by words and a comment),
         # copy indent of the opening paren line
-        execute-keys -draft k<a-x> 1s(\))(\h+\w+)*\h*(\;\h*)?(?://[^\n]+)?\n\z<ret> m<a-\;>J <a-S> 1<a-&>
+        execute-keys -draft k<a-x> 1s(\))(\h+\w+)*\h*(\;\h*)?(?://[^\n]+)?\n\z<ret> m<a-semicolon>J <a-S> 1<a-&>
     > catch %<
         # else indent new lines with the same level as the previous one
         execute-keys -draft K <a-&>
@@ -88,7 +88,7 @@ define-command -hidden c-family-indent-on-newline %< evaluate-commands -draft -i
     try %< execute-keys -draft k <a-x> s[a-zA-Z0-9_-]+:\h*$<ret> j <a-gt> >
     # indent after a statement not followed by an opening brace
     try %< execute-keys -draft k <a-x> s\)\h*(?://[^\n]+)?\n\z<ret> \
-                               <a-\;>mB <a-k>\A\b(if|for|while)\b<ret> <a-\;>j <a-gt> >
+                               <a-semicolon>mB <a-k>\A\b(if|for|while)\b<ret> <a-semicolon>j <a-gt> >
     try %< execute-keys -draft k <a-x> s \belse\b\h*(?://[^\n]+)?\n\z<ret> \
                                j <a-gt> >
     # deindent after a single line statement end
@@ -104,7 +104,7 @@ define-command -hidden c-family-indent-on-newline %< evaluate-commands -draft -i
         # Go to opening parenthesis and opening brace, then select the most nested one
         try %< execute-keys [c [({],[)}] <ret> >
         # Validate selection and get first and last char
-        execute-keys <a-k>\A[{(](\h*\S+)+\n<ret> <a-K>"(([^"]*"){2})*<ret> <a-K>'(([^']*'){2})*<ret> <a-:><a-\;>L <a-S>
+        execute-keys <a-k>\A[{(](\h*\S+)+\n<ret> <a-K>"(([^"]*"){2})*<ret> <a-K>'(([^']*'){2})*<ret> <a-:><a-semicolon>L <a-S>
         # Remove possibly incorrect indent from new line which was copied from previous line
         try %< execute-keys -draft <space> <a-h> s\h+<ret> d >
         # Now indent and align that new line with the opening parenthesis/brace
@@ -136,7 +136,7 @@ define-command -hidden c-family-insert-on-closing-curly-brace %[
 ]
 
 define-command -hidden c-family-insert-on-newline %[ evaluate-commands -itersel -draft %[
-    execute-keys \;
+    execute-keys <semicolon>
     try %[
         evaluate-commands -draft -save-regs '/"' %[
             # copy the commenting prefix

--- a/rc/filetype/cabal.kak
+++ b/rc/filetype/cabal.kak
@@ -55,7 +55,7 @@ define-command -hidden cabal-indent-on-new-line %[
         # copy '#' comment prefix and following white spaces
         try %[ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P ]
         # preserve previous line indent
-        try %[ execute-keys -draft \; K <a-&> ]
+        try %[ execute-keys -draft <semicolon> K <a-&> ]
         # filter previous line
         try %[ execute-keys -draft k : cabal-trim-indent <ret> ]
         # indent after lines ending with { or :

--- a/rc/filetype/coffee.kak
+++ b/rc/filetype/coffee.kak
@@ -75,7 +75,7 @@ define-command -hidden coffee-indent-on-new-line %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s '^\h*\K#\h*' <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : coffee-trim-indent <ret> }
         # indent after start structure

--- a/rc/filetype/css.kak
+++ b/rc/filetype/css.kak
@@ -66,7 +66,7 @@ define-command -hidden css-trim-indent %{
 define-command -hidden css-indent-on-new-line %[
     evaluate-commands -draft -itersel %[
         # preserve previous line indent
-        try %[ execute-keys -draft \; K <a-&> ]
+        try %[ execute-keys -draft <semicolon> K <a-&> ]
         # filter previous line
         try %[ execute-keys -draft k : css-trim-indent <ret> ]
         # indent after lines ending with with {

--- a/rc/filetype/cucumber.kak
+++ b/rc/filetype/cucumber.kak
@@ -85,7 +85,7 @@ define-command -hidden cucumber-indent-on-new-line %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : cucumber-trim-indent <ret> }
         # indent after lines containing :

--- a/rc/filetype/d.kak
+++ b/rc/filetype/d.kak
@@ -108,7 +108,7 @@ add-highlighter shared/d/code/ regex "\bmodule\s+([\w_-]+)\b" 1:module
 define-command -hidden d-indent-on-new-line %~
     evaluate-commands -draft -itersel %=
         # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        try %{ execute-keys -draft <semicolon>K<a-&> }
         # indent after lines ending with { or (
         try %[ execute-keys -draft k<a-x> <a-k> [{(]\h*$ <ret> j<a-gt> ]
         # cleanup trailing white spaces on the previous line
@@ -116,11 +116,11 @@ define-command -hidden d-indent-on-new-line %~
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
         # copy // comments prefix
-        try %{ execute-keys -draft \;<c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # indent after if|else|while|for
-        try %[ execute-keys -draft \;<a-F>)MB <a-k> \A(if|else|while|for)\h*\(.*\)\h*\n\h*\n?\z <ret> s \A|.\z <ret> 1<a-&>1<a-space><a-gt> ]
+        try %[ execute-keys -draft <semicolon><a-F>)MB <a-k> \A(if|else|while|for)\h*\(.*\)\h*\n\h*\n?\z <ret> s \A|.\z <ret> 1<a-&>1<a-space><a-gt> ]
     =
 ~
 

--- a/rc/filetype/dart.kak
+++ b/rc/filetype/dart.kak
@@ -84,7 +84,7 @@ evaluate-commands %sh{
 define-command -hidden dart-indent-on-new-line %~
     evaluate-commands -draft -itersel %=
         # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        try %{ execute-keys -draft <semicolon>K<a-&> }
         # indent after lines ending with { or (
         try %[ execute-keys -draft k<a-x> <a-k> [{(]\h*$ <ret> j<a-gt> ]
         # cleanup trailing white spaces on the previous line
@@ -92,11 +92,11 @@ define-command -hidden dart-indent-on-new-line %~
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
         # copy // comments prefix
-        try %{ execute-keys -draft \;<c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # indent after if|else|while|for
-        try %[ execute-keys -draft \;<a-F>)MB <a-k> \A(if|else|while|for)\h*\(.*\)\h*\n\h*\n?\z <ret> s \A|.\z <ret> 1<a-&>1<a-space><a-gt> ]
+        try %[ execute-keys -draft <semicolon><a-F>)MB <a-k> \A(if|else|while|for)\h*\(.*\)\h*\n\h*\n?\z <ret> s \A|.\z <ret> 1<a-&>1<a-space><a-gt> ]
     =
 ~
 

--- a/rc/filetype/elixir.kak
+++ b/rc/filetype/elixir.kak
@@ -70,13 +70,13 @@ define-command -hidden elixir-indent-on-new-line %{
         # copy -- comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # indent after line ending with:
 	# try %{ execute-keys -draft k x <a-k> (do|else|->)$ <ret> & }
 	# filter previous line
         try %{ execute-keys -draft k : elixir-trim-indent <ret> }
         # indent after lines ending with do or ->
-        try %{ execute-keys -draft \\; k x <a-k> ^.+(do|->)$ <ret> j <a-gt> }
+        try %{ execute-keys -draft <semicolon> k x <a-k> ^.+(do|->)$ <ret> j <a-gt> }
     }
 }
 

--- a/rc/filetype/elm.kak
+++ b/rc/filetype/elm.kak
@@ -55,7 +55,7 @@ define-command -hidden elm-trim-indent %{
 }
 
 define-command -hidden elm-indent-after "
- execute-keys -draft \\; k x <a-k> ^\\h*(if)|(case\\h+[\\w']+\\h+of|let|in|\\{\\h+\\w+|\\w+\\h+->|[=(])$ <ret> j <a-gt>
+ execute-keys -draft <semicolon> k x <a-k> ^\\h*(if)|(case\\h+[\\w']+\\h+of|let|in|\\{\\h+\\w+|\\w+\\h+->|[=(])$ <ret> j <a-gt>
 "
 
 define-command -hidden elm-indent-on-new-line %{
@@ -63,9 +63,9 @@ define-command -hidden elm-indent-on-new-line %{
         # copy -- comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # align to first clause
-        try %{ execute-keys -draft \; k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|let)\h+\K.* <ret> s \A|.\z <ret> & }
+        try %{ execute-keys -draft <semicolon> k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|let)\h+\K.* <ret> s \A|.\z <ret> & }
         # filter previous line
         try %{ execute-keys -draft k : elm-trim-indent <ret> }
         # indent after lines beginning with condition or ending with expression or =(

--- a/rc/filetype/fish.kak
+++ b/rc/filetype/fish.kak
@@ -58,9 +58,9 @@ define-command -hidden fish-trim-indent %{
 define-command -hidden fish-indent-on-char %{
     evaluate-commands -no-hooks -draft -itersel %{
         # align middle and end structures to start and indent when necessary
-        try %{ execute-keys -draft <a-x><a-k>^\h*(else)$<ret><a-\;><a-?>^\h*(if)<ret>s\A|.\z<ret>1<a-&> }
-        try %{ execute-keys -draft <a-x><a-k>^\h*(end)$<ret><a-\;><a-?>^\h*(begin|for|function|if|switch|while)<ret>s\A|.\z<ret>1<a-&> }
-        try %{ execute-keys -draft <a-x><a-k>^\h*(case)$<ret><a-\;><a-?>^\h*(switch)<ret>s\A|.\z<ret>1<a-&> }
+        try %{ execute-keys -draft <a-x><a-k>^\h*(else)$<ret><a-semicolon><a-?>^\h*(if)<ret>s\A|.\z<ret>1<a-&> }
+        try %{ execute-keys -draft <a-x><a-k>^\h*(end)$<ret><a-semicolon><a-?>^\h*(begin|for|function|if|switch|while)<ret>s\A|.\z<ret>1<a-&> }
+        try %{ execute-keys -draft <a-x><a-k>^\h*(case)$<ret><a-semicolon><a-?>^\h*(switch)<ret>s\A|.\z<ret>1<a-&> }
     }
 }
 
@@ -69,7 +69,7 @@ define-command -hidden fish-indent-on-new-line %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # cleanup trailing whitespaces from previous line
         try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
         # indent after start structure

--- a/rc/filetype/gas.kak
+++ b/rc/filetype/gas.kak
@@ -87,7 +87,7 @@ define-command -hidden gas-trim-indent %{
 define-command -hidden gas-indent-on-new-line %~
     evaluate-commands -draft -itersel %<
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : gas-trim-indent <ret> }
         # indent after label

--- a/rc/filetype/go.kak
+++ b/rc/filetype/go.kak
@@ -76,7 +76,7 @@ evaluate-commands %sh{
 define-command -hidden go-indent-on-new-line %~
     evaluate-commands -draft -itersel %=
         # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        try %{ execute-keys -draft <semicolon>K<a-&> }
         # indent after lines ending with { or (
         try %[ execute-keys -draft k<a-x> <a-k> [{(]\h*$ <ret> j<a-gt> ]
         # cleanup trailing white spaces on the previous line
@@ -84,11 +84,11 @@ define-command -hidden go-indent-on-new-line %~
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
         # copy // comments prefix
-        try %{ execute-keys -draft \;<c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # indent after if|else|while|for
-        try %[ execute-keys -draft \;<a-F>)MB <a-k> \A(if|else|while|for)\h*\(.*\)\h*\n\h*\n?\z <ret> s \A|.\z <ret> 1<a-&>1<a-space><a-gt> ]
+        try %[ execute-keys -draft <semicolon><a-F>)MB <a-k> \A(if|else|while|for)\h*\(.*\)\h*\n\h*\n?\z <ret> s \A|.\z <ret> 1<a-&>1<a-space><a-gt> ]
     =
 ~
 

--- a/rc/filetype/haml.kak
+++ b/rc/filetype/haml.kak
@@ -61,7 +61,7 @@ define-command -hidden haml-indent-on-new-line %{
         # copy '/' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K/\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : haml-trim-indent <ret> }
         # indent after lines beginning with : or -

--- a/rc/filetype/haskell.kak
+++ b/rc/filetype/haskell.kak
@@ -105,13 +105,13 @@ define-command -hidden haskell-indent-on-new-line %{
         # copy -- comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # align to first clause
-        try %{ execute-keys -draft \; k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|do|let|where)\h+\K.* <ret> s \A|.\z <ret> & }
+        try %{ execute-keys -draft <semicolon> k x X s ^\h*(if|then|else)?\h*(([\w']+\h+)+=)?\h*(case\h+[\w']+\h+of|do|let|where)\h+\K.* <ret> s \A|.\z <ret> & }
         # filter previous line
         try %{ execute-keys -draft k : haskell-trim-indent <ret> }
         # indent after lines beginning with condition or ending with expression or =(
-        try %{ execute-keys -draft \; k x <a-k> ^\h*(if)|(case\h+[\w']+\h+of|do|let|where|[=(])$ <ret> j <a-gt> }
+        try %{ execute-keys -draft <semicolon> k x <a-k> ^\h*(if)|(case\h+[\w']+\h+of|do|let|where|[=(])$ <ret> j <a-gt> }
     }
 }
 

--- a/rc/filetype/hbs.kak
+++ b/rc/filetype/hbs.kak
@@ -78,7 +78,7 @@ define-command -hidden hbs-indent-on-new-line %{
         # copy '/' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K/\h* <ret> y j p }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : hbs-trim-indent <ret> }
         # indent after lines beginning with : or -

--- a/rc/filetype/html.kak
+++ b/rc/filetype/html.kak
@@ -77,7 +77,7 @@ define-command -hidden html-indent-on-greater-than %[
 define-command -hidden html-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : html-trim-indent <ret> }
         # indent after lines ending with opening tag

--- a/rc/filetype/i3.kak
+++ b/rc/filetype/i3.kak
@@ -72,7 +72,7 @@ define-command -hidden i3-indent-on-new-line %~
         # copy # comments prefix
         try %{ execute-keys -draft k<a-x> s ^\h*#\h* <ret> y jgh P }
         # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        try %{ execute-keys -draft <semicolon>K<a-&> }
         # indent after lines ending with {
         try %[ execute-keys -draft k<a-x> <a-k> \{\h*$ <ret> j<a-gt> ]
         # cleanup trailing white spaces on the previous line

--- a/rc/filetype/java.kak
+++ b/rc/filetype/java.kak
@@ -43,7 +43,7 @@ add-highlighter shared/java/code/ regex "(?<!\w)@\w+\b" 0:meta
 define-command -hidden java-indent-on-new-line %~
     evaluate-commands -draft -itersel %=
         # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        try %{ execute-keys -draft <semicolon>K<a-&> }
         # indent after lines ending with { or (
         try %[ execute-keys -draft k<a-x> <a-k> [{(]\h*$ <ret> j<a-gt> ]
         # cleanup trailing white spaces on the previous line
@@ -51,11 +51,11 @@ define-command -hidden java-indent-on-new-line %~
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
         # copy // comments prefix
-        try %{ execute-keys -draft \;<c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # indent after keywords
-        try %[ execute-keys -draft \;<a-F>)MB <a-k> \A(if|else|while|for|try|catch)\h*\(.*\)\h*\n\h*\n?\z <ret> s \A|.\z <ret> 1<a-&>1<a-space><a-gt> ]
+        try %[ execute-keys -draft <semicolon><a-F>)MB <a-k> \A(if|else|while|for|try|catch)\h*\(.*\)\h*\n\h*\n?\z <ret> s \A|.\z <ret> 1<a-&>1<a-space><a-gt> ]
     =
 ~
 

--- a/rc/filetype/javascript.kak
+++ b/rc/filetype/javascript.kak
@@ -57,7 +57,7 @@ define-command -hidden javascript-indent-on-new-line %<
         # copy // comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : javascript-trim-indent <ret> }
         # indent after lines beginning / ending with opener token

--- a/rc/filetype/json.kak
+++ b/rc/filetype/json.kak
@@ -56,7 +56,7 @@ define-command -hidden json-indent-on-char %<
 define-command -hidden json-indent-on-new-line %<
     evaluate-commands -draft -itersel %<
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : json-trim-indent <ret> }
         # indent after lines beginning with opener token

--- a/rc/filetype/just.kak
+++ b/rc/filetype/just.kak
@@ -26,7 +26,7 @@ provide-module justfile %{
 define-command -hidden just-indent-on-new-line %{
      evaluate-commands -draft -itersel %{
         # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        try %{ execute-keys -draft <semicolon>K<a-&> }
         # cleanup trailing white spaces on previous line
         try %{ execute-keys -draft k<a-x> s \h+$ <ret>"_d }
         # copy '#' comment prefix and following white spaces

--- a/rc/filetype/kakrc.kak
+++ b/rc/filetype/kakrc.kak
@@ -20,7 +20,7 @@ hook global WinSetOption filetype=kak %~
     hook window InsertChar [>)}\]] -group kak-indent kak-indent-on-closing-matching
     hook window InsertChar (?![[{(<>)}\]])[^\s\w] -group kak-indent kak-indent-on-closing-char
     # cleanup trailing whitespaces on current line insert end
-    hook window ModeChange pop:insert:.* -group kak-trim-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
+    hook window ModeChange pop:insert:.* -group kak-trim-indent %{ try %{ execute-keys -draft <semicolon> <a-x> s ^\h+$ <ret> d } }
     set-option buffer extra_word_chars '_' '-'
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window kak-.+ }
@@ -96,7 +96,7 @@ define-command -hidden kak-indent-on-new-line %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # cleanup trailing whitespaces from previous line
         try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
         # indent after line ending with %\w*[^\s\w]

--- a/rc/filetype/ledger.kak
+++ b/rc/filetype/ledger.kak
@@ -127,7 +127,7 @@ add-highlighter shared/ledger/tag/assert     regex '^\h*assert' 0:function
 define-command -hidden ledger-indent-on-new-line %[
     evaluate-commands -draft -itersel %[
         # preserve previous line indent
-        try %[ execute-keys -draft \; K <a-&> ]
+        try %[ execute-keys -draft <semicolon> K <a-&> ]
         # cleanup trailing whitespaces from previous line
         try %[ execute-keys -draft k <a-x> s \h+$ <ret> d ]
         # indent after the first line of a transaction
@@ -136,7 +136,7 @@ define-command -hidden ledger-indent-on-new-line %[
 ]
 
 define-command -hidden ledger-trim-indent %{
-    try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d }
+    try %{ execute-keys -draft <semicolon> <a-x> s ^\h+$ <ret> d }
 }
 
 ]

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -78,8 +78,8 @@ define-command lua-alternative-file -docstring 'Jump to the alternate file (impl
 define-command -hidden lua-indent-on-char %{
     evaluate-commands -no-hooks -draft -itersel %{
         # align middle and end structures to start and indent when necessary, elseif is already covered by else
-        try %{ execute-keys -draft <a-x><a-k>^\h*(else)$<ret><a-\;><a-?>^\h*(if)<ret>s\A|\z<ret>)<a-&> }
-        try %{ execute-keys -draft <a-x><a-k>^\h*(end)$<ret><a-\;><a-?>^\h*(for|function|if|while)<ret>s\A|\z<ret>)<a-&> }
+        try %{ execute-keys -draft <a-x><a-k>^\h*(else)$<ret><a-semicolon><a-?>^\h*(if)<ret>s\A|\z<ret>)<a-&> }
+        try %{ execute-keys -draft <a-x><a-k>^\h*(end)$<ret><a-semicolon><a-?>^\h*(for|function|if|while)<ret>s\A|\z<ret>)<a-&> }
     }
 }
 

--- a/rc/filetype/makefile.kak
+++ b/rc/filetype/makefile.kak
@@ -53,7 +53,7 @@ evaluate-commands %sh{
 define-command -hidden makefile-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        try %{ execute-keys -draft <semicolon>K<a-&> }
         ## If the line above is a target indent with a tab
         try %{ execute-keys -draft Z k<a-x> <a-k>^\S.*?(::|:|!)\s<ret> z i<tab> }
         # cleanup trailing white space son previous line

--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -89,7 +89,7 @@ define-command -hidden markdown-indent-on-new-line %{
         # copy block quote(s), list item prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K((>\h*)+([*+-]\h)?|(>\h*)*[*+-]\h)\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # remove trailing white spaces
         try %{ execute-keys -draft -itersel %{ k<a-x> s \h+$ <ret> d } }
     }

--- a/rc/filetype/moon.kak
+++ b/rc/filetype/moon.kak
@@ -88,11 +88,11 @@ define-command -hidden moon-trim-indent %{
 define-command -hidden moon-indent-on-char %{
     evaluate-commands -draft -itersel %{
         # align _else_ statements to start
-        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (else(if)?) $ <ret> <a-\;> <a-?> ^ \h * (if|unless|when) <ret> s \A | \z <ret> ) <a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (else(if)?) $ <ret> <a-semicolon> <a-?> ^ \h * (if|unless|when) <ret> s \A | \z <ret> ) <a-&> }
         # align _when_ to _switch_ then indent
-        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (when) $ <ret> <a-\;> <a-?> ^ \h * (switch) <ret> s \A | \z <ret> ) <a-&> ) <space> <gt> }
+        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (when) $ <ret> <a-semicolon> <a-?> ^ \h * (switch) <ret> s \A | \z <ret> ) <a-&> ) <space> <gt> }
         # align _catch_ and _finally_ to _try_
-        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (catch|finally) $ <ret> <a-\;> <a-?> ^ \h * (try) <ret> s \A | \z <ret> ) <a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (catch|finally) $ <ret> <a-semicolon> <a-?> ^ \h * (try) <ret> s \A | \z <ret> ) <a-&> }
     }
 }
 
@@ -101,7 +101,7 @@ define-command -hidden moon-indent-on-new-line %{
         # copy -- comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^ \h * \K -- \h * <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : moon-trim-indent <ret> }
         # indent after start structure

--- a/rc/filetype/nim.kak
+++ b/rc/filetype/nim.kak
@@ -18,7 +18,7 @@ hook global WinSetOption filetype=nim %{
 
     hook window InsertChar \n -group nim-indent nim-indent-on-new-line
     # cleanup trailing whitespaces on current line insert end
-    hook window ModeChange pop:insert:.* -group nim-trim-indent %{ try %{ exec -draft \; <a-x> s ^\h+$ <ret> d } }
+    hook window ModeChange pop:insert:.* -group nim-trim-indent %{ try %{ exec -draft <semicolon> <a-x> s ^\h+$ <ret> d } }
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window nim-.+ }
 }
@@ -111,7 +111,7 @@ def -hidden nim-indent-on-new-line %{
         # copy '#' comment prefix and following white spaces
         try %{ exec -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
         # preserve previous line indent
-        try %{ exec -draft \; K <a-&> }
+        try %{ exec -draft <semicolon> K <a-&> }
         # cleanup trailing whitespaces from previous line
         try %{ exec -draft k <a-x> s \h+$ <ret> d }
         # indent after line ending with enum, tuple, object, type, import, export, const, let, var, ':' or '='

--- a/rc/filetype/nix.kak
+++ b/rc/filetype/nix.kak
@@ -104,7 +104,7 @@ define-command -hidden nix-indent-on-new-line %<
         # copy // comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : nix-trim-indent <ret> }
         # indent after lines beginning / ending with opener token

--- a/rc/filetype/perl.kak
+++ b/rc/filetype/perl.kak
@@ -93,7 +93,7 @@ add-highlighter shared/perl/code/ regex \$(LAST_REGEXP_CODE_RESULT|LIST_SEPARATO
 define-command -hidden perl-indent-on-new-line %~
     evaluate-commands -draft -itersel %=
         # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        try %{ execute-keys -draft <semicolon>K<a-&> }
         # indent after lines ending with { or (
         try %[ execute-keys -draft k<a-x> <a-k> [{(]\h*$ <ret> j<a-gt> ]
         # cleanup trailing white spaces on the previous line
@@ -101,11 +101,11 @@ define-command -hidden perl-indent-on-new-line %~
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
         # copy // comments prefix
-        try %{ execute-keys -draft \;<c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # indent after if|else|while|for
-        try %[ execute-keys -draft \;<a-F>)MB <a-k> \A(if|else|while|for)\h*\(.*\)\h*\n\h*\n?\z <ret> s \A|.\z <ret> 1<a-&>1<a-space><a-gt> ]
+        try %[ execute-keys -draft <semicolon><a-F>)MB <a-k> \A(if|else|while|for)\h*\(.*\)\h*\n\h*\n?\z <ret> s \A|.\z <ret> 1<a-&>1<a-space><a-gt> ]
     =
 ~
 

--- a/rc/filetype/php.kak
+++ b/rc/filetype/php.kak
@@ -86,7 +86,7 @@ define-command -hidden php-indent-on-new-line %<
         # copy // comments or docblock * prefix and following white spaces
         try %{ execute-keys -draft s [^/] <ret> k <a-x> s ^\h*\K(?://|[*][^/])\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : php-trim-indent <ret> }
         # indent after lines beginning / ending with opener token

--- a/rc/filetype/pony.kak
+++ b/rc/filetype/pony.kak
@@ -18,7 +18,7 @@ hook global WinSetOption filetype=pony %{
 
     hook window InsertChar \n -group pony-indent pony-indent-on-new-line
     # cleanup trailing whitespaces on current line insert end
-    hook window ModeChange pop:insert:.* -group pony-trim-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
+    hook window ModeChange pop:insert:.* -group pony-trim-indent %{ try %{ execute-keys -draft <semicolon> <a-x> s ^\h+$ <ret> d } }
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window pony-.+ }
 }

--- a/rc/filetype/protobuf.kak
+++ b/rc/filetype/protobuf.kak
@@ -69,13 +69,13 @@ evaluate-commands %sh{
 define-command -hidden protobuf-indent-on-newline %~
     evaluate-commands -draft -itersel %[
         # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        try %{ execute-keys -draft <semicolon>K<a-&> }
         # indent after lines ending with {
         try %[ execute-keys -draft k<a-x> <a-k> \{\h*$ <ret> j<a-gt> ]
         # cleanup trailing white spaces on the previous line
         try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # copy // comments prefix
-        try %{ execute-keys -draft \;<c-s>k<a-x> s ^\h*\K/{2,}(\h*(?=\S))? <ret> y<c-o>P<esc> }
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}(\h*(?=\S))? <ret> y<c-o>P<esc> }
     ]
 ~
 

--- a/rc/filetype/pug.kak
+++ b/rc/filetype/pug.kak
@@ -68,7 +68,7 @@ define-command -hidden pug-trim-indent %{
 define-command -hidden pug-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : pug-trim-indent <ret> }
         # copy '//', '|', '-' or '(!)=' prefix and following whitespace

--- a/rc/filetype/python.kak
+++ b/rc/filetype/python.kak
@@ -18,7 +18,7 @@ hook global WinSetOption filetype=python %{
 
     hook window InsertChar \n -group python-indent python-indent-on-new-line
     # cleanup trailing whitespaces on current line insert end
-    hook window ModeChange pop:insert:.* -group python-trim-indent %{ try %{ execute-keys -draft \; <a-x> s ^\h+$ <ret> d } }
+    hook window ModeChange pop:insert:.* -group python-trim-indent %{ try %{ execute-keys -draft <semicolon> <a-x> s ^\h+$ <ret> d } }
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window python-.+ }
 }
 
@@ -145,7 +145,7 @@ define-command -hidden python-indent-on-new-line %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # cleanup trailing whitespaces from previous line
         try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
         # indent after line ending with :

--- a/rc/filetype/r.kak
+++ b/rc/filetype/r.kak
@@ -52,11 +52,11 @@ define-command -hidden r-trim-indent %{
 }
 
 define-command -hidden r-indent-on-newline %< evaluate-commands -draft -itersel %<
-    execute-keys \;
+    execute-keys <semicolon>
     try %<
         # if previous line closed a paren (possibly followed by words and a comment),
         # copy indent of the opening paren line
-        execute-keys -draft k<a-x> 1s(\))(\h+\w+)*\h*(\;\h*)?(?:#[^\n]+)?\n\z<ret> m<a-\;>J <a-S> 1<a-&>
+        execute-keys -draft k<a-x> 1s(\))(\h+\w+)*\h*(\;\h*)?(?:#[^\n]+)?\n\z<ret> m<a-semicolon>J <a-S> 1<a-&>
     > catch %<
         # else indent new lines with the same level as the previous one
         execute-keys -draft K <a-&>
@@ -67,7 +67,7 @@ define-command -hidden r-indent-on-newline %< evaluate-commands -draft -itersel 
     try %< execute-keys -draft k <a-x> s[{(]\h*$<ret> j <a-gt> >
     # indent after a statement not followed by an opening brace
     try %< execute-keys -draft k <a-x> s\)\h*(?:#[^\n]+)?\n\z<ret> \
-                               <a-\;>mB <a-k>\A\b(if|for|while)\b<ret> <a-\;>j <a-gt> >
+                               <a-semicolon>mB <a-k>\A\b(if|for|while)\b<ret> <a-semicolon>j <a-gt> >
     try %< execute-keys -draft k <a-x> s \belse\b\h*(?:#[^\n]+)?\n\z<ret> \
                                j <a-gt> >
     # deindent after a single line statement end
@@ -83,7 +83,7 @@ define-command -hidden r-indent-on-newline %< evaluate-commands -draft -itersel 
         # Go to opening parenthesis and opening brace, then select the most nested one
         try %< execute-keys [c [({],[)}] <ret> >
         # Validate selection and get first and last char
-        execute-keys <a-k>\A[{(](\h*\S+)+\n<ret> <a-K>"(([^"]*"){2})*<ret> <a-K>'(([^']*'){2})*<ret> <a-:><a-\;>L <a-S>
+        execute-keys <a-k>\A[{(](\h*\S+)+\n<ret> <a-K>"(([^"]*"){2})*<ret> <a-K>'(([^']*'){2})*<ret> <a-:><a-semicolon>L <a-S>
         # Remove possibly incorrect indent from new line which was copied from previous line
         try %< execute-keys -draft <space> <a-h> s\h+<ret> d >
         # Now indent and align that new line with the opening parenthesis/brace
@@ -108,7 +108,7 @@ define-command -hidden r-indent-on-closing-curly-brace %[
 ]
 
 define-command -hidden r-insert-on-newline %[ evaluate-commands -itersel -draft %[
-    execute-keys \;
+    execute-keys <semicolon>
     try %[
         evaluate-commands -draft -save-regs '/"' %[
             # copy the commenting prefix

--- a/rc/filetype/ragel.kak
+++ b/rc/filetype/ragel.kak
@@ -65,7 +65,7 @@ define-command -hidden ragel-indent-on-new-line %<
         # copy _#_ comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : ragel-trim-indent <ret> }
         # indent after lines ending with opener token

--- a/rc/filetype/ruby.kak
+++ b/rc/filetype/ruby.kak
@@ -139,10 +139,10 @@ define-command -hidden ruby-trim-indent %{
 define-command -hidden ruby-indent-on-char %{
     evaluate-commands -no-hooks -draft -itersel %{
         # align middle and end structures to start
-        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (else|elsif) $ <ret> <a-\;> <a-?> ^ \h * (if)                                                       <ret> s \A | \z <ret> ) <a-&> }
-        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (when)       $ <ret> <a-\;> <a-?> ^ \h * (case)                                                     <ret> s \A | \z <ret> ) <a-&> }
-        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (rescue)     $ <ret> <a-\;> <a-?> ^ \h * (begin)                                                    <ret> s \A | \z <ret> ) <a-&> }
-        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (end)        $ <ret> <a-\;> <a-?> ^ \h * (begin|case|class|def|for|if|module|unless|until|while) <ret> s \A | \z <ret> ) <a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (else|elsif) $ <ret> <a-semicolon> <a-?> ^ \h * (if)                                                       <ret> s \A | \z <ret> ) <a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (when)       $ <ret> <a-semicolon> <a-?> ^ \h * (case)                                                     <ret> s \A | \z <ret> ) <a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (rescue)     $ <ret> <a-semicolon> <a-?> ^ \h * (begin)                                                    <ret> s \A | \z <ret> ) <a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (end)        $ <ret> <a-semicolon> <a-?> ^ \h * (begin|case|class|def|for|if|module|unless|until|while) <ret> s \A | \z <ret> ) <a-&> }
     }
 }
 
@@ -160,7 +160,7 @@ define-command -hidden ruby-indent-on-new-line %{
 define-command -hidden ruby-insert-on-new-line %[
     evaluate-commands -no-hooks -draft -itersel %[
         # copy _#_ comment prefix and following white spaces
-        try %{ execute-keys -draft k <a-x> s '^\h*\K#\h*' <ret> y j <a-x>\; P }
+        try %{ execute-keys -draft k <a-x> s '^\h*\K#\h*' <ret> y j <a-x><semicolon> P }
         # wisely add end structure
         evaluate-commands -save-regs x %[
             try %{ execute-keys -draft k <a-x> s ^ \h + <ret> \" x y } catch %{ reg x '' }

--- a/rc/filetype/rust.kak
+++ b/rc/filetype/rust.kak
@@ -83,7 +83,7 @@ define-command -hidden rust-indent-on-new-line %~
         # copy // comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K//[!/]?\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : rust-trim-indent <ret> }
         # indent after lines ending with { or (

--- a/rc/filetype/sass.kak
+++ b/rc/filetype/sass.kak
@@ -58,7 +58,7 @@ define-command -hidden sass-indent-on-new-line %{
         # copy '/' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K/\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : sass-trim-indent <ret> }
         # avoid indent after properties and comments

--- a/rc/filetype/scala.kak
+++ b/rc/filetype/scala.kak
@@ -64,7 +64,7 @@ define-command -hidden scala-indent-on-new-line %[
         # copy // comments prefix and following white spaces
         try %[ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P ]
         # preserve previous line indent
-        try %[ execute-keys -draft \; K <a-&> ]
+        try %[ execute-keys -draft <semicolon> K <a-&> ]
         # filter previous line
         try %[ execute-keys -draft k : scala-trim-indent <ret> ]
         # indent after lines ending with {

--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -73,7 +73,7 @@ define-command -hidden sh-indent-on-new-line %[
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : sh-trim-indent <ret> }
 

--- a/rc/filetype/taskpaper.kak
+++ b/rc/filetype/taskpaper.kak
@@ -43,7 +43,7 @@ add-highlighter shared/taskpaper/ regex (([a-z]+://\S+)|((mailto:)[\w+-]+@\S+)) 
 define-command -hidden taskpaper-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # preserve previous line indent
-        try %{ execute-keys -draft \;K<a-&> }
+        try %{ execute-keys -draft <semicolon>K<a-&> }
         ## If the line above is a project indent with a tab
         try %{ execute-keys -draft Z k<a-x> <a-k>^\h*([^:\n]+):<ret> z i<tab> }
         # cleanup trailing white spaces on previous line

--- a/rc/filetype/toml.kak
+++ b/rc/filetype/toml.kak
@@ -61,7 +61,7 @@ define-command -hidden toml-indent-on-new-line %{
         # copy comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : toml-trim-indent <ret> }
     }

--- a/rc/filetype/yaml.kak
+++ b/rc/filetype/yaml.kak
@@ -54,7 +54,7 @@ define-command -hidden yaml-indent-on-new-line %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
-        try %{ execute-keys -draft \; K <a-&> }
+        try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : yaml-trim-indent <ret> }
         # indent after :

--- a/src/keys.cc
+++ b/src/keys.cc
@@ -78,6 +78,7 @@ static constexpr KeyAndName keynamemap[] = {
     { "del", Key::Delete },
     { "plus", '+' },
     { "minus", '-' },
+    { "semicolon", ';' },
 };
 
 KeyList parse_keys(StringView str)


### PR DESCRIPTION
This commit allows using the <semicolon> expansion in commands, instead
of `\;`.

It makes commands look more elegant, and prevents new-comers from
falling into the trap of using <a-;> without escaping the semicolon.