### PR TITLE
Fix literal '"' in F# syntax highlighting.

### DIFF
--- a/rc/filetype/fsharp.kak
+++ b/rc/filetype/fsharp.kak
@@ -33,7 +33,7 @@ provide-module fsharp %§
 add-highlighter shared/fsharp regions
 add-highlighter shared/fsharp/code default-region group
 add-highlighter shared/fsharp/docstring region \(\*(?!\)) (\*\)) regions
-add-highlighter shared/fsharp/double_string region @?" (?<!\\)(\\\\)*"B? fill string
+add-highlighter shared/fsharp/double_string region @?(?<!')" (?<!\\)(\\\\)*"B? fill string
 add-highlighter shared/fsharp/comment region '//' '$' fill comment
 # https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/attributes 
 add-highlighter shared/fsharp/attributes region "\[<" ">\]" fill meta


### PR DESCRIPTION
I stumbled upon an issue with the recently merged F# filetype. There was an edge case with character literals, where `'"'` was being incorrectly highlighted.