### PR TITLE
rc fish.kak: split fish-insert hook out from fish-indent

### DIFF
--- a/rc/filetype/fish.kak
+++ b/rc/filetype/fish.kak
@@ -15,6 +15,7 @@ hook global WinSetOption filetype=fish %{
     require-module fish
 
     hook window InsertChar .* -group fish-indent fish-indent-on-char
+    hook window InsertChar \n -group fish-insert fish-insert-on-new-line
     hook window InsertChar \n -group fish-indent fish-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window fish-.+ }
@@ -64,10 +65,15 @@ define-command -hidden fish-indent-on-char %{
     }
 }
 
-define-command -hidden fish-indent-on-new-line %{
+define-command -hidden fish-insert-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
+    }
+}
+
+define-command -hidden fish-indent-on-new-line %{
+    evaluate-commands -no-hooks -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # cleanup trailing whitespaces from previous line


### PR DESCRIPTION
Same as in sh.kak; this allows to only disable the insert hook using
%opt{disabled_hooks}.