### PR TITLE
Fix perl regex highlighting for operator //

### DIFF
--- a/rc/filetype/perl.kak
+++ b/rc/filetype/perl.kak
@@ -42,7 +42,7 @@ add-highlighter shared/perl/double_string region (?<!\$)(?<!\\)"   (?<!\\)(\\\\)
 add-highlighter shared/perl/single_string region (?<!\$)(?<!\\\\)' (?<!\\)(\\\\)*' fill string
 add-highlighter shared/perl/comment       region (?<!\$)(?<!\\)#   $               fill comment
 
-add-highlighter shared/perl/regex         region m?/[^/\n]+(?=/)        /\w?       fill meta
+add-highlighter shared/perl/regex         region m?(?<!/)/[^/\n]+(?=/)  /\w?       fill meta
 add-highlighter shared/perl/sregex        region s/[^/\n]+/[^/\n]+(?=/) /\w?       fill meta
 
 add-highlighter shared/perl/q1            region -recurse \{ q\{ \}                fill string


### PR DESCRIPTION
It used to see the second / of the // operator as the potential start of a regex, turning the entire document into a string in situations like `$path // "some/default"`.