### PR TITLE
src: Fix the build on Mac

### DIFF
--- a/src/diff.hh
+++ b/src/diff.hh
@@ -7,6 +7,7 @@
 
 #include "array_view.hh"
 
+#include <algorithm>
 #include <functional>
 #include <iterator>
 #include <memory>


### PR DESCRIPTION
When compiled on Mac with `clang`, the following error occurs at
compile-time:

```
./diff.hh:56:28: error: no member named 'min' in namespace 'std'
    const int max_D = std::min((M + N + 1) / 2 + 1, cost_limit);
                      ~~~~~^
```