### PR TITLE
Fix version notes formatting

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -45,11 +45,11 @@ struct {
     StringView notes;
 } constexpr version_notes[] = { {
         20200116,
-        "» {+u}InsertCompletionHide{} parameter is now the list of inserted ranges"
+        "» {+u}InsertCompletionHide{} parameter is now the list of inserted ranges\n"
     }, {
         20191210,
-        "» {+u}ModeChange{} parameter has changed to contain push/pop "
-        "{+ui}Mode{+u}Begin{}/{+ui}Mode{+u}End{} hooks were removed\n"
+        "» {+u}ModeChange{} parameter has changed to contain push/pop\n"
+        "» {+u}ModeBegin{}/{+u}ModeEnd{} hooks were removed\n"
     }, {
         20190701,
         "» {+u}%file\\{<filename>}{} expansions to read files\n"

--- a/src/main.cc
+++ b/src/main.cc
@@ -49,7 +49,7 @@ struct {
     }, {
         20191210,
         "» {+u}ModeChange{} parameter has changed to contain push/pop\n"
-        "» {+u}ModeBegin{}/{+u}ModeEnd{} hooks were removed\n"
+        "» {+ui}Mode{+u}Begin{}/{+ui}Mode{+u}End{} hooks were removed\n"
     }, {
         20190701,
         "» {+u}%file\\{<filename>}{} expansions to read files\n"


### PR DESCRIPTION
Just a minor thing, I feel like some newlines were forgotten and formatting of the last news was a bit inconsistent... Let me know if I misunderstood and the current formatting is intended.

Before:

![image](https://user-images.githubusercontent.com/1177900/72525084-a3d84980-3863-11ea-8a6b-10ea8ab2190c.png)

After: 

![image](https://user-images.githubusercontent.com/1177900/72525131-c23e4500-3863-11ea-85ef-5a63a8ab8142.png)
