### PR TITLE
rc *sh.kak: include "-" as word character

### DIFF
--- a/rc/filetype/fish.kak
+++ b/rc/filetype/fish.kak
@@ -14,6 +14,8 @@ hook global BufCreate .*[.](fish) %{
 hook global WinSetOption filetype=fish %{
     require-module fish
 
+    set-option buffer extra_word_chars '_' '-'
+
     hook window InsertChar .* -group fish-indent fish-indent-on-char
     hook window InsertChar \n -group fish-indent fish-indent-on-new-line
 
@@ -43,7 +45,7 @@ add-highlighter shared/fish/double_string/ regex ((?<!\\)(?:\\\\)*\K\$\w+)|(\{\$
 add-highlighter shared/fish/code/ regex (?<!\\)(?:\\\\)*\K(\$\w+)|(\{\$\w+\}) 0:variable
 
 # Command names are collected using `builtin --names`.
-add-highlighter shared/fish/code/ regex \b(and|argparse|begin|bg|bind|block|break|breakpoint|builtin|case|cd|command|commandline|complete|contains|continue|count|disown|echo|else|emit|end|eval|exec|exit|false|fg|for|function|functions|history|if|jobs|math|not|or|printf|pwd|random|read|realpath|return|set|set_color|source|status|string|switch|test|time|true|ulimit|wait|while)\b 0:keyword
+add-highlighter shared/fish/code/ regex (?<!-)\b(and|argparse|begin|bg|bind|block|break|breakpoint|builtin|case|cd|command|commandline|complete|contains|continue|count|disown|echo|else|emit|end|eval|exec|exit|false|fg|for|function|functions|history|if|jobs|math|not|or|printf|pwd|random|read|realpath|return|set|set_color|source|status|string|switch|test|time|true|ulimit|wait|while)\b(?!-) 0:keyword
 
 # Commands
 # ‾‾‾‾‾‾‾‾

--- a/rc/filetype/makefile.kak
+++ b/rc/filetype/makefile.kak
@@ -12,6 +12,7 @@ hook global WinSetOption filetype=makefile %{
     require-module makefile
 
     set-option window static_words %opt{makefile_static_words}
+    set-option buffer extra_word_chars '_' '-'
 
     hook window InsertChar \n -group makefile-indent makefile-indent-on-new-line
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window makefile-.+ }

--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -5,6 +5,7 @@ hook global BufCreate .*\.(z|ba|c|k|mk)?sh(rc|_profile)? %{
 hook global WinSetOption filetype=sh %{
     require-module sh
     set-option window static_words %opt{sh_static_words}
+    set-option buffer extra_word_chars '_' '-'
 
     hook window ModeChange pop:insert:.* -group sh-trim-indent sh-trim-indent
     hook window InsertChar \n -group sh-insert sh-insert-on-new-line


### PR DESCRIPTION
This seems better given that kakrc.kak does the same, however the change to
sh.kak might be contentious.