### PR TITLE
Disable zsh autotitle

### DIFF
--- a/rc/windowing/repl/x11.kak
+++ b/rc/windowing/repl/x11.kak
@@ -18,8 +18,10 @@ define-command -docstring %{
         fi
         if [ $# -eq 0 ]; then cmd="${SHELL:-sh}"; else cmd="$@"; fi
         # The escape sequence in the printf command sets the terminal's title:
-        setsid ${kak_opt_termcmd} "printf '\e]2;kak_repl_window\a' \
+        setsid ${kak_opt_termcmd} "DISABLE_AUTO_TITLE=false \ # disable zsh auto title
+        	&& printf '\e]2;kak_repl_window\a' \    
                 && ${cmd}" < /dev/null > /dev/null 2>&1 &
+
 }}
 
 define-command x11-send-text -docstring "send the selected text to the repl window" %{


### PR DESCRIPTION
Zsh has a setting to set the title automatically and it is enable by default. To make zsh work with this script without having the user change they zsh config, we have to disable it by setting `DISABLE_AUTO_TITLE=false` .
