### PR TITLE
src: Introduce a <percent> named key

### DIFF
--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -170,7 +170,7 @@ the Shift modifier and moving will extend each selection instead.
     trim selections to only contain full lines (not including last
     end-of-line)
 
-*%*::
+*%*, *<percent>*::
     select whole buffer
 
 *<a-h>*::

--- a/rc/detection/modeline.kak
+++ b/rc/detection/modeline.kak
@@ -96,7 +96,7 @@ define-command -hidden modeline-parse-impl %{
 #   [text]{white}{vi:|vim:|Vim:|ex:}[white]se[t] {options}:[text]
 define-command modeline-parse -docstring "Read and interpret vi-format modelines at the beginning/end of the buffer" %{
     try %{ evaluate-commands -draft %{
-        execute-keys \%s\A|.\z<ret> %opt{modelines}k <a-x> %opt{modelines}X \
+        execute-keys <percent> s\A|.\z<ret> %opt{modelines}k <a-x> %opt{modelines}X \
              s^\S*?\s+?(vim?|kak(oune)?):\s?[^\n]+<ret> <a-x>
         evaluate-commands -draft -itersel modeline-parse-impl
     } }

--- a/rc/tools/doc.kak
+++ b/rc/tools/doc.kak
@@ -8,7 +8,7 @@ declare-option -hidden range-specs doc_anchors
 
 define-command -hidden -params 4 doc-render-regex %{
     evaluate-commands -draft %{ try %{
-        execute-keys \%s %arg{1} <ret>
+        execute-keys <percent> s %arg{1} <ret>
         execute-keys -draft s %arg{2} <ret> d
         execute-keys "%arg{3}"
         evaluate-commands %sh{
@@ -23,7 +23,7 @@ define-command -hidden -params 4 doc-render-regex %{
 
 define-command -hidden doc-parse-links %{
     evaluate-commands -draft %{ try %{
-        execute-keys \%s <lt><lt>(.*?),.*?<gt><gt> <ret>
+        execute-keys <percent> s <lt><lt>(.*?),.*?<gt><gt> <ret>
         execute-keys -draft s <lt><lt>.*,|<gt><gt> <ret> d
         execute-keys H
         set-option buffer doc_links %val{timestamp}
@@ -39,13 +39,13 @@ define-command -hidden doc-parse-anchors %{
     evaluate-commands -draft %{ try %{
         set-option buffer doc_anchors %val{timestamp}
         # Find sections as add them as imlicit anchors
-        execute-keys \%s ^={2,}\h+([^\n]+)$ <ret>
+        execute-keys <percent> s ^={2,}\h+([^\n]+)$ <ret>
         evaluate-commands -itersel %{
             set-option -add buffer doc_anchors "%val{selection_desc}|%sh{printf '%s' ""$kak_main_reg_1"" | tr '[A-Z ]' '[a-z-]'}"
         }
 
         # Parse explicit anchors and remove their text
-        execute-keys \%s \[\[(.*?)\]\]\s* <ret>
+        execute-keys <percent> s \[\[(.*?)\]\]\s* <ret>
         evaluate-commands -itersel %{
             set-option -add buffer doc_anchors "%val{selection_desc}|%reg{1}"
         }
@@ -110,7 +110,7 @@ define-command -params 1 -hidden doc-render %{
     }
 
     # Remove some line end markers
-    try %{ execute-keys -draft \%s \h*(\+|:{2,})$ <ret> d }
+    try %{ execute-keys -draft <percent> s \h*(\+|:{2,})$ <ret> d }
 
     # Setup the doc_render_ranges option
     set-option buffer doc_render_ranges %val{timestamp}
@@ -124,7 +124,7 @@ define-command -params 1 -hidden doc-render %{
     doc-parse-links
 
     # Remove escaping of * and `
-    try %{ execute-keys -draft \%s \\((?=\*)|(?=`)) <ret> d }
+    try %{ execute-keys -draft <percent> s \\((?=\*)|(?=`)) <ret> d }
 
     set-option buffer readonly true
     add-highlighter buffer/ ranges doc_render_ranges

--- a/src/keys.cc
+++ b/src/keys.cc
@@ -79,6 +79,7 @@ static constexpr KeyAndName keynamemap[] = {
     { "plus", '+' },
     { "minus", '-' },
     { "semicolon", ';' },
+    { "percent", '%' },
 };
 
 KeyList parse_keys(StringView str)


### PR DESCRIPTION
Similarly to the <semicolon> key, make it easier to write
`:execute-keys` commands by replacing <percent> with `%`.

Highlighters can keep escaping the sign when regular expressions are
not quoted, but built-in scripts that use `%` as an editing primitive
have been modified to use the named key, for clarity.