### PR TITLE
src: Allow `:on-key` to display an information box

### DIFF
--- a/doc/pages/commands.asciidoc
+++ b/doc/pages/commands.asciidoc
@@ -274,10 +274,11 @@ but not really useful in that context.
     prompt content will be passed as a single token. In other words,
     word splitting does not take place.
 
-*on-key* <command>::
+*on-key* [-info <info>] <command>::
     wait for next key from user, then execute <command>, the key is
     available through the `key` value, accessible through `$kak_key`
-    in shells, or `%val{key}` in commands.
+    in shells, or `%val{key}` in commands. If specified, <info> will
+    first be displayed in an information box until a key is hit.
 
 *menu* [<switches>] <label1> <commands1> <label2> <commands2> ...::
     display a menu using labels, the selected label’s commands are

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -2107,9 +2107,13 @@ const CommandDesc menu_cmd = {
 const CommandDesc on_key_cmd = {
     "on-key",
     nullptr,
-    "on-key <command>: wait for next user key and then execute <command>, "
-    "with key available in the `key` value",
-    single_param,
+    "on-key [-info <info>] <command>: wait for the next user key and then execute <command>, "
+    "with the key available in the `key` value; "
+    "if specified, <info> will first be displayed in an information box until a key is hit",
+    ParameterDesc{
+        { { "info", { true, "" } } },
+        ParameterDesc::Flags::None, 0, 1
+    },
     CommandFlags::None,
     CommandHelper{},
     CommandCompleter{},
@@ -2117,12 +2121,16 @@ const CommandDesc on_key_cmd = {
     {
         String command = parser[0];
 
+        if (auto info = parser.get_switch("info"))
+            context.client().info_show({}, info->str(), {}, InfoStyle::Prompt);
+
         CapturedShellContext sc{shell_context};
         context.input_handler().on_next_key(
             KeymapMode::None, [=](Key key, Context& context) mutable {
             sc.env_vars["key"_sv] = key_to_str(key);
             ScopedSetBool disable_history{context.history_disabled()};
 
+            context.client().info_hide();
             CommandManager::instance().execute(command, context, sc);
         });
     }


### PR DESCRIPTION
Key mappings that use `on-key` to emulate single hit prompts (like
the `t` primitive) currently have no way of notifying the user that
an input is pending.

This commit allows passing an -info flag to `on-key`, in order to
display the given string in an information box until a key is hit, e.g.

```
on-key -info "hit a key" 'echo %val{key}'
```