### PR TITLE
Better rust auto-indent for comments.

### DIFF
--- a/rc/filetype/rust.kak
+++ b/rc/filetype/rust.kak
@@ -75,7 +75,7 @@ define-command -hidden rust-indent-on-new-line %~
     evaluate-commands -draft -itersel %<
         # copy // comments prefix and following white spaces
         try %{
-            execute-keys -draft k <a-x> s ^\h*\K//[!/]?\h* <ret> y gh j P
+            execute-keys -draft k <a-x> s ^\h*//[!/]?\h* <ret> y gh j P
         } catch %|
             # preserve previous line indent
             try %{ execute-keys -draft <semicolon> K <a-&> }


### PR DESCRIPTION
Now whitespace will be matched when auto-indenting a comment (which
regressed in #3384).