### PR TITLE
Make rust auto-indenter ignore most things inside comments.

### DIFF
--- a/rc/filetype/rust.kak
+++ b/rc/filetype/rust.kak
@@ -74,15 +74,18 @@ define-command -hidden rust-trim-indent %{
 define-command -hidden rust-indent-on-new-line %~
     evaluate-commands -draft -itersel %<
         # copy // comments prefix and following white spaces
-        try %{ execute-keys -draft k <a-x> s ^\h*\K//[!/]?\h* <ret> y gh j P }
-        # preserve previous line indent
-        try %{ execute-keys -draft <semicolon> K <a-&> }
+        try %{
+            execute-keys -draft k <a-x> s ^\h*\K//[!/]?\h* <ret> y gh j P
+        } catch %|
+            # preserve previous line indent
+            try %{ execute-keys -draft <semicolon> K <a-&> }
+            # indent after lines ending with { or (
+            try %[ execute-keys -draft k <a-x> <a-k> [{(]\h*$ <ret> j <a-gt> ]
+            # indent after lines ending with [{(].+ and move first parameter to own line
+            try %< execute-keys -draft [c[({],[)}] <ret> <a-k> \A[({][^\n]+\n[^\n]*\n?\z <ret> L i<ret><esc> <gt> <a-S> <a-&> >
+        |
         # filter previous line
         try %{ execute-keys -draft k : rust-trim-indent <ret> }
-        # indent after lines ending with { or (
-        try %[ execute-keys -draft k <a-x> <a-k> [{(]\h*$ <ret> j <a-gt> ]
-        # indent after lines ending with [{(].+ and move first parameter to own line
-        try %< execute-keys -draft [c[({],[)}] <ret> <a-k> \A[({][^\n]+\n[^\n]*\n?\z <ret> L i<ret><esc> <gt> <a-S> <a-&> >
     >
 ~
 


### PR DESCRIPTION
Fixes #3352.