### PR TITLE
rc spell: Avoid C-style comments in awk

### DIFF
--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -46,11 +46,11 @@ define-command -params ..1 -docstring %{
 
                 {
                     if (/^@\(#\)/) {
-                        /* drop the identification message */
+                        # drop the identification message
                     }
 
                     else if (/^\*/) {
-                        /* nothing */
+                        # nothing
                     }
 
                     else if (/^$/) {


### PR DESCRIPTION
#3400 broke the `:spell` command on OpenBSD, because it's awk does not  support C-style comments. [POSIX says](https://pubs.opengroup.org/onlinepubs/009695399/utilities/awk.html) the following about comments:

> A comment shall consist of any characters beginning with the number sign character and terminated by, but excluding the next occurrence of, a \<newline\>.

Changing the two comments to that style fixes it for the OpenBSD awk and also seems to work with GNU awk.