### PR TITLE
Improve sh.kak

### DIFF
--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -64,7 +64,7 @@ add-highlighter shared/sh/code/alias regex \balias(\h+[-+]\w)*\h+([\w-.]+)= 2:va
 add-highlighter shared/sh/code/function regex ^\h*(\S+)\h*\(\) 1:function
 
 add-highlighter shared/sh/code/unscoped_expansion regex (?<!\\)(?:\\\\)*\K\$(\w+|#|@|\?|\$|!|-|\*) 0:value
-add-highlighter shared/sh/double_string/expansion regex (?<!\\)(?:\\\\)*\K\$(\w+|\{.+?\}) 0:value
+add-highlighter shared/sh/double_string/expansion regex (?<!\\)(?:\\\\)*\K\$(\w+|#|@|\?|\$|!|-|\*|\{.+?\}) 0:value
 
 # Commands
 # ‾‾‾‾‾‾‾‾

--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -22,12 +22,14 @@ provide-module sh %§
 
 add-highlighter shared/sh regions
 add-highlighter shared/sh/code default-region group
+add-highlighter shared/sh/arithmetic region -recurse \(.*?\( (\$|(?<=for)\h*)\(\( \)\) group
 add-highlighter shared/sh/double_string region  %{(?<!\\)(?:\\\\)*\K"} %{(?<!\\)(?:\\\\)*"} group
 add-highlighter shared/sh/single_string region %{(?<!\\)(?:\\\\)*\K'} %{'} fill string
 add-highlighter shared/sh/expansion region -recurse (?<!\\)(?:\\\\)*\K\$\{ (?<!\\)(?:\\\\)*\K\$\{ \}|\n fill value
 add-highlighter shared/sh/comment region (?<!\\)(?:\\\\)*(?:^|\h)\K# '$' fill comment
 add-highlighter shared/sh/heredoc region -match-capture '<<-?\h*''?(\w+)''?' '^\t*(\w+)$' fill string
 
+add-highlighter shared/sh/arithmetic/expansion ref sh/double_string/expansion
 add-highlighter shared/sh/double_string/fill fill string
 
 evaluate-commands %sh{


### PR DESCRIPTION
I noticed that `sh.kak` recognizes the bitwise operator `<<` in the arithmetic expression `$((1 << 8))` as the start of a here-document. To prevent this, I created a region for arithmetic expressions.

Bash supports loops such as `for (( i = 0; i < 1<<8; i++ ))`. That is why I added `(?<=for)\h*` to the region opening regex. Without the lookbehind, `for` would be part of the region and not highlighted as a keyword. Note that `barfor ((` would be treated as the start of an arithmetic expression. This is not a problem, however, since it is not syntactically correct.

I added `-recurse \(.*?\(` so that a `))` inside an arithmetic expression does not close the region too early as in `$(( (2 * (1 << 8)) ))`.

[POSIX][1] dictates that “The expression shall be treated as if it were in double-quotes”. Thus, I added `ref sh/double_string/expansion` to that region.

I also tested whether special parameters such as $@ get expanded in double quotes and arithmetic expressions. They all do, so I added them. I wonder why those were not included in the first place.

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_04