### PR TITLE
doc: Fix braces selection shortcut in TRAMPOLINE

### DIFF
--- a/contrib/TRAMPOLINE
+++ b/contrib/TRAMPOLINE
@@ -168,7 +168,7 @@ using the built-in `:doc` command.
             `---'   braces, quotes etc) have an alternative second key that
                     is displayed in the information menu that you can use to
                     minimize finger gymnastics. The previous shortcut could
-                    thus also be written: `[ r`.
+                    thus also be written: `[ b`.
 
                     ==[ MOVEMENT SELECTIONS
 


### PR DESCRIPTION
The Selecting Objects section mentions `[ r` as a shortcut for `[ (` but this is actually a shortcut for `[ [`. The correct shortcut would be `[ b`.