### PR TITLE
src: Make count on <space> relative to the main selection

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -2082,7 +2082,7 @@ void select_whole_buffer(Context& context, NormalParams)
 void keep_selection(Context& context, NormalParams p)
 {
     auto& selections = context.selections();
-    const int index = p.count ? p.count-1 : selections.main_index();
+    const int index = (selections.main_index() + p.count) % selections.size();
     if (index >= selections.size())
         throw runtime_error{format("invalid selection index: {}", index)};
 

--- a/test/indent/javascript/deindent-complex-brace-structure/cmd
+++ b/test/indent/javascript/deindent-complex-brace-structure/cmd
@@ -1,1 +1,1 @@
-c<ret><esc>Oif (true) {}<esc>hi<ret><esc>Oconsole.log();<esc>hhi<ret><esc>O{},<ret>{},<esc>hh<a-C>i<ret><esc>1<space>Ofoo: { bar: 1 },<esc>jjobaz: { bam: 2 },<esc>
+c<ret><esc>Oif (true) {}<esc>hi<ret><esc>Oconsole.log();<esc>hhi<ret><esc>O{},<ret>{},<esc>hh<a-C>i<ret><esc>2<space>Ofoo: { bar: 1 },<esc>jjobaz: { bam: 2 },<esc>


### PR DESCRIPTION
This commit makes counts passed to the <space> primitive be added
to the index of the main selection, instead of considering them the
direct index of the selection to keep.

This logic seems more helpful interactively, in cases where many
selections are off-screen, or counting the visible ones is too tedious.

Counting wraps around the selection, e.g. if the main selection if
the last one, a count of 1 will refer to the first one.

The modifications assume the selection is never empty, and uses
`selections.size()` as a modulo operand without any prior sanity
checks.

Fixes #1323.