### PR TITLE
rc repl: Normalise REPL commands

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -5,6 +5,9 @@ released versions.
 
 == Development version
 
+* The `repl` and `send-text` aliases have been renamed respectively into
+  `repl-new` and `repl-send-text`.
+
 * Daemon mode (`-d` switch) does not fork anymore.
 
 == Kakoune 2020.08.04

--- a/rc/windowing/repl/kitty.kak
+++ b/rc/windowing/repl/kitty.kak
@@ -38,7 +38,7 @@ define-command -hidden -params 0..1 \
     }
 }
 
-alias global repl kitty-repl
-alias global send-text kitty-send-text
+alias global repl-new kitty-repl
+alias global repl-send-text kitty-send-text
 
 }

--- a/rc/windowing/repl/tmux.kak
+++ b/rc/windowing/repl/tmux.kak
@@ -49,7 +49,7 @@ define-command -hidden tmux-send-text -params 0..1 -docstring %{
     }
 }
 
-alias global repl tmux-repl-horizontal
-alias global send-text tmux-send-text
+alias global repl-new tmux-repl-horizontal
+alias global repl-send-text tmux-send-text
 
 }

--- a/rc/windowing/repl/x11.kak
+++ b/rc/windowing/repl/x11.kak
@@ -31,7 +31,7 @@ define-command x11-send-text -docstring "send the selected text to the repl wind
     }
 }
 
-alias global repl x11-repl
-alias global send-text x11-send-text
+alias global repl-new x11-repl
+alias global repl-send-text x11-send-text
 
 }


### PR DESCRIPTION
It's unclear what the `send-text` alias does at first glance,
so prefixing it with "repl-" both fixes that and helps make it
discoverable via the command prompt's fuzzy matcher.

The `repl` alias also seems too generic a name, the "-new" suffix
should hopefully give a hint that it creates a new window.