### PR TITLE
Aspell undocumented buggy-behavior fixed.

### DIFF
--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -53,6 +53,10 @@ define-command -params ..1 -docstring %{
                         # nothing
                     }
 
+                    else if (/^\+/) {
+                        # required to ignore undocumented aspell functionality
+                    }
+
                     else if (/^$/) {
                         line_num++
                     }


### PR DESCRIPTION
Description of behavior:
https://lists.gnu.org/archive/html/aspell-user/2009-11/msg00003.html

tldr:
> Note that this result begins with a plus sign + instead of & * or #. I believe this means that "rsA'l" is the root word of "brsAilnA" (since b+ and +nA are affixes), but this does not seem to be part of the usual aspell/ispell pipe api.