### PR TITLE
Fix SQL function greedy highlighting

### DIFF
--- a/rc/filetype/sql.kak
+++ b/rc/filetype/sql.kak
@@ -100,7 +100,7 @@ evaluate-commands %sh{
 
     # Highlight keywords
     printf %s "
-        add-highlighter shared/sql/code/ regex '(?i)\b(${functions})\(.*\)' 0:function
+        add-highlighter shared/sql/code/ regex '(?i)\b(${functions})\(.*?\)' 0:function
         add-highlighter shared/sql/code/ regex '(?i)\b(${data_types_fn})\(.*?\)' 0:type
         add-highlighter shared/sql/code/ regex '(?i)\b(${keywords})\b' 0:keyword
         add-highlighter shared/sql/code/ regex '(?i)\b(${operators})\b' 0:operator


### PR DESCRIPTION
Just a tiny fix (added 1 character) that is described in #3786. Note that this does not fix the string issue that is also described, only the issue of function highlighting that overran the end of the closing parenthesis.

Closes #3786.