### PR TITLE
ocaml quoted-strings

### DIFF
--- a/rc/filetype/ocaml.kak
+++ b/rc/filetype/ocaml.kak
@@ -29,6 +29,7 @@ provide-module ocaml %{
 add-highlighter shared/ocaml regions
 add-highlighter shared/ocaml/code default-region group
 add-highlighter shared/ocaml/string region (?<!')" (?<!\\)(\\\\)*" fill string
+add-highlighter shared/ocaml/quotedstring region -match-capture %"\{(\w*)\|" %"\|(\w*)\}" fill string
 add-highlighter shared/ocaml/comment region -recurse \Q(* \Q(* \Q*) fill comment
 
 add-highlighter shared/ocaml/code/char regex %{\B'([^'\\]|(\\[\\"'nrtb])|(\\\d{3})|(\\x[a-fA-F0-9]{2})|(\\o[0-7]{3}))'\B} 0:value


### PR DESCRIPTION
Quoted strings in the form of {|this is a string|}

Documented here: https://caml.inria.fr/pub/docs/manual-ocaml/lex.html#sss:stringliterals