### PR TITLE
[POC] share kakrc: Allow colorschemes to be scoped

### DIFF
--- a/colors/base16.kak
+++ b/colors/base16.kak
@@ -3,6 +3,8 @@
 ##
 
 evaluate-commands %sh{
+    scope="${1:-global}"
+
     black_lighterer='rgb:383838'
     black_lighter='rgb:2D2D2D'
     black_light='rgb:1C1C1C'
@@ -18,57 +20,57 @@ evaluate-commands %sh{
 
     ## code
     echo "
-        face global value ${orange_dark}+b
-        face global type ${orange_light}
-        face global variable ${magenta_dark}
-        face global module ${green_dark}
-        face global function ${cyan_light}
-        face global string ${green_dark}
-        face global keyword ${purple_dark}+b
-        face global operator ${cyan_light}
-        face global attribute ${orange_dark}
-        face global comment ${grey_dark}
-        face global meta ${orange_light}
-        face global builtin default+b
+        face ${scope} value ${orange_dark}+b
+        face ${scope} type ${orange_light}
+        face ${scope} variable ${magenta_dark}
+        face ${scope} module ${green_dark}
+        face ${scope} function ${cyan_light}
+        face ${scope} string ${green_dark}
+        face ${scope} keyword ${purple_dark}+b
+        face ${scope} operator ${cyan_light}
+        face ${scope} attribute ${orange_dark}
+        face ${scope} comment ${grey_dark}
+        face ${scope} meta ${orange_light}
+        face ${scope} builtin default+b
     "
 
     ## markup
     echo "
-        face global title blue
-        face global header ${cyan_light}
-        face global bold ${orange_light}
-        face global italic ${orange_dark}
-        face global mono ${green_dark}
-        face global block ${orange_dark}
-        face global link blue
-        face global bullet ${magenta_light}
-        face global list ${magenta_dark}
+        face ${scope} title blue
+        face ${scope} header ${cyan_light}
+        face ${scope} bold ${orange_light}
+        face ${scope} italic ${orange_dark}
+        face ${scope} mono ${green_dark}
+        face ${scope} block ${orange_dark}
+        face ${scope} link blue
+        face ${scope} bullet ${magenta_light}
+        face ${scope} list ${magenta_dark}
     "
 
     ## builtin
     echo "
-        face global Default ${grey_light},${black_lighter}
-        face global PrimarySelection white,blue+fg
-        face global SecondarySelection black,blue+fg
-        face global PrimaryCursor black,white+fg
-        face global SecondaryCursor black,white+fg
-        face global PrimaryCursorEol black,${cyan_light}+fg
-        face global SecondaryCursorEol black,${cyan_light}+fg
-        face global LineNumbers ${grey_light},${black_lighter}
-        face global LineNumberCursor ${grey_light},rgb:282828+b
-        face global MenuForeground ${grey_light},blue
-        face global MenuBackground blue,${grey_light}
-        face global MenuInfo ${cyan_light}
-        face global Information ${black_light},${cyan_light}
-        face global Error ${grey_light},${magenta_light}
-        face global StatusLine ${grey_light},${black_lighterer}
-        face global StatusLineMode ${orange_dark}
-        face global StatusLineInfo ${cyan_light}
-        face global StatusLineValue ${green_dark}
-        face global StatusCursor ${black_lighterer},${cyan_light}
-        face global Prompt ${black_light},${cyan_light}
-        face global MatchingChar ${cyan_light},${black_light}+b
-        face global BufferPadding ${cyan_light},${black_lighter}
-        face global Whitespace ${grey_dark}+f
+        face ${scope} Default ${grey_light},${black_lighter}
+        face ${scope} PrimarySelection white,blue+fg
+        face ${scope} SecondarySelection black,blue+fg
+        face ${scope} PrimaryCursor black,white+fg
+        face ${scope} SecondaryCursor black,white+fg
+        face ${scope} PrimaryCursorEol black,${cyan_light}+fg
+        face ${scope} SecondaryCursorEol black,${cyan_light}+fg
+        face ${scope} LineNumbers ${grey_light},${black_lighter}
+        face ${scope} LineNumberCursor ${grey_light},rgb:282828+b
+        face ${scope} MenuForeground ${grey_light},blue
+        face ${scope} MenuBackground blue,${grey_light}
+        face ${scope} MenuInfo ${cyan_light}
+        face ${scope} Information ${black_light},${cyan_light}
+        face ${scope} Error ${grey_light},${magenta_light}
+        face ${scope} StatusLine ${grey_light},${black_lighterer}
+        face ${scope} StatusLineMode ${orange_dark}
+        face ${scope} StatusLineInfo ${cyan_light}
+        face ${scope} StatusLineValue ${green_dark}
+        face ${scope} StatusCursor ${black_lighterer},${cyan_light}
+        face ${scope} Prompt ${black_light},${cyan_light}
+        face ${scope} MatchingChar ${cyan_light},${black_light}+b
+        face ${scope} BufferPadding ${cyan_light},${black_lighter}
+        face ${scope} Whitespace ${grey_dark}+f
     "
 }

--- a/colors/default.kak
+++ b/colors/default.kak
@@ -1,51 +1,59 @@
 # Kakoune default color scheme
 
-# For Code
-face global value red
-face global type yellow
-face global variable green
-face global module green
-face global function cyan
-face global string magenta
-face global keyword blue
-face global operator yellow
-face global attribute green
-face global comment cyan
-face global meta magenta
-face global builtin default+b
+evaluate-commands %sh{
+    scope="${1:-global}"
 
-# For markup
-face global title blue
-face global header cyan
-face global bold red
-face global italic yellow
-face global mono green
-face global block magenta
-face global link cyan
-face global bullet cyan
-face global list yellow
+    cat <<- EOF
 
-# builtin faces
-face global Default default,default
-face global PrimarySelection white,blue+fg
-face global SecondarySelection black,blue+fg
-face global PrimaryCursor black,white+fg
-face global SecondaryCursor black,white+fg
-face global PrimaryCursorEol black,cyan+fg
-face global SecondaryCursorEol black,cyan+fg
-face global LineNumbers default,default
-face global LineNumberCursor default,default+r
-face global MenuForeground white,blue
-face global MenuBackground blue,white
-face global MenuInfo cyan
-face global Information black,yellow
-face global Error black,red
-face global StatusLine cyan,default
-face global StatusLineMode yellow,default
-face global StatusLineInfo blue,default
-face global StatusLineValue green,default
-face global StatusCursor black,cyan
-face global Prompt yellow,default
-face global MatchingChar default,default+b
-face global Whitespace default,default+f
-face global BufferPadding blue,default
+    # For Code
+    set-face "${scope}" value red
+    set-face "${scope}" type yellow
+    set-face "${scope}" variable green
+    set-face "${scope}" module green
+    set-face "${scope}" function cyan
+    set-face "${scope}" string magenta
+    set-face "${scope}" keyword blue
+    set-face "${scope}" operator yellow
+    set-face "${scope}" attribute green
+    set-face "${scope}" comment cyan
+    set-face "${scope}" meta magenta
+    set-face "${scope}" builtin default+b
+
+    # For markup
+    set-face "${scope}" title blue
+    set-face "${scope}" header cyan
+    set-face "${scope}" bold red
+    set-face "${scope}" italic yellow
+    set-face "${scope}" mono green
+    set-face "${scope}" block magenta
+    set-face "${scope}" link cyan
+    set-face "${scope}" bullet cyan
+    set-face "${scope}" list yellow
+
+    # builtin faces
+    set-face "${scope}" Default default,default
+    set-face "${scope}" PrimarySelection white,blue+fg
+    set-face "${scope}" SecondarySelection black,blue+fg
+    set-face "${scope}" PrimaryCursor black,white+fg
+    set-face "${scope}" SecondaryCursor black,white+fg
+    set-face "${scope}" PrimaryCursorEol black,cyan+fg
+    set-face "${scope}" SecondaryCursorEol black,cyan+fg
+    set-face "${scope}" LineNumbers default,default
+    set-face "${scope}" LineNumberCursor default,default+r
+    set-face "${scope}" MenuForeground white,blue
+    set-face "${scope}" MenuBackground blue,white
+    set-face "${scope}" MenuInfo cyan
+    set-face "${scope}" Information black,yellow
+    set-face "${scope}" Error black,red
+    set-face "${scope}" StatusLine cyan,default
+    set-face "${scope}" StatusLineMode yellow,default
+    set-face "${scope}" StatusLineInfo blue,default
+    set-face "${scope}" StatusLineValue green,default
+    set-face "${scope}" StatusCursor black,cyan
+    set-face "${scope}" Prompt yellow,default
+    set-face "${scope}" MatchingChar default,default+b
+    set-face "${scope}" Whitespace default,default+f
+    set-face "${scope}" BufferPadding blue,default
+
+EOF
+}

--- a/colors/desertex.kak
+++ b/colors/desertex.kak
@@ -1,82 +1,90 @@
 # desertex theme
 
-# Code
-face global value      rgb:fa8072
-face global type       rgb:dfdfbf
-face global identifier rgb:87ceeb
-face global string     rgb:fa8072
-face global error      rgb:c3bf9f+b
-face global keyword    rgb:eedc82
-face global operator   rgb:87ceeb
-face global attribute  rgb:eedc82
-face global comment    rgb:7ccd7c+i
+evaluate-commands %sh{
+    scope="${1:-global}"
 
-# #include <...>
-face global meta rgb:ee799f
+    cat <<- EOF
 
-# Markup
-face global title  blue
-face global header cyan
-face global bold   red
-face global italic yellow
-face global mono   green
-face global block  magenta
-face global link   cyan
-face global bullet cyan
-face global list   yellow
+    # Code
+    set-face "${scope}" value      rgb:fa8072
+    set-face "${scope}" type       rgb:dfdfbf
+    set-face "${scope}" identifier rgb:87ceeb
+    set-face "${scope}" string     rgb:fa8072
+    set-face "${scope}" error      rgb:c3bf9f+b
+    set-face "${scope}" keyword    rgb:eedc82
+    set-face "${scope}" operator   rgb:87ceeb
+    set-face "${scope}" attribute  rgb:eedc82
+    set-face "${scope}" comment    rgb:7ccd7c+i
 
-# Builtin
-# fg,bg+attributes
-# face global Default default,rgb:262626 <- change the terminal bg color instead
-face global Default default,default
+    # #include <...>
+    set-face "${scope}" meta rgb:ee799f
 
-face global PrimarySelection   white,blue+fg
-face global SecondarySelection black,blue+fg
+    # Markup
+    set-face "${scope}" title  blue
+    set-face "${scope}" header cyan
+    set-face "${scope}" bold   red
+    set-face "${scope}" italic yellow
+    set-face "${scope}" mono   green
+    set-face "${scope}" block  magenta
+    set-face "${scope}" link   cyan
+    set-face "${scope}" bullet cyan
+    set-face "${scope}" list   yellow
 
-face global PrimaryCursor   black,white+fg
-face global SecondaryCursor black,white+fg
+    # Builtin
+    # fg,bg+attributes
+    set-# face "${scope}" Default default,rgb:262626 <- change the terminal bg color instead
+    set-face "${scope}" Default default,default
 
-face global PrimaryCursorEol   black,rgb:7ccd7c+fg
-face global SecondaryCursorEol black,rgb:7ccd7c+fg
+    set-face "${scope}" PrimarySelection   white,blue+fg
+    set-face "${scope}" SecondarySelection black,blue+fg
 
-face global LineNumbers      rgb:605958
-face global LineNumberCursor yellow,default+b
+    set-face "${scope}" PrimaryCursor   black,white+fg
+    set-face "${scope}" SecondaryCursor black,white+fg
 
-# Bottom menu:
-# text + background
-face global MenuBackground black,rgb:c2bfa5+b
-# selected entry in the menu (use 302028 when true color support is fixed)
-face global MenuForeground rgb:f0a0c0,magenta
+    set-face "${scope}" PrimaryCursorEol   black,rgb:7ccd7c+fg
+    set-face "${scope}" SecondaryCursorEol black,rgb:7ccd7c+fg
 
-# completion menu info
-face global MenuInfo white,rgb:445599
+    set-face "${scope}" LineNumbers      rgb:605958
+    set-face "${scope}" LineNumberCursor yellow,default+b
 
-# assistant, [+]
-face global Information black,yellow
+    # Bottom menu:
+    # text + background
+    set-face "${scope}" MenuBackground black,rgb:c2bfa5+b
+    # selected entry in the menu (use 302028 when true color support is fixed)
+    set-face "${scope}" MenuForeground rgb:f0a0c0,magenta
 
-face global Error      white,red
-face global StatusLine cyan,default
+    # completion menu info
+    set-face "${scope}" MenuInfo white,rgb:445599
 
-# Status line modes and prompts:
-# insert, prompt, enter key...
-face global StatusLineMode rgb:ffd75f,default
+    # assistant, [+]
+    set-face "${scope}" Information black,yellow
 
-# 1 sel
-face global StatusLineInfo blue,default
+    set-face "${scope}" Error      white,red
+    set-face "${scope}" StatusLine cyan,default
 
-# param=value, reg=value. ex: "ey
-face global StatusLineValue green,default
+    # Status line modes and prompts:
+    # insert, prompt, enter key...
+    set-face "${scope}" StatusLineMode rgb:ffd75f,default
 
-face global StatusCursor black,cyan
+    # 1 sel
+    set-face "${scope}" StatusLineInfo blue,default
 
-# :
-face global Prompt blue
+    # param=value, reg=value. ex: "ey
+    set-face "${scope}" StatusLineValue green,default
 
-# (), {}
-face global MatchingChar cyan+b
+    set-face "${scope}" StatusCursor black,cyan
 
-# EOF tildas (~)
-face global BufferPadding blue,default
+    # :
+    set-face "${scope}" Prompt blue
 
-# Whitespace characters
-face global Whitespace default+f
+    # (), {}
+    set-face "${scope}" MatchingChar cyan+b
+
+    # EOF tildas (~)
+    set-face "${scope}" BufferPadding blue,default
+
+    # Whitespace characters
+    set-face "${scope}" Whitespace default+f
+
+EOF
+}

--- a/colors/github.kak
+++ b/colors/github.kak
@@ -3,49 +3,57 @@
 ## v1.0
 ##
 
-## code
-face global value rgb:0086B3+b
-face global type rgb:795DA3
-face global variable rgb:0086B3
-face global module rgb:0086B3
-face global function rgb:A71D5D
-face global string rgb:183691
-face global keyword rgb:A71D5D+b
-face global operator yellow
-face global attribute rgb:A71D5D
-face global comment rgb:AAAAAA
-face global meta rgb:183691
-face global builtin default+b
+evaluate-commands %sh{
+    scope="${1:-global}"
 
-## markup
-face global title blue
-face global header cyan
-face global bold red
-face global italic yellow
-face global mono green
-face global block magenta
-face global link cyan
-face global bullet cyan
-face global list yellow
+    cat <<- EOF
 
-## builtin
-face global Default rgb:121213,rgb:F8F8FF
-face global PrimarySelection default,rgb:A6F3A6+fg
-face global SecondarySelection default,rgb:DBFFDB+fg
-face global PrimaryCursor black,rgb:888888+fg
-face global SecondaryCursor black,rgb:888888+fg
-face global PrimaryCursorEol black,rgb:A71D5D+fg
-face global SecondaryCursorEol black,rgb:A71D5D+fg
-face global LineNumbers rgb:A0A0A0,rgb:ECECEC
-face global LineNumberCursor rgb:434343,rgb:DDDDDD
-face global MenuForeground rgb:434343,rgb:CDCDFD
-face global MenuBackground rgb:F8F8FF,rgb:808080
-face global Information rgb:F8F8FF,rgb:4078C0
-face global Error rgb:F8F8FF,rgb:BD2C00
-face global StatusLine rgb:434343,rgb:DDDDDD
-face global StatusCursor rgb:434343,rgb:CDCDFD
-face global Prompt rgb:F8F8FF,rgb:4078C0
-face global MatchingChar rgb:F8F8FF,rgb:4078C0+b
-face global Search default,default+u
-face global BufferPadding rgb:A0A0A0,rgb:F8F8FF
-face global Whitespace rgb:A0A0A0+f
+    ## code
+    set-face "${scope}" value rgb:0086B3+b
+    set-face "${scope}" type rgb:795DA3
+    set-face "${scope}" variable rgb:0086B3
+    set-face "${scope}" module rgb:0086B3
+    set-face "${scope}" function rgb:A71D5D
+    set-face "${scope}" string rgb:183691
+    set-face "${scope}" keyword rgb:A71D5D+b
+    set-face "${scope}" operator yellow
+    set-face "${scope}" attribute rgb:A71D5D
+    set-face "${scope}" comment rgb:AAAAAA
+    set-face "${scope}" meta rgb:183691
+    set-face "${scope}" builtin default+b
+
+    ## markup
+    set-face "${scope}" title blue
+    set-face "${scope}" header cyan
+    set-face "${scope}" bold red
+    set-face "${scope}" italic yellow
+    set-face "${scope}" mono green
+    set-face "${scope}" block magenta
+    set-face "${scope}" link cyan
+    set-face "${scope}" bullet cyan
+    set-face "${scope}" list yellow
+
+    ## builtin
+    set-face "${scope}" Default rgb:121213,rgb:F8F8FF
+    set-face "${scope}" PrimarySelection default,rgb:A6F3A6+fg
+    set-face "${scope}" SecondarySelection default,rgb:DBFFDB+fg
+    set-face "${scope}" PrimaryCursor black,rgb:888888+fg
+    set-face "${scope}" SecondaryCursor black,rgb:888888+fg
+    set-face "${scope}" PrimaryCursorEol black,rgb:A71D5D+fg
+    set-face "${scope}" SecondaryCursorEol black,rgb:A71D5D+fg
+    set-face "${scope}" LineNumbers rgb:A0A0A0,rgb:ECECEC
+    set-face "${scope}" LineNumberCursor rgb:434343,rgb:DDDDDD
+    set-face "${scope}" MenuForeground rgb:434343,rgb:CDCDFD
+    set-face "${scope}" MenuBackground rgb:F8F8FF,rgb:808080
+    set-face "${scope}" Information rgb:F8F8FF,rgb:4078C0
+    set-face "${scope}" Error rgb:F8F8FF,rgb:BD2C00
+    set-face "${scope}" StatusLine rgb:434343,rgb:DDDDDD
+    set-face "${scope}" StatusCursor rgb:434343,rgb:CDCDFD
+    set-face "${scope}" Prompt rgb:F8F8FF,rgb:4078C0
+    set-face "${scope}" MatchingChar rgb:F8F8FF,rgb:4078C0+b
+    set-face "${scope}" Search default,default+u
+    set-face "${scope}" BufferPadding rgb:A0A0A0,rgb:F8F8FF
+    set-face "${scope}" Whitespace rgb:A0A0A0+f
+
+EOF
+}

--- a/colors/gruvbox.kak
+++ b/colors/gruvbox.kak
@@ -1,6 +1,8 @@
 # gruvbox theme
 
 evaluate-commands %sh{
+    scope="${1:-global}"
+
     gray="rgb:928374"
     red="rgb:fb4934"
     green="rgb:b8bb26"
@@ -24,53 +26,53 @@ evaluate-commands %sh{
 
     echo "
         # Code highlighting
-        face global value     ${purple}
-        face global type      ${yellow}
-        face global variable  ${blue}
-        face global module    ${green}
-        face global function  ${fg}
-        face global string    ${green}
-        face global keyword   ${red}
-        face global operator  ${fg}
-        face global attribute ${orange}
-        face global comment   ${gray}+i
-        face global meta      ${aqua}
-        face global builtin   ${fg}+b
+        face ${scope} value     ${purple}
+        face ${scope} type      ${yellow}
+        face ${scope} variable  ${blue}
+        face ${scope} module    ${green}
+        face ${scope} function  ${fg}
+        face ${scope} string    ${green}
+        face ${scope} keyword   ${red}
+        face ${scope} operator  ${fg}
+        face ${scope} attribute ${orange}
+        face ${scope} comment   ${gray}+i
+        face ${scope} meta      ${aqua}
+        face ${scope} builtin   ${fg}+b
 
         # Markdown highlighting
-        face global title     ${green}+b
-        face global header    ${orange}
-        face global bold      ${fg}+b
-        face global italic    ${fg}+i
-        face global mono      ${fg4}
-        face global block     ${aqua}
-        face global link      ${blue}+u
-        face global bullet    ${yellow}
-        face global list      ${fg}
+        face ${scope} title     ${green}+b
+        face ${scope} header    ${orange}
+        face ${scope} bold      ${fg}+b
+        face ${scope} italic    ${fg}+i
+        face ${scope} mono      ${fg4}
+        face ${scope} block     ${aqua}
+        face ${scope} link      ${blue}+u
+        face ${scope} bullet    ${yellow}
+        face ${scope} list      ${fg}
 
-        face global Default            ${fg},${bg}
-        face global PrimarySelection   ${fg},${blue}+fg
-        face global SecondarySelection ${bg},${blue}+fg
-        face global PrimaryCursor      ${bg},${fg}+fg
-        face global SecondaryCursor    ${bg},${bg4}+fg
-        face global PrimaryCursorEol   ${bg},${fg4}+fg
-        face global SecondaryCursorEol ${bg},${bg2}+fg
-        face global LineNumbers        ${bg4}
-        face global LineNumberCursor   ${yellow},${bg1}
-        face global LineNumbersWrapped ${bg1}
-        face global MenuForeground     ${bg2},${blue}
-        face global MenuBackground     ${fg},${bg2}
-        face global MenuInfo           ${bg}
-        face global Information        ${bg},${fg}
-        face global Error              ${bg},${red}
-        face global StatusLine         ${fg},${bg}
-        face global StatusLineMode     ${yellow}+b
-        face global StatusLineInfo     ${purple}
-        face global StatusLineValue    ${red}
-        face global StatusCursor       ${bg},${fg}
-        face global Prompt             ${yellow}
-        face global MatchingChar       ${fg},${bg3}+b
-        face global BufferPadding      ${bg2},${bg}
-        face global Whitespace         ${bg2}+f
+        face ${scope} Default            ${fg},${bg}
+        face ${scope} PrimarySelection   ${fg},${blue}+fg
+        face ${scope} SecondarySelection ${bg},${blue}+fg
+        face ${scope} PrimaryCursor      ${bg},${fg}+fg
+        face ${scope} SecondaryCursor    ${bg},${bg4}+fg
+        face ${scope} PrimaryCursorEol   ${bg},${fg4}+fg
+        face ${scope} SecondaryCursorEol ${bg},${bg2}+fg
+        face ${scope} LineNumbers        ${bg4}
+        face ${scope} LineNumberCursor   ${yellow},${bg1}
+        face ${scope} LineNumbersWrapped ${bg1}
+        face ${scope} MenuForeground     ${bg2},${blue}
+        face ${scope} MenuBackground     ${fg},${bg2}
+        face ${scope} MenuInfo           ${bg}
+        face ${scope} Information        ${bg},${fg}
+        face ${scope} Error              ${bg},${red}
+        face ${scope} StatusLine         ${fg},${bg}
+        face ${scope} StatusLineMode     ${yellow}+b
+        face ${scope} StatusLineInfo     ${purple}
+        face ${scope} StatusLineValue    ${red}
+        face ${scope} StatusCursor       ${bg},${fg}
+        face ${scope} Prompt             ${yellow}
+        face ${scope} MatchingChar       ${fg},${bg3}+b
+        face ${scope} BufferPadding      ${bg2},${bg}
+        face ${scope} Whitespace         ${bg2}+f
     "
 }

--- a/colors/kaleidoscope-dark.kak
+++ b/colors/kaleidoscope-dark.kak
@@ -2,6 +2,8 @@
 # https://personal.sron.nl/~pault/
 
 evaluate-commands %sh{
+    scope="${1:-global}"
+
     # NOTE: tone down black and white for aesthetics,
     # ideally those should be pure #000 and #FFF
     black="rgb:303030"
@@ -73,59 +75,59 @@ evaluate-commands %sh{
     cat <<- EOF
 
     # For Code
-    set-face global keyword ${vibrant_blue}
-    set-face global attribute ${muted_purple}
-    set-face global type ${vibrant_blue}
-    set-face global string ${muted_rose}
-    set-face global value ${light_pink}
-    set-face global meta ${light_olive}
-    set-face global builtin ${vibrant_blue}+b
-    set-face global module ${vibrant_orange}
-    set-face global comment ${bright_green}+i
-    set-face global function Default
-    set-face global operator Default
-    set-face global variable Default
+    set-face "${scope}" keyword ${vibrant_blue}
+    set-face "${scope}" attribute ${muted_purple}
+    set-face "${scope}" type ${vibrant_blue}
+    set-face "${scope}" string ${muted_rose}
+    set-face "${scope}" value ${light_pink}
+    set-face "${scope}" meta ${light_olive}
+    set-face "${scope}" builtin ${vibrant_blue}+b
+    set-face "${scope}" module ${vibrant_orange}
+    set-face "${scope}" comment ${bright_green}+i
+    set-face "${scope}" function Default
+    set-face "${scope}" operator Default
+    set-face "${scope}" variable Default
 
     # For markup
-    set-face global title ${vibrant_blue}+b
-    set-face global header ${muted_cyan}
-    set-face global block ${vibrant_magenta}
-    set-face global mono ${vibrant_magenta}
-    set-face global link ${bright_cyan}+u
-    set-face global list Default
-    set-face global bullet +b
-    set-face global bold +b
-    set-face global italic +i
+    set-face "${scope}" title ${vibrant_blue}+b
+    set-face "${scope}" header ${muted_cyan}
+    set-face "${scope}" block ${vibrant_magenta}
+    set-face "${scope}" mono ${vibrant_magenta}
+    set-face "${scope}" link ${bright_cyan}+u
+    set-face "${scope}" list Default
+    set-face "${scope}" bullet +b
+    set-face "${scope}" bold +b
+    set-face "${scope}" italic +i
 
     # Built-in faces
-    set-face global Default ${white},${black}
-    set-face global PrimarySelection ${black},${pale_blue}+fg
-    set-face global SecondarySelection ${black},${pale_cyan}+fg
-    set-face global PrimaryCursor ${white},${high_contrast_blue}+fg
-    set-face global SecondaryCursor ${white},${dark_cyan}+fg
-    set-face global PrimaryCursorEol ${black},${vibrant_grey}+fg
-    set-face global SecondaryCursorEol ${black},${pale_grey}+fg
+    set-face "${scope}" Default ${white},${black}
+    set-face "${scope}" PrimarySelection ${black},${pale_blue}+fg
+    set-face "${scope}" SecondarySelection ${black},${pale_cyan}+fg
+    set-face "${scope}" PrimaryCursor ${white},${high_contrast_blue}+fg
+    set-face "${scope}" SecondaryCursor ${white},${dark_cyan}+fg
+    set-face "${scope}" PrimaryCursorEol ${black},${vibrant_grey}+fg
+    set-face "${scope}" SecondaryCursorEol ${black},${pale_grey}+fg
 
-    set-face global StatusLine ${black},${vibrant_grey}
-    set-face global StatusLineMode ${black},${light_blue}
-    set-face global StatusLineInfo ${black},${light_yellow}
-    set-face global StatusLineValue ${high_contrast_red},${light_yellow}+b
-    set-face global StatusCursor ${black},${light_orange}
-    set-face global Prompt ${black},${light_yellow}
-    set-face global MenuForeground ${black},${light_yellow}
-    set-face global MenuBackground ${black},${pale_grey}
-    set-face global MenuInfo ${vibrant_blue}+i
+    set-face "${scope}" StatusLine ${black},${vibrant_grey}
+    set-face "${scope}" StatusLineMode ${black},${light_blue}
+    set-face "${scope}" StatusLineInfo ${black},${light_yellow}
+    set-face "${scope}" StatusLineValue ${high_contrast_red},${light_yellow}+b
+    set-face "${scope}" StatusCursor ${black},${light_orange}
+    set-face "${scope}" Prompt ${black},${light_yellow}
+    set-face "${scope}" MenuForeground ${black},${light_yellow}
+    set-face "${scope}" MenuBackground ${black},${pale_grey}
+    set-face "${scope}" MenuInfo ${vibrant_blue}+i
 
-    set-face global LineNumbers ${white},${dark_grey}
-    set-face global LineNumbersWrapped ${black},${vibrant_grey}+i
-    set-face global LineNumberCursor ${black},${pale_grey}+b
-    set-face global MatchingChar ${black},${vibrant_grey}
-    set-face global Whitespace ${dark_grey}+f
-    set-face global WrapMarker ${dark_grey}+f
+    set-face "${scope}" LineNumbers ${white},${dark_grey}
+    set-face "${scope}" LineNumbersWrapped ${black},${vibrant_grey}+i
+    set-face "${scope}" LineNumberCursor ${black},${pale_grey}+b
+    set-face "${scope}" MatchingChar ${black},${vibrant_grey}
+    set-face "${scope}" Whitespace ${dark_grey}+f
+    set-face "${scope}" WrapMarker ${dark_grey}+f
 
-    set-face global Information ${black},${light_yellow}
-    set-face global Error ${white},${vibrant_red}
-    set-face global BufferPadding ${dark_grey}
+    set-face "${scope}" Information ${black},${light_yellow}
+    set-face "${scope}" Error ${white},${vibrant_red}
+    set-face "${scope}" BufferPadding ${dark_grey}
 
 EOF
 }

--- a/colors/kaleidoscope-light.kak
+++ b/colors/kaleidoscope-light.kak
@@ -2,6 +2,8 @@
 # https://personal.sron.nl/~pault/
 
 evaluate-commands %sh{
+    scope="${1:-global}"
+
     # NOTE: tone down black and white for aesthetics,
     # ideally those should be pure #000 and #FFF
     black="rgb:1C1C1C"
@@ -73,59 +75,59 @@ evaluate-commands %sh{
     cat <<- EOF
 
     # For Code
-    set-face global keyword ${muted_indigo}
-    set-face global attribute ${muted_purple}
-    set-face global type ${vibrant_blue}
-    set-face global string ${muted_wine}
-    set-face global value ${muted_rose}
-    set-face global meta ${muted_olive}
-    set-face global builtin ${muted_indigo}+b
-    set-face global module ${vibrant_orange}
-    set-face global comment ${muted_green}+i
-    set-face global function Default
-    set-face global operator Default
-    set-face global variable Default
+    set-face "${scope}" keyword ${muted_indigo}
+    set-face "${scope}" attribute ${muted_purple}
+    set-face "${scope}" type ${vibrant_blue}
+    set-face "${scope}" string ${muted_wine}
+    set-face "${scope}" value ${muted_rose}
+    set-face "${scope}" meta ${muted_olive}
+    set-face "${scope}" builtin ${muted_indigo}+b
+    set-face "${scope}" module ${vibrant_orange}
+    set-face "${scope}" comment ${muted_green}+i
+    set-face "${scope}" function Default
+    set-face "${scope}" operator Default
+    set-face "${scope}" variable Default
 
     # For markup
-    set-face global title ${muted_indigo}+b
-    set-face global header ${high_contrast_blue}
-    set-face global block ${vibrant_magenta}
-    set-face global mono ${vibrant_red}
-    set-face global link ${vibrant_blue}+u
-    set-face global list Default
-    set-face global bullet +b
-    set-face global bold +b
-    set-face global italic +i
+    set-face "${scope}" title ${muted_indigo}+b
+    set-face "${scope}" header ${high_contrast_blue}
+    set-face "${scope}" block ${vibrant_magenta}
+    set-face "${scope}" mono ${vibrant_red}
+    set-face "${scope}" link ${vibrant_blue}+u
+    set-face "${scope}" list Default
+    set-face "${scope}" bullet +b
+    set-face "${scope}" bold +b
+    set-face "${scope}" italic +i
 
     # Built-in faces
-    set-face global Default ${black},${white}
-    set-face global PrimarySelection ${black},${pale_blue}+fg
-    set-face global SecondarySelection ${black},${pale_cyan}+fg
-    set-face global PrimaryCursor ${white},${dark_blue}+fg
-    set-face global SecondaryCursor ${white},${dark_cyan}+fg
-    set-face global PrimaryCursorEol ${white},${dark_grey}+fg
-    set-face global SecondaryCursorEol ${white},${vibrant_grey}+fg
+    set-face "${scope}" Default ${black},${white}
+    set-face "${scope}" PrimarySelection ${black},${pale_blue}+fg
+    set-face "${scope}" SecondarySelection ${black},${pale_cyan}+fg
+    set-face "${scope}" PrimaryCursor ${white},${dark_blue}+fg
+    set-face "${scope}" SecondaryCursor ${white},${dark_cyan}+fg
+    set-face "${scope}" PrimaryCursorEol ${white},${dark_grey}+fg
+    set-face "${scope}" SecondaryCursorEol ${white},${vibrant_grey}+fg
 
-    set-face global StatusLine ${white},${dark_grey}
-    set-face global StatusLineMode ${black},${pale_blue}
-    set-face global StatusLineInfo ${black},${muted_sand}
-    set-face global StatusLineValue ${vibrant_orange},${muted_sand}+b
-    set-face global StatusCursor ${black},${high_contrast_yellow}
-    set-face global Prompt ${black},${muted_sand}
-    set-face global MenuForeground ${black},${muted_sand}
-    set-face global MenuBackground ${black},${pale_grey}
-    set-face global MenuInfo ${high_contrast_blue}+i
+    set-face "${scope}" StatusLine ${white},${dark_grey}
+    set-face "${scope}" StatusLineMode ${black},${pale_blue}
+    set-face "${scope}" StatusLineInfo ${black},${muted_sand}
+    set-face "${scope}" StatusLineValue ${vibrant_orange},${muted_sand}+b
+    set-face "${scope}" StatusCursor ${black},${high_contrast_yellow}
+    set-face "${scope}" Prompt ${black},${muted_sand}
+    set-face "${scope}" MenuForeground ${black},${muted_sand}
+    set-face "${scope}" MenuBackground ${black},${pale_grey}
+    set-face "${scope}" MenuInfo ${high_contrast_blue}+i
 
-    set-face global LineNumbers ${black},${pale_grey}
-    set-face global LineNumbersWrapped ${black},${vibrant_grey}+i
-    set-face global LineNumberCursor ${white},${dark_grey}+b
-    set-face global MatchingChar ${white},${dark_grey}
-    set-face global Whitespace ${vibrant_grey}+f
-    set-face global WrapMarker ${vibrant_grey}+f
+    set-face "${scope}" LineNumbers ${black},${pale_grey}
+    set-face "${scope}" LineNumbersWrapped ${black},${vibrant_grey}+i
+    set-face "${scope}" LineNumberCursor ${white},${dark_grey}+b
+    set-face "${scope}" MatchingChar ${white},${dark_grey}
+    set-face "${scope}" Whitespace ${vibrant_grey}+f
+    set-face "${scope}" WrapMarker ${vibrant_grey}+f
 
-    set-face global Information ${black},${muted_sand}
-    set-face global Error ${white},${vibrant_red}
-    set-face global BufferPadding ${vibrant_grey}
+    set-face "${scope}" Information ${black},${muted_sand}
+    set-face "${scope}" Error ${white},${vibrant_red}
+    set-face "${scope}" BufferPadding ${vibrant_grey}
 
 EOF
 }

--- a/colors/lucius.kak
+++ b/colors/lucius.kak
@@ -1,6 +1,8 @@
 # lucius theme
 
 evaluate-commands %sh{
+    scope="${1:-global}"
+
     # first we define the lucius colors as named colors
     lucius_darker_grey="rgb:303030"
     lucius_dark_grey="rgb:444444"
@@ -24,53 +26,53 @@ evaluate-commands %sh{
 
     echo "
         # then we map them to code
-        face global value ${lucius_light_green}
-        face global type ${lucius_blue}
-        face global variable ${lucius_green}
-        face global module ${lucius_green}
-        face global function ${lucius_light_blue}
-        face global string ${lucius_light_green}
-        face global keyword ${lucius_light_blue}
-        face global operator ${lucius_green}
-        face global attribute ${lucius_light_blue}
-        face global comment ${lucius_grey}
-        face global meta ${lucius_purple}
-        face global builtin default+b
+        face ${scope} value ${lucius_light_green}
+        face ${scope} type ${lucius_blue}
+        face ${scope} variable ${lucius_green}
+        face ${scope} module ${lucius_green}
+        face ${scope} function ${lucius_light_blue}
+        face ${scope} string ${lucius_light_green}
+        face ${scope} keyword ${lucius_light_blue}
+        face ${scope} operator ${lucius_green}
+        face ${scope} attribute ${lucius_light_blue}
+        face ${scope} comment ${lucius_grey}
+        face ${scope} meta ${lucius_purple}
+        face ${scope} builtin default+b
 
         # and markup
-        face global title ${lucius_light_blue}
-        face global header ${lucius_light_green}
-        face global bold ${lucius_blue}
-        face global italic ${lucius_green}
-        face global mono ${lucius_light_green}
-        face global block ${lucius_light_blue}
-        face global link ${lucius_light_green}
-        face global bullet ${lucius_green}
-        face global list ${lucius_blue}
+        face ${scope} title ${lucius_light_blue}
+        face ${scope} header ${lucius_light_green}
+        face ${scope} bold ${lucius_blue}
+        face ${scope} italic ${lucius_green}
+        face ${scope} mono ${lucius_light_green}
+        face ${scope} block ${lucius_light_blue}
+        face ${scope} link ${lucius_light_green}
+        face ${scope} bullet ${lucius_green}
+        face ${scope} list ${lucius_blue}
 
         # and built in faces
-        face global Default ${lucius_lighter_grey},${lucius_darker_grey}
-        face global PrimarySelection ${lucius_darker_grey},${lucius_orange}+fg
-        face global SecondarySelection  ${lucius_lighter_grey},${lucius_dark_blue}+fg
-        face global PrimaryCursor ${lucius_darker_grey},${lucius_lighter_grey}+fg
-        face global SecondaryCursor ${lucius_darker_grey},${lucius_lighter_grey}+fg
-        face global PrimaryCursorEol ${lucius_darker_grey},${lucius_dark_green}+fg
-        face global SecondaryCursorEol ${lucius_darker_grey},${lucius_dark_green}+fg
-        face global LineNumbers ${lucius_grey},${lucius_dark_grey}
-        face global LineNumberCursor ${lucius_grey},${lucius_dark_grey}+b
-        face global MenuForeground ${lucius_blue},${lucius_dark_blue}
-        face global MenuBackground ${lucius_darker_grey},${lucius_light_grey}
-        face global MenuInfo ${lucius_grey}
-        face global Information ${lucius_lighter_grey},${lucius_dark_green}
-        face global Error ${lucius_light_red},${lucius_dark_red}
-        face global StatusLine ${lucius_lighter_grey},${lucius_dark_grey}
-        face global StatusLineMode ${lucius_lighter_grey},${lucius_dark_green}+b
-        face global StatusLineInfo ${lucius_dark_grey},${lucius_lighter_grey}
-        face global StatusLineValue ${lucius_lighter_grey}
-        face global StatusCursor default,${lucius_blue}
-        face global Prompt ${lucius_lighter_grey}
-        face global MatchingChar ${lucius_lighter_grey},${lucius_bright_green}
-        face global BufferPadding ${lucius_green},${lucius_darker_grey}
-        face global Whitespace ${lucius_grey}+f
+        face ${scope} Default ${lucius_lighter_grey},${lucius_darker_grey}
+        face ${scope} PrimarySelection ${lucius_darker_grey},${lucius_orange}+fg
+        face ${scope} SecondarySelection  ${lucius_lighter_grey},${lucius_dark_blue}+fg
+        face ${scope} PrimaryCursor ${lucius_darker_grey},${lucius_lighter_grey}+fg
+        face ${scope} SecondaryCursor ${lucius_darker_grey},${lucius_lighter_grey}+fg
+        face ${scope} PrimaryCursorEol ${lucius_darker_grey},${lucius_dark_green}+fg
+        face ${scope} SecondaryCursorEol ${lucius_darker_grey},${lucius_dark_green}+fg
+        face ${scope} LineNumbers ${lucius_grey},${lucius_dark_grey}
+        face ${scope} LineNumberCursor ${lucius_grey},${lucius_dark_grey}+b
+        face ${scope} MenuForeground ${lucius_blue},${lucius_dark_blue}
+        face ${scope} MenuBackground ${lucius_darker_grey},${lucius_light_grey}
+        face ${scope} MenuInfo ${lucius_grey}
+        face ${scope} Information ${lucius_lighter_grey},${lucius_dark_green}
+        face ${scope} Error ${lucius_light_red},${lucius_dark_red}
+        face ${scope} StatusLine ${lucius_lighter_grey},${lucius_dark_grey}
+        face ${scope} StatusLineMode ${lucius_lighter_grey},${lucius_dark_green}+b
+        face ${scope} StatusLineInfo ${lucius_dark_grey},${lucius_lighter_grey}
+        face ${scope} StatusLineValue ${lucius_lighter_grey}
+        face ${scope} StatusCursor default,${lucius_blue}
+        face ${scope} Prompt ${lucius_lighter_grey}
+        face ${scope} MatchingChar ${lucius_lighter_grey},${lucius_bright_green}
+        face ${scope} BufferPadding ${lucius_green},${lucius_darker_grey}
+        face ${scope} Whitespace ${lucius_grey}+f
     "
 }

--- a/colors/palenight.kak
+++ b/colors/palenight.kak
@@ -3,6 +3,8 @@
 # This was ported from https://github.com/drewtempelmeyer/palenight.vim
 
 evaluate-commands %sh{
+    scope="${1:-global}"
+
     red=rgb:ff5370
     light_red=rgb:ff869a
     dark_red=rgb:be5046
@@ -25,72 +27,72 @@ evaluate-commands %sh{
 
     printf "%s\n" "
     # Code
-    face global value      $dark_yellow
-    face global type       $yellow
-    face global function   $blue
-    face global variable   $blue
-    face global identifier $blue
-    face global string     $green
-    face global error      rgb:c3bf9f+b
-    face global keyword    $purple
-    face global operator   $cyan
-    face global attribute  rgb:eedc82
-    face global comment    $comment_grey+i
+    face ${scope} value      $dark_yellow
+    face ${scope} type       $yellow
+    face ${scope} function   $blue
+    face ${scope} variable   $blue
+    face ${scope} identifier $blue
+    face ${scope} string     $green
+    face ${scope} error      rgb:c3bf9f+b
+    face ${scope} keyword    $purple
+    face ${scope} operator   $cyan
+    face ${scope} attribute  rgb:eedc82
+    face ${scope} comment    $comment_grey+i
 
     # #include <...>
-    face global meta       $yellow
+    face ${scope} meta       $yellow
 
     # Markup
-    face global title  $blue
-    face global header $cyan
-    face global bold   $red
-    face global italic $yellow
-    face global mono   $green
-    face global block  $purple
-    face global link   $cyan
-    face global bullet $cyan
-    face global list   $yellow
+    face ${scope} title  $blue
+    face ${scope} header $cyan
+    face ${scope} bold   $red
+    face ${scope} italic $yellow
+    face ${scope} mono   $green
+    face ${scope} block  $purple
+    face ${scope} link   $cyan
+    face ${scope} bullet $cyan
+    face ${scope} list   $yellow
 
     # Builtin
-    face global Default            $white,$black
+    face ${scope} Default            $white,$black
 
-    face global PrimarySelection   $black,$white+bfg
-    face global SecondarySelection $black,$white+fg
+    face ${scope} PrimarySelection   $black,$white+bfg
+    face ${scope} SecondarySelection $black,$white+fg
 
-    face global PrimaryCursor      white,$purple+bfg
-    face global SecondaryCursor    $black,$purple+fg
+    face ${scope} PrimaryCursor      white,$purple+bfg
+    face ${scope} SecondaryCursor    $black,$purple+fg
 
-    face global PrimaryCursorEol   $black,$green+fg
-    face global SecondaryCursorEol $black,$green+fg
+    face ${scope} PrimaryCursorEol   $black,$green+fg
+    face ${scope} SecondaryCursorEol $black,$green+fg
 
-    face global LineNumbers        $gutter_fg_grey
-    face global LineNumberCursor   $yellow,default+b
+    face ${scope} LineNumbers        $gutter_fg_grey
+    face ${scope} LineNumberCursor   $yellow,default+b
 
     # Bottom menu:
     # text + background
-    face global MenuBackground     $black,$white
-    face global MenuForeground     $black,$purple
+    face ${scope} MenuBackground     $black,$white
+    face ${scope} MenuForeground     $black,$purple
 
     # completion menu info
-    face global MenuInfo           $black,$white+i
+    face ${scope} MenuInfo           $black,$white+i
 
     # assistant, [+]
-    face global Information        $white,$visual_grey
+    face ${scope} Information        $white,$visual_grey
 
-    face global Error              $white,$red
-    face global StatusLine         $white,$black
+    face ${scope} Error              $white,$red
+    face ${scope} StatusLine         $white,$black
 
     # Status line
-    face global StatusLineMode     $black,$purple      # insert, prompt, enter key ...
-    face global StatusLineInfo     $white,$visual_grey # 1 sel
-    face global StatusLineValue    $visual_grey,$green # param=value, reg=value. ex: \"ey
-    face global StatusCursor       white,$purple+bg
+    face ${scope} StatusLineMode     $black,$purple      # insert, prompt, enter key ...
+    face ${scope} StatusLineInfo     $white,$visual_grey # 1 sel
+    face ${scope} StatusLineValue    $visual_grey,$green # param=value, reg=value. ex: \"ey
+    face ${scope} StatusCursor       white,$purple+bg
 
-    face global Prompt             $purple,$black # :
-    face global MatchingChar       $red+b         # (), {}
-    face global BufferPadding      $gutter_fg_grey,$black   # EOF tildas (~)
+    face ${scope} Prompt             $purple,$black # :
+    face ${scope} MatchingChar       $red+b         # (), {}
+    face ${scope} BufferPadding      $gutter_fg_grey,$black   # EOF tildas (~)
 
     # Whitespace characters
-    face global Whitespace         $gutter_fg_grey,$black+fg
+    face ${scope} Whitespace         $gutter_fg_grey,$black+fg
     "
 }

--- a/colors/plain.kak
+++ b/colors/plain.kak
@@ -1,49 +1,57 @@
 # Kakoune simple colors, mostly default
 
-# For default
-face global value default
-face global type default
-face global identifier default
-face global string blue
-face global keyword default
-face global operator default
-face global attribute default
-face global comment blue
-face global meta default
-face global builtin default
+evaluate-commands %sh{
+    scope="${1:-global}"
+
+    cat <<- EOF
+
+    # For default
+    set-face "${scope}" value default
+    set-face "${scope}" type default
+    set-face "${scope}" identifier default
+    set-face "${scope}" string blue
+    set-face "${scope}" keyword default
+    set-face "${scope}" operator default
+    set-face "${scope}" attribute default
+    set-face "${scope}" comment blue
+    set-face "${scope}" meta default
+    set-face "${scope}" builtin default
 
 
-# For default
-face global title default
-face global header default
-face global bold default
-face global italic default
-face global mono default
-face global block default
-face global link blue
-face global bullet default
-face global list default
+    # For default
+    set-face "${scope}" title default
+    set-face "${scope}" header default
+    set-face "${scope}" bold default
+    set-face "${scope}" italic default
+    set-face "${scope}" mono default
+    set-face "${scope}" block default
+    set-face "${scope}" link blue
+    set-face "${scope}" bullet default
+    set-face "${scope}" list default
 
-# builtin default
-face global Default default,default
-face global PrimarySelection white,blue
-face global SecondarySelection black,blue
-face global PrimaryCursor black,white
-face global SecondaryCursor white,blue
-face global PrimaryCursorEol default
-face global SecondaryCursorEol default
-face global LineNumbers default
-face global LineNumberCursor default
-face global MenuForeground default
-face global MenuBackground default
-face global MenuInfo default
-face global Information default
-face global Error default
-face global StatusLine default
-face global StatusLineMode default
-face global StatusLineInfo default
-face global StatusLineValue default
-face global StatusCursor default+r
-face global Prompt default
-face global MatchingChar default
-face global BufferPadding default
+    # builtin default
+    set-face "${scope}" Default default,default
+    set-face "${scope}" PrimarySelection white,blue
+    set-face "${scope}" SecondarySelection black,blue
+    set-face "${scope}" PrimaryCursor black,white
+    set-face "${scope}" SecondaryCursor white,blue
+    set-face "${scope}" PrimaryCursorEol default
+    set-face "${scope}" SecondaryCursorEol default
+    set-face "${scope}" LineNumbers default
+    set-face "${scope}" LineNumberCursor default
+    set-face "${scope}" MenuForeground default
+    set-face "${scope}" MenuBackground default
+    set-face "${scope}" MenuInfo default
+    set-face "${scope}" Information default
+    set-face "${scope}" Error default
+    set-face "${scope}" StatusLine default
+    set-face "${scope}" StatusLineMode default
+    set-face "${scope}" StatusLineInfo default
+    set-face "${scope}" StatusLineValue default
+    set-face "${scope}" StatusCursor default+r
+    set-face "${scope}" Prompt default
+    set-face "${scope}" MatchingChar default
+    set-face "${scope}" BufferPadding default
+
+EOF
+}

--- a/colors/red-phoenix.kak
+++ b/colors/red-phoenix.kak
@@ -3,6 +3,8 @@
 ##
 
 evaluate-commands %sh{
+    scope="${1:-global}"
+
     black="rgb:000000"
     blue="rgb:81a2be"
 
@@ -33,57 +35,57 @@ evaluate-commands %sh{
 
     ## code
     echo "
-        face global value ${orange2}
-        face global type ${gray2}
-        face global variable ${orange1}
-        face global module ${gray2}
-        face global function ${yellow1}
-        face global string ${tan2}
-        face global keyword ${light_orange1}
-        face global operator ${yellow1}
-        face global attribute ${tan1}
-        face global comment ${gray1}
-        face global meta ${gray2}
-        face global builtin ${tan1}
+        face ${scope} value ${orange2}
+        face ${scope} type ${gray2}
+        face ${scope} variable ${orange1}
+        face ${scope} module ${gray2}
+        face ${scope} function ${yellow1}
+        face ${scope} string ${tan2}
+        face ${scope} keyword ${light_orange1}
+        face ${scope} operator ${yellow1}
+        face ${scope} attribute ${tan1}
+        face ${scope} comment ${gray1}
+        face ${scope} meta ${gray2}
+        face ${scope} builtin ${tan1}
     "
 
     ## markup
     echo "
-        face global title blue
-        face global header ${orange1}
-        face global bold ${orange2}
-        face global italic ${orange3}
-        face global mono ${yellow1}
-        face global block ${tan1}
-        face global link blue
-        face global bullet ${gray1}
-        face global list ${gray1}
+        face ${scope} title blue
+        face ${scope} header ${orange1}
+        face ${scope} bold ${orange2}
+        face ${scope} italic ${orange3}
+        face ${scope} mono ${yellow1}
+        face ${scope} block ${tan1}
+        face ${scope} link blue
+        face ${scope} bullet ${gray1}
+        face ${scope} list ${gray1}
     "
 
     ## builtin
     echo "
-        face global Default ${text},${background}
-        face global PrimarySelection default,${selection}+fg
-        face global SecondarySelection default,${selection}+fg
-        face global PrimaryCursor black,${tan1}+fg
-        face global SecondaryCursor black,${tan2}+fg
-        face global PrimaryCursorEol black,${orange1}+fg
-        face global SecondaryCursorEol black,${orange2}+fg
-        face global LineNumbers ${text_light},${background}
-        face global LineNumberCursor ${text},${gray1}+b
-        face global MenuForeground ${text_light},blue
-        face global MenuBackground ${orange1},${window}
-        face global MenuInfo ${gray1}
-        face global Information white,${window}
-        face global Error white,${gray1}
-        face global StatusLine ${text},${window}
-        face global StatusLineMode ${yellow1}+b
-        face global StatusLineInfo ${orange2}
-        face global StatusLineValue ${orange2}
-        face global StatusCursor ${window},${orange2}
-        face global Prompt ${background},${orange2}
-        face global MatchingChar ${orange3},${background}+b
-        face global BufferPadding ${orange2},${background}
-        face global Whitespace default+f
+        face ${scope} Default ${text},${background}
+        face ${scope} PrimarySelection default,${selection}+fg
+        face ${scope} SecondarySelection default,${selection}+fg
+        face ${scope} PrimaryCursor black,${tan1}+fg
+        face ${scope} SecondaryCursor black,${tan2}+fg
+        face ${scope} PrimaryCursorEol black,${orange1}+fg
+        face ${scope} SecondaryCursorEol black,${orange2}+fg
+        face ${scope} LineNumbers ${text_light},${background}
+        face ${scope} LineNumberCursor ${text},${gray1}+b
+        face ${scope} MenuForeground ${text_light},blue
+        face ${scope} MenuBackground ${orange1},${window}
+        face ${scope} MenuInfo ${gray1}
+        face ${scope} Information white,${window}
+        face ${scope} Error white,${gray1}
+        face ${scope} StatusLine ${text},${window}
+        face ${scope} StatusLineMode ${yellow1}+b
+        face ${scope} StatusLineInfo ${orange2}
+        face ${scope} StatusLineValue ${orange2}
+        face ${scope} StatusCursor ${window},${orange2}
+        face ${scope} Prompt ${background},${orange2}
+        face ${scope} MatchingChar ${orange3},${background}+b
+        face ${scope} BufferPadding ${orange2},${background}
+        face ${scope} Whitespace default+f
     "
 }

--- a/colors/reeder.kak
+++ b/colors/reeder.kak
@@ -4,6 +4,8 @@
 ##
 
 evaluate-commands %sh{
+    scope="${1:-global}"
+
     white="rgb:f9f8f6"
     white_light="rgb:f6f5f0"
     black="rgb:383838"
@@ -22,53 +24,53 @@ evaluate-commands %sh{
     # Base color definitions
     echo "
         # then we map them to code
-        face global value      ${orange_light}+b
-        face global type       ${orange}
-        face global variable   default
-        face global module     ${green}
-        face global function   default
-        face global string     ${green}
-        face global keyword    ${brown_dark}
-        face global operator   default
-        face global attribute  ${green}
-        face global comment    ${brown_light}
-        face global meta       ${brown_dark}
-        face global builtin   default+b
+        face ${scope} value      ${orange_light}+b
+        face ${scope} type       ${orange}
+        face ${scope} variable   default
+        face ${scope} module     ${green}
+        face ${scope} function   default
+        face ${scope} string     ${green}
+        face ${scope} keyword    ${brown_dark}
+        face ${scope} operator   default
+        face ${scope} attribute  ${green}
+        face ${scope} comment    ${brown_light}
+        face ${scope} meta       ${brown_dark}
+        face ${scope} builtin   default+b
 
         # and markup
-        face global title      ${orange}+b
-        face global header     ${orange}+b
-        face global bold       default+b
-        face global italic     default+i
-        face global mono       ${green_light}
-        face global block      ${green}
-        face global link       ${orange}
-        face global bullet     ${brown_dark}
-        face global list       ${black}
+        face ${scope} title      ${orange}+b
+        face ${scope} header     ${orange}+b
+        face ${scope} bold       default+b
+        face ${scope} italic     default+i
+        face ${scope} mono       ${green_light}
+        face ${scope} block      ${green}
+        face ${scope} link       ${orange}
+        face ${scope} bullet     ${brown_dark}
+        face ${scope} list       ${black}
 
         # and built in faces
-        face global Default            ${black_light},${white}
-        face global PrimarySelection   ${black},${brown_lighter}+fg
-        face global SecondarySelection ${black_light},${grey_light}+fg
-        face global PrimaryCursor      ${black},${grey_dark}+fg
-        face global SecondaryCursor    ${black},${grey_dark}+fg
-        face global PrimaryCursorEol   ${black},${brown_dark}+fg
-        face global SecondaryCursorEol ${black},${brown_dark}+fg
-        face global LineNumbers        ${grey_dark},${white}
-        face global LineNumberCursor   ${grey_dark},${brown_lighter}
-        face global MenuForeground     ${orange},${brown_lighter}
-        face global MenuBackground     ${black_light},${brown_lighter}
-        face global MenuInfo           default,${black}
-        face global Information        ${black_light},${brown_lighter}
-        face global Error              default,${red}
-        face global StatusLine         ${black},${grey_light}
-        face global StatusLineMode     ${orange}
-        face global StatusLineInfo     ${black}+b
-        face global StatusLineValue    ${green_light}
-        face global StatusCursor       ${orange},${white_light}
-        face global Prompt             ${black_light}
-        face global MatchingChar       default+b
-        face global BufferPadding      ${grey_dark},${white}
-        face global Whitespace         ${grey_dark}+f
+        face ${scope} Default            ${black_light},${white}
+        face ${scope} PrimarySelection   ${black},${brown_lighter}+fg
+        face ${scope} SecondarySelection ${black_light},${grey_light}+fg
+        face ${scope} PrimaryCursor      ${black},${grey_dark}+fg
+        face ${scope} SecondaryCursor    ${black},${grey_dark}+fg
+        face ${scope} PrimaryCursorEol   ${black},${brown_dark}+fg
+        face ${scope} SecondaryCursorEol ${black},${brown_dark}+fg
+        face ${scope} LineNumbers        ${grey_dark},${white}
+        face ${scope} LineNumberCursor   ${grey_dark},${brown_lighter}
+        face ${scope} MenuForeground     ${orange},${brown_lighter}
+        face ${scope} MenuBackground     ${black_light},${brown_lighter}
+        face ${scope} MenuInfo           default,${black}
+        face ${scope} Information        ${black_light},${brown_lighter}
+        face ${scope} Error              default,${red}
+        face ${scope} StatusLine         ${black},${grey_light}
+        face ${scope} StatusLineMode     ${orange}
+        face ${scope} StatusLineInfo     ${black}+b
+        face ${scope} StatusLineValue    ${green_light}
+        face ${scope} StatusCursor       ${orange},${white_light}
+        face ${scope} Prompt             ${black_light}
+        face ${scope} MatchingChar       default+b
+        face ${scope} BufferPadding      ${grey_dark},${white}
+        face ${scope} Whitespace         ${grey_dark}+f
     "
 }

--- a/colors/solarized-dark-termcolors.kak
+++ b/colors/solarized-dark-termcolors.kak
@@ -1,53 +1,61 @@
 # Solarized Dark (with termcolors)
 # Useful if you've set up your terminal with the exact Solarized colors
 
-# code
-face global value              cyan
-face global type               yellow
-face global variable           blue
-face global module             cyan
-face global function           blue
-face global string             cyan
-face global keyword            green
-face global operator           green
-face global attribute          bright-magenta
-face global comment            bright-green
-face global meta               bright-red
-face global builtin            default+b
+evaluate-commands %sh{
+    scope="${1:-global}"
 
-# markup
-face global title              blue+b
-face global header             blue
-face global bold               bright-blue+b
-face global italic             bright-blue+i
-face global mono               bright-cyan
-face global block              cyan
-face global link               bright-cyan
-face global bullet             yellow
-face global list               green
+    cat <<- EOF
 
-# builtin
-face global Default            bright-blue,bright-black
-face global PrimarySelection   bright-black,blue+fg
-face global SecondarySelection bright-green,bright-cyan+fg
-face global PrimaryCursor      bright-black,bright-blue+fg
-face global SecondaryCursor    bright-black,bright-green+fg
-face global PrimaryCursorEol   bright-black,white+fg
-face global SecondaryCursorEol bright-black,bright-white+fg
-face global LineNumbers        bright-green,black
-face global LineNumberCursor   bright-cyan,black
-face global LineNumbersWrapped black,black
-face global MenuForeground     bright-black,yellow
-face global MenuBackground     bright-cyan,black
-face global MenuInfo           bright-green
-face global Information        black,bright-cyan
-face global Error              red,default+b
-face global StatusLine         bright-cyan,black+b
-face global StatusLineMode     bright-red
-face global StatusLineInfo     cyan
-face global StatusLineValue    green
-face global StatusCursor       bright-yellow,bright-white
-face global Prompt             yellow+b
-face global MatchingChar       red,bright-green+b
-face global BufferPadding      bright-green,bright-black
-face global Whitespace         blue+f
+    # code
+    set-face "${scope}" value              cyan
+    set-face "${scope}" type               yellow
+    set-face "${scope}" variable           blue
+    set-face "${scope}" module             cyan
+    set-face "${scope}" function           blue
+    set-face "${scope}" string             cyan
+    set-face "${scope}" keyword            green
+    set-face "${scope}" operator           green
+    set-face "${scope}" attribute          bright-magenta
+    set-face "${scope}" comment            bright-green
+    set-face "${scope}" meta               bright-red
+    set-face "${scope}" builtin            default+b
+
+    # markup
+    set-face "${scope}" title              blue+b
+    set-face "${scope}" header             blue
+    set-face "${scope}" bold               bright-blue+b
+    set-face "${scope}" italic             bright-blue+i
+    set-face "${scope}" mono               bright-cyan
+    set-face "${scope}" block              cyan
+    set-face "${scope}" link               bright-cyan
+    set-face "${scope}" bullet             yellow
+    set-face "${scope}" list               green
+
+    # builtin
+    set-face "${scope}" Default            bright-blue,bright-black
+    set-face "${scope}" PrimarySelection   bright-black,blue+fg
+    set-face "${scope}" SecondarySelection bright-green,bright-cyan+fg
+    set-face "${scope}" PrimaryCursor      bright-black,bright-blue+fg
+    set-face "${scope}" SecondaryCursor    bright-black,bright-green+fg
+    set-face "${scope}" PrimaryCursorEol   bright-black,white+fg
+    set-face "${scope}" SecondaryCursorEol bright-black,bright-white+fg
+    set-face "${scope}" LineNumbers        bright-green,black
+    set-face "${scope}" LineNumberCursor   bright-cyan,black
+    set-face "${scope}" LineNumbersWrapped black,black
+    set-face "${scope}" MenuForeground     bright-black,yellow
+    set-face "${scope}" MenuBackground     bright-cyan,black
+    set-face "${scope}" MenuInfo           bright-green
+    set-face "${scope}" Information        black,bright-cyan
+    set-face "${scope}" Error              red,default+b
+    set-face "${scope}" StatusLine         bright-cyan,black+b
+    set-face "${scope}" StatusLineMode     bright-red
+    set-face "${scope}" StatusLineInfo     cyan
+    set-face "${scope}" StatusLineValue    green
+    set-face "${scope}" StatusCursor       bright-yellow,bright-white
+    set-face "${scope}" Prompt             yellow+b
+    set-face "${scope}" MatchingChar       red,bright-green+b
+    set-face "${scope}" BufferPadding      bright-green,bright-black
+    set-face "${scope}" Whitespace         blue+f
+
+EOF
+}

--- a/colors/solarized-dark.kak
+++ b/colors/solarized-dark.kak
@@ -1,6 +1,8 @@
 # Solarized Dark
 
 evaluate-commands %sh{
+	scope="${1:-global}"
+
 	base03='rgb:002b36'
 	base02='rgb:073642'
 	base01='rgb:586e75'
@@ -20,54 +22,54 @@ evaluate-commands %sh{
 
    echo "
         # code
-        face global value              ${cyan}
-        face global type               ${red}
-        face global variable           ${blue}
-        face global module             ${cyan}
-        face global function           ${blue}
-        face global string             ${cyan}
-        face global keyword            ${green}
-        face global operator           ${yellow}
-        face global attribute          ${violet}
-        face global comment            ${base01}
-        face global meta               ${orange}
-        face global builtin            default+b
+        face ${scope} value              ${cyan}
+        face ${scope} type               ${red}
+        face ${scope} variable           ${blue}
+        face ${scope} module             ${cyan}
+        face ${scope} function           ${blue}
+        face ${scope} string             ${cyan}
+        face ${scope} keyword            ${green}
+        face ${scope} operator           ${yellow}
+        face ${scope} attribute          ${violet}
+        face ${scope} comment            ${base01}
+        face ${scope} meta               ${orange}
+        face ${scope} builtin            default+b
 
         # markup
-        face global title              ${blue}+b
-        face global header             ${blue}
-        face global bold               ${base0}+b
-        face global italic             ${base0}+i
-        face global mono               ${base1}
-        face global block              ${cyan}
-        face global link               ${base1}
-        face global bullet             ${yellow}
-        face global list               ${green}
+        face ${scope} title              ${blue}+b
+        face ${scope} header             ${blue}
+        face ${scope} bold               ${base0}+b
+        face ${scope} italic             ${base0}+i
+        face ${scope} mono               ${base1}
+        face ${scope} block              ${cyan}
+        face ${scope} link               ${base1}
+        face ${scope} bullet             ${yellow}
+        face ${scope} list               ${green}
 
         # builtin
-        face global Default            ${base0},${base03}
-        face global PrimarySelection   ${base03},${blue}+fg
-        face global SecondarySelection ${base01},${base1}+fg
-        face global PrimaryCursor      ${base03},${base0}+fg
-        face global SecondaryCursor    ${base03},${base01}+fg
-        face global PrimaryCursorEol   ${base03},${base2}+fg
-        face global SecondaryCursorEol ${base03},${base3}+fg
-        face global LineNumbers        ${base01},${base02}
-        face global LineNumberCursor   ${base1},${base02}
-        face global LineNumbersWrapped ${base02},${base02}
-        face global MenuForeground     ${base03},${yellow}
-        face global MenuBackground     ${base1},${base02}
-        face global MenuInfo           ${base01}
-        face global Information        ${base02},${base1}
-        face global Error              ${red},default+b
-        face global StatusLine         ${base1},${base02}+b
-        face global StatusLineMode     ${orange}
-        face global StatusLineInfo     ${cyan}
-        face global StatusLineValue    ${green}
-        face global StatusCursor       ${base00},${base3}
-        face global Prompt             ${yellow}+b
-        face global MatchingChar       ${red},${base01}+b
-        face global BufferPadding      ${base01},${base03}
-        face global Whitespace         ${base01}+f
+        face ${scope} Default            ${base0},${base03}
+        face ${scope} PrimarySelection   ${base03},${blue}+fg
+        face ${scope} SecondarySelection ${base01},${base1}+fg
+        face ${scope} PrimaryCursor      ${base03},${base0}+fg
+        face ${scope} SecondaryCursor    ${base03},${base01}+fg
+        face ${scope} PrimaryCursorEol   ${base03},${base2}+fg
+        face ${scope} SecondaryCursorEol ${base03},${base3}+fg
+        face ${scope} LineNumbers        ${base01},${base02}
+        face ${scope} LineNumberCursor   ${base1},${base02}
+        face ${scope} LineNumbersWrapped ${base02},${base02}
+        face ${scope} MenuForeground     ${base03},${yellow}
+        face ${scope} MenuBackground     ${base1},${base02}
+        face ${scope} MenuInfo           ${base01}
+        face ${scope} Information        ${base02},${base1}
+        face ${scope} Error              ${red},default+b
+        face ${scope} StatusLine         ${base1},${base02}+b
+        face ${scope} StatusLineMode     ${orange}
+        face ${scope} StatusLineInfo     ${cyan}
+        face ${scope} StatusLineValue    ${green}
+        face ${scope} StatusCursor       ${base00},${base3}
+        face ${scope} Prompt             ${yellow}+b
+        face ${scope} MatchingChar       ${red},${base01}+b
+        face ${scope} BufferPadding      ${base01},${base03}
+        face ${scope} Whitespace         ${base01}+f
     "
 }

--- a/colors/solarized-light-termcolors.kak
+++ b/colors/solarized-light-termcolors.kak
@@ -1,53 +1,61 @@
 # Solarized Light (with termcolors)
 # Useful if you've set up your terminal with the exact Solarized colors
 
-# code
-face global value              cyan
-face global type               red
-face global variable           blue
-face global module             cyan
-face global function           blue
-face global string             cyan
-face global keyword            green
-face global operator           yellow
-face global attribute          bright-magenta
-face global comment            bright-cyan
-face global meta               bright-red
-face global builtin            default+b
+evaluate-commands %sh{
+    scope="${1:-global}"
 
-# markup
-face global title              blue+b
-face global header             blue
-face global bold               bright-green+b
-face global italic             bright-green+i
-face global mono               bright-cyan
-face global block              cyan
-face global link               bright-green
-face global bullet             yellow
-face global list               green
+    cat <<- EOF
 
-# builtin
-face global Default            bright-yellow,bright-white
-face global PrimarySelection   bright-white,blue+fg
-face global SecondarySelection bright-cyan,bright-green+fg
-face global PrimaryCursor      bright-white,bright-yellow+fg
-face global SecondaryCursor    bright-white,bright-cyan+fg
-face global PrimaryCursorEol   bright-white,yellow+fg
-face global SecondaryCursorEol bright-white,bright-red+fg
-face global LineNumbers        bright-cyan,white
-face global LineNumberCursor   bright-green,white
-face global LineNumbersWrapped white,white
-face global MenuForeground     bright-white,yellow
-face global MenuBackground     bright-green,white
-face global MenuInfo           bright-cyan
-face global Information        white,bright-cyan
-face global Error              red,default+b
-face global StatusLine         bright-green,white+b
-face global StatusLineMode     bright-red
-face global StatusLineInfo     cyan
-face global StatusLineValue    green
-face global StatusCursor       bright-blue,bright-black
-face global Prompt             yellow+b
-face global MatchingChar       red,white+b
-face global BufferPadding      bright-cyan,bright-white
-face global Whitespace         yellow+f
+    # code
+    set-face "${scope}" value              cyan
+    set-face "${scope}" type               red
+    set-face "${scope}" variable           blue
+    set-face "${scope}" module             cyan
+    set-face "${scope}" function           blue
+    set-face "${scope}" string             cyan
+    set-face "${scope}" keyword            green
+    set-face "${scope}" operator           yellow
+    set-face "${scope}" attribute          bright-magenta
+    set-face "${scope}" comment            bright-cyan
+    set-face "${scope}" meta               bright-red
+    set-face "${scope}" builtin            default+b
+
+    # markup
+    set-face "${scope}" title              blue+b
+    set-face "${scope}" header             blue
+    set-face "${scope}" bold               bright-green+b
+    set-face "${scope}" italic             bright-green+i
+    set-face "${scope}" mono               bright-cyan
+    set-face "${scope}" block              cyan
+    set-face "${scope}" link               bright-green
+    set-face "${scope}" bullet             yellow
+    set-face "${scope}" list               green
+
+    # builtin
+"${scope}" "${scope}" Default            bright-yellow,bright-white
+    set-face "${scope}" PrimarySelection   bright-white,blue+fg
+    set-face "${scope}" SecondarySelection bright-cyan,bright-green+fg
+    set-face "${scope}" PrimaryCursor      bright-white,bright-yellow+fg
+    set-face "${scope}" SecondaryCursor    bright-white,bright-cyan+fg
+    set-face "${scope}" PrimaryCursorEol   bright-white,yellow+fg
+    set-face "${scope}" SecondaryCursorEol bright-white,bright-red+fg
+    set-face "${scope}" LineNumbers        bright-cyan,white
+    set-face "${scope}" LineNumberCursor   bright-green,white
+    set-face "${scope}" LineNumbersWrapped white,white
+    set-face "${scope}" MenuForeground     bright-white,yellow
+    set-face "${scope}" MenuBackground     bright-green,white
+    set-face "${scope}" MenuInfo           bright-cyan
+    set-face "${scope}" Information        white,bright-cyan
+    set-face "${scope}" Error              red,default+b
+    set-face "${scope}" StatusLine         bright-green,white+b
+    set-face "${scope}" StatusLineMode     bright-red
+    set-face "${scope}" StatusLineInfo     cyan
+    set-face "${scope}" StatusLineValue    green
+    set-face "${scope}" StatusCursor       bright-blue,bright-black
+    set-face "${scope}" Prompt             yellow+b
+    set-face "${scope}" MatchingChar       red,white+b
+    set-face "${scope}" BufferPadding      bright-cyan,bright-white
+    set-face "${scope}" Whitespace         yellow+f
+
+EOF
+}

--- a/colors/solarized-light.kak
+++ b/colors/solarized-light.kak
@@ -1,6 +1,8 @@
 # Solarized Light
 
 evaluate-commands %sh{
+	scope="${1:-global}"
+
 	base03='rgb:002b36'
 	base02='rgb:073642'
 	base01='rgb:586e75'
@@ -20,54 +22,54 @@ evaluate-commands %sh{
 
     echo "
         # code
-        face global value              ${cyan}
-        face global type               ${red}
-        face global variable           ${blue}
-        face global module             ${cyan}
-        face global function           ${blue}
-        face global string             ${cyan}
-        face global keyword            ${green}
-        face global operator           ${yellow}
-        face global attribute          ${violet}
-        face global comment            ${base1}
-        face global meta               ${orange}
-        face global builtin            default+b
+        face ${scope} value              ${cyan}
+        face ${scope} type               ${red}
+        face ${scope} variable           ${blue}
+        face ${scope} module             ${cyan}
+        face ${scope} function           ${blue}
+        face ${scope} string             ${cyan}
+        face ${scope} keyword            ${green}
+        face ${scope} operator           ${yellow}
+        face ${scope} attribute          ${violet}
+        face ${scope} comment            ${base1}
+        face ${scope} meta               ${orange}
+        face ${scope} builtin            default+b
 
         # markup
-        face global title              ${blue}+b
-        face global header             ${blue}
-        face global bold               ${base01}+b
-        face global italic             ${base01}+i
-        face global mono               ${base1}
-        face global block              ${cyan}
-        face global link               ${base01}
-        face global bullet             ${yellow}
-        face global list               ${green}
+        face ${scope} title              ${blue}+b
+        face ${scope} header             ${blue}
+        face ${scope} bold               ${base01}+b
+        face ${scope} italic             ${base01}+i
+        face ${scope} mono               ${base1}
+        face ${scope} block              ${cyan}
+        face ${scope} link               ${base01}
+        face ${scope} bullet             ${yellow}
+        face ${scope} list               ${green}
 
         # builtin
-        face global Default            ${base00},${base3}
-        face global PrimarySelection   ${base3},${blue}+fg
-        face global SecondarySelection ${base1},${base01}+fg
-        face global PrimaryCursor      ${base3},${base00}+fg
-        face global SecondaryCursor    ${base3},${base1}+fg
-        face global PrimaryCursorEol   ${base3},${yellow}+fg
-        face global SecondaryCursorEol ${base3},${orange}+fg
-        face global LineNumbers        ${base1},${base2}
-        face global LineNumberCursor   ${base01},${base2}
-        face global LineNumbersWrapped ${base2},${base2}
-        face global MenuForeground     ${base3},${yellow}
-        face global MenuBackground     ${base01},${base2}
-        face global MenuInfo           ${base1}
-        face global Information        ${base2},${base1}
-        face global Error              ${red},default+b
-        face global StatusLine         ${base01},${base2}+b
-        face global StatusLineMode     ${orange}
-        face global StatusLineInfo     ${cyan}
-        face global StatusLineValue    ${green}
-        face global StatusCursor       ${base0},${base03}
-        face global Prompt             ${yellow}+b
-        face global MatchingChar       ${red},${base2}+b
-        face global BufferPadding      ${base1},${base3}
-        face global Whitespace         ${base1}+f
+        face ${scope} Default            ${base00},${base3}
+        face ${scope} PrimarySelection   ${base3},${blue}+fg
+        face ${scope} SecondarySelection ${base1},${base01}+fg
+        face ${scope} PrimaryCursor      ${base3},${base00}+fg
+        face ${scope} SecondaryCursor    ${base3},${base1}+fg
+        face ${scope} PrimaryCursorEol   ${base3},${yellow}+fg
+        face ${scope} SecondaryCursorEol ${base3},${orange}+fg
+        face ${scope} LineNumbers        ${base1},${base2}
+        face ${scope} LineNumberCursor   ${base01},${base2}
+        face ${scope} LineNumbersWrapped ${base2},${base2}
+        face ${scope} MenuForeground     ${base3},${yellow}
+        face ${scope} MenuBackground     ${base01},${base2}
+        face ${scope} MenuInfo           ${base1}
+        face ${scope} Information        ${base2},${base1}
+        face ${scope} Error              ${red},default+b
+        face ${scope} StatusLine         ${base01},${base2}+b
+        face ${scope} StatusLineMode     ${orange}
+        face ${scope} StatusLineInfo     ${cyan}
+        face ${scope} StatusLineValue    ${green}
+        face ${scope} StatusCursor       ${base0},${base03}
+        face ${scope} Prompt             ${yellow}+b
+        face ${scope} MatchingChar       ${red},${base2}+b
+        face ${scope} BufferPadding      ${base1},${base3}
+        face ${scope} Whitespace         ${base1}+f
     "
 }

--- a/colors/tomorrow-night.kak
+++ b/colors/tomorrow-night.kak
@@ -3,6 +3,8 @@
 ##
 
 evaluate-commands %sh{
+    scope="${1:-global}"
+
     foreground="rgb:c5c8c6"
     background="rgb:272727"
     selection="rgb:373b41"
@@ -23,57 +25,57 @@ evaluate-commands %sh{
 
     ## code
     echo "
-        face global value ${orange}
-        face global type ${yellow}
-        face global variable ${magenta}
-        face global module ${green}
-        face global function ${aqua}
-        face global string ${green_dark}
-        face global keyword ${purple}
-        face global operator ${aqua}
-        face global attribute ${purple}
-        face global comment ${comment}
-        face global meta ${purple}
-        face global builtin ${orange}
+        face $scope value ${orange}
+        face $scope type ${yellow}
+        face $scope variable ${magenta}
+        face $scope module ${green}
+        face $scope function ${aqua}
+        face $scope string ${green_dark}
+        face $scope keyword ${purple}
+        face $scope operator ${aqua}
+        face $scope attribute ${purple}
+        face $scope comment ${comment}
+        face $scope meta ${purple}
+        face $scope builtin ${orange}
     "
 
     ## markup
     echo "
-        face global title blue
-        face global header ${aqua}
-        face global bold ${yellow}
-        face global italic ${orange}
-        face global mono ${green_dark}
-        face global block ${orange}
-        face global link blue
-        face global bullet ${red}
-        face global list ${red}
+        face $scope title blue
+        face $scope header ${aqua}
+        face $scope bold ${yellow}
+        face $scope italic ${orange}
+        face $scope mono ${green_dark}
+        face $scope block ${orange}
+        face $scope link blue
+        face $scope bullet ${red}
+        face $scope list ${red}
     "
 
     ## builtin
     echo "
-        face global Default ${text},${background}
-        face global PrimarySelection default,${selection}+fg
-        face global SecondarySelection default,${selection}+fg
-        face global PrimaryCursor black,${aqua}+fg
-        face global SecondaryCursor black,${aqua}+fg
-        face global PrimaryCursorEol black,${green_dark}+fg
-        face global SecondaryCursorEol black,${green_dark}+fg
-        face global LineNumbers ${text_light},${background}
-        face global LineNumberCursor ${yellow},rgb:282828+b
-        face global MenuForeground ${text_light},blue
-        face global MenuBackground ${aqua},${window}
-        face global MenuInfo ${aqua}
-        face global Information white,${window}
-        face global Error white,${red}
-        face global StatusLine ${text},${window}
-        face global StatusLineMode ${yellow}+b
-        face global StatusLineInfo ${aqua}
-        face global StatusLineValue ${green_dark}
-        face global StatusCursor ${window},${aqua}
-        face global Prompt ${background},${aqua}
-        face global MatchingChar ${yellow},${background}+b
-        face global BufferPadding ${aqua},${background}
-        face global Whitespace ${text_light}+f
+        face $scope Default ${text},${background}
+        face $scope PrimarySelection default,${selection}+fg
+        face $scope SecondarySelection default,${selection}+fg
+        face $scope PrimaryCursor black,${aqua}+fg
+        face $scope SecondaryCursor black,${aqua}+fg
+        face $scope PrimaryCursorEol black,${green_dark}+fg
+        face $scope SecondaryCursorEol black,${green_dark}+fg
+        face $scope LineNumbers ${text_light},${background}
+        face $scope LineNumberCursor ${yellow},rgb:282828+b
+        face $scope MenuForeground ${text_light},blue
+        face $scope MenuBackground ${aqua},${window}
+        face $scope MenuInfo ${aqua}
+        face $scope Information white,${window}
+        face $scope Error white,${red}
+        face $scope StatusLine ${text},${window}
+        face $scope StatusLineMode ${yellow}+b
+        face $scope StatusLineInfo ${aqua}
+        face $scope StatusLineValue ${green_dark}
+        face $scope StatusCursor ${window},${aqua}
+        face $scope Prompt ${background},${aqua}
+        face $scope MatchingChar ${yellow},${background}+b
+        face $scope BufferPadding ${aqua},${background}
+        face $scope Whitespace ${text_light}+f
     "
 }

--- a/colors/zenburn.kak
+++ b/colors/zenburn.kak
@@ -1,6 +1,8 @@
 # zenburn theme
 
 evaluate-commands %sh{
+    scope="${1:-global}"
+
     # define some named colors
     zentext="rgb:cfcfcf"
     zenselectionbg="rgb:3f7fcc"
@@ -31,53 +33,53 @@ evaluate-commands %sh{
 
     echo "
         # then we map them to code
-        face global value ${zenconstant}
-        face global type ${zentype}
-        face global variable ${zenvariable}
-        face global module ${zenstring}
-        face global function ${zenfunction}
-        face global string ${zenstring}
-        face global keyword ${zenkeyword}
-        face global operator ${zenfunction}
-        face global attribute ${zenstatement}
-        face global comment ${zencomment}
-        face global meta ${zenspecial}
-        face global builtin default+b
+        face ${scope} value ${zenconstant}
+        face ${scope} type ${zentype}
+        face ${scope} variable ${zenvariable}
+        face ${scope} module ${zenstring}
+        face ${scope} function ${zenfunction}
+        face ${scope} string ${zenstring}
+        face ${scope} keyword ${zenkeyword}
+        face ${scope} operator ${zenfunction}
+        face ${scope} attribute ${zenstatement}
+        face ${scope} comment ${zencomment}
+        face ${scope} meta ${zenspecial}
+        face ${scope} builtin default+b
 
         # and markup
-        face global title ${zenkeyword}
-        face global header ${zenconstant}
-        face global bold ${zenstorageClass}
-        face global italic ${zenfunction}
-        face global mono ${zennumber}
-        face global block ${zenstatement}
-        face global link ${zenstring}
-        face global bullet ${zenvariable}
-        face global list ${zentype}
+        face ${scope} title ${zenkeyword}
+        face ${scope} header ${zenconstant}
+        face ${scope} bold ${zenstorageClass}
+        face ${scope} italic ${zenfunction}
+        face ${scope} mono ${zennumber}
+        face ${scope} block ${zenstatement}
+        face ${scope} link ${zenstring}
+        face ${scope} bullet ${zenvariable}
+        face ${scope} list ${zentype}
 
         # and built in faces
-        face global Default ${zendefault}
-        face global PrimarySelection ${zentext},${zenselectionbg}+fg
-        face global SecondarySelection ${zensecondaryfg},${zenselectionbg}+fg
-        face global PrimaryCursor ${zencursor}+fg
-        face global SecondaryCursor ${zencursor}+fg
-        face global PrimaryCursorEol ${zencursoreol}+fg
-        face global SecondaryCursorEol ${zencursoreol}+fg
-        face global LineNumbers ${zendefault}
-        face global LineNumberCursor ${zenstatus}
-        face global MenuForeground ${zenmenufg}
-        face global MenuBackground ${zenmenubg}
-        face global MenuInfo rgb:cc9393
-        face global Information ${zeninfo}
-        face global Error default,red
-        face global StatusLine ${zenstatus}
-        face global StatusLineMode ${zencomment}
-        face global StatusLineInfo ${zenspecial}
-        face global StatusLineValue ${zennumber}
-        face global StatusCursor ${zenstatuscursor}
-        face global Prompt ${zenconstant}
-        face global MatchingChar default+b
-        face global BufferPadding ${zenpadding}
-        face global Whitespace ${zensecondaryfg}+f
+        face ${scope} Default ${zendefault}
+        face ${scope} PrimarySelection ${zentext},${zenselectionbg}+fg
+        face ${scope} SecondarySelection ${zensecondaryfg},${zenselectionbg}+fg
+        face ${scope} PrimaryCursor ${zencursor}+fg
+        face ${scope} SecondaryCursor ${zencursor}+fg
+        face ${scope} PrimaryCursorEol ${zencursoreol}+fg
+        face ${scope} SecondaryCursorEol ${zencursoreol}+fg
+        face ${scope} LineNumbers ${zendefault}
+        face ${scope} LineNumberCursor ${zenstatus}
+        face ${scope} MenuForeground ${zenmenufg}
+        face ${scope} MenuBackground ${zenmenubg}
+        face ${scope} MenuInfo rgb:cc9393
+        face ${scope} Information ${zeninfo}
+        face ${scope} Error default,red
+        face ${scope} StatusLine ${zenstatus}
+        face ${scope} StatusLineMode ${zencomment}
+        face ${scope} StatusLineInfo ${zenspecial}
+        face ${scope} StatusLineValue ${zennumber}
+        face ${scope} StatusCursor ${zenstatuscursor}
+        face ${scope} Prompt ${zenconstant}
+        face ${scope} MatchingChar default+b
+        face ${scope} BufferPadding ${zenpadding}
+        face ${scope} Whitespace ${zensecondaryfg}+f
     "
 }

--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -1,4 +1,4 @@
-def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
+def -params 1.. -docstring "colorscheme <name> [scope]: enable named colorscheme in the given scope" \
     -shell-script-candidates %{
     find -L "${kak_runtime}/colors" "${kak_config}/colors" -type f -name '*\.kak' \
         | while read -r filename; do
@@ -18,8 +18,14 @@ def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
         filename=$(find_colorscheme "${kak_runtime}/colors" "${1}")
     fi
 
+    case "${2}" in
+        "");;
+        global|buffer|window);;
+        *) echo "fail Invalid scope:" "${2}";;
+    esac
+
     if [ -n "${filename}" ]; then
-        printf 'source %%{%s}' "${filename}"
+        printf 'source %%{%s} %s' "${filename}" "${2:-global}"
     else
         echo "fail 'No such colorscheme'"
     fi


### PR DESCRIPTION
Hi,

Leveraging the additional arguments that can be passed to `:source` to allow colorschemes to be applied locally.

Example: changing the colorscheme to grey-scale when focusing out of a window https://files.catbox.moe/qifbff.mkv

Not sure it's worth merging just for the above usecase, hence the POC tag.