### PR TITLE
src: Allow shell commands on fast completion

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -216,9 +216,6 @@ struct ShellScriptCompleter
                            CommandParameters params, size_t token_to_complete,
                            ByteCount pos_in_token)
     {
-        if (flags & CompletionFlags::Fast) // no shell on fast completion
-            return Completions{};
-
         ShellContext shell_context{
             params,
             { { "token_to_complete", to_string(token_to_complete) },


### PR DESCRIPTION
Interactive user commands with parameters that can be completed upon
using shell commands won't auto-complete, because shell commands are
disabled in prompt mode.

This commit removes that restriction to allow the above usecase.

Example:

    def foo \
        -shell-script-completion %{
            if [ "${kak_token_to_complete}" = 0 ]; then
                list_options | awk -v prefix="$1" 'tolower(substr($0, 1, length(prefix))) == tolower(prefix)'
            fi
        } […]