### PR TITLE
Add illumos support for Kakoune

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -80,6 +80,9 @@ else ifeq ($(os),OpenBSD)
 else ifneq (,$(findstring CYGWIN,$(os)))
     CPPFLAGS += -D_XOPEN_SOURCE=700
     LIBS += -lncursesw -ldbghelp
+else ifeq ($(os),SunOS)
+    LIBS += -lncursesw 
+    LDFLAGS += -lsocket -rdynamic
 else
     ifeq ($(PKG_CONFIG),)
     	$(error "pkg-config not found in PATH")

--- a/src/event_manager.cc
+++ b/src/event_manager.cc
@@ -3,6 +3,10 @@
 #include "flags.hh"
 #include "ranges.hh"
 
+#if defined(__sun__)
+#include <cstring>
+#endif
+
 #include <unistd.h>
 
 namespace Kakoune

--- a/src/file.cc
+++ b/src/file.cc
@@ -654,6 +654,11 @@ String get_kak_binary_path()
     return buffer;
 #elif defined(__OpenBSD__)
     return KAK_BIN_PATH;
+#elif defined(__sun__)
+    ssize_t res = readlink("/proc/self/path/a.out", buffer, 2048);
+    kak_assert(res != -1);
+    buffer[res] = '\0';
+    return buffer;
 #else
 # error "finding executable path is not implemented on this platform"
 #endif


### PR DESCRIPTION
This PR adds support for compilation on the illumos family of operating systems. It also probably adds support for Solaris, but I'm not able to test that.

This is tested on OpenIndiana using GCC 7.5.0, GNU make 4.2.1, and GNU install from coreutils 8.31. I tried using illumos install(1M), but it acted really strangely so I added a little extra to the makefile to decide on what install to use and use ginstall on illumos. All you need to do really is run `gmake` and it works! Don't even need to redefine what C++ compiler to use, the default one works just fine.

![kakoune running on OpenIndiana, showing uname -a output in the status line](https://user-images.githubusercontent.com/67138948/92507266-52067a00-f1cc-11ea-8ee5-920ed41068b8.png)

If there's anything else that needs done, let me know!
