### PR TITLE
spell.kak: fix multibyte character handling

### DIFF
--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -37,7 +37,7 @@ define-command -params ..1 -docstring %{
         fi
 
         {
-            sed 's/^/^/' "$kak_opt_spell_tmp_file" | eval "aspell --byte-offsets -a $options" 2>&1 | awk '
+            sed 's/^/^/' "$kak_opt_spell_tmp_file" | eval "aspell --byte-offsets -a $options" 2>&1 | awk -b '
                 BEGIN {
                     line_num = 1
                     regions = ENVIRON["kak_timestamp"]
@@ -49,7 +49,7 @@ define-command -params ..1 -docstring %{
                         # drop the identification message
                     }
 
-                    else if (/^\*/) {
+                    else if (/^[-*+]/) {
                         # nothing
                     }
 


### PR DESCRIPTION
Hi,

I have no idea if it have some unwanted consequences or not. I have tested it with `en_US` and `hu_HU`, works for me.

The root and compound handling part should not be a problem, but the `awk -b` thing could be. I have made some research and I do *not* find this option in BSD awk, mawk, busybox awk.

Maybe this should be handled with a spell_awk option default to awk and write some nice docs for the users. What do You think?