### PR TITLE
Fix default value of $XDG_CONFIG_HOME in doc

### DIFF
--- a/doc/kak.1
+++ b/doc/kak.1
@@ -175,7 +175,7 @@ If not started with the \fB\-n\fR switch, Kakoune will first load
 
 .nf
 .RS
-if the \fI$KAKOUNE_CONFIG_DIR/kak/autoload\fR directory exists, recursively load every
+if the \fI$KAKOUNE_CONFIG_DIR/autoload\fR directory exists, recursively load every
 \fI*.kak\fR files in it and its sub-directories
 .RE
 .fi
@@ -196,11 +196,11 @@ configuration
 
 .nf
 .RS
-\fI$KAKOUNE_CONFIG_DIR/kak/kakrc\fR, if it exists; this is the user configuration
+\fI$KAKOUNE_CONFIG_DIR/kakrc\fR, if it exists; this is the user configuration
 .RE
 .fi
 
-Consequently, if the \fI$KAKOUNE_CONFIG_DIR/kak/autoload\fR directory exists,
+Consequently, if the \fI$KAKOUNE_CONFIG_DIR/autoload\fR directory exists,
 only scripts stored within that directory will be loaded \- the built-in
 \fI*.kak\fR files \fBwill not be\fR.
 

--- a/doc/kak.1
+++ b/doc/kak.1
@@ -158,8 +158,7 @@ defaults to \fI$XDG_CONFIG_HOME/kak\fR if unset.
 
 .TP
 .BR XDG_CONFIG_HOME
-Path to the user configuration directory, defaults to \fI$HOME/.config/kak\fR
-if unset.
+Path to the user configuration directory, defaults to \fI$HOME/.config\fR if unset.
 
 .TP
 .BR XDG_RUNTIME_DIR


### PR DESCRIPTION
`$XDG_CONFIG_HOME` is the directory containing user-specific configurations for many apps, it should default to `$HOME/.config`, instead of `$HOME/.config/kak` (which is `$KAKOUNE_CONFIG_DIR`) as currently stated in the documentation.