### PR TITLE
Implement smarter detection of windowing environments.

### DIFF
--- a/rc/windowing/detection.kak
+++ b/rc/windowing/detection.kak
@@ -1,0 +1,41 @@
+# Attempt to detect the windowing environment we're operating in
+#
+# We try to load modules from the windowing_modules str-list option in order,
+# stopping when one of the modules loads successfully. This ensures that only
+# a single module is loaded by default.
+#
+# On load each module must attempt to detect the environment it's appropriate
+# for, and if the environment isn't appropriate it must fail with an error.
+# In addition, each module must check for the length of the windowing_modules
+# str-list option defined below, and must /not/ check for an appropriate
+# environment if the list is empty. An example of this test:
+#
+# evaluate-commands %sh{
+#     [ -z "${kak_opt_windowing_modules}" ] || [ -n "$TMUX" ] || echo 'fail tmux not detected'
+# }
+#
+# Each module is expected to define at least two aliases:
+#  * terminal - create a new terminal with sensible defaults
+#  * focus - focus the specified client, defaulting to the current client
+#
+
+declare-option -docstring \
+"Ordered list of windowing modules to try and load. An empty list disables
+both automatic module loading and environment detection, enabling complete
+manual control of the module loading." \
+str-list windowing_modules 'tmux' 'screen' 'kitty' 'iterm' 'x11'
+
+hook -group windowing global KakBegin .* %{
+
+    evaluate-commands %sh{
+        set -- ${kak_opt_windowing_modules}
+        if [ $# -gt 0 ]; then
+            echo 'try %{ '
+            while [ $# -gt 1 ]; do
+                echo "require-module ${1} } catch %{ "
+                shift
+            done
+            echo "require-module ${1} }"
+        fi
+    }
+}

--- a/rc/windowing/iterm.kak
+++ b/rc/windowing/iterm.kak
@@ -1,15 +1,12 @@
 # https://www.iterm2.com
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-## The default behaviour for the `terminal` command is to open a vertical pane in
-## an iTerm session if not in a tmux session.
-hook global KakBegin .* %sh{
-    if [ "$TERM_PROGRAM" = "iTerm.app" ] && [ -z "$TMUX" ]; then
-        echo "require-module iterm"
-    fi
-}
-
 provide-module iterm %{
+
+# ensure that we're running on iTerm
+evaluate-commands %sh{
+    [-z "${kak_opt_windowing_modules}" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || echo 'fail iTerm not detected'
+}
 
 define-command -hidden -params 2.. iterm-terminal-split-impl %{
     nop %sh{

--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -1,11 +1,12 @@
-
-hook -group kitty-hooks global KakBegin .* %sh{
-    if [ "$TERM" = "xterm-kitty" ] && [ -z "$TMUX" ]; then
-        echo "require-module kitty"
-    fi
-}
+# https://sw.kovidgoyal.net/kitty/index.html
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
 provide-module kitty %{
+
+# ensure that we're running on kitty
+evaluate-commands %sh{
+    [-z "${kak_opt_windowing_modules}" ] || [ "$TERM" = "xterm-kitty" ] || echo 'fail Kitty not detected'
+}
 
 declare-option -docstring %{window type that kitty creates on new and repl calls (kitty|os)} str kitty_window_type kitty
 

--- a/rc/windowing/screen.kak
+++ b/rc/windowing/screen.kak
@@ -1,12 +1,13 @@
 # http://gnu.org/software/screen/
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook -group GNUscreen global KakBegin .* %sh{
-    [ -z "${STY}" ] && exit
-    echo "require-module screen"
-}
 
 provide-module screen %{
+
+# ensure that we're running under screen
+evaluate-commands %sh{
+    [-z "${kak_opt_windowing_modules}" ] || [ -n "$STY" ] || echo 'fail screen not detected'
+}
 
 define-command screen-terminal-impl -hidden -params 3.. %{
     nop %sh{

--- a/rc/windowing/tmux.kak
+++ b/rc/windowing/tmux.kak
@@ -1,13 +1,12 @@
 # http://tmux.github.io/
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-hook global KakBegin .* %sh{
-    if [ -n "$TMUX" ]; then
-        echo "require-module tmux"
-    fi
-}
-
 provide-module tmux %{
+
+# ensure we're running under tmux
+evaluate-commands %sh{
+    [ -z "${kak_opt_windowing_modules}" ] || [ -n "$TMUX" ] || echo 'fail tmux not detected'
+}
 
 define-command -hidden -params 2.. tmux-terminal-impl %{
     evaluate-commands %sh{

--- a/rc/windowing/x11.kak
+++ b/rc/windowing/x11.kak
@@ -1,12 +1,11 @@
 # x11
 
-hook global KakBegin .* %sh{
-    if [ -n "$DISPLAY" ] && [ -z "$TMUX" ]; then
-        echo "require-module x11"
-    fi
-}
-
 provide-module x11 %{
+
+# ensure that we're running in the right environment
+evaluate-commands %sh{
+    [-z "${kak_opt_windowing_modules}" ] || [ -n "$DISPLAY" ] || echo 'fail DISPLAY is not set'
+}
 
 # termcmd should be set such as the next argument is the whole
 # command line to execute


### PR DESCRIPTION
This fixes an issue I was having where the hooks to load *both* the x11 and kitty modules were matching, and the x11 module was being loaded on top of the kitty module - this meant that the terminal commands pointed at the x11 variants rather than the kitty variants. Merging the hooks provided by each of the windowing modules into a single hook that only loads one module avoids this issue.

Tested with kitty, gnome-terminal (x11 module), tmux and screen, all on Ubuntu Bionic.