### PR TITLE
rc perl: quoted heredocs can be empty

### DIFF
--- a/rc/filetype/perl.kak
+++ b/rc/filetype/perl.kak
@@ -53,9 +53,9 @@ add-highlighter shared/perl/quote_angle    region -recurse  < \bq[qrwx]?<   >   
 add-highlighter shared/perl/quote_punct    region -match-capture '\bq[qwx]?([:;!@#$%^&*|,.?/~=+-])' '(.)' fill string
 add-highlighter shared/perl/quote_regex    region -match-capture      '\bqr([:;!@#$%^&*|,.?/~=+-])' '(.)' fill meta
 
-add-highlighter shared/perl/double_heredoc region -match-capture <<~?\h*'(\w+)' ^\t*(\w+)\b fill string
-add-highlighter shared/perl/single_heredoc region -match-capture <<~?\h*"(\w+)" ^\t*(\w+)\b fill string
-add-highlighter shared/perl/bare_heredoc   region -match-capture <<~?(\w+)      ^\t*(\w+)\b fill string
+add-highlighter shared/perl/double_heredoc region -match-capture <<~?\h*'(\w*)' ^\t*(\w*)$ fill string
+add-highlighter shared/perl/single_heredoc region -match-capture <<~?\h*"(\w*)" ^\t*(\w*)$ fill string
+add-highlighter shared/perl/bare_heredoc   region -match-capture <<~?(\w+)      ^\t*(\w+)$ fill string
 add-highlighter shared/perl/pod            region ^=\w+  ^=cut\b                            fill string
 
 evaluate-commands %sh{


### PR DESCRIPTION
The marker can be empty, like

```perl
print <<""
included

not included
```

Also the closing line cannot have any trailing characters.
Leading tabs are allowed if <<~ is used.