### PR TITLE
Fix auto indentation for if/case and else

### DIFF
--- a/rc/filetype/ruby.kak
+++ b/rc/filetype/ruby.kak
@@ -150,10 +150,11 @@ define-command -hidden ruby-trim-indent %{
 define-command -hidden ruby-indent-on-char %{
     evaluate-commands -no-hooks -draft -itersel %{
         # align middle and end structures to start
-        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (else|elsif) $ <ret> <a-a> i <a-semicolon> <a-?> ^ \h * (if)                                                       <ret> <a-S> 1<a-&> }
-        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (else|when)  $ <ret> <a-a> i <a-semicolon> <a-?> ^ \h * (case)                                                     <ret> <a-S> 1<a-&> }
-        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (rescue)     $ <ret> <a-a> i <a-semicolon> <a-?> ^ \h * (begin|def)                                                <ret> <a-S> 1<a-&> }
-        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (end)        $ <ret> <a-a> i <a-semicolon> <a-?> ^ \h * (begin|case|class|def|for|if|module|unless|until|while)    <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (else)   $ <ret> <a-a> i <a-semicolon> <a-?> ^ \h * (if|case)                                               <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (elsif)  $ <ret> <a-a> i <a-semicolon> <a-?> ^ \h * (if)                                                    <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (when)   $ <ret> <a-a> i <a-semicolon> <a-?> ^ \h * (case)                                                  <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (rescue) $ <ret> <a-a> i <a-semicolon> <a-?> ^ \h * (begin|def)                                             <ret> <a-S> 1<a-&> }
+        try %{ execute-keys -draft <a-x> <a-k> ^ \h * (end)    $ <ret> <a-a> i <a-semicolon> <a-?> ^ \h * (begin|case|class|def|for|if|module|unless|until|while) <ret> <a-S> 1<a-&> }
     }
 }
 


### PR DESCRIPTION
This is a fix for a bug that I introduced in #3634.

Currently, if an `else` is typed, it first looks for an `if`, and then if that fails, it looks for a `case`. This doesn't work, because if a `case` statement is nested inside an `if` statement and an `else` for the `case` is typed, it is actually indented to the level of the `if`. This behavior is also seen if the `if` is nested inside a `when` clause of the `case` statement.

This fix changes the behavior. Instead of first looking for `if`, and then looking for `case`, when `else` is typed, it looks for *either* `if` or `case` in one regexp.