### PR TITLE
rc: Fill out `rc/filetype/crystal.kak`

### DIFF
--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -190,8 +190,8 @@ define-command -hidden crystal-indent-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
         # Copy previous line indent
         try %{ execute-keys -draft K <a-&> }
-        # Remove empty line indent
-        try %{ execute-keys -draft k <a-x> s ^\h+$ <ret> d }
+        # Remove previos line's trailing spaces
+        try %{ execute-keys -draft k :ruby-trim-indent <ret> }
     }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -204,6 +204,8 @@ define-command -hidden crystal-indent-on-char %{
     evaluate-commands -no-hooks -draft -itersel %{
         # align 'else/elsif' to 'if'
         try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:else|elsif)$ <ret> <a-semicolon> <a-?> ^\h*(?:if) <ret> <a-S> 1<a-&> }
+        # align 'when' to 'case'
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:when)$ <ret> <a-semicolon> <a-?> ^\h*(?:case) <ret> <a-S> 1<a-&> }
     }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -181,9 +181,9 @@ evaluate-commands %sh[
 define-command -hidden crystal-indent-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
         # Copy previous line indent
-        try %{ execute-keys -draft 'K<a-&>' }
+        try %{ execute-keys -draft K <a-&> }
         # Remove empty line indent
-        try %{ execute-keys -draft 'k<a-x>s^\h+$<ret>d' }
+        try %{ execute-keys -draft k <a-x> s ^\h+$ <ret> d }
     }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -17,7 +17,9 @@ hook global WinSetOption filetype=crystal %{
     add-highlighter window/crystal ref crystal
     evaluate-commands set-option window static_words %opt{crystal_keywords} %opt{crystal_attributes} %opt{crystal_objects}
 
+    hook window InsertChar .*   -group crystal-indent crystal-indent-on-char
     hook window InsertChar '\n' -group crystal-indent crystal-indent-on-new-line
+    hook window InsertChar '\n' -group crystal-insert crystal-insert-on-new-line
 
     hook -always -once window WinSetOption filetype=.* %{
         remove-highlighter window/crystal
@@ -184,6 +186,12 @@ define-command -hidden crystal-indent-on-new-line %{
     try %{
         execute-keys -draft 'k<a-x>s^\h+$<ret>d'
     }
+}
+
+define-command -hidden crystal-insert-on-new-line %{
+}
+
+define-command -hidden crystal-indent-on-char %{
 }
 
 define-command -hidden crystal-fetch-keywords %{

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -188,14 +188,16 @@ define-command -hidden crystal-trim-indent %{
 
 define-command -hidden crystal-indent-on-char %{
     evaluate-commands -no-hooks -draft -itersel %{
-        # align 'else/elsif' to 'if'
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:else|elsif)$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:if)                                                    <ret> <a-S> 1<a-&> }
-        # align 'else/when' to 'case'
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:else|when)$       <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:case)                                             <ret> <a-S> 1<a-&> }
+        # align 'else' to 'if/case'
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*else$   <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:if|case)                                               <ret> <a-S> 1<a-&> }
+        # align 'elsif' to 'if'
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*elsif$  <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:if)                                                    <ret> <a-S> 1<a-&> }
+        # align 'when' to 'case'
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*when$   <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:case)                                                  <ret> <a-S> 1<a-&> }
         # align 'rescue' to 'begin/def'
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:rescue)$     <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|def)                                             <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*rescue$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|def)                                             <ret> <a-S> 1<a-&> }
         # align 'end' to opening structure
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:end)$        <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|case|class|def|for|if|module|unless|until|while) <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*end$    <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|case|class|def|for|if|module|unless|until|while) <ret> <a-S> 1<a-&> }
     }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -26,184 +26,186 @@ hook global WinSetOption filetype=crystal %{
 }
 
 provide-module crystal %§
-    declare-option -hidden str-list crystal_keywords 'abstract' 'alias' 'annotation' 'as' 'asm' 'begin' 'break' 'case' 'class' 'def' 'do' 'else' 'elsif' 'end' 'ensure' 'enum' 'extend' 'false' 'for' 'fun' 'if' 'include' 'instance_sizeof' 'is_a?' 'lib' 'macro' 'module' 'next' 'nil' 'nil?' 'of' 'offsetof' 'out' 'pointerof' 'private' 'protected' 'require' 'rescue' 'responds_to?' 'return' 'select' 'self' 'sizeof' 'struct' 'super' 'then' 'true' 'type' 'typeof' 'uninitialized' 'union' 'unless' 'until' 'verbatim' 'when' 'while' 'with' 'yield'
-    # https://crystal-lang.org/reference/syntax_and_semantics/methods_and_instance_variables.html#getters-and-setters
-    declare-option -hidden str-list crystal_attributes 'getter' 'setter' 'property'
-    declare-option -hidden str-list crystal_operators '+' '-' '*' '/' '//' '%' '|' '&' '^' '~' '**' '<<' '<' '<=' '==' '!=' '=~' '!~' '>>' '>' '>=' '<=>' '===' '[]' '[]=' '[]?' '[' '&+' '&-' '&*' '&**'
-    declare-option -hidden str-list crystal_objects 'Adler32' 'ArgumentError' 'Array' 'Atomic' 'Base64' 'Benchmark' 'BigDecimal' 'BigFloat' 'BigInt' 'BigRational' 'BitArray' 'Bool' 'Box' 'Bytes' 'Channel' 'Char' 'Class' 'Colorize' 'Comparable' 'Complex' 'Concurrent' 'ConcurrentExecutionException' 'CRC32' 'Crypto' 'Crystal' 'CSV' 'Debug' 'Deprecated' 'Deque' 'Digest' 'Dir' 'DivisionByZeroError' 'DL' 'ECR' 'Enum' 'Enumerable' 'ENV' 'Errno' 'Exception' 'Fiber' 'File' 'FileUtils' 'Flags' 'Flate' 'Float' 'Float32' 'Float64' 'GC' 'Gzip' 'Hash' 'HTML' 'HTTP' 'Indexable' 'IndexError' 'INI' 'Int' 'Int128' 'Int16' 'Int32' 'Int64' 'Int8' 'InvalidBigDecimalException' 'InvalidByteSequenceError' 'IO' 'IPSocket' 'Iterable' 'Iterator' 'JSON' 'KeyError' 'Levenshtein' 'Link' 'LLVM' 'Logger' 'Markdown' 'Math' 'MIME' 'Mutex' 'NamedTuple' 'Nil' 'NilAssertionError' 'NotImplementedError' 'Number' 'OAuth' 'OAuth2' 'Object' 'OpenSSL' 'OptionParser' 'OverflowError' 'PartialComparable' 'Path' 'Pointer' 'PrettyPrint' 'Proc' 'Process' 'Random' 'Range' 'Readline' 'Reference' 'Reflect' 'Regex' 'SemanticVersion' 'Set' 'Signal' 'Slice' 'Socket' 'Spec' 'StaticArray' 'String' 'StringPool' 'StringScanner' 'Struct' 'Symbol' 'System' 'TCPServer' 'TCPSocket' 'Termios' 'Time' 'Tuple' 'TypeCastError' 'UDPSocket' 'UInt128' 'UInt16' 'UInt32' 'UInt64' 'UInt8' 'Unicode' 'Union' 'UNIXServer' 'UNIXSocket' 'URI' 'UUID' 'VaList' 'Value' 'WeakRef' 'XML' 'YAML' 'Zip' 'Zlib'
 
-    # Highlighters
-    # ‾‾‾‾‾‾‾‾‾‾‾‾
+declare-option -hidden str-list crystal_keywords 'abstract' 'alias' 'annotation' 'as' 'asm' 'begin' 'break' 'case' 'class' 'def' 'do' 'else' 'elsif' 'end' 'ensure' 'enum' 'extend' 'false' 'for' 'fun' 'if' 'include' 'instance_sizeof' 'is_a?' 'lib' 'macro' 'module' 'next' 'nil' 'nil?' 'of' 'offsetof' 'out' 'pointerof' 'private' 'protected' 'require' 'rescue' 'responds_to?' 'return' 'select' 'self' 'sizeof' 'struct' 'super' 'then' 'true' 'type' 'typeof' 'uninitialized' 'union' 'unless' 'until' 'verbatim' 'when' 'while' 'with' 'yield'
+# https://crystal-lang.org/reference/syntax_and_semantics/methods_and_instance_variables.html#getters-and-setters
+declare-option -hidden str-list crystal_attributes 'getter' 'setter' 'property'
+declare-option -hidden str-list crystal_operators '+' '-' '*' '/' '//' '%' '|' '&' '^' '~' '**' '<<' '<' '<=' '==' '!=' '=~' '!~' '>>' '>' '>=' '<=>' '===' '[]' '[]=' '[]?' '[' '&+' '&-' '&*' '&**'
+declare-option -hidden str-list crystal_objects 'Adler32' 'ArgumentError' 'Array' 'Atomic' 'Base64' 'Benchmark' 'BigDecimal' 'BigFloat' 'BigInt' 'BigRational' 'BitArray' 'Bool' 'Box' 'Bytes' 'Channel' 'Char' 'Class' 'Colorize' 'Comparable' 'Complex' 'Concurrent' 'ConcurrentExecutionException' 'CRC32' 'Crypto' 'Crystal' 'CSV' 'Debug' 'Deprecated' 'Deque' 'Digest' 'Dir' 'DivisionByZeroError' 'DL' 'ECR' 'Enum' 'Enumerable' 'ENV' 'Errno' 'Exception' 'Fiber' 'File' 'FileUtils' 'Flags' 'Flate' 'Float' 'Float32' 'Float64' 'GC' 'Gzip' 'Hash' 'HTML' 'HTTP' 'Indexable' 'IndexError' 'INI' 'Int' 'Int128' 'Int16' 'Int32' 'Int64' 'Int8' 'InvalidBigDecimalException' 'InvalidByteSequenceError' 'IO' 'IPSocket' 'Iterable' 'Iterator' 'JSON' 'KeyError' 'Levenshtein' 'Link' 'LLVM' 'Logger' 'Markdown' 'Math' 'MIME' 'Mutex' 'NamedTuple' 'Nil' 'NilAssertionError' 'NotImplementedError' 'Number' 'OAuth' 'OAuth2' 'Object' 'OpenSSL' 'OptionParser' 'OverflowError' 'PartialComparable' 'Path' 'Pointer' 'PrettyPrint' 'Proc' 'Process' 'Random' 'Range' 'Readline' 'Reference' 'Reflect' 'Regex' 'SemanticVersion' 'Set' 'Signal' 'Slice' 'Socket' 'Spec' 'StaticArray' 'String' 'StringPool' 'StringScanner' 'Struct' 'Symbol' 'System' 'TCPServer' 'TCPSocket' 'Termios' 'Time' 'Tuple' 'TypeCastError' 'UDPSocket' 'UInt128' 'UInt16' 'UInt32' 'UInt64' 'UInt8' 'Unicode' 'Union' 'UNIXServer' 'UNIXSocket' 'URI' 'UUID' 'VaList' 'Value' 'WeakRef' 'XML' 'YAML' 'Zip' 'Zlib'
 
-    add-highlighter shared/crystal regions
-    add-highlighter shared/crystal/code default-region group
+# Highlighters
+# ‾‾‾‾‾‾‾‾‾‾‾‾
 
-    # Comments
-    # https://crystal-lang.org/reference/syntax_and_semantics/comments.html
-    # Avoid string literals with interpolation
-    add-highlighter shared/crystal/comment region '#(?!\{)' '$' fill comment
+add-highlighter shared/crystal regions
+add-highlighter shared/crystal/code default-region group
 
+# Comments
+# https://crystal-lang.org/reference/syntax_and_semantics/comments.html
+# Avoid string literals with interpolation
+add-highlighter shared/crystal/comment region '#(?!\{)' '$' fill comment
+
+# String
+# https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html
+add-highlighter shared/crystal/string region '"' '(?<!\\)"' regions
+
+# Percent string literals
+# https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-literals
+add-highlighter shared/crystal/parenthesis-string region -recurse '\(' '%Q?\(' '\)' regions
+add-highlighter shared/crystal/bracket-string region -recurse '\[' '%Q?\[' '\]' regions
+add-highlighter shared/crystal/brace-string region -recurse '\{' '%Q?\{' '\}' regions
+add-highlighter shared/crystal/angle-string region -recurse '<' '%Q?<' '>' regions
+add-highlighter shared/crystal/pipe-string region '%Q?\|' '\|' regions
+# Raw
+# https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-literals
+# https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-array-literal
+# https://crystal-lang.org/reference/syntax_and_semantics/literals/symbol.html#percent-symbol-array-literal
+add-highlighter shared/crystal/raw-parenthesis-string region -recurse '\(' '%[qwi]\(' '\)' fill string
+add-highlighter shared/crystal/raw-bracket-string region -recurse '\[' '%[qwi]\[' '\]' fill string
+add-highlighter shared/crystal/raw-brace-string region -recurse '\{' '%[qwi]\{' '\}' fill string
+add-highlighter shared/crystal/raw-angle-string region -recurse '<' '%[qwi]<' '>' fill string
+add-highlighter shared/crystal/raw-pipe-string region '%[qwi]\|' '\|' fill string
+
+# Here document
+# https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#heredoc
+add-highlighter shared/crystal/heredoc region -match-capture '<<-(\w+)' '^\h*(\w+)$' regions
+# Raw
+add-highlighter shared/crystal/raw-heredoc region -match-capture "<<-'(\w+)'" '^\h*(\w+)$' regions
+add-highlighter shared/crystal/raw-heredoc/fill default-region fill string
+add-highlighter shared/crystal/raw-heredoc/interpolation region -recurse '\{' '#\{' '\}' fill meta
+
+# Symbol
+# https://crystal-lang.org/reference/syntax_and_semantics/literals/symbol.html
+add-highlighter shared/crystal/quoted-symbol region ':"' '(?<!\\)"' fill value
+
+# Regular expressions
+# https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html
+# https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#modifiers
+add-highlighter shared/crystal/regex region '/' '(?<!\\)/[imx]*' regions
+# Avoid unterminated regular expression
+add-highlighter shared/crystal/division region ' / ' '.\K' group
+
+# Percent regex literals
+# https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#percent-regex-literals
+add-highlighter shared/crystal/parenthesis-regex region -recurse '\(' '%r?\(' '\)[imx]*' regions
+add-highlighter shared/crystal/bracket-regex region -recurse '\[' '%r?\[' '\][imx]*' regions
+add-highlighter shared/crystal/brace-regex region -recurse '\{' '%r?\{' '\}[imx]*' regions
+add-highlighter shared/crystal/angle-regex region -recurse '<' '%r?<' '>[imx]*' regions
+add-highlighter shared/crystal/pipe-regex region '%r?\|' '\|[imx]*' regions
+
+# Command
+# https://crystal-lang.org/reference/syntax_and_semantics/literals/command.html
+add-highlighter shared/crystal/command region '`' '(?<!\\)`' regions
+
+# Percent command literals
+add-highlighter shared/crystal/parenthesis-command region -recurse '\(' '%x?\(' '\)' regions
+add-highlighter shared/crystal/bracket-command region -recurse '\[' '%x?\[' '\]' regions
+add-highlighter shared/crystal/brace-command region -recurse '\{' '%x?\{' '\}' regions
+add-highlighter shared/crystal/angle-command region -recurse '<' '%x?<' '>' regions
+add-highlighter shared/crystal/pipe-command region '%x?\|' '\|' regions
+
+evaluate-commands %sh[
+    # Keywords
+    eval "set -- $kak_quoted_opt_crystal_keywords"
+    regex="\\b(?:\\Q$1\\E"
+    shift
+    for keyword do
+        regex="$regex|\\Q$keyword\\E"
+    done
+    regex="$regex)\\b"
+    printf 'add-highlighter shared/crystal/code/keywords regex %s 0:keyword\n' "$regex"
+
+    # Attributes
+    eval "set -- $kak_quoted_opt_crystal_attributes"
+    regex="\\b(?:\\Q$1\\E"
+    shift
+    for attribute do
+        regex="$regex|\\Q$attribute\\E"
+    done
+    regex="$regex)\\b"
+    printf 'add-highlighter shared/crystal/code/attributes regex %s 0:attribute\n' "$regex"
+
+    # Symbols
+    eval "set -- $kak_quoted_opt_crystal_operators"
+    # Avoid to match modules
+    regex="(?<!:):(?:\\w+[?!]?"
+    for operator do
+        regex="$regex|\\Q$operator\\E"
+    done
+    regex="$regex)"
+    printf 'add-highlighter shared/crystal/code/symbols regex %%(%s) 0:value\n' "$regex"
+
+    # Objects
+    eval "set -- $kak_quoted_opt_crystal_objects"
+    regex="\\b(?:\\Q$1\\E"
+    shift
+    for object do
+        regex="$regex|\\Q$object\\E"
+    done
+    regex="$regex)\\b"
+    printf 'add-highlighter shared/crystal/code/objects regex %s 0:builtin\n' "$regex"
+
+    # Interpolation
     # String
-    # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html
-    add-highlighter shared/crystal/string region '"' '(?<!\\)"' regions
-
-    # Percent string literals
-    # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-literals
-    add-highlighter shared/crystal/parenthesis-string region -recurse '\(' '%Q?\(' '\)' regions
-    add-highlighter shared/crystal/bracket-string region -recurse '\[' '%Q?\[' '\]' regions
-    add-highlighter shared/crystal/brace-string region -recurse '\{' '%Q?\{' '\}' regions
-    add-highlighter shared/crystal/angle-string region -recurse '<' '%Q?<' '>' regions
-    add-highlighter shared/crystal/pipe-string region '%Q?\|' '\|' regions
-    # Raw
-    # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-literals
-    # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-array-literal
-    # https://crystal-lang.org/reference/syntax_and_semantics/literals/symbol.html#percent-symbol-array-literal
-    add-highlighter shared/crystal/raw-parenthesis-string region -recurse '\(' '%[qwi]\(' '\)' fill string
-    add-highlighter shared/crystal/raw-bracket-string region -recurse '\[' '%[qwi]\[' '\]' fill string
-    add-highlighter shared/crystal/raw-brace-string region -recurse '\{' '%[qwi]\{' '\}' fill string
-    add-highlighter shared/crystal/raw-angle-string region -recurse '<' '%[qwi]<' '>' fill string
-    add-highlighter shared/crystal/raw-pipe-string region '%[qwi]\|' '\|' fill string
-
-    # Here document
-    # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#heredoc
-    add-highlighter shared/crystal/heredoc region -match-capture '<<-(\w+)' '^\h*(\w+)$' regions
-    # Raw
-    add-highlighter shared/crystal/raw-heredoc region -match-capture "<<-'(\w+)'" '^\h*(\w+)$' regions
-    add-highlighter shared/crystal/raw-heredoc/fill default-region fill string
-    add-highlighter shared/crystal/raw-heredoc/interpolation region -recurse '\{' '#\{' '\}' fill meta
-
-    # Symbol
-    # https://crystal-lang.org/reference/syntax_and_semantics/literals/symbol.html
-    add-highlighter shared/crystal/quoted-symbol region ':"' '(?<!\\)"' fill value
+    # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#interpolation
+    for id in string parenthesis-string bracket-string brace-string angle-string pipe-string heredoc; do
+        printf "
+            add-highlighter shared/crystal/$id/fill default-region fill string
+            add-highlighter shared/crystal/$id/interpolation region -recurse '\\{' '#\\{' '\\}' ref crystal
+        "
+    done
 
     # Regular expressions
-    # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html
-    # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#modifiers
-    add-highlighter shared/crystal/regex region '/' '(?<!\\)/[imx]*' regions
-    # Avoid unterminated regular expression
-    add-highlighter shared/crystal/division region ' / ' '.\K' group
-
-    # Percent regex literals
-    # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#percent-regex-literals
-    add-highlighter shared/crystal/parenthesis-regex region -recurse '\(' '%r?\(' '\)[imx]*' regions
-    add-highlighter shared/crystal/bracket-regex region -recurse '\[' '%r?\[' '\][imx]*' regions
-    add-highlighter shared/crystal/brace-regex region -recurse '\{' '%r?\{' '\}[imx]*' regions
-    add-highlighter shared/crystal/angle-regex region -recurse '<' '%r?<' '>[imx]*' regions
-    add-highlighter shared/crystal/pipe-regex region '%r?\|' '\|[imx]*' regions
+    # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#interpolation
+    for id in regex parenthesis-regex bracket-regex brace-regex angle-regex pipe-regex; do
+        printf "
+            add-highlighter shared/crystal/$id/fill default-region fill meta
+            add-highlighter shared/crystal/$id/interpolation region -recurse '\\{' '#\\{' '\\}' ref crystal
+        "
+    done
 
     # Command
-    # https://crystal-lang.org/reference/syntax_and_semantics/literals/command.html
-    add-highlighter shared/crystal/command region '`' '(?<!\\)`' regions
+    for id in command parenthesis-command bracket-command brace-command angle-command pipe-command; do
+        printf "
+            add-highlighter shared/crystal/$id/fill default-region fill meta
+            add-highlighter shared/crystal/$id/interpolation region -recurse '\\{' '#\\{' '\\}' ref crystal
+        "
+    done
+]
 
-    # Percent command literals
-    add-highlighter shared/crystal/parenthesis-command region -recurse '\(' '%x?\(' '\)' regions
-    add-highlighter shared/crystal/bracket-command region -recurse '\[' '%x?\[' '\]' regions
-    add-highlighter shared/crystal/brace-command region -recurse '\{' '%x?\{' '\}' regions
-    add-highlighter shared/crystal/angle-command region -recurse '<' '%x?<' '>' regions
-    add-highlighter shared/crystal/pipe-command region '%x?\|' '\|' regions
+# Commands
+# ‾‾‾‾‾‾‾‾
 
-    evaluate-commands %sh[
-        # Keywords
-        eval "set -- $kak_quoted_opt_crystal_keywords"
-        regex="\\b(?:\\Q$1\\E"
-        shift
-        for keyword do
-            regex="$regex|\\Q$keyword\\E"
-        done
-        regex="$regex)\\b"
-        printf 'add-highlighter shared/crystal/code/keywords regex %s 0:keyword\n' "$regex"
-
-        # Attributes
-        eval "set -- $kak_quoted_opt_crystal_attributes"
-        regex="\\b(?:\\Q$1\\E"
-        shift
-        for attribute do
-            regex="$regex|\\Q$attribute\\E"
-        done
-        regex="$regex)\\b"
-        printf 'add-highlighter shared/crystal/code/attributes regex %s 0:attribute\n' "$regex"
-
-        # Symbols
-        eval "set -- $kak_quoted_opt_crystal_operators"
-        # Avoid to match modules
-        regex="(?<!:):(?:\\w+[?!]?"
-        for operator do
-            regex="$regex|\\Q$operator\\E"
-        done
-        regex="$regex)"
-        printf 'add-highlighter shared/crystal/code/symbols regex %%(%s) 0:value\n' "$regex"
-
-        # Objects
-        eval "set -- $kak_quoted_opt_crystal_objects"
-        regex="\\b(?:\\Q$1\\E"
-        shift
-        for object do
-            regex="$regex|\\Q$object\\E"
-        done
-        regex="$regex)\\b"
-        printf 'add-highlighter shared/crystal/code/objects regex %s 0:builtin\n' "$regex"
-
-        # Interpolation
-        # String
-        # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#interpolation
-        for id in string parenthesis-string bracket-string brace-string angle-string pipe-string heredoc; do
-            printf "
-                add-highlighter shared/crystal/$id/fill default-region fill string
-                add-highlighter shared/crystal/$id/interpolation region -recurse '\\{' '#\\{' '\\}' ref crystal
-            "
-        done
-
-        # Regular expressions
-        # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#interpolation
-        for id in regex parenthesis-regex bracket-regex brace-regex angle-regex pipe-regex; do
-            printf "
-                add-highlighter shared/crystal/$id/fill default-region fill meta
-                add-highlighter shared/crystal/$id/interpolation region -recurse '\\{' '#\\{' '\\}' ref crystal
-            "
-        done
-
-        # Command
-        for id in command parenthesis-command bracket-command brace-command angle-command pipe-command; do
-            printf "
-                add-highlighter shared/crystal/$id/fill default-region fill meta
-                add-highlighter shared/crystal/$id/interpolation region -recurse '\\{' '#\\{' '\\}' ref crystal
-            "
-        done
-    ]
-
-    # Commands
-    # ‾‾‾‾‾‾‾‾
-
-    define-command -hidden crystal-new-line-inserted %{
-        # Copy previous line indent
-        try %{
-            execute-keys -draft 'K<a-&>'
-        }
-        # Remove empty line indent
-        try %{
-            execute-keys -draft 'k<a-x>s^\h+$<ret>d'
-        }
+define-command -hidden crystal-new-line-inserted %{
+    # Copy previous line indent
+    try %{
+        execute-keys -draft 'K<a-&>'
     }
-
-    define-command -hidden crystal-fetch-keywords %{
-        set-register dquote %sh{
-            curl --location https://github.com/crystal-lang/crystal/raw/master/src/compiler/crystal/syntax/lexer.cr |
-            kak -f '%1scheck_ident_or_keyword\(:(\w+\??), \w+\)<ret>y%<a-R>a<ret><esc><a-_>a<del><esc>|sort<ret>'
-        }
+    # Remove empty line indent
+    try %{
+        execute-keys -draft 'k<a-x>s^\h+$<ret>d'
     }
+}
 
-    define-command -hidden crystal-fetch-operators %{
-        set-register dquote %sh{
-            curl --location https://github.com/crystal-lang/crystal/raw/master/src/compiler/crystal/syntax/parser.cr |
-            kak -f '/AtomicWithMethodCheck =<ret>x1s:"([^"]+)"<ret>y%<a-R>i''<esc>a''<ret><esc><a-_>a<del><esc>'
-        }
+define-command -hidden crystal-fetch-keywords %{
+    set-register dquote %sh{
+        curl --location https://github.com/crystal-lang/crystal/raw/master/src/compiler/crystal/syntax/lexer.cr |
+        kak -f '%1scheck_ident_or_keyword\(:(\w+\??), \w+\)<ret>y%<a-R>a<ret><esc><a-_>a<del><esc>|sort<ret>'
     }
+}
 
-    define-command -hidden crystal-fetch-objects %{
-        set-register dquote %sh{
-            curl --location https://crystal-lang.org/api/ |
-            # Remove Top Level Namespace
-            kak -f '%1sdata-id="github.com/crystal-lang/crystal/(\w+)"<ret>)<a-space>y%<a-R>a<ret><esc><a-_>a<del><esc>'
-        }
+define-command -hidden crystal-fetch-operators %{
+    set-register dquote %sh{
+        curl --location https://github.com/crystal-lang/crystal/raw/master/src/compiler/crystal/syntax/parser.cr |
+        kak -f '/AtomicWithMethodCheck =<ret>x1s:"([^"]+)"<ret>y%<a-R>i''<esc>a''<ret><esc><a-_>a<del><esc>'
     }
+}
+
+define-command -hidden crystal-fetch-objects %{
+    set-register dquote %sh{
+        curl --location https://crystal-lang.org/api/ |
+        # Remove Top Level Namespace
+        kak -f '%1sdata-id="github.com/crystal-lang/crystal/(\w+)"<ret>)<a-space>y%<a-R>a<ret><esc><a-_>a<del><esc>'
+    }
+}
+
 §

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -203,13 +203,13 @@ define-command -hidden crystal-insert-on-new-line %{
 define-command -hidden crystal-indent-on-char %{
     evaluate-commands -no-hooks -draft -itersel %{
         # align 'else/elsif' to 'if'
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:else|elsif)$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:if) <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:else|elsif)$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:if)                                                    <ret> <a-S> 1<a-&> }
         # align 'when' to 'case'
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:when)$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:case) <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:when)$       <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:case)                                                  <ret> <a-S> 1<a-&> }
         # align 'rescue' to 'begin/def'
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:rescue)$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|def) <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:rescue)$     <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|def)                                             <ret> <a-S> 1<a-&> }
         # align 'end' to opening structure
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:end)$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|case|class|def|for|if|module|unless|until|while) <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:end)$        <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|case|class|def|for|if|module|unless|until|while) <ret> <a-S> 1<a-&> }
     }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -198,6 +198,10 @@ define-command -hidden crystal-indent-on-new-line %{
 }
 
 define-command -hidden crystal-insert-on-new-line %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        # Copy comment prefix and following whitespaces
+        try %{ execute-keys -draft k <a-x> s '^\h*\K#\h*' <ret> y j gl p }
+    }
 }
 
 define-command -hidden crystal-indent-on-char %{

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -186,6 +186,19 @@ define-command -hidden crystal-trim-indent %{
     }
 }
 
+define-command -hidden crystal-indent-on-char %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        # align 'else/elsif' to 'if'
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:else|elsif)$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:if)                                                    <ret> <a-S> 1<a-&> }
+        # align 'when' to 'case'
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:when)$       <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:case)                                                  <ret> <a-S> 1<a-&> }
+        # align 'rescue' to 'begin/def'
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:rescue)$     <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|def)                                             <ret> <a-S> 1<a-&> }
+        # align 'end' to opening structure
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:end)$        <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|case|class|def|for|if|module|unless|until|while) <ret> <a-S> 1<a-&> }
+    }
+}
+
 define-command -hidden crystal-indent-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
         # Copy previous line indent
@@ -201,19 +214,6 @@ define-command -hidden crystal-insert-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
         # Copy comment prefix and following whitespaces
         try %{ execute-keys -draft k <a-x> s '^\h*\K#\h*' <ret> y j gl p }
-    }
-}
-
-define-command -hidden crystal-indent-on-char %{
-    evaluate-commands -no-hooks -draft -itersel %{
-        # align 'else/elsif' to 'if'
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:else|elsif)$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:if)                                                    <ret> <a-S> 1<a-&> }
-        # align 'when' to 'case'
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:when)$       <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:case)                                                  <ret> <a-S> 1<a-&> }
-        # align 'rescue' to 'begin/def'
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:rescue)$     <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|def)                                             <ret> <a-S> 1<a-&> }
-        # align 'end' to opening structure
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:end)$        <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|case|class|def|for|if|module|unless|until|while) <ret> <a-S> 1<a-&> }
     }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -205,7 +205,7 @@ define-command -hidden crystal-indent-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
         # Copy previous line indent
         try %{ execute-keys -draft K <a-&> }
-        # Remove previos line's trailing spaces
+        # Remove previous line's trailing spaces
         try %{ execute-keys -draft k :ruby-trim-indent <ret> }
         # Indent after start structure/opening statement
         try %{ execute-keys -draft k <a-x> <a-k> ^\h*(?:begin|case|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|.+\bdo$|.+\bdo\h\|.+(?=\|))[^0-9A-Za-z_!?] <ret> j <a-gt> }

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -25,7 +25,7 @@ hook global WinSetOption filetype=crystal %{
   }
 }
 
-provide-module crystal %🐈
+provide-module crystal %§
   declare-option -hidden str-list crystal_keywords 'abstract' 'alias' 'annotation' 'as' 'asm' 'begin' 'break' 'case' 'class' 'def' 'do' 'else' 'elsif' 'end' 'ensure' 'enum' 'extend' 'false' 'for' 'fun' 'if' 'include' 'instance_sizeof' 'is_a?' 'lib' 'macro' 'module' 'next' 'nil' 'nil?' 'of' 'offsetof' 'out' 'pointerof' 'private' 'protected' 'require' 'rescue' 'responds_to?' 'return' 'select' 'self' 'sizeof' 'struct' 'super' 'then' 'true' 'type' 'typeof' 'uninitialized' 'union' 'unless' 'until' 'verbatim' 'when' 'while' 'with' 'yield'
   # https://crystal-lang.org/reference/syntax_and_semantics/methods_and_instance_variables.html#getters-and-setters
   declare-option -hidden str-list crystal_attributes 'getter' 'setter' 'property'
@@ -206,4 +206,4 @@ provide-module crystal %🐈
       kak -f '%1sdata-id="github.com/crystal-lang/crystal/(\w+)"<ret>)<a-space>y%<a-R>a<ret><esc><a-_>a<del><esc>'
     }
   }
-🐈
+§

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -214,23 +214,19 @@ define-command -hidden crystal-indent-on-new-line %{
 
 define-command -hidden crystal-insert-on-new-line %[
     evaluate-commands -no-hooks -draft -itersel %[
-        # Copy comment prefix and following whitespaces
-        try %{ execute-keys -draft k <a-x> s '^\h*\K#\h*' <ret> y j gl p }
-
-        # Add `end` token if needs be
-        # The 'x' register is to save the leading whitespaces of the opening token
+        # copy _#_ comment prefix and following white spaces
+        try %{ execute-keys -draft k <a-x> s '^\h*\K#\h*' <ret> y j <a-x><semicolon> P }
+        # wisely add end structure
         evaluate-commands -save-regs x %[
-            # Save the leading whitespaces in register 'x'
-            try %{ execute-keys -draft k <a-x> s ^\h* <ret> \" x y }
+            try %{ execute-keys -draft k <a-x> s ^ \h + <ret> \" x y } catch %{ reg x '' }
             try %[
                 evaluate-commands -draft %[
-                    # Make sure previous line opens a block
-                    execute-keys -draft k <a-x> <a-k> ^<c-r>x(?:begin|case|class|def|for|if|module|unless|until|while|.+\bdo\h\|.+(?=\|))[^0-9A-Za-z_!?] <ret>
-                    # Make sure `end` doesn't already exist on indent level
-                    execute-keys -draft }i J <a-x> <a-K> ^<c-r>x(?:end|else|elsif|rescue|when)[^0-9A-Za-z_!?] <ret>
+                    # Check if previous line opens a block
+                    execute-keys -draft k<a-x> <a-k>^<c-r>x(?:begin|case|class|def|for|if|module|unless|until|while|.+\bdo$|.+\bdo\h\|.+(?=\|))[^0-9A-Za-z_!?]<ret>
+                    # Check that we do not already have an end for this indent level which is first set via `crystal-indent-on-new-line` hook
+                    execute-keys -draft }i J <a-x> <a-K> ^<c-r>x(?:end|else|elsif|rescue|when)[^0-9A-Za-z_!?]<ret>
                 ]
-                # Insert new line with end prepended by contents of register 'x'
-                execute-keys -draft o <c-r>x end <esc>
+                execute-keys -draft o<c-r>xend<esc> # insert a new line with containing end
             ]
         ]
     ]

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -179,13 +179,15 @@ evaluate-commands %sh[
 # ‾‾‾‾‾‾‾‾
 
 define-command -hidden crystal-indent-on-new-line %{
-    # Copy previous line indent
-    try %{
-        execute-keys -draft 'K<a-&>'
-    }
-    # Remove empty line indent
-    try %{
-        execute-keys -draft 'k<a-x>s^\h+$<ret>d'
+    evaluate-commands -no-hooks -draft -itersel %{
+        # Copy previous line indent
+        try %{
+            execute-keys -draft 'K<a-&>'
+        }
+        # Remove empty line indent
+        try %{
+            execute-keys -draft 'k<a-x>s^\h+$<ret>d'
+        }
     }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -1,9 +1,15 @@
 # Crystal
 # https://crystal-lang.org
 
+# Detection
+# ‾‾‾‾‾‾‾‾‾
+
 hook global BufCreate '.*\.cr' %{
   set-option buffer filetype crystal
 }
+
+# Initialization
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
 hook global WinSetOption filetype=crystal %{
   require-module crystal
@@ -25,6 +31,9 @@ provide-module crystal %🐈
   declare-option -hidden str-list crystal_attributes 'getter' 'setter' 'property'
   declare-option -hidden str-list crystal_operators '+' '-' '*' '/' '//' '%' '|' '&' '^' '~' '**' '<<' '<' '<=' '==' '!=' '=~' '!~' '>>' '>' '>=' '<=>' '===' '[]' '[]=' '[]?' '[' '&+' '&-' '&*' '&**'
   declare-option -hidden str-list crystal_objects 'Adler32' 'ArgumentError' 'Array' 'Atomic' 'Base64' 'Benchmark' 'BigDecimal' 'BigFloat' 'BigInt' 'BigRational' 'BitArray' 'Bool' 'Box' 'Bytes' 'Channel' 'Char' 'Class' 'Colorize' 'Comparable' 'Complex' 'Concurrent' 'ConcurrentExecutionException' 'CRC32' 'Crypto' 'Crystal' 'CSV' 'Debug' 'Deprecated' 'Deque' 'Digest' 'Dir' 'DivisionByZeroError' 'DL' 'ECR' 'Enum' 'Enumerable' 'ENV' 'Errno' 'Exception' 'Fiber' 'File' 'FileUtils' 'Flags' 'Flate' 'Float' 'Float32' 'Float64' 'GC' 'Gzip' 'Hash' 'HTML' 'HTTP' 'Indexable' 'IndexError' 'INI' 'Int' 'Int128' 'Int16' 'Int32' 'Int64' 'Int8' 'InvalidBigDecimalException' 'InvalidByteSequenceError' 'IO' 'IPSocket' 'Iterable' 'Iterator' 'JSON' 'KeyError' 'Levenshtein' 'Link' 'LLVM' 'Logger' 'Markdown' 'Math' 'MIME' 'Mutex' 'NamedTuple' 'Nil' 'NilAssertionError' 'NotImplementedError' 'Number' 'OAuth' 'OAuth2' 'Object' 'OpenSSL' 'OptionParser' 'OverflowError' 'PartialComparable' 'Path' 'Pointer' 'PrettyPrint' 'Proc' 'Process' 'Random' 'Range' 'Readline' 'Reference' 'Reflect' 'Regex' 'SemanticVersion' 'Set' 'Signal' 'Slice' 'Socket' 'Spec' 'StaticArray' 'String' 'StringPool' 'StringScanner' 'Struct' 'Symbol' 'System' 'TCPServer' 'TCPSocket' 'Termios' 'Time' 'Tuple' 'TypeCastError' 'UDPSocket' 'UInt128' 'UInt16' 'UInt32' 'UInt64' 'UInt8' 'Unicode' 'Union' 'UNIXServer' 'UNIXSocket' 'URI' 'UUID' 'VaList' 'Value' 'WeakRef' 'XML' 'YAML' 'Zip' 'Zlib'
+
+  # Highlighters
+  # ‾‾‾‾‾‾‾‾‾‾‾‾
 
   add-highlighter shared/crystal regions
   add-highlighter shared/crystal/code default-region group
@@ -161,6 +170,9 @@ provide-module crystal %🐈
       "
     done
   ]
+
+  # Commands
+  # ‾‾‾‾‾‾‾‾
 
   define-command -hidden crystal-new-line-inserted %{
     # Copy previous line indent

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -5,205 +5,205 @@
 # ‾‾‾‾‾‾‾‾‾
 
 hook global BufCreate '.*\.cr' %{
-  set-option buffer filetype crystal
+    set-option buffer filetype crystal
 }
 
 # Initialization
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
 hook global WinSetOption filetype=crystal %{
-  require-module crystal
+    require-module crystal
 
-  add-highlighter window/crystal ref crystal
-  evaluate-commands set-option window static_words %opt{crystal_keywords} %opt{crystal_attributes} %opt{crystal_objects}
+    add-highlighter window/crystal ref crystal
+    evaluate-commands set-option window static_words %opt{crystal_keywords} %opt{crystal_attributes} %opt{crystal_objects}
 
-  hook window InsertChar '\n' -group crystal-indent crystal-new-line-inserted
+    hook window InsertChar '\n' -group crystal-indent crystal-new-line-inserted
 
-  hook -always -once window WinSetOption filetype=.* %{
-    remove-highlighter window/crystal
-    remove-hooks window crystal-.+
-  }
+    hook -always -once window WinSetOption filetype=.* %{
+        remove-highlighter window/crystal
+        remove-hooks window crystal-.+
+    }
 }
 
 provide-module crystal %§
-  declare-option -hidden str-list crystal_keywords 'abstract' 'alias' 'annotation' 'as' 'asm' 'begin' 'break' 'case' 'class' 'def' 'do' 'else' 'elsif' 'end' 'ensure' 'enum' 'extend' 'false' 'for' 'fun' 'if' 'include' 'instance_sizeof' 'is_a?' 'lib' 'macro' 'module' 'next' 'nil' 'nil?' 'of' 'offsetof' 'out' 'pointerof' 'private' 'protected' 'require' 'rescue' 'responds_to?' 'return' 'select' 'self' 'sizeof' 'struct' 'super' 'then' 'true' 'type' 'typeof' 'uninitialized' 'union' 'unless' 'until' 'verbatim' 'when' 'while' 'with' 'yield'
-  # https://crystal-lang.org/reference/syntax_and_semantics/methods_and_instance_variables.html#getters-and-setters
-  declare-option -hidden str-list crystal_attributes 'getter' 'setter' 'property'
-  declare-option -hidden str-list crystal_operators '+' '-' '*' '/' '//' '%' '|' '&' '^' '~' '**' '<<' '<' '<=' '==' '!=' '=~' '!~' '>>' '>' '>=' '<=>' '===' '[]' '[]=' '[]?' '[' '&+' '&-' '&*' '&**'
-  declare-option -hidden str-list crystal_objects 'Adler32' 'ArgumentError' 'Array' 'Atomic' 'Base64' 'Benchmark' 'BigDecimal' 'BigFloat' 'BigInt' 'BigRational' 'BitArray' 'Bool' 'Box' 'Bytes' 'Channel' 'Char' 'Class' 'Colorize' 'Comparable' 'Complex' 'Concurrent' 'ConcurrentExecutionException' 'CRC32' 'Crypto' 'Crystal' 'CSV' 'Debug' 'Deprecated' 'Deque' 'Digest' 'Dir' 'DivisionByZeroError' 'DL' 'ECR' 'Enum' 'Enumerable' 'ENV' 'Errno' 'Exception' 'Fiber' 'File' 'FileUtils' 'Flags' 'Flate' 'Float' 'Float32' 'Float64' 'GC' 'Gzip' 'Hash' 'HTML' 'HTTP' 'Indexable' 'IndexError' 'INI' 'Int' 'Int128' 'Int16' 'Int32' 'Int64' 'Int8' 'InvalidBigDecimalException' 'InvalidByteSequenceError' 'IO' 'IPSocket' 'Iterable' 'Iterator' 'JSON' 'KeyError' 'Levenshtein' 'Link' 'LLVM' 'Logger' 'Markdown' 'Math' 'MIME' 'Mutex' 'NamedTuple' 'Nil' 'NilAssertionError' 'NotImplementedError' 'Number' 'OAuth' 'OAuth2' 'Object' 'OpenSSL' 'OptionParser' 'OverflowError' 'PartialComparable' 'Path' 'Pointer' 'PrettyPrint' 'Proc' 'Process' 'Random' 'Range' 'Readline' 'Reference' 'Reflect' 'Regex' 'SemanticVersion' 'Set' 'Signal' 'Slice' 'Socket' 'Spec' 'StaticArray' 'String' 'StringPool' 'StringScanner' 'Struct' 'Symbol' 'System' 'TCPServer' 'TCPSocket' 'Termios' 'Time' 'Tuple' 'TypeCastError' 'UDPSocket' 'UInt128' 'UInt16' 'UInt32' 'UInt64' 'UInt8' 'Unicode' 'Union' 'UNIXServer' 'UNIXSocket' 'URI' 'UUID' 'VaList' 'Value' 'WeakRef' 'XML' 'YAML' 'Zip' 'Zlib'
+    declare-option -hidden str-list crystal_keywords 'abstract' 'alias' 'annotation' 'as' 'asm' 'begin' 'break' 'case' 'class' 'def' 'do' 'else' 'elsif' 'end' 'ensure' 'enum' 'extend' 'false' 'for' 'fun' 'if' 'include' 'instance_sizeof' 'is_a?' 'lib' 'macro' 'module' 'next' 'nil' 'nil?' 'of' 'offsetof' 'out' 'pointerof' 'private' 'protected' 'require' 'rescue' 'responds_to?' 'return' 'select' 'self' 'sizeof' 'struct' 'super' 'then' 'true' 'type' 'typeof' 'uninitialized' 'union' 'unless' 'until' 'verbatim' 'when' 'while' 'with' 'yield'
+    # https://crystal-lang.org/reference/syntax_and_semantics/methods_and_instance_variables.html#getters-and-setters
+    declare-option -hidden str-list crystal_attributes 'getter' 'setter' 'property'
+    declare-option -hidden str-list crystal_operators '+' '-' '*' '/' '//' '%' '|' '&' '^' '~' '**' '<<' '<' '<=' '==' '!=' '=~' '!~' '>>' '>' '>=' '<=>' '===' '[]' '[]=' '[]?' '[' '&+' '&-' '&*' '&**'
+    declare-option -hidden str-list crystal_objects 'Adler32' 'ArgumentError' 'Array' 'Atomic' 'Base64' 'Benchmark' 'BigDecimal' 'BigFloat' 'BigInt' 'BigRational' 'BitArray' 'Bool' 'Box' 'Bytes' 'Channel' 'Char' 'Class' 'Colorize' 'Comparable' 'Complex' 'Concurrent' 'ConcurrentExecutionException' 'CRC32' 'Crypto' 'Crystal' 'CSV' 'Debug' 'Deprecated' 'Deque' 'Digest' 'Dir' 'DivisionByZeroError' 'DL' 'ECR' 'Enum' 'Enumerable' 'ENV' 'Errno' 'Exception' 'Fiber' 'File' 'FileUtils' 'Flags' 'Flate' 'Float' 'Float32' 'Float64' 'GC' 'Gzip' 'Hash' 'HTML' 'HTTP' 'Indexable' 'IndexError' 'INI' 'Int' 'Int128' 'Int16' 'Int32' 'Int64' 'Int8' 'InvalidBigDecimalException' 'InvalidByteSequenceError' 'IO' 'IPSocket' 'Iterable' 'Iterator' 'JSON' 'KeyError' 'Levenshtein' 'Link' 'LLVM' 'Logger' 'Markdown' 'Math' 'MIME' 'Mutex' 'NamedTuple' 'Nil' 'NilAssertionError' 'NotImplementedError' 'Number' 'OAuth' 'OAuth2' 'Object' 'OpenSSL' 'OptionParser' 'OverflowError' 'PartialComparable' 'Path' 'Pointer' 'PrettyPrint' 'Proc' 'Process' 'Random' 'Range' 'Readline' 'Reference' 'Reflect' 'Regex' 'SemanticVersion' 'Set' 'Signal' 'Slice' 'Socket' 'Spec' 'StaticArray' 'String' 'StringPool' 'StringScanner' 'Struct' 'Symbol' 'System' 'TCPServer' 'TCPSocket' 'Termios' 'Time' 'Tuple' 'TypeCastError' 'UDPSocket' 'UInt128' 'UInt16' 'UInt32' 'UInt64' 'UInt8' 'Unicode' 'Union' 'UNIXServer' 'UNIXSocket' 'URI' 'UUID' 'VaList' 'Value' 'WeakRef' 'XML' 'YAML' 'Zip' 'Zlib'
 
-  # Highlighters
-  # ‾‾‾‾‾‾‾‾‾‾‾‾
+    # Highlighters
+    # ‾‾‾‾‾‾‾‾‾‾‾‾
 
-  add-highlighter shared/crystal regions
-  add-highlighter shared/crystal/code default-region group
+    add-highlighter shared/crystal regions
+    add-highlighter shared/crystal/code default-region group
 
-  # Comments
-  # https://crystal-lang.org/reference/syntax_and_semantics/comments.html
-  # Avoid string literals with interpolation
-  add-highlighter shared/crystal/comment region '#(?!\{)' '$' fill comment
+    # Comments
+    # https://crystal-lang.org/reference/syntax_and_semantics/comments.html
+    # Avoid string literals with interpolation
+    add-highlighter shared/crystal/comment region '#(?!\{)' '$' fill comment
 
-  # String
-  # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html
-  add-highlighter shared/crystal/string region '"' '(?<!\\)"' regions
-
-  # Percent string literals
-  # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-literals
-  add-highlighter shared/crystal/parenthesis-string region -recurse '\(' '%Q?\(' '\)' regions
-  add-highlighter shared/crystal/bracket-string region -recurse '\[' '%Q?\[' '\]' regions
-  add-highlighter shared/crystal/brace-string region -recurse '\{' '%Q?\{' '\}' regions
-  add-highlighter shared/crystal/angle-string region -recurse '<' '%Q?<' '>' regions
-  add-highlighter shared/crystal/pipe-string region '%Q?\|' '\|' regions
-  # Raw
-  # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-literals
-  # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-array-literal
-  # https://crystal-lang.org/reference/syntax_and_semantics/literals/symbol.html#percent-symbol-array-literal
-  add-highlighter shared/crystal/raw-parenthesis-string region -recurse '\(' '%[qwi]\(' '\)' fill string
-  add-highlighter shared/crystal/raw-bracket-string region -recurse '\[' '%[qwi]\[' '\]' fill string
-  add-highlighter shared/crystal/raw-brace-string region -recurse '\{' '%[qwi]\{' '\}' fill string
-  add-highlighter shared/crystal/raw-angle-string region -recurse '<' '%[qwi]<' '>' fill string
-  add-highlighter shared/crystal/raw-pipe-string region '%[qwi]\|' '\|' fill string
-
-  # Here document
-  # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#heredoc
-  add-highlighter shared/crystal/heredoc region -match-capture '<<-(\w+)' '^\h*(\w+)$' regions
-  # Raw
-  add-highlighter shared/crystal/raw-heredoc region -match-capture "<<-'(\w+)'" '^\h*(\w+)$' regions
-  add-highlighter shared/crystal/raw-heredoc/fill default-region fill string
-  add-highlighter shared/crystal/raw-heredoc/interpolation region -recurse '\{' '#\{' '\}' fill meta
-
-  # Symbol
-  # https://crystal-lang.org/reference/syntax_and_semantics/literals/symbol.html
-  add-highlighter shared/crystal/quoted-symbol region ':"' '(?<!\\)"' fill value
-
-  # Regular expressions
-  # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html
-  # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#modifiers
-  add-highlighter shared/crystal/regex region '/' '(?<!\\)/[imx]*' regions
-  # Avoid unterminated regular expression
-  add-highlighter shared/crystal/division region ' / ' '.\K' group
-
-  # Percent regex literals
-  # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#percent-regex-literals
-  add-highlighter shared/crystal/parenthesis-regex region -recurse '\(' '%r?\(' '\)[imx]*' regions
-  add-highlighter shared/crystal/bracket-regex region -recurse '\[' '%r?\[' '\][imx]*' regions
-  add-highlighter shared/crystal/brace-regex region -recurse '\{' '%r?\{' '\}[imx]*' regions
-  add-highlighter shared/crystal/angle-regex region -recurse '<' '%r?<' '>[imx]*' regions
-  add-highlighter shared/crystal/pipe-regex region '%r?\|' '\|[imx]*' regions
-
-  # Command
-  # https://crystal-lang.org/reference/syntax_and_semantics/literals/command.html
-  add-highlighter shared/crystal/command region '`' '(?<!\\)`' regions
-
-  # Percent command literals
-  add-highlighter shared/crystal/parenthesis-command region -recurse '\(' '%x?\(' '\)' regions
-  add-highlighter shared/crystal/bracket-command region -recurse '\[' '%x?\[' '\]' regions
-  add-highlighter shared/crystal/brace-command region -recurse '\{' '%x?\{' '\}' regions
-  add-highlighter shared/crystal/angle-command region -recurse '<' '%x?<' '>' regions
-  add-highlighter shared/crystal/pipe-command region '%x?\|' '\|' regions
-
-  evaluate-commands %sh[
-    # Keywords
-    eval "set -- $kak_quoted_opt_crystal_keywords"
-    regex="\\b(?:\\Q$1\\E"
-    shift
-    for keyword do
-      regex="$regex|\\Q$keyword\\E"
-    done
-    regex="$regex)\\b"
-    printf 'add-highlighter shared/crystal/code/keywords regex %s 0:keyword\n' "$regex"
-
-    # Attributes
-    eval "set -- $kak_quoted_opt_crystal_attributes"
-    regex="\\b(?:\\Q$1\\E"
-    shift
-    for attribute do
-      regex="$regex|\\Q$attribute\\E"
-    done
-    regex="$regex)\\b"
-    printf 'add-highlighter shared/crystal/code/attributes regex %s 0:attribute\n' "$regex"
-
-    # Symbols
-    eval "set -- $kak_quoted_opt_crystal_operators"
-    # Avoid to match modules
-    regex="(?<!:):(?:\\w+[?!]?"
-    for operator do
-      regex="$regex|\\Q$operator\\E"
-    done
-    regex="$regex)"
-    printf 'add-highlighter shared/crystal/code/symbols regex %%(%s) 0:value\n' "$regex"
-
-    # Objects
-    eval "set -- $kak_quoted_opt_crystal_objects"
-    regex="\\b(?:\\Q$1\\E"
-    shift
-    for object do
-      regex="$regex|\\Q$object\\E"
-    done
-    regex="$regex)\\b"
-    printf 'add-highlighter shared/crystal/code/objects regex %s 0:builtin\n' "$regex"
-
-    # Interpolation
     # String
-    # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#interpolation
-    for id in string parenthesis-string bracket-string brace-string angle-string pipe-string heredoc; do
-      printf "
-        add-highlighter shared/crystal/$id/fill default-region fill string
-        add-highlighter shared/crystal/$id/interpolation region -recurse '\\{' '#\\{' '\\}' ref crystal
-      "
-    done
+    # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html
+    add-highlighter shared/crystal/string region '"' '(?<!\\)"' regions
+
+    # Percent string literals
+    # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-literals
+    add-highlighter shared/crystal/parenthesis-string region -recurse '\(' '%Q?\(' '\)' regions
+    add-highlighter shared/crystal/bracket-string region -recurse '\[' '%Q?\[' '\]' regions
+    add-highlighter shared/crystal/brace-string region -recurse '\{' '%Q?\{' '\}' regions
+    add-highlighter shared/crystal/angle-string region -recurse '<' '%Q?<' '>' regions
+    add-highlighter shared/crystal/pipe-string region '%Q?\|' '\|' regions
+    # Raw
+    # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-literals
+    # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-array-literal
+    # https://crystal-lang.org/reference/syntax_and_semantics/literals/symbol.html#percent-symbol-array-literal
+    add-highlighter shared/crystal/raw-parenthesis-string region -recurse '\(' '%[qwi]\(' '\)' fill string
+    add-highlighter shared/crystal/raw-bracket-string region -recurse '\[' '%[qwi]\[' '\]' fill string
+    add-highlighter shared/crystal/raw-brace-string region -recurse '\{' '%[qwi]\{' '\}' fill string
+    add-highlighter shared/crystal/raw-angle-string region -recurse '<' '%[qwi]<' '>' fill string
+    add-highlighter shared/crystal/raw-pipe-string region '%[qwi]\|' '\|' fill string
+
+    # Here document
+    # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#heredoc
+    add-highlighter shared/crystal/heredoc region -match-capture '<<-(\w+)' '^\h*(\w+)$' regions
+    # Raw
+    add-highlighter shared/crystal/raw-heredoc region -match-capture "<<-'(\w+)'" '^\h*(\w+)$' regions
+    add-highlighter shared/crystal/raw-heredoc/fill default-region fill string
+    add-highlighter shared/crystal/raw-heredoc/interpolation region -recurse '\{' '#\{' '\}' fill meta
+
+    # Symbol
+    # https://crystal-lang.org/reference/syntax_and_semantics/literals/symbol.html
+    add-highlighter shared/crystal/quoted-symbol region ':"' '(?<!\\)"' fill value
 
     # Regular expressions
-    # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#interpolation
-    for id in regex parenthesis-regex bracket-regex brace-regex angle-regex pipe-regex; do
-      printf "
-        add-highlighter shared/crystal/$id/fill default-region fill meta
-        add-highlighter shared/crystal/$id/interpolation region -recurse '\\{' '#\\{' '\\}' ref crystal
-      "
-    done
+    # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html
+    # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#modifiers
+    add-highlighter shared/crystal/regex region '/' '(?<!\\)/[imx]*' regions
+    # Avoid unterminated regular expression
+    add-highlighter shared/crystal/division region ' / ' '.\K' group
+
+    # Percent regex literals
+    # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#percent-regex-literals
+    add-highlighter shared/crystal/parenthesis-regex region -recurse '\(' '%r?\(' '\)[imx]*' regions
+    add-highlighter shared/crystal/bracket-regex region -recurse '\[' '%r?\[' '\][imx]*' regions
+    add-highlighter shared/crystal/brace-regex region -recurse '\{' '%r?\{' '\}[imx]*' regions
+    add-highlighter shared/crystal/angle-regex region -recurse '<' '%r?<' '>[imx]*' regions
+    add-highlighter shared/crystal/pipe-regex region '%r?\|' '\|[imx]*' regions
 
     # Command
-    for id in command parenthesis-command bracket-command brace-command angle-command pipe-command; do
-      printf "
-        add-highlighter shared/crystal/$id/fill default-region fill meta
-        add-highlighter shared/crystal/$id/interpolation region -recurse '\\{' '#\\{' '\\}' ref crystal
-      "
-    done
-  ]
+    # https://crystal-lang.org/reference/syntax_and_semantics/literals/command.html
+    add-highlighter shared/crystal/command region '`' '(?<!\\)`' regions
 
-  # Commands
-  # ‾‾‾‾‾‾‾‾
+    # Percent command literals
+    add-highlighter shared/crystal/parenthesis-command region -recurse '\(' '%x?\(' '\)' regions
+    add-highlighter shared/crystal/bracket-command region -recurse '\[' '%x?\[' '\]' regions
+    add-highlighter shared/crystal/brace-command region -recurse '\{' '%x?\{' '\}' regions
+    add-highlighter shared/crystal/angle-command region -recurse '<' '%x?<' '>' regions
+    add-highlighter shared/crystal/pipe-command region '%x?\|' '\|' regions
 
-  define-command -hidden crystal-new-line-inserted %{
-    # Copy previous line indent
-    try %{
-      execute-keys -draft 'K<a-&>'
-    }
-    # Remove empty line indent
-    try %{
-      execute-keys -draft 'k<a-x>s^\h+$<ret>d'
-    }
-  }
+    evaluate-commands %sh[
+        # Keywords
+        eval "set -- $kak_quoted_opt_crystal_keywords"
+        regex="\\b(?:\\Q$1\\E"
+        shift
+        for keyword do
+            regex="$regex|\\Q$keyword\\E"
+        done
+        regex="$regex)\\b"
+        printf 'add-highlighter shared/crystal/code/keywords regex %s 0:keyword\n' "$regex"
 
-  define-command -hidden crystal-fetch-keywords %{
-    set-register dquote %sh{
-      curl --location https://github.com/crystal-lang/crystal/raw/master/src/compiler/crystal/syntax/lexer.cr |
-      kak -f '%1scheck_ident_or_keyword\(:(\w+\??), \w+\)<ret>y%<a-R>a<ret><esc><a-_>a<del><esc>|sort<ret>'
-    }
-  }
+        # Attributes
+        eval "set -- $kak_quoted_opt_crystal_attributes"
+        regex="\\b(?:\\Q$1\\E"
+        shift
+        for attribute do
+            regex="$regex|\\Q$attribute\\E"
+        done
+        regex="$regex)\\b"
+        printf 'add-highlighter shared/crystal/code/attributes regex %s 0:attribute\n' "$regex"
 
-  define-command -hidden crystal-fetch-operators %{
-    set-register dquote %sh{
-      curl --location https://github.com/crystal-lang/crystal/raw/master/src/compiler/crystal/syntax/parser.cr |
-      kak -f '/AtomicWithMethodCheck =<ret>x1s:"([^"]+)"<ret>y%<a-R>i''<esc>a''<ret><esc><a-_>a<del><esc>'
-    }
-  }
+        # Symbols
+        eval "set -- $kak_quoted_opt_crystal_operators"
+        # Avoid to match modules
+        regex="(?<!:):(?:\\w+[?!]?"
+        for operator do
+            regex="$regex|\\Q$operator\\E"
+        done
+        regex="$regex)"
+        printf 'add-highlighter shared/crystal/code/symbols regex %%(%s) 0:value\n' "$regex"
 
-  define-command -hidden crystal-fetch-objects %{
-    set-register dquote %sh{
-      curl --location https://crystal-lang.org/api/ |
-      # Remove Top Level Namespace
-      kak -f '%1sdata-id="github.com/crystal-lang/crystal/(\w+)"<ret>)<a-space>y%<a-R>a<ret><esc><a-_>a<del><esc>'
+        # Objects
+        eval "set -- $kak_quoted_opt_crystal_objects"
+        regex="\\b(?:\\Q$1\\E"
+        shift
+        for object do
+            regex="$regex|\\Q$object\\E"
+        done
+        regex="$regex)\\b"
+        printf 'add-highlighter shared/crystal/code/objects regex %s 0:builtin\n' "$regex"
+
+        # Interpolation
+        # String
+        # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#interpolation
+        for id in string parenthesis-string bracket-string brace-string angle-string pipe-string heredoc; do
+            printf "
+                add-highlighter shared/crystal/$id/fill default-region fill string
+                add-highlighter shared/crystal/$id/interpolation region -recurse '\\{' '#\\{' '\\}' ref crystal
+            "
+        done
+
+        # Regular expressions
+        # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#interpolation
+        for id in regex parenthesis-regex bracket-regex brace-regex angle-regex pipe-regex; do
+            printf "
+                add-highlighter shared/crystal/$id/fill default-region fill meta
+                add-highlighter shared/crystal/$id/interpolation region -recurse '\\{' '#\\{' '\\}' ref crystal
+            "
+        done
+
+        # Command
+        for id in command parenthesis-command bracket-command brace-command angle-command pipe-command; do
+            printf "
+                add-highlighter shared/crystal/$id/fill default-region fill meta
+                add-highlighter shared/crystal/$id/interpolation region -recurse '\\{' '#\\{' '\\}' ref crystal
+            "
+        done
+    ]
+
+    # Commands
+    # ‾‾‾‾‾‾‾‾
+
+    define-command -hidden crystal-new-line-inserted %{
+        # Copy previous line indent
+        try %{
+            execute-keys -draft 'K<a-&>'
+        }
+        # Remove empty line indent
+        try %{
+            execute-keys -draft 'k<a-x>s^\h+$<ret>d'
+        }
     }
-  }
+
+    define-command -hidden crystal-fetch-keywords %{
+        set-register dquote %sh{
+            curl --location https://github.com/crystal-lang/crystal/raw/master/src/compiler/crystal/syntax/lexer.cr |
+            kak -f '%1scheck_ident_or_keyword\(:(\w+\??), \w+\)<ret>y%<a-R>a<ret><esc><a-_>a<del><esc>|sort<ret>'
+        }
+    }
+
+    define-command -hidden crystal-fetch-operators %{
+        set-register dquote %sh{
+            curl --location https://github.com/crystal-lang/crystal/raw/master/src/compiler/crystal/syntax/parser.cr |
+            kak -f '/AtomicWithMethodCheck =<ret>x1s:"([^"]+)"<ret>y%<a-R>i''<esc>a''<ret><esc><a-_>a<del><esc>'
+        }
+    }
+
+    define-command -hidden crystal-fetch-objects %{
+        set-register dquote %sh{
+            curl --location https://crystal-lang.org/api/ |
+            # Remove Top Level Namespace
+            kak -f '%1sdata-id="github.com/crystal-lang/crystal/(\w+)"<ret>)<a-space>y%<a-R>a<ret><esc><a-_>a<del><esc>'
+        }
+    }
 §

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -178,6 +178,14 @@ evaluate-commands %sh[
 # Commands
 # ‾‾‾‾‾‾‾‾
 
+define-command -hidden crystal-trim-indent %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        execute-keys <a-x>
+        # remove trailing white spaces
+        try %{ execute-keys -draft s \h+$ <ret> d }
+    }
+}
+
 define-command -hidden crystal-indent-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
         # Copy previous line indent
@@ -196,7 +204,7 @@ define-command -hidden crystal-indent-on-char %{
 define-command -hidden crystal-fetch-keywords %{
     set-register dquote %sh{
         curl --location https://github.com/crystal-lang/crystal/raw/master/src/compiler/crystal/syntax/lexer.cr |
-        kak -f '%1scheck_ident_or_keyword\(:(\w+\??), \w+\)<ret>y%<a-R>a<ret><esc><a-_>a<del><esc>|sort<ret>'
+    kak -f '%1scheck_ident_or_keyword\(:(\w+\??), \w+\)<ret>y%<a-R>a<ret><esc><a-_>a<del><esc>|sort<ret>'
     }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -17,7 +17,7 @@ hook global WinSetOption filetype=crystal %{
     add-highlighter window/crystal ref crystal
     evaluate-commands set-option window static_words %opt{crystal_keywords} %opt{crystal_attributes} %opt{crystal_objects}
 
-    hook window InsertChar '\n' -group crystal-indent crystal-new-line-inserted
+    hook window InsertChar '\n' -group crystal-indent crystal-indent-on-new-line
 
     hook -always -once window WinSetOption filetype=.* %{
         remove-highlighter window/crystal
@@ -175,7 +175,7 @@ evaluate-commands %sh[
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden crystal-new-line-inserted %{
+define-command -hidden crystal-indent-on-new-line %{
     # Copy previous line indent
     try %{
         execute-keys -draft 'K<a-&>'

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -208,6 +208,8 @@ define-command -hidden crystal-indent-on-char %{
         try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:when)$ <ret> <a-semicolon> <a-?> ^\h*(?:case) <ret> <a-S> 1<a-&> }
         # align 'rescue' to 'begin/def'
         try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:rescue)$ <ret> <a-semicolon> <a-?> ^\h*(?:begin|def) <ret> <a-S> 1<a-&> }
+        # align 'end' to opening structure
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:end)$ <ret> <a-semicolon> <a-?> ^\h*(?:begin|case|class|def|for|if|module|unless|until|while) <ret> <a-S> 1<a-&> }
     }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -53,19 +53,20 @@ add-highlighter shared/crystal/string region '"' '(?<!\\)"' regions
 # Percent string literals
 # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-literals
 add-highlighter shared/crystal/parenthesis-string region -recurse '\(' '%Q?\(' '\)' regions
-add-highlighter shared/crystal/bracket-string region -recurse '\[' '%Q?\[' '\]' regions
-add-highlighter shared/crystal/brace-string region -recurse '\{' '%Q?\{' '\}' regions
-add-highlighter shared/crystal/angle-string region -recurse '<' '%Q?<' '>' regions
-add-highlighter shared/crystal/pipe-string region '%Q?\|' '\|' regions
+add-highlighter shared/crystal/bracket-string     region -recurse '\[' '%Q?\[' '\]' regions
+add-highlighter shared/crystal/brace-string       region -recurse '\{' '%Q?\{' '\}' regions
+add-highlighter shared/crystal/angle-string       region -recurse '<' '%Q?<' '>'    regions
+add-highlighter shared/crystal/pipe-string        region          '%Q?\|' '\|'      regions
+
 # Raw
 # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-literals
 # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#percent-string-array-literal
 # https://crystal-lang.org/reference/syntax_and_semantics/literals/symbol.html#percent-symbol-array-literal
 add-highlighter shared/crystal/raw-parenthesis-string region -recurse '\(' '%[qwi]\(' '\)' fill string
-add-highlighter shared/crystal/raw-bracket-string region -recurse '\[' '%[qwi]\[' '\]' fill string
-add-highlighter shared/crystal/raw-brace-string region -recurse '\{' '%[qwi]\{' '\}' fill string
-add-highlighter shared/crystal/raw-angle-string region -recurse '<' '%[qwi]<' '>' fill string
-add-highlighter shared/crystal/raw-pipe-string region '%[qwi]\|' '\|' fill string
+add-highlighter shared/crystal/raw-bracket-string     region -recurse '\[' '%[qwi]\[' '\]' fill string
+add-highlighter shared/crystal/raw-brace-string       region -recurse '\{' '%[qwi]\{' '\}' fill string
+add-highlighter shared/crystal/raw-angle-string       region -recurse '<' '%[qwi]<' '>'    fill string
+add-highlighter shared/crystal/raw-pipe-string        region          '%[qwi]\|' '\|'      fill string
 
 # Here document
 # https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html#heredoc

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -201,12 +201,16 @@ define-command -hidden crystal-insert-on-new-line %{
 }
 
 define-command -hidden crystal-indent-on-char %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        # align 'else/elsif' to 'if'
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:else|elsif)$ <ret> <a-semicolon> <a-?> ^\h*(?:if) <ret> <a-S> 1<a-&> }
+    }
 }
 
 define-command -hidden crystal-fetch-keywords %{
     set-register dquote %sh{
         curl --location https://github.com/crystal-lang/crystal/raw/master/src/compiler/crystal/syntax/lexer.cr |
-        kak -f '%1scheck_ident_or_keyword\(:(\w+\??), \w+\)<ret>y%<a-R>a<ret><esc><a-_>a<del><esc>|sort<ret>'
+    kak -f '%1scheck_ident_or_keyword\(:(\w+\??), \w+\)<ret>y%<a-R>a<ret><esc><a-_>a<del><esc>|sort<ret>'
     }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -206,13 +206,15 @@ define-command -hidden crystal-indent-on-char %{
         try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:else|elsif)$ <ret> <a-semicolon> <a-?> ^\h*(?:if) <ret> <a-S> 1<a-&> }
         # align 'when' to 'case'
         try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:when)$ <ret> <a-semicolon> <a-?> ^\h*(?:case) <ret> <a-S> 1<a-&> }
+        # align 'rescue' to 'begin/def'
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:rescue)$ <ret> <a-semicolon> <a-?> ^\h*(?:begin|def) <ret> <a-S> 1<a-&> }
     }
 }
 
 define-command -hidden crystal-fetch-keywords %{
     set-register dquote %sh{
         curl --location https://github.com/crystal-lang/crystal/raw/master/src/compiler/crystal/syntax/lexer.cr |
-    kak -f '%1scheck_ident_or_keyword\(:(\w+\??), \w+\)<ret>y%<a-R>a<ret><esc><a-_>a<del><esc>|sort<ret>'
+        kak -f '%1scheck_ident_or_keyword\(:(\w+\??), \w+\)<ret>y%<a-R>a<ret><esc><a-_>a<del><esc>|sort<ret>'
     }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -210,12 +210,29 @@ define-command -hidden crystal-indent-on-new-line %{
     }
 }
 
-define-command -hidden crystal-insert-on-new-line %{
-    evaluate-commands -no-hooks -draft -itersel %{
+define-command -hidden crystal-insert-on-new-line %[
+    evaluate-commands -no-hooks -draft -itersel %[
         # Copy comment prefix and following whitespaces
         try %{ execute-keys -draft k <a-x> s '^\h*\K#\h*' <ret> y j gl p }
-    }
-}
+
+        # Add `end` token if needs be
+        # The 'x' register is to save the leading whitespaces of the opening token
+        evaluate-commands -save-regs x %[
+            # Save the leading whitespaces in register 'x'
+            try %{ execute-keys -draft k <a-x> s ^\h* <ret> \" x y }
+            try %[
+                evaluate-commands -draft %[
+                    # Make sure previous line opens a block
+                    execute-keys -draft k <a-x> <a-k> ^<c-r>x(?:begin|case|class|def|for|if|module|unless|until|while|.+\bdo\h\|.+(?=\|))[^0-9A-Za-z_!?] <ret>
+                    # Make sure `end` doesn't already exist on indent level
+                    execute-keys -draft }i J <a-x> <a-K> ^<c-r>x(?:end|else|elsif|rescue|when)[^0-9A-Za-z_!?] <ret>
+                ]
+                # Insert new line with end prepended by contents of register 'x'
+                execute-keys -draft o <c-r>x end <esc>
+            ]
+        ]
+    ]
+]
 
 define-command -hidden crystal-fetch-keywords %{
     set-register dquote %sh{

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -7,12 +7,15 @@ hook global BufCreate '.*\.cr' %{
 
 hook global WinSetOption filetype=crystal %{
   require-module crystal
-  evaluate-commands set-option window static_words %opt{crystal_keywords} %opt{crystal_attributes} %opt{crystal_objects}
+
   add-highlighter window/crystal ref crystal
-  hook -group crystal window InsertChar '\n' crystal-new-line-inserted
+  evaluate-commands set-option window static_words %opt{crystal_keywords} %opt{crystal_attributes} %opt{crystal_objects}
+
+  hook window InsertChar '\n' -group crystal-indent crystal-new-line-inserted
+
   hook -always -once window WinSetOption filetype=.* %{
     remove-highlighter window/crystal
-    remove-hooks window crystal
+    remove-hooks window crystal-.+
   }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -192,6 +192,8 @@ define-command -hidden crystal-indent-on-new-line %{
         try %{ execute-keys -draft K <a-&> }
         # Remove previos line's trailing spaces
         try %{ execute-keys -draft k :ruby-trim-indent <ret> }
+        # Indent after start structure/opening statement
+        try %{ execute-keys -draft k <a-x> <a-k> ^\h*(?:begin|case|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|.+\bdo$|.+\bdo\h\|.+(?=\|))[^0-9A-Za-z_!?] <ret> j <a-gt> }
     }
 }
 
@@ -204,7 +206,7 @@ define-command -hidden crystal-indent-on-char %{
 define-command -hidden crystal-fetch-keywords %{
     set-register dquote %sh{
         curl --location https://github.com/crystal-lang/crystal/raw/master/src/compiler/crystal/syntax/lexer.cr |
-    kak -f '%1scheck_ident_or_keyword\(:(\w+\??), \w+\)<ret>y%<a-R>a<ret><esc><a-_>a<del><esc>|sort<ret>'
+        kak -f '%1scheck_ident_or_keyword\(:(\w+\??), \w+\)<ret>y%<a-R>a<ret><esc><a-_>a<del><esc>|sort<ret>'
     }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -203,13 +203,13 @@ define-command -hidden crystal-insert-on-new-line %{
 define-command -hidden crystal-indent-on-char %{
     evaluate-commands -no-hooks -draft -itersel %{
         # align 'else/elsif' to 'if'
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:else|elsif)$ <ret> <a-semicolon> <a-?> ^\h*(?:if) <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:else|elsif)$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:if) <ret> <a-S> 1<a-&> }
         # align 'when' to 'case'
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:when)$ <ret> <a-semicolon> <a-?> ^\h*(?:case) <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:when)$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:case) <ret> <a-S> 1<a-&> }
         # align 'rescue' to 'begin/def'
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:rescue)$ <ret> <a-semicolon> <a-?> ^\h*(?:begin|def) <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:rescue)$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|def) <ret> <a-S> 1<a-&> }
         # align 'end' to opening structure
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:end)$ <ret> <a-semicolon> <a-?> ^\h*(?:begin|case|class|def|for|if|module|unless|until|while) <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:end)$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|case|class|def|for|if|module|unless|until|while) <ret> <a-S> 1<a-&> }
     }
 }
 

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -190,8 +190,8 @@ define-command -hidden crystal-indent-on-char %{
     evaluate-commands -no-hooks -draft -itersel %{
         # align 'else/elsif' to 'if'
         try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:else|elsif)$ <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:if)                                                    <ret> <a-S> 1<a-&> }
-        # align 'when' to 'case'
-        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:when)$       <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:case)                                                  <ret> <a-S> 1<a-&> }
+        # align 'else/when' to 'case'
+        try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:else|when)$       <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:case)                                             <ret> <a-S> 1<a-&> }
         # align 'rescue' to 'begin/def'
         try %{ execute-keys -draft <a-x> <a-k> ^\h*(?:rescue)$     <ret> <a-a>i <a-semicolon> <a-?> ^\h*(?:begin|def)                                             <ret> <a-S> 1<a-&> }
         # align 'end' to opening structure

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -181,13 +181,9 @@ evaluate-commands %sh[
 define-command -hidden crystal-indent-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
         # Copy previous line indent
-        try %{
-            execute-keys -draft 'K<a-&>'
-        }
+        try %{ execute-keys -draft 'K<a-&>' }
         # Remove empty line indent
-        try %{
-            execute-keys -draft 'k<a-x>s^\h+$<ret>d'
-        }
+        try %{ execute-keys -draft 'k<a-x>s^\h+$<ret>d' }
     }
 }
 


### PR DESCRIPTION
Crystal's syntax is based heavily off of ruby, yet the experience of programming Crystal in Kakoune is not comparable to that of Ruby. I added indenting on new line, inserting the closing `end` token on newline, deindenting on completion of intermediate/closing token, and copying comment prefixes from line to line. In general, I cleaned up the file with indentation and comments, making it easier to hack for the next person that comes along.