### PR TITLE
Avoid accidentally using environment variables in sh scopes

### DIFF
--- a/rc/detection/modeline.kak
+++ b/rc/detection/modeline.kak
@@ -58,9 +58,8 @@ define-command -hidden modeline-parse-impl %{
         case "${kak_selection}" in
             *vi:*|*vim:*) type_selection="vim";;
             *kak:*|*kakoune:*) type_selection="kakoune";;
-            *) echo "echo -debug Unsupported modeline format";;
+            *) echo "echo -debug Unsupported modeline format"; exit 1 ;;
         esac
-        [ -n "${type_selection}" ] || exit 1
 
         # The following subshell will keep the actual options of the modeline, and strip:
         # - the text that leads the first option, according to the official vim modeline format
@@ -82,6 +81,7 @@ define-command -hidden modeline-parse-impl %{
             case "${type_selection}" in
                 vim) tr=$(translate_opt_vim "${name_option}" "${value_option}");;
                 kakoune) tr=$(translate_opt_kakoune "${name_option}" "${value_option}");;
+                *) tr="";;
             esac
 
             [ -n "${tr}" ] && printf %s\\n "${tr}"

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -65,6 +65,8 @@ define-command lua-alternative-file -docstring 'Jump to the alternate file (impl
             [ ! -f $altfile ] && echo "fail 'implementation file not found'" && exit
         ;;
         *.lua)
+            altfile=""
+            altdir=""
             path=$kak_buffile
             dirs=$(while [ $path ]; do printf %s\\n $path; path=${path%/*}; done | tail -n +2)
             for dir in $dirs; do
@@ -74,7 +76,7 @@ define-command lua-alternative-file -docstring 'Jump to the alternate file (impl
                     break
                 fi
             done
-            [ ! -d $altdir ] && echo "fail 'spec/ not found'" && exit
+            [ ! -d "$altdir" ] && echo "fail 'spec/ not found'" && exit
         ;;
         *)
             echo "fail 'alternative file not found'" && exit

--- a/rc/filetype/ruby.kak
+++ b/rc/filetype/ruby.kak
@@ -120,6 +120,8 @@ define-command ruby-alternative-file -docstring 'Jump to the alternate file (imp
             [ ! -f $altfile ] && echo "fail 'implementation file not found'" && exit
         ;;
         *.rb)
+            altfile=""
+            altdir=""
             path=$kak_buffile
             dirs=$(while [ $path ]; do echo $path; path=${path%/*}; done | tail -n +2)
             for dir in $dirs; do
@@ -130,7 +132,7 @@ define-command ruby-alternative-file -docstring 'Jump to the alternate file (imp
                     break
                 fi
             done
-            [ ! -d $altdir ] && echo "fail 'spec/ and test/ not found'" && exit
+            [ ! -d "$altdir" ] && echo "fail 'spec/ and test/ not found'" && exit
         ;;
         *)
             echo "fail 'alternative file not found'" && exit

--- a/rc/tools/autorestore.kak
+++ b/rc/tools/autorestore.kak
@@ -9,11 +9,11 @@ define-command autorestore-restore-buffer -docstring "Restore the backup for the
 
         if [ -f "${kak_buffile}" ]; then
             newer=$(find "${buffer_dirname}"/".${buffer_basename}.kak."* -newer "${kak_buffile}" -exec ls -1t {} + 2>/dev/null | head -n 1)
-
             older=$(find "${buffer_dirname}"/".${buffer_basename}.kak."* \! -newer "${kak_buffile}" -exec ls -1t {} + 2>/dev/null | head -n 1)
         else
             # New buffers that were never written to disk.
             newer=$(ls -1t "${buffer_dirname}"/".${buffer_basename}.kak."* 2>/dev/null | head -n 1)
+            older=""
         fi
 
         if [ -z "${newer}" ]; then

--- a/rc/tools/clang.kak
+++ b/rc/tools/clang.kak
@@ -173,6 +173,8 @@ define-command clang-diagnostics-next -docstring "Jump to the next line that con
     evaluate-commands %sh{
         eval "set -- ${kak_quoted_opt_clang_errors}"
         shift # skip timestamp
+        unset line
+        unset first_line
         for error in "$@"; do
             candidate=${error%%|*}
             first_line=${first_line-$candidate}

--- a/rc/tools/doc.kak
+++ b/rc/tools/doc.kak
@@ -14,6 +14,7 @@ define-command -hidden -params 4 doc-render-regex %{
         evaluate-commands %sh{
             face="$4"
             eval "set -- $kak_quoted_selections_desc"
+            ranges=""
             for desc in "$@"; do ranges="$ranges '$desc|$face'"; done
             echo "update-option buffer doc_render_ranges"
             echo "set-option -add buffer doc_render_ranges $ranges"
@@ -154,6 +155,7 @@ define-command -params 1..2 \
     evaluate-commands %sh{
         readonly page="${kak_runtime}/doc/${1}.asciidoc"
         if [ -f "${page}" ]; then
+            jump_cmd=""
             if [ $# -eq 2 ]; then
                 jump_cmd="doc-jump-to-anchor '$2'"
             fi

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -229,6 +229,7 @@ define-command -params 1.. \
             fi
         done
 
+        wrapped=false
         if [ "$direction" = "next" ]; then
             if [ -z "$next_hunk" ]; then
                 next_hunk=${hunks%% *}

--- a/rc/tools/go/go-tools.kak
+++ b/rc/tools/go/go-tools.kak
@@ -116,6 +116,7 @@ define-command -hidden -params 1..2 gogetdoc-cmd %{
             cat ${dir}/buf | wc -c >> ${dir}/modified
             cat ${dir}/buf >> ${dir}/modified
 
+            args=""
             if [ "$2" = "1" ]; then
                 args="-json"
             fi

--- a/rc/tools/man.kak
+++ b/rc/tools/man.kak
@@ -74,6 +74,9 @@ define-command -params ..1 \
             pagenum="${pagenum%\)}"
             subject="${subject%%\(*}"
             ;;
+        *)
+            pagenum=""
+            ;;
     esac
 
     printf %s\\n "evaluate-commands -try-client %opt{docsclient} man-impl man $pagenum $subject"

--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -143,6 +143,7 @@ define-command spell-next %{ evaluate-commands %sh{
 define-command \
     -docstring "Suggest replacement words for the current selection, against the last language used by the spell-check command" \
     spell-replace %{ evaluate-commands %sh{
+    options=""
     if [ -n "$kak_opt_spell_last_lang" ]; then
         options="-l '$kak_opt_spell_last_lang'"
     fi
@@ -159,6 +160,7 @@ define-command \
 define-command -params 0.. \
     -docstring "Add the current selection to the dictionary" \
     spell-add %{ evaluate-commands %sh{
+    options=""
     if [ -n "$kak_opt_spell_last_lang" ]; then
         options="-l '$kak_opt_spell_last_lang'"
     fi

--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -11,6 +11,7 @@ def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
         find -L "${1}" -type f -name "${2}".kak | head -n 1
     }
 
+    filename=""
     if [ -d "${kak_config}/colors" ]; then
         filename=$(find_colorscheme "${kak_config}/colors" "${1}")
     fi


### PR DESCRIPTION
On the instances with `altfile` this was already the case, but this makes it more obvious.

Closes #3673