### PR TITLE
gopls: Fix format/imports error reporting

### DIFF
--- a/rc/tools/go/gopls.kak
+++ b/rc/tools/go/gopls.kak
@@ -62,7 +62,7 @@ define-command -hidden -params 1 gopls-cmd %{
         fi
     }
     edit!
-    evaluate-commands %sh{ rm -r "${kak_opt_gopls_tmp_dir}" }
+    nop %sh{ rm -rf "${kak_opt_gopls_tmp_dir}" }
 }
 
 # gopls definition


### PR DESCRIPTION
Remove unnecessary single quotes and whitespaces in %file{}
Do not delete error file before sending to debug buffer
Fix gopls definition error handling and empty sting check
Silence shellcheck warnings