### PR TITLE
fish.kak: do not treat escaped quotes as region start

### DIFF
--- a/rc/filetype/fish.kak
+++ b/rc/filetype/fish.kak
@@ -33,8 +33,8 @@ provide-module fish %{
 
 add-highlighter shared/fish regions
 add-highlighter shared/fish/code default-region group
-add-highlighter shared/fish/double_string region '"' (?<!\\)(\\\\)*"  group
-add-highlighter shared/fish/single_string region "'" (?<!\\)(\\\\)*'  fill string
+add-highlighter shared/fish/double_string region (?<!\\)(?:\\\\)*\K" (?<!\\)(\\\\)*"  group
+add-highlighter shared/fish/single_string region (?<!\\)(?:\\\\)*\K' (?<!\\)(\\\\)*'  fill string
 add-highlighter shared/fish/comment       region '#' '$'              fill comment
 
 add-highlighter shared/fish/double_string/ fill string


### PR DESCRIPTION
Just like in sh.kak, for example:

	echo \" \\\" this-text-is-not-quoted