### PR TITLE
asciidoc: Fix bullet face regular expression

### DIFF
--- a/rc/filetype/asciidoc.kak
+++ b/rc/filetype/asciidoc.kak
@@ -33,14 +33,16 @@ add-highlighter shared/asciidoc/ regex (\A|\n\n)[^\n]+\n\^{2,}\h*$ 0:header
 add-highlighter shared/asciidoc/ regex (\A|\n\n)=\h+[^\n]+$ 0:title
 add-highlighter shared/asciidoc/ regex (\A|\n\n)={2,}\h+[^\n]+$ 0:header
 
-add-highlighter shared/asciidoc/ regex ^\h+([-\*])\h+[^\n]*(\n\h+[^-\*]\S+[^\n]*)*$ 0:list 1:bullet
+add-highlighter shared/asciidoc/ regex ^\h*(?<bullet>[-\*])\h+[^\n]+$ 0:list bullet:bullet
+add-highlighter shared/asciidoc/ regex ^\h*(?<bullet>[-\*]+)\h+[^\n]+(\n\h+[^-\*\n]*)?$ 0:list bullet:bullet
 add-highlighter shared/asciidoc/ regex ^(-{3,})\n[^\n\h].*?\n(-{3,})$ 0:block
 add-highlighter shared/asciidoc/ regex ^(={3,})\n[^\n\h].*?\n(={3,})$ 0:block
 add-highlighter shared/asciidoc/ regex ^(~{3,})\n[^\n\h].*?\n(~{3,})$ 0:block
 add-highlighter shared/asciidoc/ regex ^(\*{3,})\n[^\n\h].*?\n(\*{3,})$ 0:block
 add-highlighter shared/asciidoc/ regex \B(?:\+[^\n]+?\+|`[^\n]+?`)\B 0:mono
 add-highlighter shared/asciidoc/ regex \b_[^\n]+?_\b 0:+i
-add-highlighter shared/asciidoc/ regex \B\*[^\n]+?\*\B 0:+b
+add-highlighter shared/asciidoc/ regex \s\*[^\n\*]+\*\B 0:+b
+add-highlighter shared/asciidoc/ regex \h\*[^\n\*]+\*\B 0:+b
 add-highlighter shared/asciidoc/ regex ^:[-\w]+: 0:meta
 
 # Commands


### PR DESCRIPTION
Additionally, change the bolding regex to account for this.

Fixes #3605.

There's still one outstanding problem: I haven't cracked how to highlight indented lines following a bullet past the first indented line. I figure I'm missing something obvious but it isn't jumping out at me right now.

