### PR TITLE
Add a zero-indexed version of the #-register

### DIFF
--- a/doc/pages/registers.asciidoc
+++ b/doc/pages/registers.asciidoc
@@ -66,6 +66,9 @@ contain some special data
 *#* (hash)::
     selection indices (first selection has 1, second has 2, ...)
 
+*$* (dollar)::
+    zero indexed selection indices (first selection has 0, second has 1, ...)
+
 *_* (underscore)::
     null register, always empty
 

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -162,6 +162,7 @@ constexpr StringView register_doc =
     "%:     buffer name\n"
     ".:     selection contents\n"
     "#:     selection index\n"
+    "$:     selection index (zero-indexed)\n"
     "_:     null register\n"
     "\":     default yank/paste register\n"
     "@:     default macro register\n"

--- a/src/main.cc
+++ b/src/main.cc
@@ -49,6 +49,7 @@ struct {
         "» prompts auto select {+i}menu{} completions on space\n"
         "» explicit completion support ({+b}<c-x>...{}) in prompts\n"
         "» {+u}write -atomic{} was replaced with {+u}write -method <method>{}\n"
+        "» Added $-register for selection index, starting at zero\n"
     }, {
         20200901,
         "» daemon mode does not fork anymore\n"

--- a/src/main.cc
+++ b/src/main.cc
@@ -399,6 +399,17 @@ void register_registers()
             return res;
         }));
 
+    register_manager.add_register('$', make_dyn_reg(
+        "$",
+        [](const Context& context) {
+            const size_t count = context.selections().size();
+            StringList res;
+            res.reserve(count);
+            for (size_t i = 0; i < count; ++i)
+                res.push_back(to_string((int)i));
+            return res;
+        }));
+
     for (size_t i = 0; i < 10; ++i)
     {
         register_manager.add_register('0'+i, make_dyn_reg(

--- a/src/register_manager.cc
+++ b/src/register_manager.cc
@@ -65,6 +65,7 @@ static const HashMap<String, Codepoint> reg_names = {
     { "percent", '%' },
     { "dot", '.' },
     { "hash", '#' },
+    { "dollar", '$' },
     { "underscore", '_' },
     { "colon", ':' }
 };


### PR DESCRIPTION
## Motivation

As a lot of programming languages use 0 as a start for arrays and other constructs, the `#`-register does not work very well when for example editing multiple lines, which all do something to an index in an array. An example of this is the following excerpt from a project I've been working on:

```py
object.set_thingy_at_idx(0, "blah")
object.set_thingy_at_idx(1, "xyz")
object.set_thingy_at_idx(2, "foobar")
object.set_thingy_at_idx(3, "haha")
object.set_thingy_at_idx(4, "kakoune")

```

Here, the simplest method to insert all the numbers would be to use the `#`-register, `<a-)>` all selections forwards so that all except the first number is correct, and then fix the first number manually, which is less than optimal.

## This request

This pull request adds the `$`-register, which functions exactly like the `#`-register, except that it starts at zero.

The choice for symbol is quite arbitrary, but I chose `$` both because it is next to `#` on my keyboard, and also that it is next to `#` in the ASCII table (`#` is 0x23, `$`is 0x24). I would have liked to use something like `a-#`, but I am not sure whether most keyboards can type that symbol, and Kakoune also seems to represent registers using single characters, and I do not feel confident enough to make it support those kinds of modifiers.

Some unused symbols which could be used instead are `+` (looks a bit like the `#` if you squint), `-` (could represent `n-1`, which makes sense as the numbers in this registers are one less than those from `#`), or possibly `£` (altGR+`#` on some keyboards, but it is not ASCII, which might cause problems). I would be happy to hear any other suggestions!

I think I've changed all the necessary files (implementation and documentation). There was no tests for the `#`-register already, so I do not think tests for the `$`-register are necessary.