### PR TITLE
rc: conservative comment highlighting for shells

### DIFF
--- a/rc/filetype/fish.kak
+++ b/rc/filetype/fish.kak
@@ -35,7 +35,7 @@ add-highlighter shared/fish regions
 add-highlighter shared/fish/code default-region group
 add-highlighter shared/fish/double_string region (?<!\\)(?:\\\\)*\K" (?<!\\)(\\\\)*"  group
 add-highlighter shared/fish/single_string region (?<!\\)(?:\\\\)*\K' (?<!\\)(\\\\)*'  fill string
-add-highlighter shared/fish/comment       region '#' '$'              fill comment
+add-highlighter shared/fish/comment       region (?<!\\)(?:\\\\)*(?:^|\h)\K# '$' fill comment
 
 add-highlighter shared/fish/double_string/ fill string
 add-highlighter shared/fish/double_string/ regex (\$\w+)|(\{\$\w+\}) 0:variable

--- a/rc/filetype/makefile.kak
+++ b/rc/filetype/makefile.kak
@@ -30,7 +30,7 @@ provide-module makefile %{
 add-highlighter shared/makefile regions
 
 add-highlighter shared/makefile/content default-region group
-add-highlighter shared/makefile/comment region '#' '$' fill comment
+add-highlighter shared/makefile/comment region (?<!\\)(?:\\\\)*(?:^|\h)\K# '$' fill comment
 add-highlighter shared/makefile/evaluate-commands region -recurse '\(' '\$\(' '\)' fill value
 
 add-highlighter shared/makefile/content/ regex ^\S.*?(::|:|!)\s 0:variable

--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -23,7 +23,7 @@ add-highlighter shared/sh/code default-region group
 add-highlighter shared/sh/double_string region  %{(?<!\\)(?:\\\\)*\K"} %{(?<!\\)(?:\\\\)*"} group
 add-highlighter shared/sh/single_string region %{(?<!\\)(?:\\\\)*\K'} %{'} fill string
 add-highlighter shared/sh/expansion region '\$\{' '\}|\n' fill value
-add-highlighter shared/sh/comment region '(?<!\$)(?<!\$\{)#' '$' fill comment
+add-highlighter shared/sh/comment region (?<!\\)(?:\\\\)*(?:^|\h)\K# '$' fill comment
 add-highlighter shared/sh/heredoc region -match-capture '<<-?\h*''?(\w+)''?' '^\t*(\w+)$' fill string
 
 add-highlighter shared/sh/double_string/fill fill string


### PR DESCRIPTION
Fixes spurious comment highlighting for these examples:

	echo \# foo
	echo 1#foo
	echo 2\ #foo