### PR TITLE
Clear more environment variables

### DIFF
--- a/rc/detection/file.kak
+++ b/rc/detection/file.kak
@@ -12,6 +12,7 @@ hook global BufOpenFile .* %{ evaluate-commands %sh{
             text/*)   filetype="${mime#text/}" ;;
             application/x-*) filetype="${mime#application/x-}" ;;
             application/*) filetype="${mime#application/}" ;;
+            *) exit ;;
         esac
         if [ -n "${filetype}" ]; then
             printf "set-option buffer filetype '%s'\n" "${filetype}"

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -78,6 +78,7 @@ define-command -params 1.. \
            diff) filetype=diff ;;
            log|show)  filetype=git-log ;;
            status)  filetype=git-status ;;
+           *) return 1 ;;
         esac
         output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-git.XXXXXXXX)/fifo
         mkfifo ${output}


### PR DESCRIPTION
This adds two things I forgot in
9a7d8df4 (Avoid accidentally using environment variables in sh scopes)

Mea culpa, the problem was that I was skipping matches like "filetype="
because that's usually just a hook parameter as in `WinSetOption filetype=..`

	rg --pcre2 '\b(?!filetype=)\w+=' rc/

So I missed these two cases where a shell variable is actually called "filetype".

The one in git.kak was not a problem because show_git_cmd_output is only
ever called with sane inputs.  However, file.kak does use the filetype
environment variable for many mime types, for example:

	filetype=somefiletype\''; echo -debug injection; nop '\' kak /dev/null

Will run the echo since /dev/null has mime type "inode/chardevice"

---

Thanks to lenormf for reporting. The timing is awkward, but maybe it's unlikely that this will actually negatively affect users?