### PR TITLE
Master backport fedora spec

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,8 @@
 debug ?= no
 static ?= no
 gzip_man ?= yes
+# to get format compatible with GitHub archive use "gzip -S .gz" here
+compress_bin ?= bzip2
 
 ifneq ($(gzip_man),yes)
     ifneq ($(gzip_man),no)
@@ -148,7 +150,7 @@ dist:
 	echo "$(version)" > src/.version;                                         \
 	tar --transform "s,^,$${basename}/," -rf $${basename}.tar src/.version;   \
 	rm src/.version;                                                          \
-	bzip2 $${basename}.tar;
+	$(compress_bin) $${basename}.tar;
 
 distclean: clean
 	rm -f kak kak$(suffix)


### PR DESCRIPTION
Kakoune is now officially packaged to Fedora. Update the spec file based on the downstream spec.

Spec file was modified by Artem Polishchuk (@tim77). Thanks a lot for your work!

This change will also add possibility to change default compression for make dist because `bz2` format is not supported by GitHub so to stay consistent. This is mainly necessary to be able to find tarball during the build.