### PR TITLE
rc markdown: Highlight inline code blocks properly

### DIFF
--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -82,7 +82,7 @@ add-highlighter shared/markdown/inline/text/ regex ^\h*(>\h*)+ 0:comment
 add-highlighter shared/markdown/inline/text/ regex "\H( {2,})$" 1:+r@meta
 
 # Inline code
-add-highlighter shared/markdown/inline/text/ regex "^    [^\n]*" 0:meta
+add-highlighter shared/markdown/inline/text/ regex "^( {4}|\t)+([^\n]+)" 2:meta
 
 # Commands
 # ‾‾‾‾‾‾‾‾


### PR DESCRIPTION
This commit allows code blocks to be prefixed with tabulation
characters to be picked up and highlighted by the editor.

Indenting caused by the inclusion of an inline code block into a
list item is also taken into account. However, that might cause false
positives, for example with a hard wrapped list item indented with
an amount of spaces congruent to 4.