### PR TITLE
Improve sh syntax highlighting for variables, aliases and functions

### DIFF
--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -55,7 +55,7 @@ evaluate-commands %sh{
 }
 
 add-highlighter shared/sh/code/operators regex [\[\]\(\)&|]{1,2} 0:operator
-add-highlighter shared/sh/code/variable regex ([\w-]+)= 1:variable
+add-highlighter shared/sh/code/variable regex ((?<![-:])\b\w+)= 1:variable
 add-highlighter shared/sh/code/function regex ^\h*(\w+)\h*\(\) 1:function
 
 add-highlighter shared/sh/code/unscoped_expansion regex \$(\w+|#|@|\?|\$|!|-|\*) 0:value

--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -48,10 +48,10 @@ evaluate-commands %sh{
     printf %s\\n "declare-option str-list sh_static_words $(join "${keywords}" ' ') $(join "${builtins}" ' ')"
 
     # Highlight keywords
-    printf %s\\n "add-highlighter shared/sh/code/ regex \b($(join "${keywords}" '|'))\b 0:keyword"
+    printf %s\\n "add-highlighter shared/sh/code/ regex (?<!-)\b($(join "${keywords}" '|'))\b(?!-) 0:keyword"
 
     # Highlight builtins
-    printf %s "add-highlighter shared/sh/code/builtin regex \b($(join "${builtins}" '|'))\b 0:builtin"
+    printf %s "add-highlighter shared/sh/code/builtin regex (?<!-)\b($(join "${builtins}" '|'))\b(?!-) 0:builtin"
 }
 
 add-highlighter shared/sh/code/operators regex [\[\]\(\)&|]{1,2} 0:operator

--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -56,7 +56,8 @@ evaluate-commands %sh{
 
 add-highlighter shared/sh/code/operators regex [\[\]\(\)&|]{1,2} 0:operator
 add-highlighter shared/sh/code/variable regex ((?<![-:])\b\w+)= 1:variable
-add-highlighter shared/sh/code/function regex ^\h*(\w+)\h*\(\) 1:function
+add-highlighter shared/sh/code/alias regex \balias(\h+[-+]\w)*\h+([\w-.]+)= 2:variable
+add-highlighter shared/sh/code/function regex ^\h*(\S+)\h*\(\) 1:function
 
 add-highlighter shared/sh/code/unscoped_expansion regex \$(\w+|#|@|\?|\$|!|-|\*) 0:value
 add-highlighter shared/sh/double_string/expansion regex \$(\w+|\{.+?\}) 0:value


### PR DESCRIPTION
Before:
![screenshot before this PR](https://user-images.githubusercontent.com/37733333/73686160-5e1edc00-46bf-11ea-88b0-c8b084f7682d.png)
Afer:
![screenshot after this PR](https://user-images.githubusercontent.com/37733333/73686173-624af980-46bf-11ea-9d2c-ece4352eab6e.png)

This PR removes the highlighting of words in front of equal signs that come after a colon or hyphen to filter out the cases where command line options are recognized as variables.

Additionally I allowed more characters in aliases and functions:
Which characters are allowed?
- Aliases: See [Bash Manual](https://www.gnu.org/software/bash/manual/html_node/Aliases.html)
- Functions: See [Unix Stackexchange](https://unix.stackexchange.com/questions/245331/shell-valid-function-name-characters)

For aliases I chose `[\w-.]` instead of blacklisting many forbidden characters. For functions I chose `\S`.

Edit: I pushed a commit fixing wrong highlighting of keywords and builtins, for example `xinput --set-prop` (`set` is a builtin) or `bindkey "^X^E" edit-command-line` (`command` is a builtin). This can also be seen in the first screenshot where the `in` of `valid-in-bash` is highlighted.