### PR TITLE
Fix +line:col initial buffer position when connecting to session

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1164,8 +1164,14 @@ int main(int argc, char* argv[])
                 }
             }
             String new_files;
-            for (auto name : files)
-                new_files += format("edit '{}';", escape(real_path(name), "'", '\\'));
+            for (auto name : files) {
+                new_files += format("edit '{}'", escape(real_path(name), "'", '\\'));
+                if (init_coord) {
+                    new_files += format(" {} {}", init_coord->line + 1, init_coord->column + 1);
+                    init_coord.reset();
+                }
+                new_files += ";";
+            }
 
             return run_client(*server_session, {}, new_files + client_init, init_coord, ui_type, false);
         }


### PR DESCRIPTION
A command line argument like `+line[:column]` can be used to specify a
target line and column for the first file.

This did not work when connecting to a session, because the client
opens its file parameters with `-e "edit file1; edit file2"` which is
executed after the initial buffer position is set. Work around this by
setting the position for the first file and avoid moving the position
in unrelated files.

Reproduce:

	kak -s foo
	kak -c foo +4:11 README.asciidoc