### PR TITLE
src: Implement custom insert-mode completers

### DIFF
--- a/doc/pages/commands.asciidoc
+++ b/doc/pages/commands.asciidoc
@@ -193,6 +193,11 @@ of the file onto the filesystem
     *-lock*:::
         stay in mode until `<esc>` is pressed
 
+*complete* [-docstring <docstring>] <key> <option>::
+    declare a user completion engine mapped to `<key>` and taking candidates
+    from `<option>`; if specified, `<docstring>` will be shown in the
+    insert completion menu to describe the mapping (See <<keys#insert-mode-completion,`:doc keys insert-mode-completion`>>)
+
 == Hooks
 
 *hook* [-group <group>] <scope> <hook_name> <filtering_regex> <command>::

--- a/doc/pages/hooks.asciidoc
+++ b/doc/pages/hooks.asciidoc
@@ -178,6 +178,9 @@ name. Hooks with no description will always use an empty string.
 *ModuleLoaded* `module`::
     Triggered after a module is evaluated by the first `require-module` call
 
+*InsertUserCompletion* `option_name`::
+    Triggered when a user completion mapping is hit, before the option associated with it is read to return a list of completion candidates (See <<commands#commands-and-keys,`:doc commands commands-and-keys`>>)
+
 Note that some hooks will not consider underlying scopes depending on what
 context they are bound to be run into, e.g. the `BufWritePost` hook is a buffer
 hook, and will not consider the `window` scope.

--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -75,6 +75,8 @@ the value specified in the `idle_timeout` option is reached.
     *L*:::
         explicit line completion (all buffers)
 
+    User completion mappings (if any) will also be selectable in that menu (See <<commands#commands-and-keys,`:doc commands commands-and-keys`>>)
+
 == Using Counts
 
 In normal mode, commands can be prefixed with a numeric `count`, which can control

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -45,6 +45,7 @@ namespace Kakoune
 {
 
 extern const char* version;
+extern UserCompletionMappings user_completion_mappings;
 
 namespace
 {
@@ -2567,6 +2568,38 @@ const CommandDesc require_module_cmd = {
     }
 };
 
+const CommandDesc complete_cmd = {
+    "complete",
+    nullptr,
+    "complete [<switches>] <key> <option>: declare a user completion mapping",
+    ParameterDesc{
+        { { "docstring", { true,  "user completion mapping description" } } },
+        ParameterDesc::Flags::SwitchesOnlyAtStart, 2, 2
+    },
+    CommandFlags::None,
+    CommandHelper{},
+    make_completer(complete_nothing, [](const Context&, CompletionFlags,
+                                        const String& prefix, ByteCount cursor_pos) -> Completions
+    {
+        return { 0_byte, prefix.length(),
+                 GlobalScope::instance().option_registry().complete_option_name(prefix, cursor_pos) };
+    }),
+    [](const ParametersParser& parser, Context& context, const ShellContext&)
+    {
+        const auto docstring = parser.get_switch("docstring").value_or("").str();
+
+        auto keys = parse_keys(parser[0]);
+        if (keys.size() != 1)
+            throw runtime_error("only a single key can be mapped");
+
+        const auto& option_name = parser[1];
+        if (not context.options()[option_name].is_of_type<StaticWords>())
+            throw runtime_error{format("option '{}' must be of type str-list", option_name)};
+
+        user_completion_mappings[keys[0]] = UserCompletionMapping{option_name, docstring};
+    }
+};
+
 }
 
 void register_commands()
@@ -2634,6 +2667,7 @@ void register_commands()
     register_command(enter_user_mode_cmd);
     register_command(provide_module_cmd);
     register_command(require_module_cmd);
+    register_command(complete_cmd);
 }
 
 }

--- a/src/hook_manager.hh
+++ b/src/hook_manager.hh
@@ -53,7 +53,8 @@ enum class Hook
     WinDisplay,
     WinResize,
     WinSetOption,
-    ModuleLoaded
+    ModuleLoaded,
+    InsertUserCompletion
 };
 
 constexpr auto enum_desc(Meta::Type<Hook>)
@@ -95,7 +96,8 @@ constexpr auto enum_desc(Meta::Type<Hook>)
         {Hook::WinDisplay, "WinDisplay"},
         {Hook::WinResize, "WinResize"},
         {Hook::WinSetOption, "WinSetOption"},
-        {Hook::ModuleLoaded, "ModuleLoaded"}
+        {Hook::ModuleLoaded, "ModuleLoaded"},
+        {Hook::InsertUserCompletion, "InsertUserCompletion"}
     });
 }
 

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1130,7 +1130,7 @@ private:
 class Insert : public InputMode
 {
 public:
-    Insert(InputHandler& input_handler, InsertMode mode, int count)
+    Insert(InputHandler& input_handler, InsertMode mode, int count, const UserCompletionMappings* user_completion_mappings)
         : InputMode(input_handler),
           m_edition(context()),
           m_completer(context()),
@@ -1141,7 +1141,8 @@ public:
                            m_completer.update(m_auto_complete);
                            context().hooks().run_hook(Hook::InsertIdle, "", context());
                        }},
-          m_disable_hooks{context().hooks_disabled(), context().hooks_disabled()}
+          m_disable_hooks{context().hooks_disabled(), context().hooks_disabled()},
+          m_user_completion_mappings(user_completion_mappings)
     {
         context().buffer().throw_if_read_only();
 
@@ -1150,6 +1151,7 @@ public:
         last_insert().keys.clear();
         last_insert().disable_hooks = context().hooks_disabled();
         last_insert().count = count;
+        last_insert().user_completion_mappings = user_completion_mappings;
         prepare(mode, count);
     }
 
@@ -1309,12 +1311,21 @@ public:
                         m_completer.explicit_line_buffer_complete();
                     else if (key.key == 'L')
                         m_completer.explicit_line_all_complete();
+                    else if (const auto& it = m_user_completion_mappings->find(key);
+                             it != m_user_completion_mappings->end())
+                    {
+                        context().hooks().run_hook(Hook::InsertUserCompletion, it->value.option_name, context());
+                        m_completer.explicit_option_complete(it->value.option_name);
+                    }
             }, "enter completion type",
             "f: filename\n"
             "w: word (current buffer)\n"
             "W: word (all buffers)\n"
             "l: line (current buffer)\n"
-            "L: line (all buffers)\n");
+            "L: line (all buffers)\n" +
+            join(*m_user_completion_mappings | transform([](auto& i) {
+                return format("{}: {}", i.key.key, i.value.docstring);
+            }), '\n'));
             update_completions = false;
         }
         else if (key == ctrl('o'))
@@ -1482,13 +1493,14 @@ private:
         buffer.check_invariant();
     }
 
-    ScopedEdition   m_edition;
-    InsertCompleter m_completer;
-    const bool      m_restore_cursor;
-    bool            m_auto_complete;
-    Timer           m_idle_timer;
-    MouseHandler    m_mouse_handler;
-    ScopedSetBool   m_disable_hooks;
+    ScopedEdition                 m_edition;
+    InsertCompleter               m_completer;
+    const bool                    m_restore_cursor;
+    bool                          m_auto_complete;
+    Timer                         m_idle_timer;
+    MouseHandler                  m_mouse_handler;
+    ScopedSetBool                 m_disable_hooks;
+    const UserCompletionMappings* m_user_completion_mappings;
 };
 
 }
@@ -1537,9 +1549,9 @@ void InputHandler::reset_normal_mode()
         pop_mode(m_mode_stack.back().get());
 }
 
-void InputHandler::insert(InsertMode mode, int count)
+void InputHandler::insert(InsertMode mode, int count, const UserCompletionMappings* user_completion_mappings)
 {
-    push_mode(new InputModes::Insert(*this, mode, count));
+    push_mode(new InputModes::Insert(*this, mode, count, user_completion_mappings));
 }
 
 void InputHandler::repeat_last_insert()
@@ -1556,7 +1568,8 @@ void InputHandler::repeat_last_insert()
     ScopedSetBool disable_hooks(context().hooks_disabled(),
                                 m_last_insert.disable_hooks);
 
-    push_mode(new InputModes::Insert(*this, m_last_insert.mode, m_last_insert.count));
+    push_mode(new InputModes::Insert(*this, m_last_insert.mode, m_last_insert.count,
+                                     m_last_insert.user_completion_mappings));
     for (auto& key : keys)
     {
         // refill last_insert,  this is very inefficient, but necessary at the moment

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1301,13 +1301,13 @@ public:
                 [this](Key key, Context&) {
                     if (key.key == 'f')
                         m_completer.explicit_file_complete();
-                    if (key.key == 'w')
+                    else if (key.key == 'w')
                         m_completer.explicit_word_buffer_complete();
-                    if (key.key == 'W')
+                    else if (key.key == 'W')
                         m_completer.explicit_word_all_complete();
-                    if (key.key == 'l')
+                    else if (key.key == 'l')
                         m_completer.explicit_line_buffer_complete();
-                    if (key.key == 'L')
+                    else if (key.key == 'L')
                         m_completer.explicit_line_all_complete();
             }, "enter completion type",
             "f: filename\n"

--- a/src/input_handler.hh
+++ b/src/input_handler.hh
@@ -50,6 +50,14 @@ enum class CursorMode;
 using PromptCompleter = std::function<Completions (const Context&, CompletionFlags,
                                                    StringView, ByteCount)>;
 
+struct UserCompletionMapping
+{
+    String option_name;
+    String docstring;
+};
+
+using UserCompletionMappings = HashMap<Key, UserCompletionMapping>;
+
 class InputHandler : public SafeCountable
 {
 public:
@@ -59,7 +67,7 @@ public:
     ~InputHandler();
 
     // switch to insert mode
-    void insert(InsertMode mode, int count);
+    void insert(InsertMode mode, int count, const UserCompletionMappings* user_completion_mappings);
     // repeat last insert mode key sequence
     void repeat_last_insert();
 
@@ -127,7 +135,8 @@ private:
         Vector<Key> keys;
         bool disable_hooks;
         int count;
-    } m_last_insert = { {}, InsertMode::Insert, {}, false, 1 };
+        const UserCompletionMappings* user_completion_mappings;
+    } m_last_insert = { {}, InsertMode::Insert, {}, false, 1, nullptr };
 
     char   m_recording_reg = 0;
     String m_recorded_keys;

--- a/src/insert_completer.cc
+++ b/src/insert_completer.cc
@@ -603,32 +603,32 @@ bool InsertCompleter::try_complete(Func complete_func)
 
 void InsertCompleter::explicit_file_complete()
 {
-    try_complete(complete_filename<false>);
-    m_explicit_completer = complete_filename<false>;
+    if (try_complete(complete_filename<false>))
+        m_explicit_completer = complete_filename<false>;
 }
 
 void InsertCompleter::explicit_word_buffer_complete()
 {
-    try_complete(complete_word<false>);
-    m_explicit_completer = complete_word<false>;
+    if (try_complete(complete_word<false>))
+        m_explicit_completer = complete_word<false>;
 }
 
 void InsertCompleter::explicit_word_all_complete()
 {
-    try_complete(complete_word<true>);
-    m_explicit_completer = complete_word<true>;
+    if (try_complete(complete_word<true>))
+        m_explicit_completer = complete_word<true>;
 }
 
 void InsertCompleter::explicit_line_buffer_complete()
 {
-    try_complete(complete_line<false>);
-    m_explicit_completer = complete_line<false>;
+    if (try_complete(complete_line<false>))
+        m_explicit_completer = complete_line<false>;
 }
 
 void InsertCompleter::explicit_line_all_complete()
 {
-    try_complete(complete_line<true>);
-    m_explicit_completer = complete_line<true>;
+    if (try_complete(complete_line<true>))
+        m_explicit_completer = complete_line<true>;
 }
 
 }

--- a/src/insert_completer.cc
+++ b/src/insert_completer.cc
@@ -22,6 +22,7 @@
 namespace Kakoune
 {
 
+using namespace std::placeholders;
 using StringList = Vector<String, MemoryDomain::Options>;
 
 String option_to_string(const InsertCompleterDesc& opt)
@@ -68,7 +69,8 @@ namespace
 template<bool other_buffers>
 InsertCompletion complete_word(const SelectionList& sels,
                                const OptionManager& options,
-                               const FaceRegistry& faces)
+                               const FaceRegistry& faces,
+                               StringView = {})
 {
     ConstArrayView<Codepoint> extra_word_chars = options["extra_word_chars"].get<Vector<Codepoint, MemoryDomain::Options>>();
     auto is_word_pred = [extra_word_chars](Codepoint c) { return is_word(c, extra_word_chars); };
@@ -144,7 +146,6 @@ InsertCompletion complete_word(const SelectionList& sels,
         }
     }
 
-    using StaticWords = Vector<String, MemoryDomain::Options>;
     for (auto& word : options["static_words"].get<StaticWords>())
         if (RankedMatch match{word, prefix})
             matches.emplace_back(match, nullptr);
@@ -185,7 +186,8 @@ InsertCompletion complete_word(const SelectionList& sels,
 template<bool require_slash>
 InsertCompletion complete_filename(const SelectionList& sels,
                                    const OptionManager& options,
-                                   const FaceRegistry&)
+                                   const FaceRegistry&,
+                                   StringView = {})
 {
     const Buffer& buffer = sels.buffer();
     auto pos = buffer.iterator_at(sels.main().cursor());
@@ -336,7 +338,8 @@ InsertCompletion complete_option(const SelectionList& sels,
 template<bool other_buffers>
 InsertCompletion complete_line(const SelectionList& sels,
                                const OptionManager& options,
-                               const FaceRegistry&)
+                               const FaceRegistry&,
+                               StringView = {})
 {
     const Buffer& buffer = sels.buffer();
     BufferCoord cursor_pos = sels.main().cursor();
@@ -373,6 +376,43 @@ InsertCompletion complete_line(const SelectionList& sels,
         {
             if (buf.get() != &buffer and not (buf->flags() & Buffer::Flags::Debug))
                 add_candidates(*buf);
+        }
+    }
+
+    if (candidates.empty())
+        return {};
+    std::sort(candidates.begin(), candidates.end());
+    candidates.erase(std::unique(candidates.begin(), candidates.end()), candidates.end());
+    return { std::move(candidates), cursor_pos.line, cursor_pos, buffer.timestamp() };
+}
+
+InsertCompletion complete_from_option(const SelectionList& sels,
+                                      const OptionManager& options,
+                                      const FaceRegistry&,
+                                      StringView option_name)
+{
+    const Buffer& buffer = sels.buffer();
+    BufferCoord cursor_pos = sels.main().cursor();
+
+    const ColumnCount tabstop = options["tabstop"].get<int>();
+    const ColumnCount column = get_column(buffer, tabstop, cursor_pos);
+
+    StringView prefix = buffer[cursor_pos.line].substr(0_byte, cursor_pos.column);
+    InsertCompletion::CandidateList candidates;
+
+    const auto& option = options[option_name];
+
+    for (auto& word : option.get<StaticWords>())
+    {
+        if (word.length() > prefix.length() and
+            prefix == word.substr(0_byte, prefix.length()))
+        {
+            StringView candidate = word.substr(0_byte, word.length());
+            candidates.push_back({candidate.str(), "",
+                                  {expand_tabs(candidate, tabstop, column), {}}});
+            // perf: it's unlikely the user intends to search among >10 candidates anyway
+            if (candidates.size() >= 100)
+                break;
         }
     }
 
@@ -515,11 +555,7 @@ bool InsertCompleter::setup_ifn()
                 try_complete(complete_filename<true>))
                 return true;
             if (completer.mode == InsertCompleterDesc::Option and
-                try_complete([&](const SelectionList& sels,
-                                 const OptionManager& options,
-                                 const FaceRegistry& faces) {
-                   return complete_option(sels, options, faces, *completer.param);
-                }))
+                try_complete(complete_option, *completer.param))
                 return true;
             if (completer.mode == InsertCompleterDesc::Word and
                 *completer.param == "buffer" and
@@ -579,12 +615,12 @@ void InsertCompleter::on_option_changed(const Option& opt)
 }
 
 template<typename Func>
-bool InsertCompleter::try_complete(Func complete_func)
+bool InsertCompleter::try_complete(Func complete_func, StringView param)
 {
     auto& sels = m_context.selections();
     try
     {
-        m_completions = complete_func(sels, m_options, m_faces);
+        m_completions = complete_func(sels, m_options, m_faces, param);
     }
     catch (runtime_error& e)
     {
@@ -629,6 +665,12 @@ void InsertCompleter::explicit_line_all_complete()
 {
     if (try_complete(complete_line<true>))
         m_explicit_completer = complete_line<true>;
+}
+
+void InsertCompleter::explicit_option_complete(StringView option)
+{
+    if (try_complete(complete_from_option, option))
+        m_explicit_completer = std::bind(complete_from_option, _1, _2, _3, option);
 }
 
 }

--- a/src/insert_completer.hh
+++ b/src/insert_completer.hh
@@ -8,6 +8,8 @@
 
 #include "optional.hh"
 
+#include <functional>
+
 namespace Kakoune
 {
 
@@ -53,6 +55,8 @@ inline StringView option_type_name(Meta::Type<CompletionList>)
     return "completions";
 }
 
+using StaticWords = Vector<String, MemoryDomain::Options>;
+
 struct InsertCompletion
 {
     struct Candidate
@@ -91,12 +95,13 @@ public:
     void explicit_word_all_complete();
     void explicit_line_buffer_complete();
     void explicit_line_all_complete();
+    void explicit_option_complete(StringView option);
 
 private:
     bool setup_ifn();
 
     template<typename Func>
-    bool try_complete(Func complete_func);
+    bool try_complete(Func complete_func, StringView param = {});
     void on_option_changed(const Option& opt) override;
 
     void menu_show();
@@ -109,8 +114,9 @@ private:
 
     using CompleteFunc = InsertCompletion (const SelectionList& sels,
                                            const OptionManager& options,
-                                           const FaceRegistry& faces);
-    CompleteFunc* m_explicit_completer = nullptr;
+                                           const FaceRegistry& faces,
+                                           StringView param);
+    std::function<CompleteFunc> m_explicit_completer = nullptr;
 };
 
 }

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -150,10 +150,12 @@ void select_coord(Buffer& buffer, BufferCoord coord, SelectionList& selections)
     }
 }
 
+UserCompletionMappings user_completion_mappings;
+
 template<InsertMode mode>
 void enter_insert_mode(Context& context, NormalParams params)
 {
-    context.input_handler().insert(mode, params.count);
+    context.input_handler().insert(mode, params.count, &user_completion_mappings);
 }
 
 void repeat_last_insert(Context& context, NormalParams)


### PR DESCRIPTION
This commit allows users to declare custom insert completion methods.

A new command `complete` is introduced that takes a key (to hit in
the <c-x> menu) and an option from which the completion candidates
will be loaded, as argument.

The `InsertUserCompletion` hook, triggered before the option is
read, allows setting candidates dynamically.

Examples:

```
declare-option -hidden str-list my_dictionary Kakoune
complete -docstring "personal dictionary" d my_dictionary
exec i<c-x>d
```

```
declare-option -hidden str-list my_dictionary
complete -docstring "dynamic dictionary" t my_dictionary
hook buffer InsertUserCompletion .* %{ %sh{ printf 'set buffer my_dictionary %s' … } }
exec i<c-x>d
```

Fixes #3222