### PR TITLE
rc spell: Allow storing a language in an option

### DIFF
--- a/rc/detection/modeline.kak
+++ b/rc/detection/modeline.kak
@@ -34,6 +34,7 @@ define-command -hidden modeline-parse-impl %{
                 ft|filetype) tr="filetype ${value}";;
                 bomb) tr="BOM utf8";;
                 nobomb) tr="BOM none";;
+                spelllang|spl) tr="spell_lang ${value%%,*}";;
                 *) printf %s\\n "echo -debug 'Unsupported vim variable: ${key}'";;
             esac
 
@@ -46,7 +47,7 @@ define-command -hidden modeline-parse-impl %{
             readonly value="$2"
 
             case "${key}" in
-                scrolloff|tabstop|indentwidth|autowrap_column|eolformat|filetype|BOM);;
+                scrolloff|tabstop|indentwidth|autowrap_column|eolformat|filetype|BOM|spell_lang);;
                 *) printf %s\\n "echo -debug 'Unsupported kakoune variable: ${key}'"
                    return;;
             esac

--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -1,14 +1,17 @@
 declare-option -hidden range-specs spell_regions
-declare-option -hidden str spell_lang
+declare-option -hidden str spell_last_lang
 declare-option -hidden str spell_tmp_file
 
-define-command -params ..1 \
-    -docstring %{spell [<language>]: spell check the current buffer
-The first optional argument is the language against which the check will be performed
-Formats of language supported:
- - ISO language code, e.g. 'en'
- - language code above followed by a dash or underscore with an ISO country code, e.g. 'en-US'} \
-    spell %{
+declare-option -docstring "default language to use when none is passed to the spell-check command" str spell_lang
+
+define-command -params ..1 -docstring %{
+    spell [<language>]: spell check the current buffer
+
+    The first optional argument is the language against which the check will be performed (overrides `spell_lang`)
+    Formats of language supported:
+      - ISO language code, e.g. 'en'
+      - language code above followed by a dash or underscore with an ISO country code, e.g. 'en-US'
+    } spell %{
     try %{ add-highlighter window/ ranges 'spell_regions' }
     evaluate-commands %sh{
         file=$(mktemp -d "${TMPDIR:-/tmp}"/kak-spell.XXXXXXXX)/buffer
@@ -16,15 +19,21 @@ Formats of language supported:
         printf 'set-option buffer spell_tmp_file %s\n' "${file}"
     }
     evaluate-commands %sh{
-        if [ $# -ge 1 ]; then
-            if [ ${#1} -ne 2 ] && [ ${#1} -ne 5 ]; then
-                echo "echo -markup '{Error}Invalid language code (examples of expected format: en, en_US, en-US)'"
+        use_lang() {
+            if ! printf %s "$1" | grep -qE '^[a-z]{2,3}([_-][A-Z]{2})?$'; then
+                echo "fail 'Invalid language code (examples of expected format: en, en_US, en-US)'"
                 rm -rf "$(dirname "$kak_opt_spell_tmp_file")"
                 exit 1
             else
                 options="-l '$1'"
-                printf 'set-option buffer spell_lang %s\n' "$1"
+                printf 'set-option buffer spell_last_lang %s\n' "$1"
             fi
+        }
+
+        if [ $# -ge 1 ]; then
+            use_lang "$1"
+        elif [ -n "${kak_opt_spell_lang}" ]; then
+            use_lang "${kak_opt_spell_lang}"
         fi
 
         {
@@ -107,9 +116,11 @@ define-command spell-next %{ evaluate-commands %sh{
     fi
 } }
 
-define-command spell-replace %{ evaluate-commands %sh{
-    if [ -n "$kak_opt_spell_lang" ]; then
-        options="-l '$kak_opt_spell_lang'"
+define-command \
+    -docstring "Suggest replacement words for the current selection, against the last language used by the spell-check command" \
+    spell-replace %{ evaluate-commands %sh{
+    if [ -n "$kak_opt_spell_last_lang" ]; then
+        options="-l '$kak_opt_spell_last_lang'"
     fi
     suggestions=$(printf %s "$kak_selection" | eval "aspell -a $options" | grep '^&' | cut -d: -f2)
     menu=$(printf %s "${suggestions#?}" | awk -F', ' '


### PR DESCRIPTION
This commit adds a `spell_lang` option that will be used by the
`spell` command when no language is passed to it directly.

Setting a buffer/window local option allows using `:spell` seamlessly
across several buffers, written in different languages.