### PR TITLE
src: Complete register names in `%reg{}` expansions

### DIFF
--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -675,6 +675,11 @@ Completions CommandManager::complete(const Context& context,
 
     switch (token.type)
     {
+    case Token::Type::RegisterExpand:
+        return {start , cursor_pos,
+                RegisterManager::instance().complete_register_name(
+                    token.content, cursor_pos_in_token) };
+
     case Token::Type::OptionExpand:
         return {start , cursor_pos,
                 GlobalScope::instance().option_registry().complete_option_name(

--- a/src/register_manager.cc
+++ b/src/register_manager.cc
@@ -7,23 +7,24 @@
 namespace Kakoune
 {
 
+static const HashMap<String, Codepoint> reg_names = {
+    { "slash", '/' },
+    { "dquote", '"' },
+    { "pipe", '|' },
+    { "caret", '^' },
+    { "arobase", '@' },
+    { "percent", '%' },
+    { "dot", '.' },
+    { "hash", '#' },
+    { "underscore", '_' },
+    { "colon", ':' }
+};
+
 Register& RegisterManager::operator[](StringView reg) const
 {
     if (reg.length() == 1)
         return (*this)[reg[0_byte]];
 
-    static const HashMap<String, Codepoint> reg_names = {
-        { "slash", '/' },
-        { "dquote", '"' },
-        { "pipe", '|' },
-        { "caret", '^' },
-        { "arobase", '@' },
-        { "percent", '%' },
-        { "dot", '.' },
-        { "hash", '#' },
-        { "underscore", '_' },
-        { "colon", ':' }
-    };
     auto it = reg_names.find(reg);
     if (it == reg_names.end())
         throw runtime_error(format("no such register: '{}'", reg));
@@ -45,6 +46,11 @@ void RegisterManager::add_register(Codepoint c, std::unique_ptr<Register> reg)
     auto& reg_ptr = m_registers[c];
     kak_assert(not reg_ptr);
     reg_ptr = std::move(reg);
+}
+
+CandidateList RegisterManager::complete_register_name(StringView prefix, ByteCount cursor_pos) const
+{
+    return complete(prefix, cursor_pos, reg_names | transform([](auto& i) { return i.key; }) | gather<Vector<String>>());
 }
 
 }

--- a/src/register_manager.hh
+++ b/src/register_manager.hh
@@ -2,6 +2,7 @@
 #define register_manager_hh_INCLUDED
 
 #include "array_view.hh"
+#include "completion.hh"
 #include "exception.hh"
 #include "utils.hh"
 #include "hash_map.hh"
@@ -146,6 +147,7 @@ public:
     Register& operator[](StringView reg) const;
     Register& operator[](Codepoint c) const;
     void add_register(Codepoint c, std::unique_ptr<Register> reg);
+    CandidateList complete_register_name(StringView prefix, ByteCount cursor_pos) const;
 
 protected:
     HashMap<Codepoint, std::unique_ptr<Register>, MemoryDomain::Registers> m_registers;


### PR DESCRIPTION
Builtin registers have name aliases that can be completed upon when
using a `%reg{}` expansion from the prompt.