### PR TITLE
src: Use `begin()` to get iterators

### DIFF
--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -282,7 +282,7 @@ void Buffer::reload(StringView data, timespec fs_timestamp)
                         parsed_lines.lines[(int)(d.posB + line)]});
 
                 m_changes.push_back({ Change::Insert, cur_line, cur_line + d.len });
-                m_lines.insert(it, &parsed_lines.lines[d.posB], &parsed_lines.lines[d.posB + d.len]);
+                m_lines.insert(it, parsed_lines.lines.begin() + d.posB, parsed_lines.lines.begin() + d.posB + d.len);
                 it = m_lines.begin() + (int)(cur_line + d.len);
             }
             else if (d.mode == Diff::Remove)

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -512,7 +512,7 @@ BufferCoord apply_diff(Buffer& buffer, BufferCoord pos, StringView before, Strin
                            lines_after.begin(), (int)lines_after.size());
 
     auto byte_count = [](auto&& lines, int first, int count) {
-        return std::accumulate(&lines[first], &lines[first+count], 0_byte,
+        return std::accumulate(lines.begin() + first, lines.begin() + first + count, 0_byte,
                                [](ByteCount l, StringView s) { return l + s.length(); });
     };
 


### PR DESCRIPTION
When compiling the code with `-Wp,-D_GLIBCXX_ASSERTIONS`, the process
gets aborted, likely because iterators to standard containers are
not obtained in a safe way.

Fixes #3226.