### PR TITLE
rc nix: dash in extra_word_chars

### DIFF
--- a/rc/filetype/nix.kak
+++ b/rc/filetype/nix.kak
@@ -18,6 +18,7 @@ hook global WinSetOption filetype=nix %{
     hook window InsertChar .* -group nix-indent nix-indent-on-char
     hook window InsertChar \n -group nix-indent nix-indent-on-new-line
 
+    set-option buffer extra_word_chars _ -
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window nix-.+ }
 }
 


### PR DESCRIPTION
Previous PR fixed highlighting, forgot extra_word_chars.