### PR TITLE
diff.kak: add diff file and diff hunk text objects

### DIFF
--- a/rc/filetype/diff.kak
+++ b/rc/filetype/diff.kak
@@ -11,3 +11,36 @@ hook -group diff-highlight global WinSetOption filetype=diff %{
     add-highlighter window/diff ref diff
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/diff }
 }
+
+define-command \
+    -docstring %{diff-select-file: Select surrounding patch file} \
+    -params 0 \
+    diff-select-file %{
+    evaluate-commands -itersel -save-regs 'ose/' %{
+        try %{
+            execute-keys '"oZgl<a-?>^diff <ret>;"sZ' 'Ge"eZ'
+            try %{ execute-keys '"sz?\n(?=diff )<ret>"e<a-Z><lt>' }
+            execute-keys '"ez'
+        } catch %{
+            execute-keys '"oz'
+            fail 'Not in a diff file'
+        }
+    }
+}
+
+define-command \
+    -docstring %{diff-select-hunk: Select surrounding patch hunk} \
+    -params 0 \
+    diff-select-hunk %{
+    evaluate-commands -itersel -save-regs 'ose/' %{
+        try %{
+            execute-keys '"oZgl<a-?>^@@ <ret>;"sZ' 'Ge"eZ'
+            try %{ execute-keys '"sz?\n(?=diff )<ret>"e<a-Z><lt>' }
+            try %{ execute-keys '"sz?\n(?=@@ )<ret>"e<a-Z><lt>' }
+            execute-keys '"ez'
+        } catch %{
+            execute-keys '"oz'
+            fail 'Not in a diff hunk'
+        }
+    }
+}


### PR DESCRIPTION
These really only support `<a-a>` mode, but I expect they are super
useful as-is.