### PR TITLE
Fix version comparison in show_startup_info

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -107,7 +107,7 @@ void show_startup_info(Client* local_client, int last_version)
     DisplayLineList info;
     for (auto note : version_notes)
     {
-        if (note.version and note.version < last_version)
+        if (note.version and note.version <= last_version)
             continue;
 
         if (not note.version)


### PR DESCRIPTION
The description of startup_info_version in the manual says "only messages relating to a Kakoune version greater than this value will be displayed," but showed messages relating to the version equal to that value.
This change aligns the code with the manual and makes a workaround that set startup_info_version next to the original version (ex. 20200117) unnecessary.