### PR TITLE
just: highlight function expressions

### DIFF
--- a/rc/filetype/just.kak
+++ b/rc/filetype/just.kak
@@ -60,7 +60,7 @@ add-highlighter shared/justfile/body/interpreters/defaultshell/ regex '^\h+(@)' 
 add-highlighter shared/justfile/body/interpreters/bash region '^\h+#!\h?/usr/bin/env bash' '^[^\h]' ref sh
 add-highlighter shared/justfile/body/interpreters/sh region '^\h+#!\h?/usr/bin/env sh' '^[^\h]' ref sh
 
-add-highlighter shared/justfile/body/ regex '(\{{2})([\w-]+)(\}{2})' 1:operator 2:variable 3:operator
+add-highlighter shared/justfile/body/ regex '(\{{2})([\w-]+(?:\(\))?)(\}{2})' 1:operator 2:variable 3:operator
 
 
 }


### PR DESCRIPTION
This changes enables correct highlight of function expressions:

![image](https://user-images.githubusercontent.com/7548295/93846558-004cfd80-fc6a-11ea-9743-f3e66814f57b.png)

Previously, the `()` broke the regex so that function expressions where not highlighted, only variable type expressions where.

This change does not break regular variable type expressions:

![image](https://user-images.githubusercontent.com/7548295/93846619-31c5c900-fc6a-11ea-8df7-7948cb4fa397.png)

