### PR TITLE
rc: Use the standard `fail` command to report errors

### DIFF
--- a/rc/detection/editorconfig.kak
+++ b/rc/detection/editorconfig.kak
@@ -13,7 +13,7 @@ hook global BufCreate .*[.](editorconfig) %{
 
 define-command editorconfig-load -params ..1 -docstring "editorconfig-load [file]: set formatting behavior according to editorconfig" %{
     evaluate-commands %sh{
-        command -v editorconfig >/dev/null 2>&1 || { printf %s\\n 'echo -markup "{Error}editorconfig could not be found"'; exit 1; }
+        command -v editorconfig >/dev/null 2>&1 || { echo "fail editorconfig could not be found"; exit 1; }
 
         file="${1:-$kak_buffile}"
         case $file in

--- a/rc/tools/clang.kak
+++ b/rc/tools/clang.kak
@@ -188,7 +188,7 @@ define-command clang-diagnostics-next -docstring "Jump to the next line that con
         if [ -n "$line" ]; then
             printf %s\\n "execute-keys ${line} g"
         else
-            echo "echo -markup '{Error}no next clang diagnostic'"
+            echo "fail no next clang diagnostic"
         fi
     } }
 

--- a/rc/tools/ctags.kak
+++ b/rc/tools/ctags.kak
@@ -49,7 +49,7 @@ define-command -params ..1 \
                 menu_item = $2; gsub("!", "!!", menu_item);
                 edit_path = path($2); gsub("&", "&&", edit_path); gsub("#", "##", edit_path); gsub("\\|", "||", edit_path);
                 select = $1; gsub(/</, "<lt>", select); gsub(/\t/, "<c-v><c-i>", select); gsub("!", "!!", select); gsub("&", "&&", select); gsub("#", "##", select); gsub("\\|", "||", select);
-                out = out "%!" menu_item ": {MenuInfo}" menu_info "! %!evaluate-commands %# try %& edit -existing %|" edit_path "|; execute-keys %|/\\Q" keys "<ret>vc| & catch %& echo -markup %|{Error}unable to find tag| &; try %& execute-keys %|s\\Q" select "<ret>| & # !"
+                out = out "%!" menu_item ": {MenuInfo}" menu_info "! %!evaluate-commands %# try %& edit -existing %|" edit_path "|; execute-keys %|/\\Q" keys "<ret>vc| & catch %& fail unable to find tag &; try %& execute-keys %|s\\Q" select "<ret>| & # !"
             }
             /[^\t]+\t[^\t]+\t[0-9]+/ {
                 menu_item = $2; gsub("!", "!!", menu_item);
@@ -57,9 +57,9 @@ define-command -params ..1 \
                 menu_info = $3; gsub("!", "!!", menu_info); gsub("{", "\\{", menu_info);
                 edit_path = path($2); gsub("!", "!!", edit_path); gsub("#", "##", edit_path); gsub("&", "&&", edit_path); gsub("\\|", "||", edit_path);
                 line_number = $3;
-                out = out "%!" menu_item ": {MenuInfo}" menu_info "! %!evaluate-commands %# try %& edit -existing %|" edit_path "|; execute-keys %|" line_number "gx| & catch %& echo -markup %|{Error}unable to find tag| &; try %& execute-keys %|s\\Q" select "<ret>| & # !"
+                out = out "%!" menu_item ": {MenuInfo}" menu_info "! %!evaluate-commands %# try %& edit -existing %|" edit_path "|; execute-keys %|" line_number "gx| & catch %& fail unable to find tag &; try %& execute-keys %|s\\Q" select "<ret>| & # !"
             }
-            END { print ( length(out) == 0 ? "echo -markup %{{Error}no such tag " ENVIRON["tagname"] "}" : "menu -markup -auto-single " out ) }
+            END { print ( length(out) == 0 ? "fail no such tag " ENVIRON["tagname"] : "menu -markup -auto-single " out ) }
             # Ensure x is an absolute file path, by prepending with tagroot
             function path(x) { return x ~/^\// ? x : tagroot x }'
     ]]

--- a/rc/tools/doc.kak
+++ b/rc/tools/doc.kak
@@ -67,7 +67,7 @@ define-command doc-jump-to-anchor -params 1 %{
                 exit
             fi
         done
-        printf "echo -markup {Error}No such anchor '%s'" "${anchor}"
+        printf "fail No such anchor '%s'\n" "${anchor}"
     }
 }
 
@@ -157,7 +157,7 @@ An optional keyword argument can be passed to the function, which will be automa
             fi
             printf %s\\n "evaluate-commands -try-client %opt{docsclient} %{ doc-render ${page}; ${jump_cmd} }"
         else
-            printf %s\\n "echo -markup '{Error}No such doc file: ${page}'"
+            printf 'fail No such doc file: %s\n' "${page}"
         fi
     }
 }

--- a/rc/tools/format.kak
+++ b/rc/tools/format.kak
@@ -11,7 +11,7 @@ define-command format-buffer -docstring "Format the contents of the buffer" %{
 define-command format-selections -docstring "Format the selections individually" %{
     evaluate-commands %sh{
         if [ -z "${kak_opt_formatcmd}" ]; then
-            printf "fail 'The option ''formatcmd'' must be set'"
+            echo "fail 'The option ''formatcmd'' must be set'"
         fi
     }
     evaluate-commands -draft -no-hooks -save-regs '|' %{
@@ -24,7 +24,7 @@ define-command format-selections -docstring "Format the selections individually"
             if [ $? -eq 0 ]; then
                 cat "$format_out"
             else
-                printf 'eval -client %s %%{ echo -markup %%{{Error}formatter returned an error %s} }' "$kak_client" "$?" | kak -p "$kak_session"
+                printf 'eval -client %s %%{ fail formatter returned an error %s }\n' "$kak_client" "$?" | kak -p "$kak_session"
                 cat "$format_in"
             fi
             rm -f "$format_in" "$format_out"

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -39,7 +39,7 @@ Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-
     cd_bufdir() {
         dirname_buffer="${kak_buffile%/*}"
         cd "${dirname_buffer}" 2>/dev/null || {
-            printf 'echo -markup {Error}Unable to change the current working directory to: %s' "${dirname_buffer}"
+            printf 'fail Unable to change the current working directory to: %s\n' "${dirname_buffer}"
             exit 1
         }
     }
@@ -103,7 +103,7 @@ Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-
         if git "${@}" > /dev/null 2>&1; then
           printf %s "echo -markup '{Information}git $1 succeeded'"
         else
-          printf %s "echo -markup '{Error}git $1 failed'"
+          printf 'fail git %s failed\n' "$1"
         fi
     }
 
@@ -168,7 +168,7 @@ Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-
             if git commit "$@" > /dev/null 2>&1; then
                 echo 'echo -markup "{Information}Commit succeeded"'
             else
-                echo 'echo -markup "{Error}Commit failed"'
+                echo 'fail Commit failed'
             fi
             exit
         fi <<-EOF
@@ -183,7 +183,7 @@ Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-
                   if git commit -F '$msgfile' --cleanup=strip $* > /dev/null; then
                      printf %s 'evaluate-commands -client $kak_client echo -markup %{{Information}Commit succeeded}; delete-buffer'
                   else
-                     printf %s 'evaluate-commands -client $kak_client echo -markup %{{Error}Commit failed}'
+                     printf 'evaluate-commands -client %s fail Commit failed\n' "$kak_client"
                   fi
               } }"
     }
@@ -227,7 +227,7 @@ Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-
             run_git_cmd "$@"
             ;;
         *)
-            printf %s "echo -markup %{{Error}unknown git command '$1'}"
+            printf "fail unknown git command '%s'\n" "$1"
             exit
             ;;
     esac

--- a/rc/tools/lint.kak
+++ b/rc/tools/lint.kak
@@ -11,7 +11,7 @@ declare-option -hidden int lint_warning_count
 define-command lint -docstring 'Parse the current buffer with a linter' %{
     evaluate-commands %sh{
         if [ -z "${kak_opt_lintcmd}" ]; then
-            printf %s\\n 'echo -markup {Error}The `lintcmd` option is not set'
+            echo 'fail The `lintcmd` option is not set'
             exit 1
         fi
 
@@ -139,7 +139,7 @@ define-command lint-next-error -docstring "Jump to the next line that contains a
         if [ -n "${range}" ]; then
             printf 'select %s\n' "${range}"
         else
-            printf 'echo -markup "{Error}no lint diagnostics"\n'
+            echo 'fail no lint diagnostics'
         fi
     }
 }
@@ -167,7 +167,7 @@ define-command lint-previous-error -docstring "Jump to the previous line that co
             range="${range:-${1%%|*}}"
             printf 'select %s\n' "${range}"
         else
-            printf 'echo -markup "{Error}no lint diagnostics"\n'
+            echo 'fail no lint diagnostics'
         fi
     }
 }

--- a/rc/tools/man.kak
+++ b/rc/tools/man.kak
@@ -45,16 +45,11 @@ define-command -hidden -params 2..3 man-impl %{ evaluate-commands %sh{
                 set-option buffer filetype man
                 set-option window manpage $buffer_name $*
         "
-    elif [ "${retval}" -eq 16 ]; then
-        printf %s\\n "
-        echo -markup %{{Error}$(cat $manerr)}
-        nop %sh{ rm ${colout}; rm ${manerr} }
-        "
     else
-        printf %s\\n "
-        fail $(cat $manerr)
-        nop %sh{ rm ${colout}; rm ${manerr} }
-        "
+        printf '
+            fail %%{%s}
+            nop %%sh{ rm "%s"; rm "%s" }
+        ' "$(cat "$manerr")" "${colout}" "${manerr}"
     fi
 } }
 

--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -56,7 +56,7 @@ define-command -params ..1 -docstring %{
                             ;;
                         '') line_num=$((line_num + 1));;
                         \*) ;;
-                        *) printf 'echo -markup %%{{Error}%s}\n' "${line}" | kak -p "${kak_session}";;
+                        *) printf 'fail %s\n' "${line}" | kak -p "${kak_session}";;
                     esac
                 done
                 printf 'set-option "buffer=%s" spell_regions %s' "${kak_bufname}" "${regions}" \

--- a/rc/windowing/repl/tmux.kak
+++ b/rc/windowing/repl/tmux.kak
@@ -12,7 +12,7 @@ declare-option -docstring "tmux pane id in which the REPL is running" str tmux_r
 define-command -hidden -params 1..2 tmux-repl-impl %{
     evaluate-commands %sh{
         if [ -z "$TMUX" ]; then
-            echo "echo -markup '{Error}This command is only available in a tmux session'"
+            echo 'fail This command is only available in a tmux session'
             exit
         fi
         tmux_args="$1"
@@ -49,7 +49,7 @@ define-command -hidden tmux-send-text -params 0..1 -docstring "tmux-send-text [t
 
 define-command -hidden tmux-repl-disabled %{ evaluate-commands %sh{
     VERSION_TMUX=$(tmux -V)
-    printf %s "echo -markup %{{Error}The version of tmux is too old: got ${VERSION_TMUX}, expected >= 2.x}"
+    printf 'fail The version of tmux is too old: got %s, expected >= 2.x\n' "${VERSION_TMUX}"
 } }
 
 evaluate-commands %sh{

--- a/rc/windowing/repl/x11.kak
+++ b/rc/windowing/repl/x11.kak
@@ -11,7 +11,7 @@ All optional parameters are forwarded to the new window} \
     -shell-completion \
     x11-repl %{ evaluate-commands %sh{
         if [ -z "${kak_opt_termcmd}" ]; then
-           echo "echo -markup '{Error}termcmd option is not set'"
+           echo 'fail termcmd option is not set'
            exit
         fi
         if [ $# -eq 0 ]; then cmd="${SHELL:-sh}"; else cmd="$@"; fi


### PR DESCRIPTION
Merely using `echo` with markup doesn't log errors in the debug
buffers, and is also less readable.