### PR TITLE
rc rust: Don't set an arbitrary formatter

### DIFF
--- a/rc/filetype/rust.kak
+++ b/rc/filetype/rust.kak
@@ -25,14 +25,6 @@ hook -group rust-highlight global WinSetOption filetype=rust %{
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/rust }
 }
 
-# Configuration
-# ‾‾‾‾‾‾‾‾‾‾‾‾‾
-
-hook global WinSetOption filetype=rust %{
-    set window formatcmd 'rustfmt'
-}
-
-
 provide-module rust %§
 
 # Highlighters


### PR DESCRIPTION
Users who want to use a formatter are free to pick a tool of their
choosing and set `formatcmd` in their user configuration.