### PR TITLE
Override runtime by setting $KAKOUNE_RUNTIME

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -306,8 +306,8 @@ The following expansions are supported (with required context _in italics_):
     current register when the mapping was triggered
 
 *%val{runtime}*::
-    directory containing the kak support files, determined from Kakoune's
-    binary location
+    the directory containing the kak support files, which is determined from
+    Kakoune's binary location if `$KAKOUNE_RUNTIME` is not set
 
 *%val{select_mode}*::
     _for commands executed from the object menu's `<a-;>` only_ +

--- a/src/main.cc
+++ b/src/main.cc
@@ -138,6 +138,9 @@ inline void write_stderr(StringView str) { try { write(STDERR_FILENO, str); } ca
 
 String runtime_directory()
 {
+    if (const char* runtime_directory = getenv("KAKOUNE_RUNTIME"))
+        return runtime_directory;
+
     char relpath[PATH_MAX+1];
     format_to(relpath, "{}../share/kak", split_path(get_kak_binary_path()).first);
     struct stat st;


### PR DESCRIPTION
This is motivated by NixOS's packaging preferences and NixOS/nixpkgs#91792.

Specifically, Nix wants to make immutable (read-only) packages, and also wants to be able to configure installed plugins.  The usual way to do this is to make an "unwrapped" package with the basic runtime, separate packages for plugins, and a configurable package which ties everything together.  It usually does this by making a tree of symlinks and making a small shell wrapper telling the program to use the symlink farm for its config.

I wrote the previous wrapper, and made a fairly awkward and overly complicated wrapper that parsed arguments in order to decide whether it could pass `-E` to kakoune in order to run a script loading plugins.  This has the problem that plugins are loaded after kakrc is sourced.  To fix it, the above PR copies the `kak` binary into the user package so that it finds the configuration there.  This works mostly (although kak seems to not want to autocomplete documentation pages now), but the duplication of the executable is "surprising" from a Nix perspective, hence this PR introducing `$KAKOUNE_RUNTIME`.