### PR TITLE
Add window position builtin env variables

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -283,6 +283,22 @@ static const EnvVarDesc builtin_env_vars[] = { {
         [](StringView name, const Context& context, Quoting quoting) -> String
         { return to_string(context.window().dimensions().line); }
     }, {
+        "window_left", false,
+        [](StringView name, const Context& context, Quoting quoting) -> String
+        { return to_string(context.window().position().column + 1); }
+    }, {
+        "window_top", false,
+        [](StringView name, const Context& context, Quoting quoting) -> String
+        { return to_string(context.window().position().line + 1); }
+    }, {
+        "window_right", false,
+        [](StringView name, const Context& context, Quoting quoting) -> String
+        { return to_string(context.window().position().column + context.window().dimensions().column); }
+    }, {
+        "window_bottom", false,
+        [](StringView name, const Context& context, Quoting quoting) -> String
+        { return to_string(context.window().position().line + context.window().dimensions().line); }
+    }, {
         "user_modes", false,
         [](StringView name, const Context& context, Quoting quoting) -> String
         { return join(context.keymaps().user_modes(), ' ', false); }


### PR DESCRIPTION
Related to #3128 

Export window_top, window_bottom, window_left, window_right builtin environment variables for scripting. Bottom and right ones can be excluded, but are nice to have. Also not sure if left and top should be incremented, but it seems to make more sense for scripting purposes.