### PR TITLE
Coalesce User Mode Mappings

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -195,13 +195,11 @@ String build_autoinfo_for_mapping(const Context& context, KeymapMode mode,
     for (auto& key : keymaps.get_mapped_keys(mode))
     {
         KeymapManager::KeymapInfo key_info = keymaps.get_mapping(key, mode);
-        std::pair<String, String> cmd_and_docstr = {join(key_info.keys | transform(key_to_str)),
+        std::pair<String, String> cmd_and_docstr = {accumulate(key_info.keys | transform(key_to_str),
+                                                               String{},
+                                                               std::plus{}),
                                                     key_info.docstring};
-        if (synonyms.contains(cmd_and_docstr)) {
-          synonyms[cmd_and_docstr].push_back(key_to_str(key));
-        } else {
-          synonyms.insert({std::move(cmd_and_docstr), {key_to_str(key)}});
-        }
+        synonyms[cmd_and_docstr].push_back(key_to_str(key));
     }
 
     for (auto& [cmd_and_docstr, keys] : synonyms) {

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -202,9 +202,8 @@ String build_autoinfo_for_mapping(const Context& context, KeymapMode mode,
         synonyms[cmd_and_docstr].push_back(key_to_str(key));
     }
 
-    for (auto& [cmd_and_docstr, keys] : synonyms) {
+    for (auto& [cmd_and_docstr, keys] : synonyms)
         descs.emplace_back(join(keys, ',', false), cmd_and_docstr.second);
-    }
 
     auto max_len = 0_col;
     for (auto& desc : descs)

--- a/src/string_utils.hh
+++ b/src/string_utils.hh
@@ -56,6 +56,17 @@ String join(const Container& container, StringView joiner)
     return res;
 }
 
+template<typename Container>
+String join(const Container& container)
+{
+    String res;
+    for (const auto& str : container)
+    {
+        res += str;
+    }
+    return res;
+}
+
 inline bool prefix_match(StringView str, StringView prefix)
 {
     return str.substr(0_byte, prefix.length()) == prefix;

--- a/src/string_utils.hh
+++ b/src/string_utils.hh
@@ -56,17 +56,6 @@ String join(const Container& container, StringView joiner)
     return res;
 }
 
-template<typename Container>
-String join(const Container& container)
-{
-    String res;
-    for (const auto& str : container)
-    {
-        res += str;
-    }
-    return res;
-}
-
 inline bool prefix_match(StringView str, StringView prefix)
 {
     return str.substr(0_byte, prefix.length()) == prefix;


### PR DESCRIPTION
This patch resolves #3902. Some user-mode-like autoinfos have multiple keys bound to the same action, such as `<a-i>`, which has `b,(,)` mapping to an action. There is currently no way to combine multiple mappings in a user mode.

This PR combines (non `built_in`) keymaps in an autoinfo that have the **exact same command and docstring**. For example,
```
map global user p ": echo test" -docstring "some command"
map global user n ": echo test" -docstring "some command"
```
Will now show up as:
![image](https://user-images.githubusercontent.com/5505315/99876435-d006da00-2b9a-11eb-83a9-76357b4b1782.png)

This change also applies to custom user modes.

## Disclaimer
This is my first time attempting to contribute to Kakoune's codebase, so I'm not super familiar with the containers and custom string types. I'm also not that experienced in C++, so I'm sure I'm performing some unnecessary copies somewhere in here. And lastly of course please reject this if this change isn't desired.