### PR TITLE
rc perl.kak: fix regex highlighting of s{foo}{bar}

### DIFF
--- a/rc/filetype/perl.kak
+++ b/rc/filetype/perl.kak
@@ -42,9 +42,9 @@ add-highlighter shared/perl/double_string  region (?<!\$)(?<!\\)"   (?<!\\)(\\\\
 add-highlighter shared/perl/single_string  region (?<!\$)(?<!\\\\)' (?<!\\)(\\\\)*' fill string
 add-highlighter shared/perl/comment        region (?<!\$)(?<!\\)#   $               fill comment
 
-add-highlighter shared/perl/regex          region m?(?<!/)(?<!qr)/[^/\n]+(?=/)  /\w?   fill meta
-add-highlighter shared/perl/sregex         region s/[^/\n]+/[^/\n]+(?=/) /\w?          fill meta
-add-highlighter shared/perl/bregex         region s\{[^\}\n]+\}\{[^\}\n]+(?=\}) \}     fill meta
+add-highlighter shared/perl/regex          region m?(?<!/)(?<!qr)/[^/\n]+(?=/)  /\w*   fill meta
+add-highlighter shared/perl/sregex         region s/[^/\n]+/[^/\n]+(?=/)        /\w*   fill meta
+add-highlighter shared/perl/bregex         region s\{[^\}\n]+\}\{[^\}\n]+(?=\}) \}\w*  fill meta
 
 add-highlighter shared/perl/quote_brace    region -recurse \{ \bq[qrwx]?\{ \}          fill string
 add-highlighter shared/perl/quote_paren    region -recurse \( \bq[qrwx]?\( \)          fill string

--- a/rc/filetype/perl.kak
+++ b/rc/filetype/perl.kak
@@ -44,7 +44,7 @@ add-highlighter shared/perl/comment        region (?<!\$)(?<!\\)#   $           
 
 add-highlighter shared/perl/regex          region m?(?<!/)(?<!qr)/[^/\n]+(?=/)  /\w*   fill meta
 add-highlighter shared/perl/sregex         region s/[^/\n]+/[^/\n]+(?=/)        /\w*   fill meta
-add-highlighter shared/perl/bregex         region s\{[^\}\n]+\}\{[^\}\n]+(?=\}) \}\w*  fill meta
+add-highlighter shared/perl/bregex         region s\{[^\}\n]+\}\{[^\}\n]*(?=\}) \}\w*  fill meta
 
 add-highlighter shared/perl/quote_brace    region -recurse \{ \bq[qrwx]?\{ \}          fill string
 add-highlighter shared/perl/quote_paren    region -recurse \( \bq[qrwx]?\( \)          fill string


### PR DESCRIPTION
- rc perl.kak: highlight multiple regex modifiers
- rc perl.kak: highlight substitution with empty replacement, like `s{foo}{}`