### PR TITLE
Support rxvt style s-F3 to s-F12

### DIFF
--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -712,6 +712,14 @@ Optional<Key> NCursesUI::get_next_key()
                 return masked_key(Key::F6 + params[0] - 17);
             case 23: case 24:
                 return masked_key(Key::F11 + params[0] - 23);
+            case 25: case 26:
+                return Key{Key::Modifiers::Shift, Key::F3 + params[0] - 25}; // rxvt style
+            case 28: case 29:
+                return Key{Key::Modifiers::Shift, Key::F5 + params[0] - 28}; // rxvt style
+            case 31: case 32:
+                return Key{Key::Modifiers::Shift, Key::F7 + params[0] - 31}; // rxvt style
+            case 33: case 34:
+                return Key{Key::Modifiers::Shift, Key::F9 + params[0] - 33}; // rxvt style
             }
             return {};
         case 'u':

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -640,7 +640,7 @@ Optional<Key> NCursesUI::get_next_key()
             else
                 return {};
         }
-        if (c < 0x40 or c > 0x7e)
+        if (c != '$' and (c < 0x40 or c > 0x7e))
             return {};
 
         auto parse_mask = [](int mask) {
@@ -678,6 +678,13 @@ Optional<Key> NCursesUI::get_next_key()
 
         switch (c)
         {
+        case '$':
+            switch (params[0])
+            {
+            case 23: case 24:
+                return Key{Key::Modifiers::Shift, Key::F11 + params[0] - 23}; // rxvt style
+            }
+            return {};
         case 'A': return masked_key(Key::Up);
         case 'B': return masked_key(Key::Down);
         case 'C': return masked_key(Key::Right);


### PR DESCRIPTION
Rxvt emits `\E[23$` and `\E[24$` for `F21` and `F22` (alias `s-F11` and
`s-F12` ~~provided that `ncurses_shift_function_key` is set to `10`~~),
respectively.
_Addendum:_ Added support for `s-F3` to `s-F10` following @Screwtapello's suggestion.