### PR TITLE
doc: mention comma key for entering user-mode

### DIFF
--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -803,3 +803,9 @@ The following keys are recognized by this mode to help with editing
 
 *<a-;>*, *<a-semicolon>*::
     escape to normal mode for a single command
+
+== User commands
+
+*,*::
+    enter default `user mode` to access custom commands
+    (See <<modes#user-mode,`:doc modes user-mode`>>)

--- a/doc/pages/modes.asciidoc
+++ b/doc/pages/modes.asciidoc
@@ -69,12 +69,12 @@ See view commands <<keys#view-commands,`:doc keys view-commands`>>.
 
 === Menu mode
 
-Menu mode is entered when a menu is displayed with the *menu* command.
+Menu mode is entered when a menu is displayed with the `menu` command.
 Mappings are used to filter and select intended items.
 
 === Prompt mode
 
-Mode entered with `:`, `/` or the `:prompt` command. During prompt mode a
+Mode entered with `:`, `/` or the `prompt` command. During prompt mode a
 line of text is edited and then validated with `<ret>` or abandoned with
 `<esc>`.
 
@@ -89,9 +89,9 @@ See object commands <<keys#object-commands,`:doc keys object-commands`>>.
 
 === User mode
 
-The user mode is empty by default and is the opportunity to store custom
-mappings with no risk to shadow builtin ones. The context of execution
-is always the Normal mode.
+Mode entered with `,` (comma key). The user mode is empty by default and is
+the opportunity to store custom mappings with no risk to shadow builtin ones.
+The context of execution is always the Normal mode.
 
 == User modes
 


### PR DESCRIPTION
Hi

Strangely enough, the `,` key was not mentioned in `keys.asciidoc`