### PR TITLE
Fix python docstring highlighter

### DIFF
--- a/rc/filetype/python.kak
+++ b/rc/filetype/python.kak
@@ -35,7 +35,7 @@ provide-module python %§
 
 add-highlighter shared/python regions
 add-highlighter shared/python/code default-region group
-add-highlighter shared/python/docstring     region -match-capture ("""|''') ("""|''') regions
+add-highlighter shared/python/docstring     region -match-capture ("""|''') (?<!\\)(?:\\\\)*("""|''') regions
 add-highlighter shared/python/double_string region '"'   (?<!\\)(\\\\)*"  fill string
 add-highlighter shared/python/single_string region "'"   (?<!\\)(\\\\)*'  fill string
 add-highlighter shared/python/documentation region '##'  '$'              fill documentation


### PR DESCRIPTION
Fixes #3725 