### PR TITLE
rc tmux-repl: changed scope of `tmux_repl_id` from `global` to `current`

### DIFF
--- a/rc/windowing/repl/tmux.kak
+++ b/rc/windowing/repl/tmux.kak
@@ -19,7 +19,7 @@ define-command -hidden -params 1.. tmux-repl-impl %{
         tmux_args="$1"
         shift
         tmux $tmux_args "$@"
-        printf "set-option global tmux_repl_id '%s'" $(tmux display-message -p '#{session_id}:#{window_id}.#{pane_id}')
+        printf "set-option current tmux_repl_id '%s'" $(tmux display-message -p '#{session_id}:#{window_id}.#{pane_id}')
     }
 }
 


### PR DESCRIPTION
By setting the `tmux_repl_id` in the `current` scope it is possible to have different REPLs for different buffers or windows. So you can do `set-option buffer tmux_repl_id ""; repl-new` to create a new REPL for that buffer. By unsetting the option in that scope it uses the global REPL again. If someone does not want to use that feature she can just ignore it and use the tmux REPL in the same way as before.