### PR TITLE
rc python: Fix and improve highlighting of operators

### DIFF
--- a/rc/filetype/python.kak
+++ b/rc/filetype/python.kak
@@ -136,7 +136,7 @@ evaluate-commands %sh{
     "
 }
 
-add-highlighter shared/python/code/ regex (?<=[\w\s\d\)\]'"_])(<=|<<|>>|>=|<>|<|>|!=|==|\||\^|&|\+|-|\*\*|\*|//?|%|~) 0:operator
+add-highlighter shared/python/code/ regex (?<=[\w\s\d\)\]'"_])(<=|<<|>>|>=|<>?|>|!=|==|\||\^|&|\+|-|\*\*?|//?|%|~) 0:operator
 add-highlighter shared/python/code/ regex (?<=[\w\s\d'"_])((?<![=<>!])=(?![=])|[+*-]=) 0:builtin
 add-highlighter shared/python/code/ regex ^\h*(?:from|import)\h+(\S+) 1:module
 

--- a/rc/filetype/python.kak
+++ b/rc/filetype/python.kak
@@ -137,7 +137,7 @@ evaluate-commands %sh{
 }
 
 add-highlighter shared/python/code/ regex (?<=[\w\s\d\)\]'"_])(<=|<<|>>|>=|<>?|>|!=|==|\||\^|&|\+|-|\*\*?|//?|%|~) 0:operator
-add-highlighter shared/python/code/ regex (?<=[\w\s\d'"_])((?<![=<>!])=(?![=])|[+*-]=) 0:builtin
+add-highlighter shared/python/code/ regex (?<=[\w\s\d'"_])((?<![=<>!]):?=(?![=])|[+*-]=) 0:builtin
 add-highlighter shared/python/code/ regex ^\h*(?:from|import)\h+(\S+) 1:module
 
 # Commands


### PR DESCRIPTION
Fixes highlighting of `<>` and `**` operators similar to https://github.com/mawww/kakoune/pull/3166. Also adds highlighting for `:=` (walrus) operator for [assignment expressions](https://www.python.org/dev/peps/pep-0572/).