### PR TITLE
Support highlighting of pandoc's markdown raw_attribute extension

### DIFF
--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -47,7 +47,7 @@ evaluate-commands %sh{
     ruby rust sass scala scss sh swift toml tupfile typescript yaml sql
   "
   for lang in ${languages}; do
-    printf 'add-highlighter shared/markdown/%s region -match-capture ^(\h*)```\h*%s\\b   ^(\h*)``` regions\n' "${lang}" "${lang}"
+    printf 'add-highlighter shared/markdown/%s region -match-capture ^(\h*)```\h*(%s|\\{=%s\\}))\\b   ^(\h*)``` regions\n' "${lang}" "${lang}" "${lang}"
     printf 'add-highlighter shared/markdown/%s/ default-region fill meta\n' "${lang}"
     [ "${lang}" = kak ] && ref=kakrc || ref="${lang}"
     printf 'add-highlighter shared/markdown/%s/inner region \A```[^\\n]*\K (?=```) ref %s\n' "${lang}" "${ref}"
@@ -100,7 +100,7 @@ define-command -hidden markdown-indent-on-new-line %{
 
 define-command -hidden markdown-load-languages %{
     evaluate-commands -draft %{ try %{
-        execute-keys 'gtGbGls```\h*\K[^\s]+<ret>'
+        execute-keys 'gtGbGls```\h*\{?=?\K[^}\s]+<ret>'
         evaluate-commands -itersel %{ require-module %val{selection} }
     }}
 }


### PR DESCRIPTION
https://pandoc.org/MANUAL.html#extension-raw_attribute
I only enabled highlighting for code blocks, not inline.

Let me know if there's a better way to regex this or if I missed anything!