### PR TITLE
Expose environment variable `$kak_binary_path`

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -179,6 +179,10 @@ static const EnvVarDesc builtin_env_vars[] = { {
         [](StringView name, const Context& context, Quoting quoting)
         { return join(context.selections_content() | transform(quoter(quoting)), ' ', false); }
     }, {
+        "binary_path", false,
+        [](StringView name, const Context& context, Quoting quoting)
+        { return get_kak_binary_path(); }
+    }, {
         "runtime", false,
         [](StringView name, const Context& context, Quoting quoting)
         { return runtime_directory(); }


### PR DESCRIPTION
The usual pattern `kak -p $kak_session` potentially picks up a wrong
`kak` binary. The pattern `$kak_binary_path -p $kak_session` seems to be
superior.