### PR TITLE
Fix circular dependency between elixir and eex modules

### DIFF
--- a/rc/filetype/elixir.kak
+++ b/rc/filetype/elixir.kak
@@ -52,7 +52,6 @@ add-highlighter shared/eex/code region '<%=?' '%>' ref elixir
 }
 
 provide-module elixir %[
-require-module eex
 
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾


### PR DESCRIPTION
Fixes #3651 

Following this change, similar to Jinja, getting `eex` highlighting in `*.ex` (elixir) files will require users to setup a filetype hook similar to the following:

```
hook global WinSetOption filetype=elixir %{
    require-module eex
    add-highlighter window/eex ref eex
}
```

This is done both to fix a circular dependency between the `elixir` and `eex` modules, and avoid polluting `elixir` files with false positives from `eex` highlighting given `eex` is framework specific

`eex` template files (`*.eex`) will still load the `eex` and `elixir` modules by default
