### PR TITLE
Add a shebang filetype detection hook

### DIFF
--- a/rc/detection/shebang.kak
+++ b/rc/detection/shebang.kak
@@ -1,0 +1,20 @@
+declare-option -docstring "mapping between shebang exec and actual filetype" \
+    str shebang_filetypes 'bash=sh zsh=sh dash=sh python3=python'
+
+# Add the following function to a hook on BufWritePost to automatically parse shebangs
+define-command -hidden shebang-parse %{
+    evaluate-commands %sh{
+        if [ -z "${kak_opt_filetype}" ] || [ "plain" = "${kak_opt_filetype}" ]; then
+            first_line="$(head -n+1 "${kak_buffile}")"
+
+            if [ 0 -eq "$(expr "$first_line" : "#!")" ]; then
+                return
+            fi
+
+            filetype="$(basename "$(echo "$first_line" | awk -F '(/| )' '{print $NF}')")"
+            filetype="$(echo "$kak_opt_shebang_filetypes" | sed -E "s/.*${filetype}=([a-z0-9^\s]*).*/\1/")"
+
+            printf "set-option buffer filetype '%s'\n" "${filetype}"
+        fi
+    }
+}


### PR DESCRIPTION
This work with filetypes as

* #!/bin/sh
* #!/bin/sh -x
* #!/bin/env sh
* #!/bin/env python
* #!/bin/env python3

This will strip last digit to transfrom python3 to python

This will cause trouble with shebang as /bin/bash as bash is not
the correct filetype which is sh.

You still can use this to map this kind of filetype

hook global WinSetOption filetype=bash %{
	set buffer filetype sh
}

edit: a mapping has been added to handle python3 and bash execs.