### PR TITLE
rc git: Fix highlighting of ‘:git log --graph’

### DIFF
--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -3,9 +3,9 @@ declare-option -docstring "name of the client in which documentation is to be di
 
 hook -group git-log-highlight global WinSetOption filetype=git-log %{
     add-highlighter window/git-log group
-    add-highlighter window/git-log/ regex '^([\*|\\ /_])*' 0:keyword
-    add-highlighter window/git-log/ regex '^( ?[\*|\\/_])*\h{,3}(commit )?(\b[0-9a-f]{4,40}\b)' 2:keyword 3:comment
-    add-highlighter window/git-log/ regex '^( ?[\*|\\/_])*\h{,3}([a-zA-Z_-]+:) (.*?)$' 2:variable 3:value
+    add-highlighter window/git-log/ regex '^([*|\\ /_.-])*' 0:keyword
+    add-highlighter window/git-log/ regex '^( ?[*|\\ /_.-])*\h{,3}(commit )?(\b[0-9a-f]{4,40}\b)' 2:keyword 3:comment
+    add-highlighter window/git-log/ regex '^( ?[*|\\ /_.-])*\h{,3}([a-zA-Z_-]+:) (.*?)$' 2:variable 3:value
     add-highlighter window/git-log/ ref diff # highlight potential diffs from the -p option
 
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-log }


### PR DESCRIPTION
Looks like hyphens and periods are sometimes printed as part of
git-log(1)’s graphing feature; for example, in this repository:

    git log --graph 55e7f857