### PR TITLE
Fix `wcwidth()` compile error with MSYS2

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -77,7 +77,8 @@ else ifeq ($(os),OpenBSD)
     CPPFLAGS += -D'KAK_BIN_PATH="$(bindir)/kak"' -I/usr/local/include
     LDFLAGS += -L/usr/local/lib
     mandir := $(DESTDIR)$(PREFIX)/man/man1
-else ifneq (,$(findstring CYGWIN,$(os)))
+else ifneq (,$(findstring _NT,$(os)))
+    # Both Cygwin and MSYS2 have "_NT" in their uname.
     CPPFLAGS += -D_XOPEN_SOURCE=700
     LIBS += -lncursesw -ldbghelp
 else ifeq ($(os),SunOS)


### PR DESCRIPTION
We try to detect when compiling under Cygwin, so we can set the
_XOPEN_SOURCE define which lets us use wcwidth(). We look for the
string "CYGWIN" in the uname, which looks like:

    CYGWIN-NT_10.0

MSYS2 is also based on Cygwin, so all of the above should still work.
However, we detect Cygwin by looking for the string "CYGWIN" in the
uname. In MSYS2, the uname looks like:

    MSYS_NT-10.0-18362

This patch looks for the string "_NT" instead of the string "CYGWIN"
in the uname, since it's common to both environments. This fixes a
compilation error on MSYS2.