### PR TITLE
make the Insert key work in st again

### DIFF
--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -316,9 +316,6 @@ are exclusively available to built-in options.
             Function key from which shifted function key start, if the
             terminal sends F13 for <s-F1>, this should be set to 12.
 
-        *ncurses_builtin_key_parser*:::
-            Bypass ncurses key parser and use an internal one.
-
 [[startup-info]]
 *startup_info_version* `int`::
     _default_ 0 +

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -691,6 +691,7 @@ Optional<Key> NCursesUI::get_next_key()
         case 'D': return masked_key(Key::Left);
         case 'F': return masked_key(Key::End);   // PC/xterm style
         case 'H': return masked_key(Key::Home);  // PC/xterm style
+        case 'L': return Key{Key::Modifiers::Control, Key::Insert}; // st style
         case 'P': return masked_key(Key::F1);
         case 'Q': return masked_key(Key::F2);
         case 'R': return masked_key(Key::F3);
@@ -722,6 +723,14 @@ Optional<Key> NCursesUI::get_next_key()
                 return Key{Key::Modifiers::Shift, Key::F9 + params[0] - 33}; // rxvt style
             }
             return {};
+        case 'h':
+            if (params[0] == 4) // st style
+                return Key{Key::Insert};
+            break;
+        case 'l':
+            if (params[0] == 4) // st style
+                return Key{Key::Modifiers::Shift, Key::Insert};
+            break;
         case 'u':
             return masked_key(static_cast<Codepoint>(params[0]));
         case 'Z': return shift(Key::Tab);


### PR DESCRIPTION
After switching to the builtin key parser, the Insert key stopped working in [st](https://st.suckless.org/). With this patch the corresponding CSI codes get handled.