### PR TITLE
rc git: indented # is not a comment in commit message

### DIFF
--- a/rc/filetype/git.kak
+++ b/rc/filetype/git.kak
@@ -37,17 +37,17 @@ hook -group git-rebase-highlight global WinSetOption filetype=git-rebase %{
 provide-module git-commit %{
 add-highlighter shared/git-commit regions
 add-highlighter shared/git-commit/diff region '^diff --git' '^(?=diff --git)' ref diff # highlight potential diffs from the -v option
-add-highlighter shared/git-commit/comments region '^\h*#' '$' group
+add-highlighter shared/git-commit/comments region ^# $ group
 add-highlighter shared/git-commit/comments/ fill comment
 add-highlighter shared/git-commit/comments/ regex "\b(?:(modified)|(deleted)|(new file)|(renamed|copied)):([^\n]*)$" 1:yellow 2:red 3:green 4:blue 5:magenta
 }
 
 provide-module git-notes %{
-add-highlighter shared/git-notes regex '^\h*#[^\n]*$' 0:comment
+add-highlighter shared/git-notes regex ^#[^\n]*$ 0:comment
 }
 
 provide-module git-rebase %{
 add-highlighter shared/git-rebase group
-add-highlighter shared/git-rebase/ regex "#[^\n]*\n" 0:comment
+add-highlighter shared/git-rebase/ regex "^\h*#[^\n]*\n" 0:comment
 add-highlighter shared/git-rebase/ regex "^(?:(pick|p)|(edit|reword|squash|fixup|exec|break|drop|label|reset|merge|[ersfxbdltm])) (\w+)" 1:keyword 2:value 3:meta
 }


### PR DESCRIPTION
Git includes them in commit messages and notes, which is sometimes useful
when adding shell script snippets:

    # this is included in the commit message!