### PR TITLE
Fix build on FreeBSD again

### DIFF
--- a/src/json_ui.cc
+++ b/src/json_ui.cc
@@ -9,6 +9,7 @@
 #include "ranges.hh"
 #include "string_utils.hh"
 
+#include <cstdio>
 #include <utility>
 
 #include <unistd.h>


### PR DESCRIPTION
```
json_ui.cc:29:9: error: use of undeclared identifier 'sprintf'
        sprintf(buffer, R"("#%02x%02x%02x")", color.r, color.g, color.b);
        ^
1 error generated.
```

Regressed by 7cdbe1d3d24c1cc13bd7cbc3fe252f1e88747ffb