### PR TITLE
Add html module to hbs filetype to correctly highlight hbs files

### DIFF
--- a/rc/filetype/hbs.kak
+++ b/rc/filetype/hbs.kak
@@ -29,6 +29,8 @@ hook -group hbs-highlight global WinSetOption filetype=hbs %{
 
 provide-module hbs %[
 
+require-module html
+
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 


### PR DESCRIPTION
Previously the handlebars filetype threw an error since the hbs highlighter depends on the `html` module. This resolves part of https://github.com/mawww/kakoune/issues/3230 .