### PR TITLE
src: Implement a `-N` flag to ignore user configuration

### DIFF
--- a/doc/kak.1
+++ b/doc/kak.1
@@ -32,7 +32,7 @@ kak \- a vim inspired, selection oriented code editor
 .B kak \-s
 .I session_id
 .B \-d
-[\fB\-n\fR] [\fB\-ro\fR]
+[\fB\-n\fR|\fB\-N\fR] [\fB\-ro\fR]
 [\fB\-E\fR \fIcommand\fR]
 [\fB+line\fR[\fB:column\fR]|\fB+:\fR]
 .IR file ...
@@ -40,7 +40,7 @@ kak \- a vim inspired, selection oriented code editor
 .PP
 .B kak
 [\fB\-c\fR \fIsession_id\fR|\fB\-s\fR \fIsession_id\fR]
-[\fB\-n\fR] [\fB\-ro\fR]
+[\fB\-n\fR|\fB\-N\fR] [\fB\-ro\fR]
 [\fB\-ui\fR \fIui_type\fR] [\fB\-e\fR \fIcommand\fR]
 [\fB\-E\fR \fIcommand\fR]
 [\fB+line\fR[\fB:column\fR]|\fB+:\fR]
@@ -81,7 +81,11 @@ display kakoune version and quit
 
 .TP
 .BR \-n
-do not load resource files on startup (\fIkakrc\fR, \fIautoload\fR, \fIrc\fR etc)
+do not load any resource files on startup (\fIkakrc\fR, \fIautoload\fR, \fIrc\fR etc)
+
+.TP
+.BR \-N
+do not load user configuration files on startup, conflicts with \fB-n\fR above
 
 .TP
 .BR \-l
@@ -203,6 +207,10 @@ configuration
 Consequently, if the \fI$KAKOUNE_CONFIG_DIR/autoload\fR directory exists,
 only scripts stored within that directory will be loaded \- the built-in
 \fI*.kak\fR files \fBwill not be\fR.
+
+If the \fB\-N\fR switch was passed, Kakoune will load system files
+(stored in \fI<rtdir>\fR) and ignore the user configuration (stored in
+\fI$KAKOUNE_CONFIG_DIR\fR).
 
 Users who still want to have the built\-in scripts loaded along their own
 can create a symbolic link to \fI<rtdir>/autoload\fR (or to individual

--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -31,9 +31,12 @@ evaluate-commands %sh{
             | sed 's/.*/try %{ source "&" } catch %{ echo -debug Autoload: could not load "&" }/'
     }
 
+    readonly SYSTEM_ONLY="$1"
+
     echo "colorscheme default"
 
-    if [ -d "${kak_config}/autoload" ]; then
+    if [ -d "${kak_config}/autoload" ] \
+       && [ "${SYSTEM_ONLY}" != "true" ]; then
         autoload_directory ${kak_config}/autoload
     elif [ -d "${kak_runtime}/autoload" ]; then
         autoload_directory ${kak_runtime}/autoload
@@ -43,7 +46,8 @@ evaluate-commands %sh{
         echo "source '${kak_runtime}/kakrc.local'"
     fi
 
-    if [ -f "${kak_config}/kakrc" ]; then
+    if [ -f "${kak_config}/kakrc" ] \
+       && [ "${SYSTEM_ONLY}" != "true" ]; then
         echo "source '${kak_config}/kakrc'"
     fi
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -699,11 +699,12 @@ struct convert_to_client_mode
 
 enum class ServerFlags
 {
-    None        = 0,
-    IgnoreKakrc = 1 << 0,
-    Daemon      = 1 << 1,
-    ReadOnly    = 1 << 2,
-    StartupInfo = 1 << 3,
+    None            = 0,
+    IgnoreKakrc     = 1 << 0,
+    Daemon          = 1 << 1,
+    ReadOnly        = 1 << 2,
+    StartupInfo     = 1 << 3,
+    SystemKakrcOnly = 1 << 4,
 };
 constexpr bool with_bit_ops(Meta::Type<ServerFlags>) { return true; }
 
@@ -769,7 +770,8 @@ int run_server(StringView session, StringView server_init,
     if (not (flags & ServerFlags::IgnoreKakrc)) try
     {
         Context init_context{Context::EmptyContextFlag{}};
-        command_manager.execute(format("source {}/kakrc", runtime_directory()),
+        command_manager.execute(format("source {}/kakrc {}", runtime_directory(),
+                                       (flags & ServerFlags::SystemKakrcOnly) ? "true" : "false"),
                                 init_context);
     }
     catch (runtime_error& error)
@@ -1042,6 +1044,7 @@ int main(int argc, char* argv[])
                    { "e", { true,  "execute argument on client initialisation" } },
                    { "E", { true,  "execute argument on server initialisation" } },
                    { "n", { false, "do not source kakrc files on startup" } },
+                   { "N", { false, "do not source user configuration files on startup" } },
                    { "s", { true,  "set session name" } },
                    { "d", { false, "run as a headless session (requires -s)" } },
                    { "p", { true,  "just send stdin as commands to the given session" } },
@@ -1107,7 +1110,7 @@ int main(int argc, char* argv[])
 
         if (auto session = parser.get_switch("p"))
         {
-            for (auto opt : { "c", "n", "s", "d", "e", "E", "ro" })
+            for (auto opt : { "c", "n", "N", "s", "d", "e", "E", "ro" })
             {
                 if (parser.get_switch(opt))
                 {
@@ -1167,7 +1170,7 @@ int main(int argc, char* argv[])
 
         if (auto server_session = parser.get_switch("c"))
         {
-            for (auto opt : { "n", "s", "d", "E", "ro" })
+            for (auto opt : { "n", "N", "s", "d", "E", "ro" })
             {
                 if (parser.get_switch(opt))
                 {
@@ -1193,11 +1196,20 @@ int main(int argc, char* argv[])
             try
             {
                 auto ignore_kakrc = (bool)parser.get_switch("n");
-                auto flags = (ignore_kakrc                                ? ServerFlags::IgnoreKakrc : ServerFlags::None) |
-                             (parser.get_switch("d")                      ? ServerFlags::Daemon      : ServerFlags::None) |
-                             (parser.get_switch("ro")                     ? ServerFlags::ReadOnly    : ServerFlags::None) |
-                             ((argc == 1 or (ignore_kakrc and argc == 2))
-                              and isatty(0)                               ? ServerFlags::StartupInfo : ServerFlags::None);
+                auto ignore_user_kakrc = (bool)parser.get_switch("N");
+
+                if (ignore_kakrc and ignore_user_kakrc)
+                {
+                    write_stderr("error: -N is incompatible with -n\n");
+                    return -1;
+                }
+
+                auto flags = (ignore_kakrc            ? ServerFlags::IgnoreKakrc     : ServerFlags::None) |
+                             (parser.get_switch("N")  ? ServerFlags::SystemKakrcOnly : ServerFlags::SystemKakrcOnly) |
+                             (parser.get_switch("d")  ? ServerFlags::Daemon          : ServerFlags::None) |
+                             (parser.get_switch("ro") ? ServerFlags::ReadOnly        : ServerFlags::None) |
+                             ((argc == 1 or ((ignore_kakrc or ignore_user_kakrc) and argc == 2))
+                              and isatty(0)           ? ServerFlags::StartupInfo     : ServerFlags::None);
                 auto debug_flags = option_from_string(Meta::Type<DebugFlags>{}, parser.get_switch("debug").value_or(""));
                 return run_server(session, server_init, client_init, init_coord, flags, ui_type, debug_flags, files);
             }


### PR DESCRIPTION
Users with a heavy configuration that customise a lot of default
settings/side-effects cannot easily have it ignored by the editor.

This commit implements a `-N` flag that instructs the editor to load
system files, but skip those written by the user. In terms of built-in
options:

* load files in %val{runtime}
* ignore files in %val{config}

Note that, despite being user-created, the `kakrc.local` file will
still be loaded.