### PR TITLE
gruvbox: invert colors for info box

### DIFF
--- a/colors/gruvbox.kak
+++ b/colors/gruvbox.kak
@@ -60,7 +60,7 @@ evaluate-commands %sh{
         face global MenuForeground     ${bg2},${blue}
         face global MenuBackground     ${fg},${bg2}
         face global MenuInfo           ${bg}
-        face global Information        ${bg},${fg}
+        face global Information        ${fg},${bg}
         face global Error              ${bg},${red}
         face global StatusLine         ${fg},${bg}
         face global StatusLineMode     ${yellow}+b


### PR DESCRIPTION
I've been using `gruvbox` colorscheme for a long time, and one thing that always bothered me is that while the theme is generally dark, the amount of "white" color that info box produces is simply blinding, especially at night.

I inverted the colors and was really happy with the result, so I propose we do it for everyone.

Before:

![image](https://user-images.githubusercontent.com/1177900/87767694-52f9db80-c81b-11ea-82ac-2dc63b50cbf7.png)


After:

![image](https://user-images.githubusercontent.com/1177900/87767676-4aa1a080-c81b-11ea-9cf5-e399ad28d69c.png)
