### PR TITLE
better scheme highlighter for char,string,comment

### DIFF
--- a/rc/filetype/scheme.kak
+++ b/rc/filetype/scheme.kak
@@ -38,14 +38,15 @@ require-module lisp
 add-highlighter shared/scheme regions
 add-highlighter shared/scheme/code default-region group
 
-add-highlighter shared/scheme/string region '"' (?<!\\)(\\\\)*" fill string
-add-highlighter shared/scheme/comment region ';' '$' fill comment
+add-highlighter shared/scheme/string region %{(?<!#\\)"} (?<!\\)(\\\\)*" fill string
+add-highlighter shared/scheme/comment region %{(?<!#\\);} '$' fill comment
 add-highlighter shared/scheme/comment-form region -recurse "\(" "#;\(" "\)" fill comment
 add-highlighter shared/scheme/comment-block region "#\|" "\|#" fill comment
 add-highlighter shared/scheme/quoted-form region -recurse "\(" "'\(" "\)" fill variable
 
 add-highlighter shared/scheme/code/ regex (#t|#f) 0:value
 add-highlighter shared/scheme/code/ regex \b[0-9]+\.[0-9]*\b 0:value
+add-highlighter shared/scheme/code/ regex (#\\((\w+)|(.))) 0:value
 
 evaluate-commands %sh{ exec awk -f - <<'EOF'
     BEGIN {


### PR DESCRIPTION
This should address highlighting issues with regards to:

* mistaking char `#\;` for beginning of a comment. eg. `(foo #\; another-thing)`
* mistaking char `#\"` for beginning of a string. eg. `(foo #\" another-thing)`
* not highlighting chars

also @eraserhd since he might be interested