### PR TITLE
filetype: add support for .make extension

### DIFF
--- a/rc/filetype/makefile.kak
+++ b/rc/filetype/makefile.kak
@@ -1,7 +1,7 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*(/?[mM]akefile|\.mk) %{
+hook global BufCreate .*(/?[mM]akefile|\.mk|\.make) %{
     set-option buffer filetype makefile
 }
 


### PR DESCRIPTION
While building fish-shell which uses `cmake`, a lot of regular Makefiles are generated with this extension.