### PR TITLE
expansions.asciidoc: Add an example of file expansion.

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -171,6 +171,13 @@ Kakoune uses a shell command, such as the `|`, `!` or `$` normal mode commands
 Expansions with the type `file` will expand to the content of the filename
 given in argument as read from the host filesystem.
 
+For example, this command stores the entire content of `/etc/passwd` into the
+`a` register.
+
+----
+set-register a %file{/etc/passwd}
+----
+
 == Value expansions
 
 Expansions with the type `val` give access to Kakoune internal data that is


### PR DESCRIPTION
Properly speaking, all expansions are of the form "%abc{}" where "abc" is the expansion type. All expansion types are listed in the documentation, as they should be. However, when searching through the documentation, a keyword like "file" is likely to hit a lot of false-positives, so a smart user is likely to search for the more-unique "%file" instead. Unfortunately, unlike every other expansion-type, file-expansions did not include an example, so a search for "%file" resulted in no hits, potentially leading people to believe it was undocumented.

Now there's an example, so people searching for "%file" will find what they're looking for.