### PR TITLE
Fix 'error: non-constant-expression cannot be narrowed...'

### DIFF
--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -753,7 +753,7 @@ Optional<Key> NCursesUI::get_next_key()
             const int y = (sgr ? params[2] : next_char() - 32) - 1;
             auto coord = encode_coord({y - content_line_offset(), x});
             Key::Modifiers mod = parse_mask((b >> 2) & 0x7);
-            switch (auto code = b & 0x43; code)
+            switch (const int code = b & 0x43; code)
             {
             case 0: case 1: case 2:
                 return mouse_button(mod, Key::MouseButton{code}, coord, c == 'm');


### PR DESCRIPTION
Fix **clang** based builds that raise the following error:

```
ncurses_ui.cc:759:59: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'Key::MouseButton' in initializer list [-Wc++11-narrowing]
                return mouse_button(mod, Key::MouseButton{code}, coord, c == 'm');
                                                          ^~~~
```