### PR TITLE
rc git: Improve git wrapper highlighters

### DIFF
--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -3,8 +3,9 @@ declare-option -docstring "name of the client in which documentation is to be di
 
 hook -group git-log-highlight global WinSetOption filetype=git-log %{
     add-highlighter window/git-log group
-    add-highlighter window/git-log/ regex '^(commit) ([0-9a-f]+)( [^\n]+)?$' 1:keyword 2:meta 3:comment
-    add-highlighter window/git-log/ regex '^([a-zA-Z_-]+:) (.*?)$' 1:variable 2:value
+    add-highlighter window/git-log/ regex '^([\*|\\ /_])*' 0:keyword
+    add-highlighter window/git-log/ regex '^( ?[\*|\\/_])*\h{,3}(commit )?(\b[0-9a-f]{4,40}\b)' 2:keyword 3:comment
+    add-highlighter window/git-log/ regex '^( ?[\*|\\/_])*\h{,3}([a-zA-Z_-]+:) (.*?)$' 2:variable 3:value
     add-highlighter window/git-log/ ref diff # highlight potential diffs from the -p option
 
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-log }

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -13,6 +13,15 @@ hook -group git-log-highlight global WinSetOption filetype=git-log %{
 
 hook -group git-status-highlight global WinSetOption filetype=git-status %{
     add-highlighter window/git-status group
+    add-highlighter window/git-status/ regex '^## ' 0:comment
+    add-highlighter window/git-status/ regex '^## (\S*[^\s\.@])' 1:green
+    add-highlighter window/git-status/ regex '^## (\S*[^\s\.@])(\.\.+)(\S*[^\s\.@])' 1:green 2:comment 3:red
+    add-highlighter window/git-status/ regex '^(##) (No commits yet on) (\S*[^\s\.@])' 1:comment 2:Default 3:green
+    add-highlighter window/git-status/ regex '^## \S+ \[[^\n]*ahead (\d+)[^\n]*\]' 1:green
+    add-highlighter window/git-status/ regex '^## \S+ \[[^\n]*behind (\d+)[^\n]*\]' 1:red
+    add-highlighter window/git-status/ regex '^(?:([Aa])|([Cc])|([Dd!?])|([MUmu])|([Rr])|([Tt]))[ !\?ACDMRTUacdmrtu]\h' 1:green 2:blue 3:red 4:yellow 5:cyan 6:cyan
+    add-highlighter window/git-status/ regex '^[ !\?ACDMRTUacdmrtu](?:([Aa])|([Cc])|([Dd!?])|([MUmu])|([Rr])|([Tt]))\h' 1:green 2:blue 3:red 4:yellow 5:cyan 6:cyan
+    add-highlighter window/git-status/ regex '^R[ !\?ACDMRTUacdmrtu] [^\n]+( -> )' 1:cyan
     add-highlighter window/git-status/ regex '^\h+(?:((?:both )?modified:)|(added:|new file:)|(deleted(?: by \w+)?:)|(renamed:)|(copied:))(?:.*?)$' 1:yellow 2:green 3:red 4:cyan 5:blue 6:magenta
 
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-status }

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -58,8 +58,8 @@ Available commands:\n  add\n  rm\n  blame\n  commit\n  checkout\n  diff\n  hide-
     show_git_cmd_output() {
         local filetype
         case "$1" in
-           show|diff) filetype=diff ;;
-           log)  filetype=git-log ;;
+           diff) filetype=diff ;;
+           log|show)  filetype=git-log ;;
            status)  filetype=git-status ;;
         esac
         output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-git.XXXXXXXX)/fifo


### PR DESCRIPTION
This fixes highlighting of

- `--pretty=oneline` and `--graph` formats for the `git-log` filetype
- `--short` and `--branch` formats for the `git-status` filetype