### PR TITLE
rc markdown: Highlight trailing spaces properly

### DIFF
--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -79,7 +79,7 @@ add-highlighter shared/markdown/inline/text/ regex (?<!_)(__([^\s_]|([^\s_](\n?[
 add-highlighter shared/markdown/inline/text/ regex <(([a-z]+://.*?)|((mailto:)?[\w+-]+@[a-z]+[.][a-z]+))> 0:link
 add-highlighter shared/markdown/inline/text/ regex ^\[[^\]\n]*\]:\h*([^\n]*) 1:link
 add-highlighter shared/markdown/inline/text/ regex ^\h*(>\h*)+ 0:comment
-add-highlighter shared/markdown/inline/text/ regex \H\K\h\h$ 0:PrimarySelection
+add-highlighter shared/markdown/inline/text/ regex "\H( {2,})$" 1:+r@meta
 
 # Inline code
 add-highlighter shared/markdown/inline/text/ regex "^    [^\n]*" 0:meta


### PR DESCRIPTION
This commit addresses the following issues:

* highlight trailing space characters with the `meta` face, instead of
  `PrimarySelection`
* make the regex more readable by using a capture group in stead of
  `\K`
* specifically match space characters, not other horizontal whitespace
  characters
* match two or more space characters

Reference[1]:

> When you do want to insert a <br /> break tag using Markdown, you
> end a line with two or more spaces, then type return.

[1] https://daringfireball.net/projects/markdown/syntax#p

Note that the original reproducer doesn't seem to work anymore,
probably because of changes made to how lists are highlighted.

Fixes #911