### PR TITLE
rc clang: Handle nested tags in completion

### DIFF
--- a/rc/tools/clang.kak
+++ b/rc/tools/clang.kak
@@ -55,7 +55,7 @@ The syntaxic errors detected during parsing are shown when auto-diagnostics are 
                         awk -F ': ' '
                             /^COMPLETION:/ && $2 !~ /[(,](Hidden|Inaccessible)[),]/ {
                                  candidate=$3
-                                 gsub(/[[<{]#[^#]+#[]>}]/, "", candidate)
+                                 gsub(/[[<{]#.+?#[]>}]/, "", candidate)
                                  gsub(/~/, "~~", candidate)
                                  gsub(/\|/, "\\|", candidate)
 


### PR DESCRIPTION
Some completion candidates have e.g. `{#…#}` tags in their
name/description. They can be nested, which the cleanup regex doesn't
take into account.