### PR TITLE
rc spell: Handle errors returned on the first line

### DIFF
--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -40,9 +40,11 @@ define-command -params ..1 -docstring %{
             sed 's/^/^/' "$kak_opt_spell_tmp_file" | eval "aspell --byte-offsets -a $options" 2>&1 | {
                 line_num=1
                 regions=$kak_timestamp
-                read line # drop the identification message
                 while read -r line; do
                     case "$line" in
+                        @\(\#\)*)
+                            # drop the identification message
+                        ;;
                         [\#\&]*)
                             if expr "$line" : '^&' >/dev/null; then
                                pos=$(printf %s\\n "$line" | cut -d ' ' -f 4 | sed 's/:$//')


### PR DESCRIPTION
The first line returned by `aspell` isn't always an identification
string, it can also be an error.

This commit prevents the first line from being ignored in any case,
and allows errors to be reported consistently.

Related to #3330