### PR TITLE
Fix for select-display-column test

### DIFF
--- a/test/compose/select-display-columns/enabled
+++ b/test/compose/select-display-columns/enabled
@@ -1,0 +1,15 @@
+#!/bin/sh
+if ! locale | grep LC_CTYPE | grep -qi 'utf-*8'; then
+    exit 1
+fi
+if ! ldd --version >/dev/null 2>&1; then
+    # not glibc environment
+    exit 0
+fi
+ldd --version |awk 'NR == 1{
+    if ($2 " " $3 != "(GNU libc)")
+        exit(0);
+    split($4, version, ".");
+    if ((version[1] * 10000 + version[2]) <= 20022)
+        exit(1);
+}'


### PR DESCRIPTION
This should disable test select-display-column test when UTF8
is not present, and hopefully it will enable UTF8 in Travis CI.

According to the docs, it is already available in Travis CI, but
the man page for wcwidth() only says it depends on LC_CTYPE.  So
if this PR fails to build, it is likely that ncurses is too old to
recognize the emojis in the select-display-column case.