### PR TITLE
Detect text/x-script.* and application/x-* types

### DIFF
--- a/rc/detection/file.kak
+++ b/rc/detection/file.kak
@@ -7,8 +7,10 @@ hook global BufOpenFile .* %{ evaluate-commands %sh{
             image/*+xml) filetype="xml" ;; #SVG
             message/rfc822) filetype="mail" ;;
             text/x-shellscript) filetype="sh" ;;
+            text/x-script.*) filetype="${mime#text/x-script.}" ;;
             text/x-*) filetype="${mime#text/x-}" ;;
             text/*)   filetype="${mime#text/}" ;;
+            application/x-*) filetype="${mime#application/x-}" ;;
             application/*) filetype="${mime#application/}" ;;
         esac
         if [ -n "${filetype}" ]; then


### PR DESCRIPTION
Motivation: Scheme scripts have used the first one in the past,
as well as tcl scripts, zsh, csh, and some others.  The second
one seems to be the preferred format for adding a new, local
programming language mime type, so I followed this convention
locally in my `~/.magic` for my scheme files.