### PR TITLE
Use internal linkage for file-local functions 

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -5,7 +5,7 @@ released versions.
 
 == Development version
 
-* `set-option -remove` support for substracting/removing from option values
+* `set-option -remove` support for subtracting/removing from option values
 
 == Kakoune 2020.09.01
 

--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -66,7 +66,7 @@ are exclusively available to built-in options.
     an integer number.
 
     `set -add` performs a math addition. +
-    `set -remove` performs a math substraction. +
+    `set -remove` performs a math subtraction. +
 
 *bool*::
     a boolean value, yes/true or no/false

--- a/src/Makefile
+++ b/src/Makefile
@@ -90,7 +90,7 @@ else
     LDFLAGS += -rdynamic
 endif
 
-CXXFLAGS += -pedantic -std=c++17 -g -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-address
+CXXFLAGS += -pedantic -std=c++17 -g -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-address -Wmissing-declarations
 
 compiler := $(shell $(CXX) --version)
 ifneq (,$(findstring clang,$(compiler)))

--- a/src/buffer_utils.cc
+++ b/src/buffer_utils.cc
@@ -246,7 +246,7 @@ void write_to_debug_buffer(StringView str)
 }
 
 
-auto to_string(Buffer::HistoryId id)
+static auto to_string(Buffer::HistoryId id)
 {
     using Result = decltype(to_string(size_t{}));
     if (id == Buffer::HistoryId::Invalid)

--- a/src/client.cc
+++ b/src/client.cc
@@ -123,7 +123,7 @@ DisplayCoord Client::dimensions() const
     return m_ui->dimensions();
 }
 
-String generate_context_info(const Context& context)
+static String generate_context_info(const Context& context)
 {
     String s = "";
     if (context.buffer().is_modified())

--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -487,7 +487,7 @@ struct command_not_found : runtime_error
         : runtime_error(format("no such command: '{}'", name)) {}
 };
 
-StringView resolve_alias(const Context& context, StringView name)
+static StringView resolve_alias(const Context& context, StringView name)
 {
     auto alias = context.aliases()[name];
     return alias.empty() ? name : alias;

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -890,7 +890,7 @@ Highlighter& get_highlighter(const Context& context, StringView path)
     auto sep_it = find(path, '/');
     StringView scope{path.begin(), sep_it};
     auto* root = (scope == "shared") ? static_cast<HighlighterGroup*>(&SharedHighlighters::instance())
-                                     : static_cast<HighlighterGroup*>(&get_scope(scope, context).highlighters().group());
+                                     : &get_scope(scope, context).highlighters().group();
     if (sep_it != path.end())
         return root->get_child(StringView{sep_it+1, path.end()});
     return *root;

--- a/src/context.cc
+++ b/src/context.cc
@@ -26,7 +26,7 @@ Buffer& Context::buffer() const
 {
     if (not has_buffer())
         throw runtime_error("no buffer in context");
-    return const_cast<Buffer&>((*m_selections).buffer());
+    return m_selections->buffer();
 }
 
 Window& Context::window() const

--- a/src/face_registry.cc
+++ b/src/face_registry.cc
@@ -56,7 +56,7 @@ static FaceRegistry::FaceSpec parse_face(StringView facedesc)
     return spec;
 }
 
-String to_string(Attribute attributes)
+static String to_string(Attribute attributes)
 {
     if (attributes == Attribute::Normal)
         return "";

--- a/src/file.cc
+++ b/src/file.cc
@@ -332,7 +332,7 @@ void write_buffer_to_fd(Buffer& buffer, int fd)
     }
 }
 
-int open_temp_file(StringView filename, char (&buffer)[PATH_MAX])
+static int open_temp_file(StringView filename, char (&buffer)[PATH_MAX])
 {
     String path = real_path(filename);
     auto [dir,file] = split_path(path);
@@ -345,7 +345,7 @@ int open_temp_file(StringView filename, char (&buffer)[PATH_MAX])
     return mkstemp(buffer);
 }
 
-int open_temp_file(StringView filename)
+static int open_temp_file(StringView filename)
 {
     char buffer[PATH_MAX];
     return open_temp_file(filename, buffer);

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -125,7 +125,7 @@ void replace_range(DisplayBuffer& display_buffer,
     func(*first_it, first_atom_it);
 }
 
-void apply_highlighter(HighlightContext context,
+static void apply_highlighter(HighlightContext context,
                        DisplayBuffer& display_buffer,
                        BufferCoord begin, BufferCoord end,
                        Highlighter& highlighter)
@@ -478,7 +478,7 @@ private:
     RegexHighlighter m_highlighter;
 };
 
-std::unique_ptr<Highlighter> create_dynamic_regex_highlighter(HighlighterParameters params, Highlighter*)
+static std::unique_ptr<Highlighter> create_dynamic_regex_highlighter(HighlighterParameters params, Highlighter*)
 {
     if (params.size() < 2)
         throw runtime_error("wrong parameter count");
@@ -543,7 +543,7 @@ std::unique_ptr<Highlighter> create_dynamic_regex_highlighter(HighlighterParamet
     return make_hl(get_regex, get_face);
 }
 
-std::unique_ptr<Highlighter> create_line_highlighter(HighlighterParameters params, Highlighter*)
+static std::unique_ptr<Highlighter> create_line_highlighter(HighlighterParameters params, Highlighter*)
 {
     if (params.size() != 2)
         throw runtime_error("wrong parameter count");
@@ -590,7 +590,7 @@ std::unique_ptr<Highlighter> create_line_highlighter(HighlighterParameters param
     return make_highlighter(std::move(func));
 }
 
-std::unique_ptr<Highlighter> create_column_highlighter(HighlighterParameters params, Highlighter*)
+static std::unique_ptr<Highlighter> create_column_highlighter(HighlighterParameters params, Highlighter*)
 {
     if (params.size() != 2)
         throw runtime_error("wrong parameter count");
@@ -1179,7 +1179,7 @@ private:
 constexpr StringView LineNumbersHighlighter::ms_id;
 
 
-void show_matching_char(HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
+static void show_matching_char(HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
 {
     const Face face = context.context.faces()["MatchingChar"];
     const auto& matching_pairs = context.context.options()["matching_pairs"].get<Vector<Codepoint, MemoryDomain::Options>>();
@@ -1237,12 +1237,12 @@ void show_matching_char(HighlightContext context, DisplayBuffer& display_buffer,
     }
 }
 
-std::unique_ptr<Highlighter> create_matching_char_highlighter(HighlighterParameters params, Highlighter*)
+static std::unique_ptr<Highlighter> create_matching_char_highlighter(HighlighterParameters params, Highlighter*)
 {
     return make_highlighter(show_matching_char);
 }
 
-void highlight_selections(HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
+static void highlight_selections(HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
 {
     const auto& buffer = context.context.buffer();
     const auto& faces = context.context.faces();
@@ -1275,7 +1275,7 @@ void highlight_selections(HighlightContext context, DisplayBuffer& display_buffe
     }
 }
 
-void expand_unprintable(HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
+static void expand_unprintable(HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
 {
     const auto& buffer = context.context.buffer();
     auto error = context.context.faces()["Error"];
@@ -1448,7 +1448,7 @@ private:
     String m_default_face;
 };
 
-bool is_empty(const InclusiveBufferRange& range)
+static bool is_empty(const InclusiveBufferRange& range)
 {
     return range.last < BufferCoord{0,0};
 }
@@ -1519,8 +1519,8 @@ private:
     const String m_option_name;
 };
 
-BufferCoord& get_first(RangeAndString& r) { return std::get<0>(r).first; }
-BufferCoord& get_last(RangeAndString& r) { return std::get<0>(r).last; }
+static BufferCoord& get_first(RangeAndString& r) { return std::get<0>(r).first; }
+static BufferCoord& get_last(RangeAndString& r) { return std::get<0>(r).last; }
 
 void option_list_postprocess(Vector<RangeAndString, MemoryDomain::Options>& opt)
 {
@@ -1634,7 +1634,7 @@ private:
     }
 };
 
-HighlightPass parse_passes(StringView str)
+static HighlightPass parse_passes(StringView str)
 {
     HighlightPass passes{};
     for (auto pass : str | split<StringView>('|'))
@@ -1654,7 +1654,7 @@ HighlightPass parse_passes(StringView str)
     return passes;
 }
 
-std::unique_ptr<Highlighter> create_highlighter_group(HighlighterParameters params, Highlighter*)
+static std::unique_ptr<Highlighter> create_highlighter_group(HighlighterParameters params, Highlighter*)
 {
     static const ParameterDesc param_desc{
         { { "passes", { true, "" } } },
@@ -1736,7 +1736,7 @@ struct RegexMatch
 
 using RegexMatchList = Vector<RegexMatch, MemoryDomain::Regions>;
 
-void insert_matches(const Buffer& buffer, RegexMatchList& matches, const Regex& regex, bool capture, LineRange range)
+static void insert_matches(const Buffer& buffer, RegexMatchList& matches, const Regex& regex, bool capture, LineRange range)
 {
     size_t pivot = matches.size();
     capture = capture and regex.mark_count() > 0;
@@ -1766,7 +1766,7 @@ void insert_matches(const Buffer& buffer, RegexMatchList& matches, const Regex& 
     std::rotate(pos, matches.begin() + pivot, matches.end());
 }
 
-void update_matches(const Buffer& buffer, ConstArrayView<LineModification> modifs,
+static void update_matches(const Buffer& buffer, ConstArrayView<LineModification> modifs,
                     RegexMatchList& matches)
 {
     // remove out of date matches and update line for others

--- a/src/highlighters.hh
+++ b/src/highlighters.hh
@@ -3,6 +3,7 @@
 
 #include "color.hh"
 #include "highlighter.hh"
+#include "highlighter_group.hh"
 #include "option.hh"
 
 namespace Kakoune
@@ -38,6 +39,8 @@ constexpr StringView option_type_name(Meta::Type<RangeAndStringList>)
 }
 void option_update(RangeAndStringList& opt, const Context& context);
 void option_list_postprocess(Vector<RangeAndString, MemoryDomain::Options>& opt);
+
+void setup_builtin_highlighters(HighlighterGroup& group);
 
 }
 

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -72,12 +72,12 @@ private:
 namespace InputModes
 {
 
-std::chrono::milliseconds get_idle_timeout(const Context& context)
+static std::chrono::milliseconds get_idle_timeout(const Context& context)
 {
     return std::chrono::milliseconds{context.options()["idle_timeout"].get<int>()};
 }
 
-std::chrono::milliseconds get_fs_check_timeout(const Context& context)
+static std::chrono::milliseconds get_fs_check_timeout(const Context& context)
 {
     return std::chrono::milliseconds{context.options()["fs_check_timeout"].get<int>()};
 }

--- a/src/insert_completer.cc
+++ b/src/insert_completer.cc
@@ -454,8 +454,8 @@ void InsertCompleter::update(bool allow_implicit)
         setup_ifn();
 }
 
-auto& get_first(BufferRange& range) { return range.begin; }
-auto& get_last(BufferRange& range) { return range.end; }
+static auto& get_first(BufferRange& range) { return range.begin; }
+static auto& get_last(BufferRange& range) { return range.end; }
 
 void InsertCompleter::reset()
 {

--- a/src/json.cc
+++ b/src/json.cc
@@ -42,7 +42,7 @@ static bool is_digit(char c) { return c >= '0' and c <= '9'; }
 
 static constexpr size_t max_parsing_depth = 100;
 
-JsonResult parse_json_impl(const char* pos, const char* end, size_t depth)
+static JsonResult parse_json_impl(const char* pos, const char* end, size_t depth)
 {
     if (not skip_while(pos, end, is_blank))
         return {};

--- a/src/json_ui.cc
+++ b/src/json_ui.cc
@@ -22,7 +22,7 @@ struct invalid_rpc_request : runtime_error {
         : runtime_error(format("invalid json rpc request ({})", message)) {}
 };
 
-String to_json(Color color)
+static String to_json(Color color)
 {
     if (color.color == Kakoune::Color::RGB)
     {
@@ -33,7 +33,7 @@ String to_json(Color color)
     return to_json(to_string(color));
 }
 
-String to_json(Attribute attributes)
+static String to_json(Attribute attributes)
 {
     struct Attr { Attribute attr; StringView name; }
     attrs[] {
@@ -54,28 +54,28 @@ String to_json(Attribute attributes)
                       ',', false) + "]";
 }
 
-String to_json(Face face)
+static String to_json(Face face)
 {
     return format(R"(\{ "fg": {}, "bg": {}, "attributes": {} })",
                   to_json(face.fg), to_json(face.bg), to_json(face.attributes));
 }
 
-String to_json(const DisplayAtom& atom)
+static String to_json(const DisplayAtom& atom)
 {
     return format(R"(\{ "face": {}, "contents": {} })", to_json(atom.face), to_json(atom.content()));
 }
 
-String to_json(const DisplayLine& line)
+static String to_json(const DisplayLine& line)
 {
     return to_json(line.atoms());
 }
 
-String to_json(DisplayCoord coord)
+static String to_json(DisplayCoord coord)
 {
     return format(R"(\{ "line": {}, "column": {} })", coord.line, coord.column);
 }
 
-String to_json(MenuStyle style)
+static String to_json(MenuStyle style)
 {
     switch (style)
     {
@@ -86,7 +86,7 @@ String to_json(MenuStyle style)
     return "";
 }
 
-String to_json(InfoStyle style)
+static String to_json(InfoStyle style)
 {
     switch (style)
     {
@@ -100,7 +100,7 @@ String to_json(InfoStyle style)
     return "";
 }
 
-String to_json(CursorMode mode)
+static String to_json(CursorMode mode)
 {
     switch (mode)
     {
@@ -110,7 +110,7 @@ String to_json(CursorMode mode)
     return "";
 }
 
-String concat()
+static String concat()
 {
     return "";
 }

--- a/src/line_modification.cc
+++ b/src/line_modification.cc
@@ -88,7 +88,7 @@ Vector<LineModification> compute_line_modifications(const Buffer& buffer, size_t
     return res;
 }
 
-bool operator==(const LineModification& lhs, const LineModification& rhs)
+static bool operator==(const LineModification& lhs, const LineModification& rhs)
 {
     return lhs.old_line == rhs.old_line and lhs.new_line == rhs.new_line and
            lhs.num_removed == rhs.num_removed and lhs.num_added == rhs.num_added;

--- a/src/main.cc
+++ b/src/main.cc
@@ -113,7 +113,7 @@ struct {
         "» {+b}<backtab>{} key is gone, use {+b}<s-tab>{} instead\n"
 } };
 
-void show_startup_info(Client* local_client, int last_version)
+static void show_startup_info(Client* local_client, int last_version)
 {
     const Face version_face{Color::Default, Color::Default, Attribute::Bold};
     DisplayLineList info;
@@ -148,7 +148,7 @@ void show_startup_info(Client* local_client, int last_version)
 inline void write_stdout(StringView str) { try { write(STDOUT_FILENO, str); } catch (runtime_error&) {} }
 inline void write_stderr(StringView str) { try { write(STDERR_FILENO, str); } catch (runtime_error&) {} }
 
-String runtime_directory()
+static String runtime_directory()
 {
     if (const char* runtime_directory = getenv("KAKOUNE_RUNTIME"))
         return runtime_directory;
@@ -162,7 +162,7 @@ String runtime_directory()
     return "/usr/share/kak";
 }
 
-String config_directory()
+static String config_directory()
 {
     if (StringView kak_cfg_dir = getenv("KAKOUNE_CONFIG_DIR"); not kak_cfg_dir.empty())
         return kak_cfg_dir.str();
@@ -361,7 +361,7 @@ static const EnvVarDesc builtin_env_vars[] = { {
     }
 };
 
-void register_registers()
+static void register_registers()
 {
     RegisterManager& register_manager = RegisterManager::instance();
 
@@ -424,7 +424,7 @@ void register_registers()
     register_manager.add_register('_', std::make_unique<NullRegister>());
 }
 
-void register_keymaps()
+static void register_keymaps()
 {
     auto& keymaps = GlobalScope::instance().keymaps();
     keymaps.map_key(Key::Left, KeymapMode::Normal, {'h'}, "");
@@ -479,7 +479,7 @@ static void check_matching_pairs(const Vector<Codepoint, MemoryDomain::Options>&
         throw runtime_error{"matching pairs can only be punctuation"};
 }
 
-void register_options()
+static void register_options()
 {
     OptionsRegistry& reg = GlobalScope::instance().option_registry();
 
@@ -573,7 +573,7 @@ enum class UIType
     Dummy,
 };
 
-UIType parse_ui_type(StringView ui_name)
+static UIType parse_ui_type(StringView ui_name)
 {
     if (ui_name == "ncurses") return UIType::NCurses;
     if (ui_name == "json") return UIType::Json;
@@ -582,7 +582,7 @@ UIType parse_ui_type(StringView ui_name)
     throw parameter_error(format("error: unknown ui type: '{}'", ui_name));
 }
 
-std::unique_ptr<UserInterface> make_ui(UIType ui_type)
+static std::unique_ptr<UserInterface> make_ui(UIType ui_type)
 {
     struct DummyUI : UserInterface
     {
@@ -614,7 +614,7 @@ std::unique_ptr<UserInterface> make_ui(UIType ui_type)
     throw logic_error{};
 }
 
-pid_t fork_server_to_background()
+static pid_t fork_server_to_background()
 {
     if (pid_t pid = fork())
         return pid;
@@ -628,7 +628,7 @@ pid_t fork_server_to_background()
     return 0;
 }
 
-std::unique_ptr<UserInterface> create_local_ui(UIType ui_type)
+static std::unique_ptr<UserInterface> create_local_ui(UIType ui_type)
 {
     if (ui_type != UIType::NCurses)
         return make_ui(ui_type);
@@ -674,7 +674,7 @@ std::unique_ptr<UserInterface> create_local_ui(UIType ui_type)
     return std::make_unique<LocalUI>();
 }
 
-int run_client(StringView session, StringView name, StringView client_init,
+static int run_client(StringView session, StringView name, StringView client_init,
                Optional<BufferCoord> init_coord, UIType ui_type,
                bool suspend)
 {
@@ -726,7 +726,7 @@ enum class ServerFlags
 };
 constexpr bool with_bit_ops(Meta::Type<ServerFlags>) { return true; }
 
-int run_server(StringView session, StringView server_init,
+static int run_server(StringView session, StringView server_init,
                StringView client_init, Optional<BufferCoord> init_coord,
                ServerFlags flags, UIType ui_type, DebugFlags debug_flags,
                ConstArrayView<StringView> files)
@@ -913,7 +913,7 @@ int run_server(StringView session, StringView server_init,
     return local_client_exit;
 }
 
-int run_filter(StringView keystr, ConstArrayView<StringView> files, bool quiet, StringView suffix_backup)
+static int run_filter(StringView keystr, ConstArrayView<StringView> files, bool quiet, StringView suffix_backup)
 {
     StringRegistry  string_registry;
     GlobalScope     global_scope;
@@ -978,7 +978,7 @@ int run_filter(StringView keystr, ConstArrayView<StringView> files, bool quiet, 
     return 0;
 }
 
-int run_pipe(StringView session)
+static int run_pipe(StringView session)
 {
     try
     {
@@ -992,7 +992,7 @@ int run_pipe(StringView session)
     return 0;
 }
 
-void signal_handler(int signal)
+static void signal_handler(int signal)
 {
     NCursesUI::abort();
     const char* text = nullptr;

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -48,7 +48,7 @@ constexpr auto enum_desc(Meta::Type<SelectMode>)
         { SelectMode::Append, "append" },
     });
 }
-void merge_selections(Selection& sel, const Selection& new_sel)
+static void merge_selections(Selection& sel, const Selection& new_sel)
 {
     const bool forward = sel.cursor() >= sel.anchor();
     const bool new_forward = new_sel.cursor() > new_sel.anchor();
@@ -163,12 +163,12 @@ void enter_insert_mode(Context& context, NormalParams params)
     context.input_handler().insert(mode, params.count);
 }
 
-void repeat_last_insert(Context& context, NormalParams)
+static void repeat_last_insert(Context& context, NormalParams)
 {
     context.input_handler().repeat_last_insert();
 }
 
-void repeat_last_select(Context& context, NormalParams)
+static void repeat_last_select(Context& context, NormalParams)
 {
     context.repeat_last_select();
 }
@@ -404,7 +404,7 @@ void view_commands(Context& context, NormalParams params)
          {{'l'},     "scroll right"}}));
 }
 
-void replace_with_char(Context& context, NormalParams)
+static void replace_with_char(Context& context, NormalParams)
 {
     on_next_key_with_autoinfo(context, "replace-char", KeymapMode::None,
                              [](Key key, Context& context) {
@@ -424,7 +424,7 @@ void replace_with_char(Context& context, NormalParams)
     }, "replace with char", "enter char to replace with\n");
 }
 
-Codepoint swap_case(Codepoint cp)
+static Codepoint swap_case(Codepoint cp)
 {
     Codepoint res = to_lower(cp);
     return res == cp ? to_upper(cp) : res;
@@ -452,7 +452,7 @@ void for_each_codepoint(Context& context, NormalParams)
     selections.insert(strings, InsertMode::Replace);
 }
 
-void command(const Context& context, EnvVarMap env_vars)
+static void command(const Context& context, EnvVarMap env_vars)
 {
     if (not CommandManager::has_instance())
         throw runtime_error{"commands are not supported"};
@@ -501,7 +501,7 @@ void command(const Context& context, EnvVarMap env_vars)
         });
 }
 
-void command(Context& context, NormalParams params)
+static void command(Context& context, NormalParams params)
 {
     EnvVarMap env_vars = {
         { "count", to_string(params.count) },
@@ -510,7 +510,7 @@ void command(Context& context, NormalParams params)
     command(context, std::move(env_vars));
 }
 
-BufferCoord apply_diff(Buffer& buffer, BufferCoord pos, StringView before, StringView after)
+static BufferCoord apply_diff(Buffer& buffer, BufferCoord pos, StringView before, StringView after)
 {
     const auto lines_before = before | split_after<StringView>('\n') | gather<Vector<StringView>>();
     const auto lines_after = after | split_after<StringView>('\n') | gather<Vector<StringView>>();
@@ -662,7 +662,7 @@ void insert_output(Context& context, NormalParams)
         });
 }
 
-void yank(Context& context, NormalParams params)
+static void yank(Context& context, NormalParams params)
 {
     const char reg = params.reg ? params.reg : '"';
     RegisterManager::instance()[reg].set(context, context.selections_content());
@@ -694,7 +694,7 @@ void change(Context& context, NormalParams params)
     enter_insert_mode<InsertMode::Replace>(context, params);
 }
 
-InsertMode adapt_for_linewise(InsertMode mode)
+static InsertMode adapt_for_linewise(InsertMode mode)
 {
     switch (mode)
     {
@@ -975,7 +975,7 @@ void use_selection_as_search_pattern(Context& context, NormalParams params)
         context.window().force_redraw();
 }
 
-void select_regex(Context& context, NormalParams params)
+static void select_regex(Context& context, NormalParams params)
 {
     const char reg = to_lower(params.reg ? params.reg : '/');
     const int capture = params.count;
@@ -997,7 +997,7 @@ void select_regex(Context& context, NormalParams params)
     });
 }
 
-void split_regex(Context& context, NormalParams params)
+static void split_regex(Context& context, NormalParams params)
 {
     const char reg = to_lower(params.reg ? params.reg : '/');
     const int capture = params.count;
@@ -1019,7 +1019,7 @@ void split_regex(Context& context, NormalParams params)
     });
 }
 
-void split_lines(Context& context, NormalParams params)
+static void split_lines(Context& context, NormalParams params)
 {
     const LineCount count{params.count == 0 ? 1 : params.count};
     auto& selections = context.selections();
@@ -1046,7 +1046,7 @@ void split_lines(Context& context, NormalParams params)
     selections = std::move(res);
 }
 
-void select_boundaries(Context& context, NormalParams)
+static void select_boundaries(Context& context, NormalParams)
 {
     auto& selections = context.selections();
     Vector<Selection> res;
@@ -1059,7 +1059,7 @@ void select_boundaries(Context& context, NormalParams)
     selections = std::move(res);
 }
 
-void join_lines_select_spaces(Context& context, NormalParams)
+static void join_lines_select_spaces(Context& context, NormalParams)
 {
     auto& buffer = context.buffer();
     Vector<Selection> selections;
@@ -1083,7 +1083,7 @@ void join_lines_select_spaces(Context& context, NormalParams)
     context.selections().insert(" "_str, InsertMode::Replace);
 }
 
-void join_lines(Context& context, NormalParams params)
+static void join_lines(Context& context, NormalParams params)
 {
     SelectionList sels{context.selections()};
     auto restore_sels = on_scope_end([&]{
@@ -1133,7 +1133,7 @@ void keep(Context& context, NormalParams params)
     });
 }
 
-void keep_pipe(Context& context, NormalParams)
+static void keep_pipe(Context& context, NormalParams)
 {
     context.input_handler().prompt(
         "keep pipe:", {}, {}, context.faces()["Prompt"],
@@ -1525,7 +1525,7 @@ void select_to_next_char(Context& context, NormalParams params)
     }, get_title(), "enter char to select to");
 }
 
-void start_or_end_macro_recording(Context& context, NormalParams params)
+static void start_or_end_macro_recording(Context& context, NormalParams params)
 {
     if (context.input_handler().is_recording())
         context.input_handler().stop_recording();
@@ -1538,13 +1538,13 @@ void start_or_end_macro_recording(Context& context, NormalParams params)
     }
 }
 
-void end_macro_recording(Context& context, NormalParams)
+static void end_macro_recording(Context& context, NormalParams)
 {
     if (context.input_handler().is_recording())
         context.input_handler().stop_recording();
 }
 
-void replay_macro(Context& context, NormalParams params)
+static void replay_macro(Context& context, NormalParams params)
 {
     const char reg = to_lower(params.reg ? params.reg : '@');
     if (not is_basic_alpha(reg) and reg != '@')
@@ -1586,14 +1586,14 @@ void jump(Context& context, NormalParams params)
     context.selections_write_only() = jump;
 }
 
-void push_selections(Context& context, NormalParams)
+static void push_selections(Context& context, NormalParams)
 {
     context.push_jump(true);
     context.print_status({ format("saved {} selections", context.selections().size()),
                            context.faces()["Information"] });
 }
 
-void align(Context& context, NormalParams)
+static void align(Context& context, NormalParams)
 {
     auto& selections = context.selections();
     auto& buffer = context.buffer();
@@ -1644,7 +1644,7 @@ void align(Context& context, NormalParams)
     }
 }
 
-void copy_indent(Context& context, NormalParams params)
+static void copy_indent(Context& context, NormalParams params)
 {
     int selection = params.count;
     auto& buffer = context.buffer();
@@ -1681,7 +1681,7 @@ void copy_indent(Context& context, NormalParams params)
     }
 }
 
-void tabs_to_spaces(Context& context, NormalParams params)
+static void tabs_to_spaces(Context& context, NormalParams params)
 {
     auto& buffer = context.buffer();
     const ColumnCount opt_tabstop = context.options()["tabstop"].get<int>();
@@ -1706,7 +1706,7 @@ void tabs_to_spaces(Context& context, NormalParams params)
         SelectionList{ buffer, std::move(tabs) }.insert(spaces, InsertMode::Replace);
 }
 
-void spaces_to_tabs(Context& context, NormalParams params)
+static void spaces_to_tabs(Context& context, NormalParams params)
 {
     auto& buffer = context.buffer();
     const ColumnCount opt_tabstop = context.options()["tabstop"].get<int>();
@@ -1742,7 +1742,7 @@ void spaces_to_tabs(Context& context, NormalParams params)
         SelectionList{ buffer, std::move(spaces) }.insert("\t"_str, InsertMode::Replace);
 }
 
-void trim_selections(Context& context, NormalParams)
+static void trim_selections(Context& context, NormalParams)
 {
     auto& buffer = context.buffer();
     auto& selections = context.selections();
@@ -1773,7 +1773,7 @@ void trim_selections(Context& context, NormalParams)
         selections.remove(i);
 }
 
-SelectionList read_selections_from_register(char reg, Context& context)
+static SelectionList read_selections_from_register(char reg, Context& context)
 {
     if (not is_basic_alpha(reg) and reg != '^')
         throw runtime_error("selections can only be saved to the '^' and alphabetic registers");
@@ -1809,7 +1809,7 @@ enum class CombineOp
     SelectShortest,
 };
 
-CombineOp key_to_combine_op(Key key)
+static CombineOp key_to_combine_op(Key key)
 {
     switch (key.key)
     {
@@ -1824,7 +1824,7 @@ CombineOp key_to_combine_op(Key key)
     throw runtime_error{format("no such combine operator: '{}'", key.key)};
 }
 
-void combine_selection(const Buffer& buffer, Selection& sel, const Selection& other, CombineOp op)
+static void combine_selection(const Buffer& buffer, Selection& sel, const Selection& other, CombineOp op)
 {
     switch (op)
     {
@@ -1950,7 +1950,7 @@ void restore_selections(Context& context, NormalParams params)
         combine_selections(context, std::move(selections), set_selections, "combine selections from register");
 }
 
-void undo(Context& context, NormalParams params)
+static void undo(Context& context, NormalParams params)
 {
     Buffer& buffer = context.buffer();
     size_t timestamp = buffer.timestamp();
@@ -1964,7 +1964,7 @@ void undo(Context& context, NormalParams params)
         throw runtime_error("nothing left to undo");
 }
 
-void redo(Context& context, NormalParams params)
+static void redo(Context& context, NormalParams params)
 {
     Buffer& buffer = context.buffer();
     size_t timestamp = buffer.timestamp();
@@ -2001,7 +2001,7 @@ void move_in_history(Context& context, NormalParams params)
                             history_id, max_history_id));
 }
 
-void exec_user_mappings(Context& context, NormalParams params)
+static void exec_user_mappings(Context& context, NormalParams params)
 {
     on_next_key_with_autoinfo(context, "user-mapping", KeymapMode::None,
                              [params](Key key, Context& context) mutable {
@@ -2073,13 +2073,13 @@ void move_cursor(Context& context, NormalParams params)
     selections.sort_and_merge_overlapping();
 }
 
-void select_whole_buffer(Context& context, NormalParams)
+static void select_whole_buffer(Context& context, NormalParams)
 {
     auto& buffer = context.buffer();
     context.selections_write_only() = SelectionList{buffer, {{0,0}, {buffer.back_coord(), max_column}}};
 }
 
-void keep_selection(Context& context, NormalParams p)
+static void keep_selection(Context& context, NormalParams p)
 {
     auto& selections = context.selections();
     const int index = p.count ? p.count-1 : selections.main_index();
@@ -2090,7 +2090,7 @@ void keep_selection(Context& context, NormalParams p)
     selections.check_invariant();
 }
 
-void remove_selection(Context& context, NormalParams p)
+static void remove_selection(Context& context, NormalParams p)
 {
     auto& selections = context.selections();
     const int index = p.count ? p.count-1 : selections.main_index();
@@ -2103,13 +2103,13 @@ void remove_selection(Context& context, NormalParams p)
     selections.check_invariant();
 }
 
-void clear_selections(Context& context, NormalParams)
+static void clear_selections(Context& context, NormalParams)
 {
     for (auto& sel : context.selections())
         sel.anchor() = sel.cursor();
 }
 
-void flip_selections(Context& context, NormalParams)
+static void flip_selections(Context& context, NormalParams)
 {
     for (auto& sel : context.selections())
     {
@@ -2120,7 +2120,7 @@ void flip_selections(Context& context, NormalParams)
     context.selections().check_invariant();
 }
 
-void ensure_forward(Context& context, NormalParams)
+static void ensure_forward(Context& context, NormalParams)
 {
     for (auto& sel : context.selections())
     {
@@ -2131,13 +2131,13 @@ void ensure_forward(Context& context, NormalParams)
     context.selections().check_invariant();
 }
 
-void merge_consecutive(Context& context, NormalParams params)
+static void merge_consecutive(Context& context, NormalParams params)
 {
     ensure_forward(context, params);
     context.selections().merge_consecutive();
 }
 
-void force_redraw(Context& context, NormalParams)
+static void force_redraw(Context& context, NormalParams)
 {
     if (context.has_client())
     {

--- a/src/ranked_match.cc
+++ b/src/ranked_match.cc
@@ -29,7 +29,7 @@ UsedLetters used_letters(StringView str)
     return res;
 }
 
-bool matches(UsedLetters query, UsedLetters letters)
+static bool matches(UsedLetters query, UsedLetters letters)
 {
     return (query & letters) == query;
 }

--- a/src/remote.cc
+++ b/src/remote.cc
@@ -596,7 +596,7 @@ String session_directory()
         return format("{}/kakoune", xdg_runtime_dir);
 }
 
-void make_session_directory()
+static void make_session_directory()
 {
     StringView xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
     if (xdg_runtime_dir.empty())

--- a/src/remote.cc
+++ b/src/remote.cc
@@ -764,9 +764,9 @@ void send_command(StringView session, StringView command)
 
 
 // A client accepter handle a connection until it closes or a nul byte is
-// recieved. Everything recieved before is considered to be a command.
+// recieved. Everything received before is considered to be a command.
 //
-// * When a nul byte is recieved, the socket is handed to a new Client along
+// * When a nul byte is received, the socket is handed to a new Client along
 //   with the command.
 // * When the connection is closed, the command is run in an empty context.
 class Server::Accepter

--- a/src/selection.cc
+++ b/src/selection.cc
@@ -117,8 +117,8 @@ Iterator merge_overlapping(Iterator begin, Iterator end, size_t& main, OverlapsF
 
 }
 
-BufferCoord& get_first(Selection& sel) { return sel.min(); }
-BufferCoord& get_last(Selection& sel) { return sel.max(); }
+static BufferCoord& get_first(Selection& sel) { return sel.min(); }
+static BufferCoord& get_last(Selection& sel) { return sel.max(); }
 
 Vector<Selection> compute_modified_ranges(const Buffer& buffer, size_t timestamp)
 {
@@ -351,7 +351,7 @@ void SelectionList::sort_and_merge_overlapping()
     merge_overlapping();
 }
 
-BufferCoord get_insert_pos(const Buffer& buffer, const Selection& sel,
+static BufferCoord get_insert_pos(const Buffer& buffer, const Selection& sel,
                            InsertMode mode)
 {
     switch (mode)


### PR DESCRIPTION
Almost all of these functions were effectively static.
Except for setup_builtin_highlighters which is actually used elsewhere,
so declare it in the header file.

Found with -Wmissing-declarations. This also adds that warning to the CXXFLAGS,
at least clang and gcc support it.

Added some small linter and typo fixes, too.