### PR TITLE
fix justfile highlighter

### DIFF
--- a/rc/filetype/just.kak
+++ b/rc/filetype/just.kak
@@ -57,6 +57,9 @@ add-highlighter shared/justfile/body/interpreters/defaultshell default-region gr
 add-highlighter shared/justfile/body/interpreters/defaultshell/ ref sh
 add-highlighter shared/justfile/body/interpreters/defaultshell/ regex '^\h+(@)' 1:operator
 
+add-highlighter shared/justfile/body/interpreters/bash region '^\h+#!\h?/usr/bin/env bash' '^[^\h]' ref sh
+add-highlighter shared/justfile/body/interpreters/sh region '^\h+#!\h?/usr/bin/env sh' '^[^\h]' ref sh
+
 add-highlighter shared/justfile/body/ regex '(\{{2})([\w-]+)(\}{2})' 1:operator 2:variable 3:operator
 
 

--- a/rc/filetype/just.kak
+++ b/rc/filetype/just.kak
@@ -38,18 +38,23 @@ define-command -hidden just-indent-on-new-line %{
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
 add-highlighter shared/justfile regions
+
 add-highlighter shared/justfile/content default-region group
+add-highlighter shared/justfile/content/recipe regex '^@?([\w-]+)([^\n]*):(?!=)([^\n]*)' 1:function 2:meta 3:keyword
+add-highlighter shared/justfile/content/assignments regex ^([\w-]+\h*:=\h*[^\n]*) 1:meta
+add-highlighter shared/justfile/content/operator regex '((^@|:=|=|\+|\(|\)))' 1:operator
+add-highlighter shared/justfile/content/strings regions
+add-highlighter shared/justfile/content/strings/double region '"' (?<!\\)(\\\\)*" fill string
+add-highlighter shared/justfile/content/strings/single region "'" (?<!\\)(\\\\)*' fill string
+
 add-highlighter shared/justfile/comment  region '#' '$'  fill comment
-add-highlighter shared/justfile/double_string region '"' (?<!\\)(\\\\)*" fill string
-add-highlighter shared/justfile/single_string region "'" (?<!\\)(\\\\)*' fill string
+
 add-highlighter shared/justfile/inline   region '`' '`' ref sh
 
 add-highlighter shared/justfile/shell  region '^\h+' '^[^\h]' group
 add-highlighter shared/justfile/shell/ ref sh
 add-highlighter shared/justfile/shell/ regex '(\{{2})([\w-]+)(\}{2})' 1:operator 2:variable 3:operator
+add-highlighter shared/justfile/shell/ regex '^\h+(@)' 1:operator
 
-add-highlighter shared/justfile/content/ regex '^(@)?([\w-]+)(?:\s(.+))?\s?(:)(.+)?$' 1:operator 2:function 3:value 4:operator 5:type
-add-highlighter shared/justfile/content/ regex '([=+])' 1:operator
-add-highlighter shared/justfile/content/ regex '^([\w-]+)\s=' 1:value
 
 }

--- a/rc/filetype/just.kak
+++ b/rc/filetype/just.kak
@@ -51,10 +51,13 @@ add-highlighter shared/justfile/comment  region '#' '$'  fill comment
 
 add-highlighter shared/justfile/inline   region '`' '`' ref sh
 
-add-highlighter shared/justfile/shell  region '^\h+' '^[^\h]' group
-add-highlighter shared/justfile/shell/ ref sh
-add-highlighter shared/justfile/shell/ regex '(\{{2})([\w-]+)(\}{2})' 1:operator 2:variable 3:operator
-add-highlighter shared/justfile/shell/ regex '^\h+(@)' 1:operator
+add-highlighter shared/justfile/body  region '^\h+' '^[^\h]' group
+add-highlighter shared/justfile/body/interpreters regions
+add-highlighter shared/justfile/body/interpreters/defaultshell default-region group
+add-highlighter shared/justfile/body/interpreters/defaultshell/ ref sh
+add-highlighter shared/justfile/body/interpreters/defaultshell/ regex '^\h+(@)' 1:operator
+
+add-highlighter shared/justfile/body/ regex '(\{{2})([\w-]+)(\}{2})' 1:operator 2:variable 3:operator
 
 
 }


### PR DESCRIPTION
This fixes serveral shortcomings of the current implementation:

- valid recipt definitions eg 
foo bar="quz":
where previously interrupted by justfile/double_string
and therefore they where not highlighted correctly

- global variable assignments where not captured at all


**Now**:
- see how globals in first line are shown red `nixEnvs`
- see how `deploy env="active"` is shown correctly

![image](https://user-images.githubusercontent.com/7548295/93259406-6cf56300-f765-11ea-948b-a266e6a5ab89.png)

![image](https://user-images.githubusercontent.com/7548295/93259538-9f06c500-f765-11ea-9e1c-b2ad12854e78.png)

Also: 
![image](https://user-images.githubusercontent.com/7548295/93259805-0c1a5a80-f766-11ea-9dbc-c5dc3b26252e.png)


