### PR TITLE
Improve shell indentation implementation.

### DIFF
--- a/test/indent/sh/no-deindent-after-else/cmd
+++ b/test/indent/sh/no-deindent-after-else/cmd
@@ -1,0 +1,1 @@
+gk3jobaz

--- a/test/indent/sh/no-deindent-after-else/in
+++ b/test/indent/sh/no-deindent-after-else/in
@@ -1,0 +1,7 @@
+if [ $foo ]; then
+    if [ $bar ]; then
+        foobar
+    else
+        qux
+    fi
+fi

--- a/test/indent/sh/no-deindent-after-else/out
+++ b/test/indent/sh/no-deindent-after-else/out
@@ -1,0 +1,8 @@
+if [ $foo ]; then
+    if [ $bar ]; then
+        foobar
+    else
+        baz
+        qux
+    fi
+fi

--- a/test/indent/sh/no-deindent-after-else/rc
+++ b/test/indent/sh/no-deindent-after-else/rc
@@ -1,0 +1,3 @@
+source "%val{runtime}/colors/default.kak"
+source "%val{runtime}/rc/filetype/sh.kak"
+set buffer filetype sh

--- a/test/indent/sh/no-deindent-after-fi/cmd
+++ b/test/indent/sh/no-deindent-after-fi/cmd
@@ -1,0 +1,1 @@
+gk5jobaz

--- a/test/indent/sh/no-deindent-after-fi/in
+++ b/test/indent/sh/no-deindent-after-fi/in
@@ -1,0 +1,7 @@
+if [ $foo ]; then
+    if [ $bar ]; then
+        foobar
+    else
+        qux
+    fi
+fi

--- a/test/indent/sh/no-deindent-after-fi/out
+++ b/test/indent/sh/no-deindent-after-fi/out
@@ -1,0 +1,8 @@
+if [ $foo ]; then
+    if [ $bar ]; then
+        foobar
+    else
+        qux
+    fi
+    baz
+fi

--- a/test/indent/sh/no-deindent-after-fi/rc
+++ b/test/indent/sh/no-deindent-after-fi/rc
@@ -1,0 +1,3 @@
+source "%val{runtime}/colors/default.kak"
+source "%val{runtime}/rc/filetype/sh.kak"
+set buffer filetype sh


### PR DESCRIPTION
Use the custom object match command for copying indentation of blocks,
rather than simply increasing/decreasing indentation when start and end
statements are encountered.

This fixes an issue where a newline added after an already correctly
placed `else` or `fi` would trigger an unnecessary deindent. Tests have
been added to ensure no regression in this behaviour.