### PR TITLE
rc ini: More leniently highlight section names

### DIFF
--- a/rc/filetype/ini.kak
+++ b/rc/filetype/ini.kak
@@ -18,7 +18,7 @@ add-highlighter shared/ini regions
 add-highlighter shared/ini/code default-region group
 add-highlighter shared/ini/comment region '(^|\h)\K[#;]' $ fill comment
 
-add-highlighter shared/ini/code/ regex "^\h*\[[^\]]*\]" 0:title
+add-highlighter shared/ini/code/ regex "(?S)^\h*(\[.+?\])\h*$" 1:title
 add-highlighter shared/ini/code/ regex "^\h*([^\[][^=\n]*)=([^\n]*)" 1:variable 2:value
 
 }


### PR DESCRIPTION
Highlight every character between brackets, including more
brackets. This allows alternative constructs in INI files such as:

```
[section]
    [[subsection]]
```

This commit also only applies the appropriate face on the section
name itself, not the entire line (including hypothetical surrounding
whitespace characters).