### PR TITLE
Update Fedora installation info

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -131,11 +131,16 @@ brew install kakoune
 [TIP]
 .Fedora supported versions and Rawhide
 ====
-Use the https://copr.fedoraproject.org/coprs/jkonecny/kakoune/[copr]
-repository.
-
 ---------------------------------
-dnf copr enable jkonecny/kakoune
+dnf install kakoune
+---------------------------------
+====
+
+[TIP]
+.RHEL/CentOS 8
+====
+Kakoune can be found in the https://src.fedoraproject.org/rpms/kakoune/tree/epel8[EPEL8 repositories].
+---------------------------------
 dnf install kakoune
 ---------------------------------
 ====


### PR DESCRIPTION
Kakoune packaged and available now in official Fedora repos and RHEL/CentOS 8. Now on QA:

- [Fedora 30](https://bodhi.fedoraproject.org/updates/FEDORA-2019-e0134fff7d)
- [Fedora 31](https://bodhi.fedoraproject.org/updates/FEDORA-2019-8836948189)
- [EPEL8](https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2019-30e0921175)

@jkonecny12 please message me for co-maintainership if you wish.