### PR TITLE
colors: Retire the `bold` and `italic` faces

### DIFF
--- a/colors/base16.kak
+++ b/colors/base16.kak
@@ -37,8 +37,6 @@ evaluate-commands %sh{
     echo "
         face global title blue
         face global header ${cyan_light}
-        face global bold ${orange_light}
-        face global italic ${orange_dark}
         face global mono ${green_dark}
         face global block ${orange_dark}
         face global link blue

--- a/colors/default.kak
+++ b/colors/default.kak
@@ -18,8 +18,6 @@ face global builtin default+b
 # For markup
 face global title blue
 face global header cyan
-face global bold red
-face global italic yellow
 face global mono green
 face global block magenta
 face global link cyan

--- a/colors/desertex.kak
+++ b/colors/desertex.kak
@@ -18,8 +18,6 @@ face global meta rgb:ee799f
 # Markup
 face global title  blue
 face global header cyan
-face global bold   red
-face global italic yellow
 face global mono   green
 face global block  magenta
 face global link   cyan

--- a/colors/github.kak
+++ b/colors/github.kak
@@ -21,8 +21,6 @@ face global builtin default+b
 ## markup
 face global title blue
 face global header cyan
-face global bold red
-face global italic yellow
 face global mono green
 face global block magenta
 face global link cyan

--- a/colors/greyscale.kak
+++ b/colors/greyscale.kak
@@ -37,8 +37,6 @@ evaluate-commands %sh{
     set-face global link ${grey}+u
     set-face global list Default
     set-face global bullet +b
-    set-face global bold +b
-    set-face global italic +i
 
     # Built-in faces
     set-face global Default ${grey},${grey_light_2}

--- a/colors/gruvbox.kak
+++ b/colors/gruvbox.kak
@@ -41,8 +41,6 @@ evaluate-commands %sh{
         # Markdown highlighting
         face global title     ${green}+b
         face global header    ${orange}
-        face global bold      ${fg}+b
-        face global italic    ${fg}+i
         face global mono      ${fg4}
         face global block     ${aqua}
         face global link      ${blue}+u

--- a/colors/kaleidoscope-dark.kak
+++ b/colors/kaleidoscope-dark.kak
@@ -95,8 +95,6 @@ evaluate-commands %sh{
     set-face global link ${bright_cyan}+u
     set-face global list Default
     set-face global bullet +b
-    set-face global bold +b
-    set-face global italic +i
 
     # Built-in faces
     set-face global Default ${white},${black}

--- a/colors/kaleidoscope-light.kak
+++ b/colors/kaleidoscope-light.kak
@@ -95,8 +95,6 @@ evaluate-commands %sh{
     set-face global link ${vibrant_blue}+u
     set-face global list Default
     set-face global bullet +b
-    set-face global bold +b
-    set-face global italic +i
 
     # Built-in faces
     set-face global Default ${black},${white}

--- a/colors/lucius.kak
+++ b/colors/lucius.kak
@@ -41,8 +41,6 @@ evaluate-commands %sh{
         # and markup
         face global title ${lucius_light_blue}
         face global header ${lucius_light_green}
-        face global bold ${lucius_blue}
-        face global italic ${lucius_green}
         face global mono ${lucius_light_green}
         face global block ${lucius_light_blue}
         face global link ${lucius_light_green}

--- a/colors/palenight.kak
+++ b/colors/palenight.kak
@@ -44,8 +44,6 @@ evaluate-commands %sh{
     # Markup
     face global title  $blue
     face global header $cyan
-    face global bold   $red
-    face global italic $yellow
     face global mono   $green
     face global block  $purple
     face global link   $cyan

--- a/colors/plain.kak
+++ b/colors/plain.kak
@@ -17,8 +17,6 @@ face global builtin default
 # For default
 face global title default
 face global header default
-face global bold default
-face global italic default
 face global mono default
 face global block default
 face global link blue

--- a/colors/red-phoenix.kak
+++ b/colors/red-phoenix.kak
@@ -52,8 +52,6 @@ evaluate-commands %sh{
     echo "
         face global title blue
         face global header ${orange1}
-        face global bold ${orange2}
-        face global italic ${orange3}
         face global mono ${yellow1}
         face global block ${tan1}
         face global link blue

--- a/colors/reeder.kak
+++ b/colors/reeder.kak
@@ -39,8 +39,6 @@ evaluate-commands %sh{
         # and markup
         face global title      ${orange}+b
         face global header     ${orange}+b
-        face global bold       default+b
-        face global italic     default+i
         face global mono       ${green_light}
         face global block      ${green}
         face global link       ${orange}

--- a/colors/solarized-dark-termcolors.kak
+++ b/colors/solarized-dark-termcolors.kak
@@ -19,8 +19,6 @@ face global builtin            default+b
 # markup
 face global title              blue+b
 face global header             blue
-face global bold               bright-blue+b
-face global italic             bright-blue+i
 face global mono               bright-cyan
 face global block              cyan
 face global link               bright-cyan

--- a/colors/solarized-dark.kak
+++ b/colors/solarized-dark.kak
@@ -37,8 +37,6 @@ evaluate-commands %sh{
         # markup
         face global title              ${blue}+b
         face global header             ${blue}
-        face global bold               ${base0}+b
-        face global italic             ${base0}+i
         face global mono               ${base1}
         face global block              ${cyan}
         face global link               ${base1}

--- a/colors/solarized-light-termcolors.kak
+++ b/colors/solarized-light-termcolors.kak
@@ -19,8 +19,6 @@ face global builtin            default+b
 # markup
 face global title              blue+b
 face global header             blue
-face global bold               bright-green+b
-face global italic             bright-green+i
 face global mono               bright-cyan
 face global block              cyan
 face global link               bright-green

--- a/colors/solarized-light.kak
+++ b/colors/solarized-light.kak
@@ -37,8 +37,6 @@ evaluate-commands %sh{
         # markup
         face global title              ${blue}+b
         face global header             ${blue}
-        face global bold               ${base01}+b
-        face global italic             ${base01}+i
         face global mono               ${base1}
         face global block              ${cyan}
         face global link               ${base01}

--- a/colors/tomorrow-night.kak
+++ b/colors/tomorrow-night.kak
@@ -42,8 +42,6 @@ evaluate-commands %sh{
     echo "
         face global title blue
         face global header ${aqua}
-        face global bold ${yellow}
-        face global italic ${orange}
         face global mono ${green_dark}
         face global block ${orange}
         face global link blue

--- a/colors/zenburn.kak
+++ b/colors/zenburn.kak
@@ -48,8 +48,6 @@ evaluate-commands %sh{
         # and markup
         face global title ${zenkeyword}
         face global header ${zenconstant}
-        face global bold ${zenstorageClass}
-        face global italic ${zenfunction}
         face global mono ${zennumber}
         face global block ${zenstatement}
         face global link ${zenstring}

--- a/rc/filetype/asciidoc.kak
+++ b/rc/filetype/asciidoc.kak
@@ -39,8 +39,8 @@ add-highlighter shared/asciidoc/ regex ^(={3,})\n[^\n\h].*?\n(={3,})$ 0:block
 add-highlighter shared/asciidoc/ regex ^(~{3,})\n[^\n\h].*?\n(~{3,})$ 0:block
 add-highlighter shared/asciidoc/ regex ^(\*{3,})\n[^\n\h].*?\n(\*{3,})$ 0:block
 add-highlighter shared/asciidoc/ regex \B(?:\+[^\n]+?\+|`[^\n]+?`)\B 0:mono
-add-highlighter shared/asciidoc/ regex \b_[^\n]+?_\b 0:italic
-add-highlighter shared/asciidoc/ regex \B\*[^\n]+?\*\B 0:bold
+add-highlighter shared/asciidoc/ regex \b_[^\n]+?_\b 0:+i
+add-highlighter shared/asciidoc/ regex \B\*[^\n]+?\*\B 0:+b
 add-highlighter shared/asciidoc/ regex ^:[-\w]+: 0:meta
 
 # Commands

--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -72,10 +72,10 @@ add-highlighter shared/markdown/inline/text/ regex (\A|\n\n)[^\n]+\n-{2,}\h*\n\h
 # Atx-style header
 add-highlighter shared/markdown/inline/text/ regex ^#[^\n]* 0:header
 
-add-highlighter shared/markdown/inline/text/ regex (?<!\*)(\*([^\s*]|([^\s*](\n?[^\n*])*[^\s*]))\*)(?!\*) 1:italic
-add-highlighter shared/markdown/inline/text/ regex (?<!_)(_([^\s_]|([^\s_](\n?[^\n_])*[^\s_]))_)(?!_) 1:italic
-add-highlighter shared/markdown/inline/text/ regex (?<!\*)(\*\*([^\s*]|([^\s*](\n?[^\n*])*[^\s*]))\*\*)(?!\*) 1:bold
-add-highlighter shared/markdown/inline/text/ regex (?<!_)(__([^\s_]|([^\s_](\n?[^\n_])*[^\s_]))__)(?!_) 1:bold
+add-highlighter shared/markdown/inline/text/ regex (?<!\*)(\*([^\s*]|([^\s*](\n?[^\n*])*[^\s*]))\*)(?!\*) 1:+i
+add-highlighter shared/markdown/inline/text/ regex (?<!_)(_([^\s_]|([^\s_](\n?[^\n_])*[^\s_]))_)(?!_) 1:+i
+add-highlighter shared/markdown/inline/text/ regex (?<!\*)(\*\*([^\s*]|([^\s*](\n?[^\n*])*[^\s*]))\*\*)(?!\*) 1:+b
+add-highlighter shared/markdown/inline/text/ regex (?<!_)(__([^\s_]|([^\s_](\n?[^\n_])*[^\s_]))__)(?!_) 1:+b
 add-highlighter shared/markdown/inline/text/ regex <(([a-z]+://.*?)|((mailto:)?[\w+-]+@[a-z]+[.][a-z]+))> 0:link
 add-highlighter shared/markdown/inline/text/ regex ^\[[^\]\n]*\]:\h*([^\n]*) 1:link
 add-highlighter shared/markdown/inline/text/ regex ^\h*(>\h*)+ 0:comment

--- a/rc/filetype/restructuredtext.kak
+++ b/rc/filetype/restructuredtext.kak
@@ -75,8 +75,8 @@ add-highlighter shared/restructuredtext/content/ regex (\A|\n\n)(\}{3,}\n)?[^\n]
 add-highlighter shared/restructuredtext/content/ regex (\A|\n\n)(~{3,}\n)?[^\n]+\n(~{3,})$ 0:header
 
 # Inline markup
-add-highlighter shared/restructuredtext/content/ regex [^*](\*\*([^\s*]|([^\s*][^*]*[^\s*]))\*\*)[^*] 1:bold
-add-highlighter shared/restructuredtext/content/ regex [^*](\*([^\s*]|([^\s*][^*]*[^\s*]))\*)[^*] 1:italic
+add-highlighter shared/restructuredtext/content/ regex [^*](\*\*([^\s*]|([^\s*][^*]*[^\s*]))\*\*)[^*] 1:+b
+add-highlighter shared/restructuredtext/content/ regex [^*](\*([^\s*]|([^\s*][^*]*[^\s*]))\*)[^*] 1:+i
 add-highlighter shared/restructuredtext/content/ regex [^`](``([^\s`]|([^\s`][^`]*[^\s`]))``)[^`] 1:mono
 
 }


### PR DESCRIPTION
This commit removes declarations and mentions to the built-in `bold`
and `italic` faces.

While they could be a user-friendly way of customising how tokens
are emphasised in Markdown documents (similarly to the
`$LESS_TERMCAP_*` environment variables for `man` pagers), most other
markup languages do not have the concept of "strong" and "emphasis"
but refer directly to the font style/weight.

The faces were also not even set by default to highlight as their
names implied, so having markup language support scripts directly
use the +b and +i face attributes is more consistent.