### PR TITLE
highlighters.cc: Add a '-min-width' flag to the number-lines highlighter

### DIFF
--- a/doc/pages/highlighters.asciidoc
+++ b/doc/pages/highlighters.asciidoc
@@ -62,6 +62,11 @@ from the remaining parameters.
         specify a string to separate the line numbers column with
         the rest of the buffer (default is '|')
 
+    *-min-digits* <num>:::
+        always reserve room for at least *num* digits,
+        so text doesn't jump around as lines are added or removed
+        (default is 2)
+
 *wrap* [options]::
     soft wrap buffer text at window width, with the following *options*:
 


### PR DESCRIPTION
Fixes #3260.