### PR TITLE
rc: Consistently use a dot as template separator

### DIFF
--- a/rc/tools/format.kak
+++ b/rc/tools/format.kak
@@ -16,8 +16,8 @@ define-command format-selections -docstring "Format the selections individually"
     }
     evaluate-commands -draft -no-hooks -save-regs '|' %{
         set-register '|' %{
-            format_in="$(mktemp "${TMPDIR:-/tmp}"/kak-formatter-XXXXXX)"
-            format_out="$(mktemp "${TMPDIR:-/tmp}"/kak-formatter-XXXXXX)"
+            format_in="$(mktemp "${TMPDIR:-/tmp}"/kak-formatter.XXXXXX)"
+            format_out="$(mktemp "${TMPDIR:-/tmp}"/kak-formatter.XXXXXX)"
 
             cat > "$format_in"
             eval "$kak_opt_formatcmd" < "$format_in" > "$format_out"

--- a/rc/tools/man.kak
+++ b/rc/tools/man.kak
@@ -33,9 +33,9 @@ define-command -hidden -params ..3 man-impl %{ evaluate-commands %sh{
         exit
     fi
     shift
-    manout=$(mktemp "${TMPDIR:-/tmp}"/kak-man-XXXXXX)
-    manerr=$(mktemp "${TMPDIR:-/tmp}"/kak-man-XXXXXX)
-    colout=$(mktemp "${TMPDIR:-/tmp}"/kak-man-XXXXXX)
+    manout=$(mktemp "${TMPDIR:-/tmp}"/kak-man.XXXXXX)
+    manerr=$(mktemp "${TMPDIR:-/tmp}"/kak-man.XXXXXX)
+    colout=$(mktemp "${TMPDIR:-/tmp}"/kak-man.XXXXXX)
     env MANWIDTH=${kak_window_range##* } man "$@" > "$manout" 2> "$manerr"
     retval=$?
     col -b -x > ${colout} < ${manout}


### PR DESCRIPTION
Other scripts uses a dot `.` to separate the seed from the rest of
the template, making that standard across the codebase allows running
cleanup commands like `rm -rf /tmp/kak-*.*`.