### PR TITLE
fix indent behavior of coq syntax file for lines without indent 

### DIFF
--- a/rc/filetype/coq.kak
+++ b/rc/filetype/coq.kak
@@ -111,7 +111,7 @@ provide-module coq %{
 # Hence here only a simple mechanism of copying indent is done.
     define-command -hidden coq-copy-indent-on-newline %{
         evaluate-commands -draft -itersel %{
-            try %{ execute-keys -draft k <a-x> s ^\h* <ret> y gh j P }
+            try %{ execute-keys -draft k <a-x> s ^\h+ <ret> y gh j P }
         }
 }
 


### PR DESCRIPTION
The previous coq syntax file's indent behavior is incorrect 
It wrongly copies the first letter of previous line, when the previous line has no indentation.
This PR fixes the problem.

[Previous PR](https://github.com/mawww/kakoune/pull/3454).