### PR TITLE
Fix python operator highlighter

### DIFF
--- a/rc/filetype/python.kak
+++ b/rc/filetype/python.kak
@@ -134,7 +134,7 @@ evaluate-commands %sh{
     "
 }
 
-add-highlighter shared/python/code/ regex (?<=[\w\s\d'"_])(<=|<<|>>|>=|<>|<|>|!=|==|\||\^|&|\+|-|\*\*|\*|//|/|%|~) 0:operator
+add-highlighter shared/python/code/ regex (?<=[\w\s\d\)\]'"_])(<=|<<|>>|>=|<>|<|>|!=|==|\||\^|&|\+|-|\*\*|\*|//?|%|~) 0:operator
 add-highlighter shared/python/code/ regex (?<=[\w\s\d'"_])((?<![=<>!])=(?![=])|[+*-]=) 0:builtin
 add-highlighter shared/python/code/ regex ^\h*(?:from|import)\h+(\S+) 1:module
 


### PR DESCRIPTION
Until this PR, Python operator highlighter does not highlight operators that follow right after a bracket:

```python
# This  highlights the asterisk:
a = (1 + x) * 2
# This does not:
a = (1 + x)*2
```

Also the PR fixes `//` operator highlighting. Instead of the rule `(...|//|/|...)`, using `(...|//?|...)` highlights the operator correctly.