### PR TITLE
src: Fix a compilation bug with g++-8

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -312,7 +312,7 @@ static const EnvVarDesc builtin_env_vars[] = { {
         "selections_length", false,
         [](StringView name, const Context& context) -> Vector<String>
         { return context.selections() |
-                     transform([&](const Selection& s) {
+                     transform([&](const Selection& s) -> String {
                          return to_string(char_length(context.buffer(), s));
                      }) | gather<Vector<String>>(); }
     }, {


### PR DESCRIPTION
The Ubuntu Disco distribution comes with `g++` v8 installed by default,
which is not able to deduce the return type of a particular call to
`transform()`.

This commit explicitly declares the return type to mitigate that
problem, and allow the file to compile.

Fixes #3410