### PR TITLE
tmux.kak: use TMUX_PANE for tmux-terminal-{horizontal,vertical}

### DIFF
--- a/rc/windowing/tmux.kak
+++ b/rc/windowing/tmux.kak
@@ -16,6 +16,9 @@ define-command -hidden -params 2.. tmux-terminal-impl %{
             exit
         fi
         tmux_args="$1"
+        if [ "${1%%-*}" = split ]; then
+            tmux_args="$tmux_args -t ${kak_client_env_TMUX_PANE}"
+        fi
         shift
         # ideally we should escape single ';' to stop tmux from interpreting it as a new command
         # but that's probably too rare to care


### PR DESCRIPTION
In case a user connects to the same Kakoune session from multiple tmux
windows/sessions, this makes the splits appear next to the calling client,
instead of the client where the Kakoune session was started.