### PR TITLE
Fix missing whitespace from improved windowing module detection.

### DIFF
--- a/rc/windowing/iterm.kak
+++ b/rc/windowing/iterm.kak
@@ -5,7 +5,7 @@ provide-module iterm %{
 
 # ensure that we're running on iTerm
 evaluate-commands %sh{
-    [-z "${kak_opt_windowing_modules}" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || echo 'fail iTerm not detected'
+    [ -z "${kak_opt_windowing_modules}" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || echo 'fail iTerm not detected'
 }
 
 define-command -hidden -params 2.. iterm-terminal-split-impl %{

--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -5,7 +5,7 @@ provide-module kitty %{
 
 # ensure that we're running on kitty
 evaluate-commands %sh{
-    [-z "${kak_opt_windowing_modules}" ] || [ "$TERM" = "xterm-kitty" ] || echo 'fail Kitty not detected'
+    [ -z "${kak_opt_windowing_modules}" ] || [ "$TERM" = "xterm-kitty" ] || echo 'fail Kitty not detected'
 }
 
 declare-option -docstring %{window type that kitty creates on new and repl calls (kitty|os)} str kitty_window_type kitty

--- a/rc/windowing/screen.kak
+++ b/rc/windowing/screen.kak
@@ -6,7 +6,7 @@ provide-module screen %{
 
 # ensure that we're running under screen
 evaluate-commands %sh{
-    [-z "${kak_opt_windowing_modules}" ] || [ -n "$STY" ] || echo 'fail screen not detected'
+    [ -z "${kak_opt_windowing_modules}" ] || [ -n "$STY" ] || echo 'fail screen not detected'
 }
 
 define-command screen-terminal-impl -hidden -params 3.. %{

--- a/rc/windowing/x11.kak
+++ b/rc/windowing/x11.kak
@@ -4,7 +4,7 @@ provide-module x11 %{
 
 # ensure that we're running in the right environment
 evaluate-commands %sh{
-    [-z "${kak_opt_windowing_modules}" ] || [ -n "$DISPLAY" ] || echo 'fail DISPLAY is not set'
+    [ -z "${kak_opt_windowing_modules}" ] || [ -n "$DISPLAY" ] || echo 'fail DISPLAY is not set'
 }
 
 # termcmd should be set such as the next argument is the whole


### PR DESCRIPTION
A space was missing from some of the tests for a zero length `windowing_modules` option, making them invalid shell code.

This has been tested with kitty, tmux, screen and x11 environments.