### PR TITLE
spell.kak: Present spelling suggestions with :prompt

### DIFF
--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -142,20 +142,27 @@ define-command spell-next %{ evaluate-commands %sh{
 
 define-command \
     -docstring "Suggest replacement words for the current selection, against the last language used by the spell-check command" \
-    spell-replace %{ evaluate-commands %sh{
-    options=""
-    if [ -n "$kak_opt_spell_last_lang" ]; then
-        options="-l '$kak_opt_spell_last_lang'"
-    fi
-    suggestions=$(printf %s "$kak_selection" | eval "aspell -a $options" | grep '^&' | cut -d: -f2)
-    menu=$(printf %s "${suggestions#?}" | awk -F', ' '
-        {
-            for (i=1; i<=NF; i++)
-                printf "%s", "%{"$i"}" "%{execute-keys -itersel %{c"$i"<esc>be}}"
+    spell-replace %{
+    prompt \
+        -init %val{selection} \
+        -shell-script-candidates %{
+            options=""
+            if [ -n "$kak_opt_spell_last_lang" ]; then
+                options="-l '$kak_opt_spell_last_lang'"
+            fi
+            printf %s "$kak_selection" |
+                eval "aspell -a $options" |
+                kak -f '<a-s><a-K>^&<ret>d%s^[^:]*: <ret>d%s, <ret>c<ret><esc>'
+        } \
+        "Replace with: " \
+        %{
+            evaluate-commands -save-regs a %{
+                set-register a %val{text}
+                execute-keys c <c-r>a <esc>
+            }
         }
-    ')
-    printf 'try %%{ menu -auto-single %s }' "${menu}"
-} }
+}
+
 
 define-command -params 0.. \
     -docstring "Add the current selection to the dictionary" \

--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -152,7 +152,7 @@ define-command \
             fi
             printf %s "$kak_selection" |
                 eval "aspell -a $options" |
-                kak -f '<a-s><a-K>^&<ret>d%s^[^:]*: <ret>d%s, <ret>c<ret><esc>'
+                sed -n -e '/^&/ { s/^[^:]*: //; s/, /\n/g; p }'
         } \
         "Replace with: " \
         %{


### PR DESCRIPTION
Previously, spelling suggestions were presented with the :menu command, requiring the user to cycle through wild and fanciful alternatives to get to the one they wanted. Now, we present suggestions with the :prompt command, which allows the user to type to filter down the list, and also to customise the replacement after they've chose it (perhaps to fix capitalisation or add apostrophe-S).

We also use the mispelled word as the initial content of the prompt. That filters out the wildest alternatives by default, and allows the user to edit the original word instead of forcing them to choose from among the suggestions. To get the full list of suggestions, it's easy enough to just backspace until the word you want appears in the list.