### PR TITLE
Improve `tomorrow-night` and `github` colorschemes

### DIFF
--- a/colors/github.kak
+++ b/colors/github.kak
@@ -29,12 +29,12 @@ face global list yellow
 
 ## builtin
 face global Default rgb:121213,rgb:F8F8FF
-face global PrimarySelection default,rgb:A6F3A6+fg
-face global SecondarySelection default,rgb:DBFFDB+fg
-face global PrimaryCursor black,rgb:888888+fg
-face global SecondaryCursor black,rgb:888888+fg
-face global PrimaryCursorEol black,rgb:A71D5D+fg
-face global SecondaryCursorEol black,rgb:A71D5D+fg
+face global PrimarySelection rgb:121213,rgb:A6F3A6+fg
+face global SecondarySelection rgb:121213,rgb:DBFFDB+fg
+face global PrimaryCursor rgb:121213,rgb:888888+fg
+face global SecondaryCursor rgb:121213,rgb:AAAAAA+fg
+face global PrimaryCursorEol rgb:121213,rgb:A71D5D+fg
+face global SecondaryCursorEol rgb:121213,rgb:A71D5D+fg
 face global LineNumbers rgb:A0A0A0,rgb:ECECEC
 face global LineNumberCursor rgb:434343,rgb:DDDDDD
 face global MenuForeground rgb:434343,rgb:CDCDFD

--- a/colors/tomorrow-night.kak
+++ b/colors/tomorrow-night.kak
@@ -1,78 +1,73 @@
-##
+#
 ## Tomorrow-night, adapted by nicholastmosher
 ##
 
 evaluate-commands %sh{
-    foreground="rgb:c5c8c6"
-    background="rgb:272727"
-    selection="rgb:373b41"
-    window="rgb:383838"
-    text="rgb:D8D8D8"
-    text_light="rgb:4E4E4E"
-    line="rgb:282a2e"
-    comment="rgb:969896"
-    red="rgb:cc6666"
-    orange="rgb:d88860"
-    yellow="rgb:f0c674"
-    green="rgb:b5bd68"
-    green_dark="rgb:a1b56c"
-    blue="rgb:81a2be"
-    aqua="rgb:87afaf"
-    magenta="rgb:ab4642"
-    purple="rgb:b294bb"
+    foreground="rgb:c5c8c6" # gui05
+    background="rgb:1d1f21" # gui00
+    selection="rgb:373b41"  # gui02
+    window="rgb:282a2e"     # gui01
+    comment="rgb:969896"    # gui03
+    red="rgb:cc6666"        # gui08
+    orange="rgb:de935f"     # gui09
+    yellow="rgb:f0c674"     # gui0A
+    green="rgb:b5bd68"      # gui0B
+    blue="rgb:81a2be"       # gui0D
+    aqua="rgb:8abeb7"       # gui0C
+    purple="rgb:b294bb"     # gui0E
 
     ## code
     echo "
         face global value ${orange}
         face global type ${yellow}
-        face global variable ${magenta}
-        face global module ${green}
-        face global function ${aqua}
-        face global string ${green_dark}
+        face global variable ${red}
+        face global module ${blue}
+        face global function ${blue}
+        face global string ${green}
         face global keyword ${purple}
         face global operator ${aqua}
         face global attribute ${purple}
         face global comment ${comment}
         face global documentation comment
         face global meta ${purple}
-        face global builtin ${orange}
+        face global builtin ${yellow}
     "
 
     ## markup
     echo "
-        face global title blue
+        face global title ${blue}
         face global header ${aqua}
-        face global mono ${green_dark}
+        face global mono ${green}
         face global block ${orange}
-        face global link blue
+        face global link ${blue}
         face global bullet ${red}
         face global list ${red}
     "
 
     ## builtin
     echo "
-        face global Default ${text},${background}
-        face global PrimarySelection default,${selection}+fg
-        face global SecondarySelection default,${selection}+fg
-        face global PrimaryCursor black,${aqua}+fg
-        face global SecondaryCursor black,${aqua}+fg
-        face global PrimaryCursorEol black,${green_dark}+fg
-        face global SecondaryCursorEol black,${green_dark}+fg
-        face global LineNumbers ${text_light},${background}
-        face global LineNumberCursor ${yellow},rgb:282828+b
-        face global MenuForeground ${text_light},blue
-        face global MenuBackground ${aqua},${window}
-        face global MenuInfo ${aqua}
-        face global Information white,${window}
-        face global Error white,${red}
-        face global StatusLine ${text},${window}
+        face global Default ${foreground},${background}
+        face global PrimarySelection ${foreground},${selection}+fg
+        face global SecondarySelection ${foreground},${window}+fg
+        face global PrimaryCursor ${background},${foreground}+fg
+        face global SecondaryCursor ${background},${aqua}+fg
+        face global PrimaryCursorEol ${background},${green}+fg
+        face global SecondaryCursorEol ${background},${green}+fg
+        face global LineNumbers ${comment},${window}
+        face global LineNumberCursor ${yellow},${window}+b
+        face global MenuForeground ${window},${foreground}
+        face global MenuBackground ${foreground},${window}
+        face global MenuInfo ${red}
+        face global Information ${foreground},${window}
+        face global Error ${foreground},${red}
+        face global StatusLine ${foreground},${selection}
         face global StatusLineMode ${yellow}+b
         face global StatusLineInfo ${aqua}
-        face global StatusLineValue ${green_dark}
+        face global StatusLineValue ${green}
         face global StatusCursor ${window},${aqua}
         face global Prompt ${background},${aqua}
         face global MatchingChar ${yellow},${background}+b
         face global BufferPadding ${aqua},${background}
-        face global Whitespace ${text_light}+f
+        face global Whitespace ${comment}+f
     "
 }


### PR DESCRIPTION
When switching through the built-in colorschemes with the [colorscheme browser](https://github.com/shachaf/kak/blob/master/scripts/colorscheme-browser.kak), I noticed a few of them had legibility issues, usually regarding distinguishing primary and secondary selections.

I started with `tomorrow-night` and that led to an effort to make it more faithful to the original taking the [Vim version](https://github.com/chriskempson/base16-vim/blob/master/colors/base16-tomorrow-night.vim) as reference. The most significant change is the background color.

For `github` I just made sure that the default faces are overridden since the selections were obscuring the foreground text at least with a dark terminal scheme. I also changed the lightness of the SecondaryCursor to distinguish it from the PrimaryCursor, which is important if each selection is a single character.

`tomorrow-night` before/after/Vim:
![tomorrow-night](https://user-images.githubusercontent.com/7876996/83978999-19e75680-a8c0-11ea-9914-c4403c93345b.png)

`github` before/after:
![github](https://user-images.githubusercontent.com/7876996/83979021-456a4100-a8c0-11ea-8091-af9171d3d580.png)

I also think there is a discussion to be had regarding how much distinguishability we should expect with the built-in colorschemes. I think we should definitely expect `PrimarySelection` and `SecondarySelection` are distinguishable (at least when there is foreground text), which this PR is addressing. I'd also like to have `PrimaryCursor` and `SecondaryCursor` distinguishable, but that is not the case for most colorschemes including the default one and more colors might need to be defined per colorscheme. Going further, `PrimaryCursorEol` and `SecondaryCursorEol` difference can also be enforced, but I don't think it is critical since it is rare that only eol characters will be selected with multiple selection.