### PR TITLE
share kakrc: Use `fail` in the `:colorscheme` command

### DIFF
--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -21,7 +21,7 @@ def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
     if [ -n "${filename}" ]; then
         printf 'source %%{%s}' "${filename}"
     else
-        echo "echo -markup '{Error}No such colorscheme'"
+        echo "fail 'No such colorscheme'"
     fi
 }}
 


### PR DESCRIPTION
When an invalid colorscheme is selected from the user configuration
file, the editor doesn't report any errors at startup unless the
`fail` command is used.