### PR TITLE
rc: Improve Ruby percent literals

### DIFF
--- a/rc/filetype/ruby.kak
+++ b/rc/filetype/ruby.kak
@@ -52,6 +52,7 @@ add-highlighter shared/ruby/              region -recurse \( '%[iqrswxIQRSWX]?\(
 add-highlighter shared/ruby/              region -recurse \{ '%[iqrswxIQRSWX]?\{' \} fill meta
 add-highlighter shared/ruby/              region -recurse \[ '%[iqrswxIQRSWX]?\[' \] fill meta
 add-highlighter shared/ruby/              region -recurse  < '%[iqrswxIQRSWX]?<'   > fill meta
+add-highlighter shared/ruby/              region -match-capture '%[iqrswxIQRSWX]?([^0-9A-Za-z\(\{\[<>\]\}\)])' ([^0-9A-Za-z\(\{\[<>\]\}\)]) fill meta
 add-highlighter shared/ruby/heredoc region '<<[-~]?(?!self)(\w+)'      '^\h*(\w+)$' fill string
 add-highlighter shared/ruby/division region '[\w\)\]]\K(/|(\h+/\h+))' '\w' group # Help Kakoune to better detect /…/ literals
 

--- a/rc/filetype/ruby.kak
+++ b/rc/filetype/ruby.kak
@@ -33,7 +33,7 @@ hook -group ruby-highlight global WinSetOption filetype=ruby %{
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/ruby }
 }
 
-provide-module ruby %[
+provide-module ruby %§
 
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
@@ -48,11 +48,21 @@ add-highlighter shared/ruby/backtick      region '(?<![$:])`' (?<!\\)(\\\\)*`   
 add-highlighter shared/ruby/regex         region '(?<![$:])/' (?<!\\)(\\\\)*/[imox]* regions
 add-highlighter shared/ruby/              region '#' '$'                             fill comment
 add-highlighter shared/ruby/              region ^=begin ^=end                       fill comment
-add-highlighter shared/ruby/              region -recurse \( '%[iqrswxIQRSWX]?\(' \) fill meta
-add-highlighter shared/ruby/              region -recurse \{ '%[iqrswxIQRSWX]?\{' \} fill meta
-add-highlighter shared/ruby/              region -recurse \[ '%[iqrswxIQRSWX]?\[' \] fill meta
-add-highlighter shared/ruby/              region -recurse  < '%[iqrswxIQRSWX]?<'   > fill meta
-add-highlighter shared/ruby/              region -match-capture '%[iqrswxIQRSWX]?([^0-9A-Za-z\(\{\[<>\]\}\)])' ([^0-9A-Za-z\(\{\[<>\]\}\)]) fill meta
+add-highlighter shared/ruby/              region -recurse \( '%[qwQW]?\(' \) fill string
+add-highlighter shared/ruby/              region -recurse \{ '%[qwQW]?\{' \} fill string
+add-highlighter shared/ruby/              region -recurse \[ '%[qwQW]?\[' \] fill string
+add-highlighter shared/ruby/              region -recurse  < '%[qwQW]?<'   > fill string
+add-highlighter shared/ruby/              region -recurse \( '%[isIS]\(' \) fill variable
+add-highlighter shared/ruby/              region -recurse \{ '%[isIS]\{' \} fill variable
+add-highlighter shared/ruby/              region -recurse \[ '%[isIS]\[' \] fill variable
+add-highlighter shared/ruby/              region -recurse  < '%[isIS]<'   > fill variable
+add-highlighter shared/ruby/              region -recurse \( '%[rxRX]\(' \) fill meta
+add-highlighter shared/ruby/              region -recurse \{ '%[rxRX]\{' \} fill meta
+add-highlighter shared/ruby/              region -recurse \[ '%[rxRX]\[' \] fill meta
+add-highlighter shared/ruby/              region -recurse  < '%[rxRX]<'   > fill meta
+add-highlighter shared/ruby/              region -match-capture '%[qwQW]?([^0-9A-Za-z\(\{\[<>\]\}\)])' ([^0-9A-Za-z\(\{\[<>\]\}\)]) fill string
+add-highlighter shared/ruby/              region -match-capture '%[isIS]([^0-9A-Za-z\(\{\[<>\]\}\)])' ([^0-9A-Za-z\(\{\[<>\]\}\)]) fill variable
+add-highlighter shared/ruby/              region -match-capture '%[rxRX]([^0-9A-Za-z\(\{\[<>\]\}\)])' ([^0-9A-Za-z\(\{\[<>\]\}\)]) fill meta
 add-highlighter shared/ruby/heredoc region '<<[-~]?(?!self)(\w+)'      '^\h*(\w+)$' fill string
 add-highlighter shared/ruby/division region '[\w\)\]]\K(/|(\h+/\h+))' '\w' group # Help Kakoune to better detect /…/ literals
 
@@ -178,4 +188,4 @@ define-command -hidden ruby-insert-on-new-line %[
     ]
 ]
 
-]
+§

--- a/rc/filetype/ruby.kak
+++ b/rc/filetype/ruby.kak
@@ -48,18 +48,18 @@ add-highlighter shared/ruby/backtick      region '(?<![$:])`' (?<!\\)(\\\\)*`   
 add-highlighter shared/ruby/regex         region '(?<![$:])/' (?<!\\)(\\\\)*/[imox]* regions
 add-highlighter shared/ruby/              region '#' '$'                             fill comment
 add-highlighter shared/ruby/              region ^=begin ^=end                       fill comment
-add-highlighter shared/ruby/              region -recurse \( '%[qwQW]?\(' \) fill string
-add-highlighter shared/ruby/              region -recurse \{ '%[qwQW]?\{' \} fill string
-add-highlighter shared/ruby/              region -recurse \[ '%[qwQW]?\[' \] fill string
-add-highlighter shared/ruby/              region -recurse  < '%[qwQW]?<'   > fill string
-add-highlighter shared/ruby/              region -recurse \( '%[isIS]\(' \) fill variable
-add-highlighter shared/ruby/              region -recurse \{ '%[isIS]\{' \} fill variable
-add-highlighter shared/ruby/              region -recurse \[ '%[isIS]\[' \] fill variable
-add-highlighter shared/ruby/              region -recurse  < '%[isIS]<'   > fill variable
-add-highlighter shared/ruby/              region -recurse \( '%[rxRX]\(' \) fill meta
-add-highlighter shared/ruby/              region -recurse \{ '%[rxRX]\{' \} fill meta
-add-highlighter shared/ruby/              region -recurse \[ '%[rxRX]\[' \] fill meta
-add-highlighter shared/ruby/              region -recurse  < '%[rxRX]<'   > fill meta
+add-highlighter shared/ruby/              region -recurse \( '%[qwQW]?\(' \)         fill string
+add-highlighter shared/ruby/              region -recurse \{ '%[qwQW]?\{' \}         fill string
+add-highlighter shared/ruby/              region -recurse \[ '%[qwQW]?\[' \]         fill string
+add-highlighter shared/ruby/              region -recurse  < '%[qwQW]?<'   >         fill string
+add-highlighter shared/ruby/              region -recurse \( '%[isIS]\('  \)         fill variable
+add-highlighter shared/ruby/              region -recurse \{ '%[isIS]\{'  \}         fill variable
+add-highlighter shared/ruby/              region -recurse \[ '%[isIS]\['  \]         fill variable
+add-highlighter shared/ruby/              region -recurse  < '%[isIS]<'    >         fill variable
+add-highlighter shared/ruby/              region -recurse \( '%[rxRX]\('  \)         fill meta
+add-highlighter shared/ruby/              region -recurse \{ '%[rxRX]\{'  \}         fill meta
+add-highlighter shared/ruby/              region -recurse \[ '%[rxRX]\['  \]         fill meta
+add-highlighter shared/ruby/              region -recurse  < '%[rxRX]<'    >         fill meta
 add-highlighter shared/ruby/              region -match-capture '%[qwQW]?([^0-9A-Za-z\(\{\[<>\]\}\)])' ([^0-9A-Za-z\(\{\[<>\]\}\)]) fill string
 add-highlighter shared/ruby/              region -match-capture '%[isIS]([^0-9A-Za-z\(\{\[<>\]\}\)])' ([^0-9A-Za-z\(\{\[<>\]\}\)]) fill variable
 add-highlighter shared/ruby/              region -match-capture '%[rxRX]([^0-9A-Za-z\(\{\[<>\]\}\)])' ([^0-9A-Za-z\(\{\[<>\]\}\)]) fill meta


### PR DESCRIPTION
Currently Ruby percent literals are implemented very nicely. However, there was much left to be desired in the realm of syntax highlighting. Because Ruby percent literals are used for strings, symbols, regexp, shell execution, arrays of strings, and arrays of symbols, it makes sense to highlight different types accordingly.

With my changes, the syntax highlighting is broken into 3 categories:

- `string`: for strings, array of words (strings). Same highlighter used for strings.
- `variable`: for symbols, array of symbols. Same highlighter used for symbols.
- `meta`: for shell execution, regexp. Same highlighter used for respective non-percent literals.

I also added some basic support for percent literals that don't use brace-style chars (`(){}[]<>`). Example: `%w^this is a valid array of words syntax^`.