### PR TITLE
Add installation command for Gentoo.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -171,6 +171,9 @@ pacman -S kakoune
 ====
 Kakoune is found in portage as
 https://packages.gentoo.org/packages/app-editors/kakoune[app-editors/kakoune]
+--------------------------------
+emerge kakoune
+--------------------------------
 ====
 
 [TIP]


### PR DESCRIPTION
The other package managers have their explicit commands listed, so I figured it only made sense to have it for Gentoo as well.