### PR TITLE
Separate auto-insert and auto-indent hooks in sh and kakrc filetypes

### DIFF
--- a/rc/filetype/kakrc.kak
+++ b/rc/filetype/kakrc.kak
@@ -16,6 +16,7 @@ hook global WinSetOption filetype=kak %~
 
     set-option window static_words %opt{kak_static_words}
 
+    hook window InsertChar \n -group kak-insert kak-insert-on-new-line
     hook window InsertChar \n -group kak-indent kak-indent-on-new-line
     hook window InsertChar [>)}\]] -group kak-indent kak-indent-on-closing-matching
     hook window InsertChar (?![[{(<>)}\]])[^\s\w] -group kak-indent kak-indent-on-closing-char
@@ -90,10 +91,15 @@ add-highlighter shared/kakrc/single_string/escape regex "''" 0:default+b
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden kak-indent-on-new-line %~
+define-command -hidden kak-insert-on-new-line %~
     evaluate-commands -draft -itersel %=
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
+    =
+~
+
+define-command -hidden kak-indent-on-new-line %~
+    evaluate-commands -draft -itersel %=
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # cleanup trailing whitespaces from previous line

--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -7,6 +7,7 @@ hook global WinSetOption filetype=sh %{
     set-option window static_words %opt{sh_static_words}
 
     hook window ModeChange pop:insert:.* -group sh-trim-indent sh-trim-indent
+    hook window InsertChar \n -group sh-insert sh-insert-on-new-line
     hook window InsertChar \n -group sh-indent sh-indent-on-new-line
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window sh-.+ }
 }
@@ -78,10 +79,15 @@ define-command -hidden sh-trim-indent %{
 # Of necessity, this is also fairly opinionated about indentation styles.
 # Doing it "properly" would require far more context awareness than we can
 # bring to this kind of thing.
-define-command -hidden sh-indent-on-new-line %[
+define-command -hidden sh-insert-on-new-line %[
     evaluate-commands -draft -itersel %[
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
+    ]
+]
+
+define-command -hidden sh-indent-on-new-line %[
+    evaluate-commands -draft -itersel %[
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line


### PR DESCRIPTION
Relevant issues: #3179 #3647 
