### PR TITLE
src: Some recommended fixes from cppcheck

### DIFF
--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -195,12 +195,12 @@ BufferCoord Buffer::clamp(BufferCoord coord) const
     return coord;
 }
 
-BufferCoord Buffer::offset_coord(BufferCoord coord, CharCount offset, ColumnCount, bool)
+BufferCoord Buffer::offset_coord(BufferCoord coord, CharCount offset, ColumnCount, bool) const
 {
     return utf8::advance(iterator_at(coord), offset < 0 ? begin() : end()-1, offset).coord();
 }
 
-BufferCoordAndTarget Buffer::offset_coord(BufferCoordAndTarget coord, LineCount offset, ColumnCount tabstop, bool avoid_eol)
+BufferCoordAndTarget Buffer::offset_coord(BufferCoordAndTarget coord, LineCount offset, ColumnCount tabstop, bool avoid_eol) const
 {
     const auto column = coord.target == -1 ? get_column(*this, tabstop, coord) : coord.target;
     const auto line = Kakoune::clamp(coord.line + offset, 0_line, line_count()-1);

--- a/src/buffer.hh
+++ b/src/buffer.hh
@@ -188,8 +188,8 @@ public:
     // returns nearest valid coordinates from given ones
     BufferCoord clamp(BufferCoord coord) const;
 
-    BufferCoord offset_coord(BufferCoord coord, CharCount offset, ColumnCount, bool);
-    BufferCoordAndTarget offset_coord(BufferCoordAndTarget coord, LineCount offset, ColumnCount tabstop, bool avoid_eol);
+    BufferCoord offset_coord(BufferCoord coord, CharCount offset, ColumnCount, bool) const;
+    BufferCoordAndTarget offset_coord(BufferCoordAndTarget coord, LineCount offset, ColumnCount tabstop, bool avoid_eol) const;
 
     const String& name() const { return m_name; }
     const String& display_name() const { return m_display_name; }

--- a/src/client.cc
+++ b/src/client.cc
@@ -212,7 +212,7 @@ void Client::redraw_ifn()
     if (m_ui_pending == 0)
         return;
 
-    auto& faces = context().faces();
+    const auto& faces = context().faces();
 
     if (m_ui_pending & Draw)
         m_ui->draw(window.update_display_buffer(context()),

--- a/src/client.hh
+++ b/src/client.hh
@@ -49,7 +49,7 @@ public:
     void info_hide(bool even_modal = false);
 
     void print_status(DisplayLine status_line);
-    const DisplayLine& current_status() { return m_status_line; }
+    const DisplayLine& current_status() const { return m_status_line; }
 
     DisplayCoord dimensions() const;
 

--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -284,12 +284,12 @@ Token parse_percent_token(Reader& reader, bool throw_on_unterminated)
     }
 }
 
-auto expand_option(Option& opt, std::true_type)
+auto expand_option(const Option& opt, std::true_type)
 {
     return opt.get_as_string(Quoting::Raw);
 }
 
-auto expand_option(Option& opt, std::false_type)
+auto expand_option(const Option& opt, std::false_type)
 {
     return opt.get_as_strings();
 }

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -278,7 +278,7 @@ struct ShellCandidatesCompleter
         CandidateList res;
         // Gather best max_count matches
         for_n_best(matches, max_count, [](auto& lhs, auto& rhs) { return rhs < lhs; },
-                   [&] (RankedMatch& m) {
+                   [&] (const RankedMatch& m) {
             if (not res.empty() and res.back() == m.candidate())
                 return false;
             res.push_back(m.candidate().str());
@@ -519,7 +519,7 @@ const CommandDesc force_write_cmd = {
     write_buffer<true>,
 };
 
-void write_all_buffers(Context& context, bool sync = false)
+void write_all_buffers(const Context& context, bool sync = false)
 {
     // Copy buffer list because hooks might be creating/deleting buffers
     Vector<SafePtr<Buffer>> buffers;
@@ -1105,7 +1105,7 @@ void define_command(const ParametersParser& parser, Context& context, const Shel
                        size_t token_to_complete, ByteCount pos_in_token)
         {
              const String& prefix = params[token_to_complete];
-             auto& ignored_files = context.options()["ignored_files"].get<Regex>();
+             const auto& ignored_files = context.options()["ignored_files"].get<Regex>();
              return Completions{0_byte, pos_in_token,
                                 complete_filename(prefix, ignored_files,
                                                   pos_in_token, FilenameFlags::Expand),
@@ -1739,7 +1739,7 @@ void context_wrap(const ParametersParser& parser, Context& context, StringView d
         (int)(bool)parser.get_switch("try-client") > 1)
         throw runtime_error{"only one of -buffer, -client or -try-client can be specified"};
 
-    auto& register_manager = RegisterManager::instance();
+    const auto& register_manager = RegisterManager::instance();
     auto make_register_restorer = [&](char c) {
         return on_scope_end([&, c, save=register_manager[c].save(context)] {
             try

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -899,9 +899,9 @@ struct WrapHighlighter : Highlighter
         }
 
         return pos;
-    };
+    }
 
-    ColumnCount line_indent(const Buffer& buffer, int tabstop, LineCount line) const
+    static ColumnCount line_indent(const Buffer& buffer, int tabstop, LineCount line)
     {
         StringView l = buffer[line];
         auto col = 0_byte;
@@ -947,7 +947,7 @@ struct TabulationHighlighter : Highlighter
     void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange) override
     {
         const ColumnCount tabstop = context.context.options()["tabstop"].get<int>();
-        auto& buffer = context.context.buffer();
+        const auto& buffer = context.context.buffer();
         auto win_column = context.setup.window_pos.column;
         for (auto& line : display_buffer.lines())
         {
@@ -1033,7 +1033,7 @@ private:
     {
         const int tabstop = context.context.options()["tabstop"].get<int>();
         auto whitespaceface = context.context.faces()["Whitespace"];
-        auto& buffer = context.context.buffer();
+        const auto& buffer = context.context.buffer();
         auto win_column = context.setup.window_pos.column;
         for (auto& line : display_buffer.lines())
         {
@@ -1112,7 +1112,7 @@ private:
         if (contains(context.disabled_ids, ms_id))
             return;
 
-        auto& faces = context.context.faces();
+        const auto& faces = context.context.faces();
         const Face face = faces["LineNumbers"];
         const Face face_wrapped = faces["LineNumbersWrapped"];
         const Face face_absolute = faces["LineNumberCursor"];
@@ -1153,7 +1153,7 @@ private:
         unique_ids.push_back(ms_id);
     }
 
-    int compute_digit_count(const Context& context) const
+    static int compute_digit_count(const Context& context)
     {
         int digit_count = 0;
         LineCount last_line = context.buffer().line_count();
@@ -1268,7 +1268,7 @@ void highlight_selections(HighlightContext context, DisplayBuffer& display_buffe
 
 void expand_unprintable(HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
 {
-    auto& buffer = context.context.buffer();
+    const auto& buffer = context.context.buffer();
     auto error = context.context.faces()["Error"];
     for (auto& line : display_buffer.lines())
     {
@@ -1367,7 +1367,7 @@ private:
     void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange) override
     {
         auto& line_flags = context.context.options()[m_option_name].get_mutable<LineAndSpecList>();
-        auto& buffer = context.context.buffer();
+        const auto& buffer = context.context.buffer();
         update_line_specs_ifn(buffer, line_flags);
 
         auto def_face = context.context.faces()[m_default_face];
@@ -1417,7 +1417,7 @@ private:
     void do_compute_display_setup(HighlightContext context, DisplaySetup& setup) const override
     {
         auto& line_flags = context.context.options()[m_option_name].get_mutable<LineAndSpecList>();
-        auto& buffer = context.context.buffer();
+        const auto& buffer = context.context.buffer();
         update_line_specs_ifn(buffer, line_flags);
 
         ColumnCount width = 0;

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -1029,7 +1029,7 @@ struct ShowWhitespacesHighlighter : Highlighter
     }
 
 private:
-    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
+    void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange) override
     {
         const int tabstop = context.context.options()["tabstop"].get<int>();
         auto whitespaceface = context.context.faces()["Whitespace"];

--- a/src/insert_completer.cc
+++ b/src/insert_completer.cc
@@ -545,7 +545,7 @@ void InsertCompleter::on_option_changed(const Option& opt)
         m_current_candidate != m_completions.candidates.size() - 1)
         return;
 
-    auto& completers = m_options["completers"].get<InsertCompleterDescList>();
+    const auto& completers = m_options["completers"].get<InsertCompleterDescList>();
     for (auto& completer : completers)
     {
         if (completer.mode == InsertCompleterDesc::Option and

--- a/src/json_ui.cc
+++ b/src/json_ui.cc
@@ -19,7 +19,7 @@ namespace Kakoune
 {
 
 struct invalid_rpc_request : runtime_error {
-    invalid_rpc_request(String message)
+    invalid_rpc_request(const String& message)
         : runtime_error(format("invalid json rpc request ({})", message)) {}
 };
 

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -638,7 +638,7 @@ Optional<Key> NCursesUI::get_next_key()
         }
         for (int count = 0; count < 16 and c >= 0x30 && c <= 0x3f; c = next_char())
         {
-            if ('0' <= 'c' and c <= '9')
+            if (isdigit(c))
                 params[count] = params[count] * 10 + c - '0';
             else if (c == ';')
                 ++count;

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -166,7 +166,7 @@ void repeat_last_select(Context& context, NormalParams)
     context.repeat_last_select();
 }
 
-String build_autoinfo_for_mapping(Context& context, KeymapMode mode,
+String build_autoinfo_for_mapping(const Context& context, KeymapMode mode,
                                   ConstArrayView<KeyInfo> built_ins)
 {
     auto& keymaps = context.keymaps();
@@ -445,7 +445,7 @@ void for_each_codepoint(Context& context, NormalParams)
     selections.insert(strings, InsertMode::Replace);
 }
 
-void command(Context& context, EnvVarMap env_vars)
+void command(const Context& context, EnvVarMap env_vars)
 {
     if (not CommandManager::has_instance())
         throw runtime_error{"commands are not supported"};
@@ -1190,7 +1190,7 @@ void deindent(Context& context, NormalParams params)
         indent_width = tabstop;
     indent_width = indent_width * count;
 
-    auto& buffer = context.buffer();
+    const auto& buffer = context.buffer();
     Vector<Selection> sels;
     LineCount last_line = 0;
     for (auto& sel : context.selections())
@@ -1378,7 +1378,7 @@ enum Direction { Backward = -1, Forward = 1 };
 template<Direction direction, bool half = false>
 void scroll(Context& context, NormalParams params)
 {
-    Window& window = context.window();
+    const Window& window = context.window();
     const int count = params.count ? params.count : 1;
     const LineCount offset = (window.dimensions().line - 2) / (half ? 2 : 1) * count;
 

--- a/src/normal.hh
+++ b/src/normal.hh
@@ -37,7 +37,7 @@ struct KeyInfo
     StringView docstring;
 };
 
-String build_autoinfo_for_mapping(Context& context, KeymapMode mode,
+String build_autoinfo_for_mapping(const Context& context, KeymapMode mode,
                                   ConstArrayView<KeyInfo> built_ins);
 
 }

--- a/src/optional.hh
+++ b/src/optional.hh
@@ -94,7 +94,7 @@ public:
     }
 
     template<typename U>
-    auto cast() -> Optional<U>
+    auto cast() const -> Optional<U>
     {
         if (not m_valid)
             return {};

--- a/src/ranges.hh
+++ b/src/ranges.hh
@@ -356,7 +356,7 @@ struct ConcatView
         RangeIt2 m_it2;
     };
 
-    ConcatView(Range1& range1, Range2& range2)
+    ConcatView(const Range1& range1, const Range2& range2)
         : m_range1(range1), m_range2(range2) {}
 
     Iterator begin() const { return {m_range1.begin(), m_range1.end(), m_range2.begin()}; }

--- a/src/regex_impl.cc
+++ b/src/regex_impl.cc
@@ -161,7 +161,7 @@ struct RegexParser
 private:
     struct InvalidPolicy
     {
-        Codepoint operator()(Codepoint cp) { throw regex_error{"Invalid utf8 in regex"}; }
+        Codepoint operator()(Codepoint cp) const { throw regex_error{"Invalid utf8 in regex"}; }
     };
 
     enum class Flags
@@ -425,7 +425,7 @@ private:
         parse_error(format("unknown atom escape '{}'", cp));
     }
 
-    void normalize_ranges(Vector<CharacterClass::Range, MemoryDomain::Regex>& ranges)
+    static void normalize_ranges(Vector<CharacterClass::Range, MemoryDomain::Regex>& ranges)
     {
         if (ranges.empty())
             return;
@@ -1140,7 +1140,7 @@ String dump_regex(const CompiledRegex& program)
                 res += "match\n";
         }
     }
-    auto dump_start_desc = [&](CompiledRegex::StartDesc& desc, StringView name) {
+    auto dump_start_desc = [&](const CompiledRegex::StartDesc& desc, StringView name) {
         res += name + " start desc: [";
         for (size_t c = 0; c < CompiledRegex::StartDesc::count; ++c)
         {

--- a/src/regex_impl.hh
+++ b/src/regex_impl.hh
@@ -521,7 +521,7 @@ private:
         }
     }
 
-    void to_next_start(Iterator& start, const ExecConfig& config, const StartDesc& start_desc)
+    static void to_next_start(Iterator& start, const ExecConfig& config, const StartDesc& start_desc)
     {
         while (start != config.end)
         {
@@ -540,7 +540,7 @@ private:
     {
         using Lookaround = CompiledRegex::Lookaround;
 
-        if (not look_forward) 
+        if (not look_forward)
         {
             if (pos == config.subject_begin)
                 return m_program.lookarounds[index] == Lookaround::EndOfLookaround;

--- a/src/scope.hh
+++ b/src/scope.hh
@@ -57,7 +57,7 @@ class GlobalScope : public Scope, public OptionManagerWatcher, public Singleton<
         OptionsRegistry& option_registry() { return m_option_registry; }
         const OptionsRegistry& option_registry() const { return m_option_registry; }
     private:
-        void on_option_changed(const Option& option);
+        void on_option_changed(const Option& option) override;
 
         OptionsRegistry m_option_registry;
 };

--- a/src/selection.cc
+++ b/src/selection.cc
@@ -45,7 +45,7 @@ void SelectionList::set(Vector<Selection> list, size_t main)
 
 bool compare_selections(const Selection& lhs, const Selection& rhs)
 {
-    const auto lmin = lhs.min(), rmin = rhs.min();
+    const auto& lmin = lhs.min(), rmin = rhs.min();
     return lmin == rmin ? lhs.max() < rhs.max() : lmin < rmin;
 }
 

--- a/src/selection.cc
+++ b/src/selection.cc
@@ -111,7 +111,7 @@ Iterator merge_overlapping(Iterator begin, Iterator end, size_t& main, OverlapsF
 BufferCoord& get_first(Selection& sel) { return sel.min(); }
 BufferCoord& get_last(Selection& sel) { return sel.max(); }
 
-Vector<Selection> compute_modified_ranges(Buffer& buffer, size_t timestamp)
+Vector<Selection> compute_modified_ranges(const Buffer& buffer, size_t timestamp)
 {
     Vector<Selection> ranges;
     auto changes = buffer.changes_since(timestamp);
@@ -211,7 +211,7 @@ void clamp_selections(Vector<Selection>& selections, const Buffer& buffer)
         clamp(sel, buffer);
 }
 
-void update_selections(Vector<Selection>& selections, size_t& main, Buffer& buffer, size_t timestamp, bool merge)
+void update_selections(Vector<Selection>& selections, size_t& main, const Buffer& buffer, size_t timestamp, bool merge)
 {
     if (timestamp == buffer.timestamp())
         return;
@@ -474,8 +474,8 @@ void SelectionList::erase()
 
 String selection_to_string(const Selection& selection)
 {
-    auto& cursor = selection.cursor();
-    auto& anchor = selection.anchor();
+    const auto& cursor = selection.cursor();
+    const auto& anchor = selection.anchor();
     return format("{}.{},{}.{}", anchor.line + 1, anchor.column + 1,
                   cursor.line + 1, cursor.column + 1);
 }

--- a/src/selection.hh
+++ b/src/selection.hh
@@ -65,7 +65,7 @@ inline bool overlaps(const Selection& lhs, const Selection& rhs)
 }
 
 void update_selections(Vector<Selection>& selections, size_t& main,
-                       Buffer& buffer, size_t timestamp, bool merge = true);
+                       const Buffer& buffer, size_t timestamp, bool merge = true);
 
 bool compare_selections(const Selection& lhs, const Selection& rhs);
 void sort_selections(Vector<Selection>& selections, size_t& main);
@@ -155,7 +155,7 @@ private:
     size_t m_timestamp;
 };
 
-Vector<Selection> compute_modified_ranges(Buffer& buffer, size_t timestamp);
+Vector<Selection> compute_modified_ranges(const Buffer& buffer, size_t timestamp);
 
 String selection_to_string(const Selection& selection);
 String selection_list_to_string(const SelectionList& selection);

--- a/src/string_utils.cc
+++ b/src/string_utils.cc
@@ -9,16 +9,6 @@
 namespace Kakoune
 {
 
-StringView trim_whitespaces(StringView str)
-{
-    auto beg = str.begin(), end = str.end();
-    while (beg != end and is_blank(*beg))
-        ++beg;
-    while (beg != end and is_blank(*(end-1)))
-        --end;
-    return {beg, end};
-}
-
 String trim_indent(StringView str)
 {
     if (str.empty())

--- a/src/string_utils.hh
+++ b/src/string_utils.hh
@@ -9,7 +9,6 @@
 namespace Kakoune
 {
 
-StringView trim_whitespaces(StringView str);
 String trim_indent(StringView str);
 
 String escape(StringView str, StringView characters, char escape);

--- a/src/window.cc
+++ b/src/window.cc
@@ -280,7 +280,7 @@ ColumnCount find_display_column(const DisplayLine& line, const Buffer& buffer,
 BufferCoord find_buffer_coord(const DisplayLine& line, const Buffer& buffer,
                               ColumnCount column)
 {
-    auto& range = line.range();
+    const auto& range = line.range();
     for (auto& atom : line)
     {
         ColumnCount len = atom.length();


### PR DESCRIPTION
I ran it to see if there was dead code, and there was only one function, which is quite nice.

Most of the changes were making functions static or const, which I figured could have some mild, nice performance implications, if not just code readability.

It also found one outright bug parsing OSI escape sequences and an unnecessary BufferCoord copy, both of which I fixed.

There are two scary warnings left which I'm not quite sure how to deal with:

```
src/commands.cc:2431:13: note: Calling function 'on_next_key_with_autoinfo', 4th argument 'lock?format("{} (lock)",mode_name):mode_name' value is <Moved>
    }, lock ? format("{} (lock)", mode_name) : mode_name,
            ^
```

I think this is right, and it's a false positive.  I think everything that uses the `StringView` title runs before the call returns, and I'm just weirded out trying to figure out how a C++ can generate the code to conditionally destroy an object created in a ternary for a parameter after the call returns.  It is supposed to, right?

```
src/highlighters.cc:63:66: note: Missing bounds check for extra iterator increment in loop.
        for (auto atom_it = line.begin(); atom_it != line.end(); ++atom_it)
```

This one, there's an extra `++atom_it` on 79, which doesn't check if we've reached past-the-end.  I'm not sure if we know that it won't.