### PR TITLE
Merge selection list parsing into selection_list_from_strings

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -2336,7 +2336,7 @@ const CommandDesc select_cmd = {
     {
         auto& buffer = context.buffer();
         const size_t timestamp = parser.get_switch("timestamp").map(str_to_int_ifp).cast<size_t>().value_or(buffer.timestamp());
-        context.selections_write_only() = selection_list_from_string(buffer, parser.positionals_from(0), timestamp);
+        context.selections_write_only() = selection_list_from_strings(buffer, parser.positionals_from(0), timestamp, 0);
     }
 };
 

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1774,20 +1774,7 @@ SelectionList read_selections_from_register(char reg, Context& context)
     const size_t timestamp = str_to_int(desc[1]);
     size_t main = str_to_int(desc[2]);
 
-    if (timestamp > buffer.timestamp())
-        throw runtime_error{"register '{}' refers to an invalid timestamp"};
-
-    auto sels = content | skip(1) | transform(selection_from_string) | gather<Vector<Selection>>();
-    sort_selections(sels, main);
-    merge_overlapping_selections(sels, main);
-    if (timestamp < buffer.timestamp())
-        update_selections(sels, main, buffer, timestamp);
-    else
-        clamp_selections(sels, buffer);
-
-    SelectionList res{buffer, std::move(sels)};
-    res.set_main_index(main);
-    return res;
+    return selection_list_from_strings(buffer, content | skip(1), timestamp, main);
 }
 
 enum class CombineOp

--- a/src/selection.cc
+++ b/src/selection.cc
@@ -27,13 +27,6 @@ SelectionList::SelectionList(Buffer& buffer, Vector<Selection> list, size_t time
 SelectionList::SelectionList(Buffer& buffer, Vector<Selection> list)
     : SelectionList(buffer, std::move(list), buffer.timestamp()) {}
 
-SelectionList::SelectionList(SelectionList::UnsortedTag, Buffer& buffer, Vector<Selection> list, size_t timestamp, size_t main)
-    : m_selections(std::move(list)), m_buffer(&buffer), m_timestamp(timestamp)
-{
-    sort_and_merge_overlapping();
-    check_invariant();
-}
-
 void SelectionList::remove(size_t index)
 {
     m_selections.erase(begin() + index);
@@ -516,16 +509,6 @@ Selection selection_from_string(StringView desc)
         throw runtime_error(format("coordinates must be >= 1: '{}'", desc));
 
     return Selection{anchor, cursor};
-}
-
-SelectionList selection_list_from_string(Buffer& buffer, ConstArrayView<String> descs, size_t timestamp)
-{
-    if (descs.empty())
-        throw runtime_error{"empty selection description"};
-
-    auto sels = descs | transform([&](auto&& d) { auto s = selection_from_string(d); clamp(s, buffer); return s; })
-                      | gather<Vector<Selection>>();
-    return {SelectionList::UnsortedTag{}, buffer, std::move(sels), timestamp, 0};
 }
 
 }


### PR DESCRIPTION
Two places built `SelectionList`s from a list of strings.
The one used by `:select` ignored the timestamp when clamping the selections, so I extracted the code from `read_selections_from_register` and added added a check that `main` is in bounds.
(Otherwise, this would have fell through to a `kak_assert` in `check_invariant`.)

I actually didn't experience the clamping issue.  I'm looking at the code to
see about implementing something a la the proposal at the end of #2724.