### PR TITLE
src/ncurses_ui.cc: Teach Kakoune about ctrl-symbol keys.

### DIFF
--- a/src/keys.cc
+++ b/src/keys.cc
@@ -229,6 +229,10 @@ UnitTest test_keys{[]()
          alt('j'),
          ctrl('r'),
          shift(Key::Up),
+         ctrl('['),
+         ctrl('\\'),
+         ctrl(']'),
+         ctrl('_'),
     };
     String keys_as_str;
     for (auto& key : keys)

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -623,8 +623,19 @@ Optional<Key> NCursesUI::get_next_key()
             kill(0, SIGTSTP); // We suspend at this line
             return {};
         }
+        // Special case: you can type NUL with Ctrl-2 or Ctrl-Shift-2 or
+        // Ctrl-Backtick, but the most straightforward way is Ctrl-Space.
+        if (c == 0)
+            return ctrl(' ');
+        // Represent Ctrl-letter combinations in lower-case, to be clear
+        // that Shift is not involved.
         if (c < 27)
             return ctrl(c - 1 + 'a');
+        // Represent Ctrl-symbol combinations in "upper-case", as they are
+        // traditionally-rendered.
+        // Note that Escape is handled elsewhere.
+        if (c < 32)
+            return ctrl(c - 1 + 'A');
 
        struct Sentinel{};
        struct CharIterator


### PR DESCRIPTION
Previously, Kakoune only handled ctrl-codes less than 27, representing them as lower-case ASCII codes. For regular keys like `<c-a>`, that worked fine. However, NUL became the unorthodox ``<c-`>`` and other ctrl-symbols (`<c-\>`, `<c-]>`, `<c-_>`) weren't supported at all.

Now NUL is rendered as the more comfortable `<c-space>`, and the other ctrl-symbol codes are properly decoded.

Fixes #2553.