### PR TITLE
rc x11-repl: identify the REPL window by window id instead of title

### DIFF
--- a/rc/windowing/repl/x11.kak
+++ b/rc/windowing/repl/x11.kak
@@ -13,8 +13,9 @@ define-command -docstring %{
     -params .. \
     -shell-completion \
     x11-repl %{ x11-terminal sh -c %{
+        winid="${WINDOWID:-$(xdotool search --pid ${PPID} | tail -1)}"
         printf "evaluate-commands -try-client $1 \
-            'set-option current x11_repl_id ${WINDOWID}'" | kak -p "$2"
+            'set-option current x11_repl_id ${winid}'" | kak -p "$2"
         shift 2;
         [ "$1" ] && "$@" || "$SHELL"
     } -- %val{client} %val{session} %arg{@}

--- a/rc/windowing/repl/x11.kak
+++ b/rc/windowing/repl/x11.kak
@@ -6,26 +6,19 @@ provide-module x11-repl %{
 
 declare-option -docstring "window id of the REPL window" str x11_repl_id
 
-# termcmd should already be set in x11.kak
 define-command -docstring %{
     x11-repl [<arguments>]: create a new window for repl interaction
     All optional parameters are forwarded to the new window
 } \
     -params .. \
     -shell-completion \
-    x11-repl %{ evaluate-commands %sh{
-        if [ -z "${kak_opt_termcmd}" ]; then
-           echo 'fail termcmd option is not set'
-           exit
-        fi
-        if [ $# -eq 0 ]; then cmd="${SHELL:-sh}"; else cmd="$@"; fi
-        # put the window id of the REPL into the option x11_repl_id
-        wincmd=$(printf 'printf "evaluate-commands -try-client %s \
-                    set-option current x11_repl_id ${WINDOWID}" | kak -p %s' \
-                    "${kak_client}" "${kak_session}")
-        setsid ${kak_opt_termcmd} "${SHELL} -c '${wincmd} && ${cmd}'" \
-            < /dev/null > /dev/null 2>&1 &
-}}
+    x11-repl %{ x11-terminal sh -c %{
+        printf "evaluate-commands -try-client $1 \
+            'set-option current x11_repl_id ${WINDOWID}'" | kak -p "$2"
+        shift 2;
+        [ "$1" ] && "$@" || "$SHELL"
+    } -- %val{client} %val{session} %arg{@}
+}
 
 define-command x11-send-text -docstring "send the selected text to the repl window" %{
     evaluate-commands %sh{


### PR DESCRIPTION
Now it uses the window id to identify the REPL window. It is stored in the option `x11_repl_id`. That way it is possible to have different REPLs for different buffers or windows. And AFAICT there are less issues with different termcmds and shells.
#1795 #3011 #2973