### PR TITLE
Disabled backtick escaping

### DIFF
--- a/doc/pages/command-parsing.asciidoc
+++ b/doc/pages/command-parsing.asciidoc
@@ -69,12 +69,12 @@ No other escaping takes place in balanced strings.
 Other words are non-quoted. Non-quoted words end either on a whitespaces
 or a `;`.
 
-If they start with `\\` followed by `%`, `'` or `"`, then that leading
-`\\` is discarded.
+If they start with `\` followed by `%`, `'` or `"`, then that leading
+`\` is discarded.
 
-If a whitespace or `;` is preceded by `\\`, then the `\\` is discarded
-and the whitespace or `;` becomes part of the word. Any other `\\`
-is treated as a literal `\\`.
+If a whitespace or `;` is preceded by `\`, then the `\` is discarded
+and the whitespace or `;` becomes part of the word. Any other `\`
+is treated as a literal `\`.
 
 == Typed Expansions
 

--- a/doc/pages/hooks.asciidoc
+++ b/doc/pages/hooks.asciidoc
@@ -205,17 +205,10 @@ vars are available:
 
 == Disabling Hooks
 
-Any normal mode command can be prefixed with `\ ` which will disable hook
-execution for the duration of the command (including the duration of modes
-the command could move to, so `\i` will disable hooks for the whole insert
-session).
-
-As autoindentation is implemented in terms of hooks, this can be used to
-disable it when pasting text.
-
-A less temporary alternative is to set the `disabled_hooks` option which
-accepts a regex describing which hooks won't be executed.
-For example indentation hooks can be disabled with '.*-indent'.
+Hooks can be disabled temporarily by prefixing any normal mode command by `\`
+(see <<keys#,`:doc keys`>>) and permanently by setting the `disabled_hooks` option
+which accepts a regex describing which hooks won't be executed. For example
+indentation hooks can be disabled with '.*-indent'.
 
 Finally, hook execution can be disabled while using the `execute-keys` or
 `evaluate-commands` commands by using the `-no-hooks` switch.

--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -85,9 +85,10 @@ the right of the end of each selection.
 
 == Disabling Hooks
 
-Any normal mode command can be prefixed with *\* which will disable hook execution
+Any normal mode command can be prefixed with `\` which will disable hook execution
 for the duration for the command (including the duration of modes the command could
-move to, so *\i* will disable hooks for the whole insert session).
+move to, so `\i` will disable hooks for the whole insert session) (see
+<<hooks#,`:doc hooks`>>).
 
 As autoindentation is implemented in terms of hooks, this can be used to disable
 it when pasting text.

--- a/rc/tools/doc.kak
+++ b/rc/tools/doc.kak
@@ -117,7 +117,7 @@ define-command -params 1 -hidden doc-render %{
     set-option buffer doc_render_ranges %val{timestamp}
     doc-render-regex \B(?<!\\)\*(?=\S)[^\n]+?(?<=\S)(?<!\\)\*\B \A|.\z 'H' default+b
     doc-render-regex \b(?<!\\)_(?=\S)[^\n]+?(?<=\S)(?<!\\)_\b \A|.\z 'H' default+i
-    doc-render-regex \B(?<!\\)`(?=\S)[^\n]+?(?<=\S)(?<!\\)`\B \A|.\z 'H' mono
+    doc-render-regex \B(?<!\\)`(?=\S)[^\n]+?(?<=\S)`\B \A|.\z 'H' mono
     doc-render-regex ^=\h+[^\n]+ ^=\h+ '~' title
     doc-render-regex ^={2,}\h+[^\n]+ ^={2,}\h+ '' header
     doc-render-regex ^\h*-{2,}\n\h*.*?^\h*-{2,}\n ^\h*-{2,}\n '' block


### PR DESCRIPTION
Fixes issue #2377 by removing the ability to escape backticks in backticks in compliance with asciidoc's behaviour.