### PR TITLE
Fix test suite freeze

### DIFF
--- a/test/regression/2056-assert-on-small-window/script
+++ b/test/regression/2056-assert-on-small-window/script
@@ -1,1 +1,2 @@
+ui_out '{ "jsonrpc": "2.0", "method": "set_ui_options", "params": [{}] }'
 ui_in '{ "jsonrpc": "2.0", "method": "resize", "params": [ 5, 2 ] }'


### PR DESCRIPTION
The issue is that the `test/regression/2056-assert-on-small-window`
sent JSON UI input without waiting for for the JSON UI to be
initialized.

Closes #3196

It could be nice to fix the deadlock at a more fundamental level,
but it's probably not a normal use case to send JSON input messages
before reading the first JSON UI output message.