### PR TITLE
Remove outdated information from faq

### DIFF
--- a/doc/pages/faq.asciidoc
+++ b/doc/pages/faq.asciidoc
@@ -15,17 +15,6 @@ project to this operating system is pretty low.
 Moreover, you can get pretty decent performance by using Kakoune on Cygwin
 (which is officially supported).
 
-== Kakoune is very slow on big files, what can I do about it ?
-
-The default build mode (set in the `Makefile` of the `src` directory of the
-project) is "debug", which makes it convenient to track issues but also
-affects performance. To disable the debug mode, recompile the project by
-setting the `debug` variable in `src/Makefile` to `no`.
-
-Note that if your distribution provides a "kakoune" package, the program should
-already be built in non-debug mode (if you still experience slowness, please
-report the issue on the bug tracker).
-
 == Can I use Kakoune as a pager ?
 
 Kakoune can be used as a pager, either by setting the `PAGER` environment


### PR DESCRIPTION
Default build mode is release since c07f052.