### PR TITLE
rc lint: Check the `lintcmd` option is set in `:lint-buffer`

### DIFF
--- a/rc/tools/lint.kak
+++ b/rc/tools/lint.kak
@@ -277,6 +277,12 @@ define-command \
     } \
     lint-buffer \
 %{
+    evaluate-commands %sh{
+        if [ -z "${kak_opt_lintcmd}" ]; then
+            echo 'fail The lintcmd option is not set'
+            exit 1
+        fi
+    }
     evaluate-commands -draft %{
         execute-keys '%'
         lint-cleaned-selections %opt{lintcmd}


### PR DESCRIPTION
Calling `:lint-buffer` when `lintcmd` is empty results in a temporary
directory being created, but never removed when the underlying linting
code errors out.