### PR TITLE
fix comment highlighting

### DIFF
--- a/rc/filetype/haskell.kak
+++ b/rc/filetype/haskell.kak
@@ -35,7 +35,7 @@ provide-module haskell %[
 add-highlighter shared/haskell regions
 add-highlighter shared/haskell/code default-region group
 add-highlighter shared/haskell/string       region (?<!'\\)(?<!')"                 (?<!\\)(\\\\)*"  fill string
-add-highlighter shared/haskell/macro        region ^\h*?\K#                        (?<!\\)\n        fill meta
+add-highlighter shared/haskell/macro        region ^\K#                            (?<!\\)\n        fill meta
 add-highlighter shared/haskell/pragma       region -recurse \{- \{-#               '#-\}'           fill meta
 add-highlighter shared/haskell/comment      region -recurse \{- \{-                  -\}            fill comment
 add-highlighter shared/haskell/line_comment region --(?:[^!#$%&*+./<>?@\\\^|~=]|$) $                fill comment


### PR DESCRIPTION
`#` will be considered a comment only if it is the first character of the line, including blank characters.

Fix issue #3769 