### PR TITLE
rc kakrc: Highlight numbers

### DIFF
--- a/rc/filetype/kakrc.kak
+++ b/rc/filetype/kakrc.kak
@@ -82,6 +82,7 @@ evaluate-commands %sh{
 }
 
 add-highlighter shared/kakrc/code/colors regex \b(rgb:[0-9a-fA-F]{6}|rgba:[0-9a-fA-F]{8})\b 0:value
+add-highlighter shared/kakrc/code/numbers regex \b\d+\b 0:value
 
 add-highlighter shared/kakrc/double_string/fill fill string
 add-highlighter shared/kakrc/double_string/escape regex '""' 0:default+b


### PR DESCRIPTION
All number-words will be highlighted, resulting in atoms that are not necessarily option values being highlighted:

![](https://files.catbox.moe/rc2xl5.png)

The TextMate grammar submitted to Linguist to highlight scripts on Github does that too, and it's arguably helpful, so there you go.