### PR TITLE
Avoid extra indent when line does not end on keyword

### DIFF
--- a/rc/filetype/dhall.kak
+++ b/rc/filetype/dhall.kak
@@ -89,7 +89,7 @@ define-command -hidden dhall-indent-on-new-line %{
         # filter previous line
         try %{ execute-keys -draft k : dhall-trim-indent <ret> }
         # indent after lines ending with let, : or =
-        try %{ execute-keys -draft \; k x <a-k> (let|:|=)$ <ret> j <a-gt> }
+        try %{ execute-keys -draft \; k x <a-k> (\blet|:|=)$ <ret> j <a-gt> }
     }
 }
 

--- a/rc/filetype/elixir.kak
+++ b/rc/filetype/elixir.kak
@@ -98,11 +98,11 @@ define-command -hidden elixir-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # indent after line ending with:
-	# try %{ execute-keys -draft k x <a-k> (do|else|->)$ <ret> & }
+	# try %{ execute-keys -draft k x <a-k> (\bdo|\belse|->)$ <ret> & }
 	# filter previous line
         try %{ execute-keys -draft k : elixir-trim-indent <ret> }
         # indent after lines ending with do or ->
-        try %{ execute-keys -draft <semicolon> k x <a-k> ^.+(do|->)$ <ret> j <a-gt> }
+        try %{ execute-keys -draft <semicolon> k x <a-k> ^.+(\bdo|->)$ <ret> j <a-gt> }
     }
 }
 

--- a/rc/filetype/elm.kak
+++ b/rc/filetype/elm.kak
@@ -58,7 +58,7 @@ define-command -hidden elm-trim-indent %{
 }
 
 define-command -hidden elm-indent-after "
- execute-keys -draft <semicolon> k x <a-k> ^\\h*(if)|(case\\h+[\\w']+\\h+of|let|in|\\{\\h+\\w+|\\w+\\h+->|[=(])$ <ret> j <a-gt>
+ execute-keys -draft <semicolon> k x <a-k> ^\\h*if|[=(]$|\\b(case\\h+[\\w']+\\h+of|let|in)$|(\\{\\h+\\w+|\\w+\\h+->)$ <ret> j <a-gt>
 "
 
 define-command -hidden elm-indent-on-new-line %{

--- a/rc/filetype/fsharp.kak
+++ b/rc/filetype/fsharp.kak
@@ -135,7 +135,7 @@ define-command -hidden fsharp-indent-on-new-line %{
         # indent after line ending with =
         try %{ execute-keys -draft <space> k <a-x> <a-k> =$ <ret> j <a-gt> }
         # indent after line ending with "do"
-        try %{ execute-keys -draft <space> k <a-x> <a-k> do$ <ret> j <a-gt> }
+        try %{ execute-keys -draft <space> k <a-x> <a-k> \bdo$ <ret> j <a-gt> }
     }
 }
 

--- a/rc/filetype/gluon.kak
+++ b/rc/filetype/gluon.kak
@@ -88,7 +88,7 @@ define-command -hidden gluon-indent-on-new-line %~
         try %{ execute-keys -draft k : gluon-trim-indent <ret> }
         # indent after lines ending with (open) braces, =, ->, condition, rec,
         # or in
-        try %{ execute-keys -draft \; k x <a-k> (\(|\{|\[|=|->|then|else|rec|in)$ <ret> j <a-gt> }
+        try %{ execute-keys -draft \; k x <a-k> (\(|\{|\[|=|->|\b(?:then|else|rec|in))$ <ret> j <a-gt> }
         # deindent closing brace(s) when after cursor
         try %< execute-keys -draft <a-x> <a-k> ^\h*[})\]] <ret> gh / \})\]] <ret> m <a-S> 1<a-&> >
     _

--- a/rc/filetype/haskell.kak
+++ b/rc/filetype/haskell.kak
@@ -114,7 +114,7 @@ define-command -hidden haskell-indent-on-new-line %{
         # filter previous line
         try %{ execute-keys -draft k : haskell-trim-indent <ret> }
         # indent after lines beginning with condition or ending with expression or =(
-        try %{ execute-keys -draft <semicolon> k x <a-k> ^\h*(if)|(case\h+[\w']+\h+of|do|let|where|[=(])$ <ret> j <a-gt> }
+        try %{ execute-keys -draft <semicolon> k x <a-k> ^\h*if|[=(]$|\b(case\h+[\w']+\h+of|do|let|where)$ <ret> j <a-gt> }
     }
 }
 

--- a/rc/filetype/nim.kak
+++ b/rc/filetype/nim.kak
@@ -117,7 +117,7 @@ def -hidden nim-indent-on-new-line %{
         # cleanup trailing whitespaces from previous line
         try %{ exec -draft k <a-x> s \h+$ <ret> d }
         # indent after line ending with enum, tuple, object, type, import, export, const, let, var, ':' or '='
-        try %{ exec -draft <space> k <a-x> <a-k> (:|=|enum|tuple|object|const|let|var|import|export|type)$ <ret> j <a-gt> }
+        try %{ exec -draft <space> k <a-x> <a-k> (:|=|\b(?:enum|tuple|object|const|let|var|import|export|type))$ <ret> j <a-gt> }
     }
 }
 

--- a/rc/filetype/pony.kak
+++ b/rc/filetype/pony.kak
@@ -89,9 +89,9 @@ define-command -hidden pony-indent-on-new-line %{
         # copy '//' comment prefix and following white spaces
         # try %{ execute-keys -draft k x s ^\h*//\h* <ret> y jgh P }
         # indent after line ending with :
-        try %{ execute-keys -draft <space> k x <a-k> (do|try|then|else|:|=>)$ <ret> j <a-gt> }
+        try %{ execute-keys -draft <space> k x <a-k> (\b(?:do|try|then|else)|:|=>)$ <ret> j <a-gt> }
         # else, end are always de-indented
-        try %{ execute-keys -draft <space> k x <a-k> (else|end):$ <ret> k x s ^\h* <ret> y j x <a-k> ^<c-r>" <ret> J <a-lt> }
+        try %{ execute-keys -draft <space> k x <a-k> \b(else|end):$ <ret> k x s ^\h* <ret> y j x <a-k> ^<c-r>" <ret> J <a-lt> }
     }
 }
 

--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -112,9 +112,9 @@ define-command -hidden sh-indent-on-new-line %[
         # done
         #
         # indent after do
-        try %{ execute-keys -draft <space> k <a-x> <a-k> do$ <ret> j <a-gt> }
+        try %{ execute-keys -draft <space> k <a-x> <a-k> \bdo$ <ret> j <a-gt> }
         # deindent after done
-        try %{ execute-keys -draft <space> k <a-x> <a-k> done$ <ret> K <a-&> j <a-lt> j K <a-&> }
+        try %{ execute-keys -draft <space> k <a-x> <a-k> \bdone$ <ret> K <a-&> j <a-lt> j K <a-&> }
 
         # Indent if/then/else syntax, e.g.:
         # if [ $foo = $bar ]; then
@@ -132,12 +132,12 @@ define-command -hidden sh-indent-on-new-line %[
         # fi
         #
         # indent after then
-        try %{ execute-keys -draft <space> k <a-x> <a-k> then$ <ret> j <a-gt> }
+        try %{ execute-keys -draft <space> k <a-x> <a-k> \bthen$ <ret> j <a-gt> }
         # deindent after fi
-        try %{ execute-keys -draft <space> k <a-x> <a-k> fi$ <ret> K <a-&> j <a-lt> j K <a-&> }
+        try %{ execute-keys -draft <space> k <a-x> <a-k> \bfi$ <ret> K <a-&> j <a-lt> j K <a-&> }
         # deindent and reindent after else - deindent the else, then back
         # down and return to the previous indent level.
-        try %{ execute-keys -draft <space> k <a-x> <a-k> else$ <ret> <a-lt> j }
+        try %{ execute-keys -draft <space> k <a-x> <a-k> \belse$ <ret> <a-lt> j }
 
         # Indent case syntax, e.g.:
         # case "$foo" in
@@ -157,9 +157,9 @@ define-command -hidden sh-indent-on-new-line %[
         # esac
         #
         # indent after in
-        try %{ execute-keys -draft <space> k <a-x> <a-k> in$ <ret> j <a-gt> }
+        try %{ execute-keys -draft <space> k <a-x> <a-k> \bin$ <ret> j <a-gt> }
         # deindent after esac
-        try %{ execute-keys -draft <space> k <a-x> <a-k> esac$ <ret> <a-lt> j K <a-&> }
+        try %{ execute-keys -draft <space> k <a-x> <a-k> \besac$ <ret> <a-lt> j K <a-&> }
         # indent after )
         try %{ execute-keys -draft <space> k <a-x> <a-k> ^\s*\(?[^(]+[^)]\)$ <ret> j <a-gt> }
         # deindent after ;;


### PR DESCRIPTION
For example there was an indent after a line like "echo todo" with filetype sh
because the "do" in "todo" was recognised as keyword.