### PR TITLE
LaTeX highlighter improvements/fixes

### DIFF
--- a/rc/filetype/latex.kak
+++ b/rc/filetype/latex.kak
@@ -39,7 +39,7 @@ add-highlighter shared/latex/content/ regex '\\(?!_)\w+\b' 0:keyword
 # Options passed to scopes, between brackets
 add-highlighter shared/latex/content/ regex '\\(?!_)\w+\b\[([^\]]+)\]' 1:value
 # Content between dollar signs/pairs
-add-highlighter shared/latex/content/ regex '(\$(\\\$|[^$])+\$)|(\$\$(\\\$|[^$])+\$\$)' 0:meta
+add-highlighter shared/latex/content/ regex '((?<!\\)\$(\\\$|[^$])+\$)|((?<!\\)\$\$(\\\$|[^$])+\$\$)|((?<!\\)\\\[.*?\\\])|(\\\(.*?\\\))' 0:meta
 # Emphasized text
 add-highlighter shared/latex/content/ regex '\\(emph|textit)\{([^}]+)\}' 2:default+i
 # Bold text


### PR DESCRIPTION
LaTeX delimits math by `$...$` `$$...$$` `\[...\]` `\(...\)`. This change does a few things:

 - Adds `\[...\]` `\(...\)`
 - Skips `\$`, as that is a normal dollar sign and not math.

The regex for `\[...\]` also checks for a preceding `\`, as `\\[...]` is a new line break of specific size.