### PR TITLE
python.kak: Do not indent after comments ending in :

### DIFF
--- a/rc/filetype/python.kak
+++ b/rc/filetype/python.kak
@@ -156,7 +156,7 @@ define-command -hidden python-indent-on-new-line %<
         # cleanup trailing whitespaces from previous line
         try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
         # indent after line ending with :
-        try %{ execute-keys -draft <space> k <a-x> <a-k> :$ <ret> j <a-gt> }
+        try %{ execute-keys -draft <space> k <a-x> <a-k> :$ <ret> <a-K> ^\h*# <ret> j <a-gt> }
         # deindent closing brace/bracket when after cursor (for arrays and dictionaries)
         try %< execute-keys -draft <a-x> <a-k> ^\h*[}\]] <ret> gh / [}\]] <ret> m <a-S> 1<a-&> >
     >


### PR DESCRIPTION
Fixes #3693

This will not work for lines like the one below but I think that's okay
because it does work for most comments.

	foo() # foo: