### PR TITLE
Elixir: Fix triple-string, add support for Eex

### DIFF
--- a/rc/filetype/elixir.kak
+++ b/rc/filetype/elixir.kak
@@ -8,6 +8,10 @@ hook global BufCreate .*[.](ex|exs) %{
     set-option buffer filetype elixir
 }
 
+hook global BufCreate .*[.]html[.]l?eex %{
+    set-option buffer filetype eex
+}
+
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
@@ -25,18 +29,39 @@ hook -group elixir-highlight global WinSetOption filetype=elixir %{
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/elixir }
 }
 
+hook global WinSetOption filetype=eex %{
+    require-module eex
+
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window eex-.+ }
+}
+
+hook -group eex-highlight global WinSetOption filetype=eex %{
+    add-highlighter window/eex ref eex
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/eex }
+}
+
+provide-module eex %{
+require-module html
+require-module elixir
+
+add-highlighter shared/eex regions
+add-highlighter shared/eex/html default-region ref html
+add-highlighter shared/eex/code region '<%='     '%>' ref elixir
+}
 
 provide-module elixir %[
+require-module eex
 
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
 add-highlighter shared/elixir regions
 add-highlighter shared/elixir/code default-region group
-add-highlighter shared/elixir/double_string region '"'   (?<!\\)(\\\\)*"   regions
-add-highlighter shared/elixir/triple_string region '"""' (?<!\\)(\\\\)*""" ref shared/elixir/double_string
-add-highlighter shared/elixir/single_string region "'"   (?<!\\)(\\\\)*'   fill string
-add-highlighter shared/elixir/comment       region '#'   '$'               fill comment
+add-highlighter shared/elixir/double_string region -match-capture ("""|") (?<!\\)(?:\\\\)*("""|") regions
+add-highlighter shared/elixir/single_string region "'" "(?<!\\)(?:\\\\)*'" fill string
+add-highlighter shared/elixir/comment region '#' '$' fill comment
+
+add-highlighter shared/elixir/leex region -match-capture '~L("""|")' '(?<!\\)(?:\\\\)*("""|")' ref eex
 
 add-highlighter shared/elixir/double_string/base default-region fill string
 add-highlighter shared/elixir/double_string/interpolation region -recurse \{ \Q#{ \} fill builtin

--- a/rc/filetype/elixir.kak
+++ b/rc/filetype/elixir.kak
@@ -46,7 +46,7 @@ require-module elixir
 
 add-highlighter shared/eex regions
 add-highlighter shared/eex/html default-region ref html
-add-highlighter shared/eex/code region '<%='     '%>' ref elixir
+add-highlighter shared/eex/code region '<%=?' '%>' ref elixir
 }
 
 provide-module elixir %[

--- a/rc/filetype/elixir.kak
+++ b/rc/filetype/elixir.kak
@@ -46,6 +46,8 @@ require-module elixir
 
 add-highlighter shared/eex regions
 add-highlighter shared/eex/html default-region ref html
+add-highlighter shared/eex/comment region '<%#' '%>' fill comment
+add-highlighter shared/eex/quote region '<%%' '%>' ref html
 add-highlighter shared/eex/code region '<%=?' '%>' ref elixir
 }
 


### PR DESCRIPTION
This adds support for the Eex templating that is used in the Phoenix
web framework. Eex files include HTML and Elixir code, and Elixir files
can include Eex in string literals marked with the `~L` prefix.

Additionally this unbreaks `"""` string literals, which did not work because
`"` was matched before `"""`