### PR TITLE
src: Don't escape completion candidates with `\`

### DIFF
--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -758,7 +758,9 @@ Completions CommandManager::complete(const Context& context,
         if (not (completions.flags & Completions::Flags::Quoted) and token.type == Token::Type::Raw)
         {
             for (auto& c : completions.candidates)
-                c = (not c.empty() and contains("%'\"", c[0]) ? "\\" : "") + escape(c, "; \t", '\\');
+                c = (not c.empty() and c[0] == '%') or
+                        any_of(c, [](auto i) { return contains("; \t'\"", i); }) ?
+                            format("'{}'", replace(c, "'", "''")) : c;
         }
 
         return completions;


### PR DESCRIPTION
Completion candidates are currently escaped with a backslash `\`
character, which leads to ugly interactive commands on the prompt,
especially when they contain space characters.

This commit makes completion candidates be escaped by simple quoting.

Examples:

    candidate\ with\ spaces
    \%opt{foo}
    \"dquote
    \'quote

become:

    'candidate with spaces'
    '%opt{foo}'
    '"dquote'
    '''quote'