### PR TITLE
Fixed need for double escaping \ in custom object desc (\\\\ to match \)

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1302,7 +1302,8 @@ void select_object(Context& context, NormalParams params)
                     struct error : runtime_error { error(size_t) : runtime_error{"desc parsing failed, expected <open>,<close>"} {} };
 
                     auto params = cmdline | split<StringView>(',', '\\') |
-                        transform(unescape<',', '\\'>) | static_gather<error, 2>();
+                        transform([](auto s) { return unescape(s, {','}, '\\'); }) |
+                        static_gather<error, 2>();
 
                     if (params[0].empty() or params[1].empty())
                         throw error{0};


### PR DESCRIPTION
In custom object desc (eg `<a-a>c`), matching `\` requires entering `\\\\`. This is because of unescaping `\\` at the same time as `\,`. This fix simply avoids unescaping `\\`, so that the input behaves like a normal regex.

Example:
Buffer: `\\_,` with cursor at `_`
`<a-a>c\\,\,` now gives `\[\_,]` as expected.