### PR TITLE
File type detection fix

### DIFF
--- a/rc/detection/file.kak
+++ b/rc/detection/file.kak
@@ -1,6 +1,6 @@
 hook global BufOpenFile .* %{ evaluate-commands %sh{
     if [ -z "${kak_opt_filetype}" ]; then
-        mime=$(file -b -i -L "${kak_buffile}")
+        mime=$(file -b --mime-type -L "${kak_buffile}")
         mime=${mime%;*}
         case "${mime}" in
             application/*+xml) filetype="xml" ;;


### PR DESCRIPTION
Fixes filetype detection on Mac.

The --mime-type option is (mostly) portable:
- Linux uses --mime-type
- macOS uses --mime-type
- FreeBSD uses --mime-type
- NetBSD uses --mime-type
- OpenBSD uses --mime-type and does not use the same implementation as everybody else
- Solaris does not support MIME types at all

On Mac, the `-i` option means something else:

    ჻ man file | grep -i -- -i
    -i      If the file is a regular file, do not classify its contents.

See the [discussion](https://github.com/mawww/kakoune/issues/3373) for more details.

