### PR TITLE
doc commands: Sort command names

### DIFF
--- a/doc/pages/commands.asciidoc
+++ b/doc/pages/commands.asciidoc
@@ -20,10 +20,30 @@ of the file onto the filesystem
     given. Buffers that do not appear in the parameters will remain at the
     end of the list, keeping their current order.
 
+*buffer* <name>::
+    *alias* b +
+    switch to buffer <name>
+
+*buffer-next*::
+    *alias* bn +
+    switch to the next buffer.
+    Debug buffers are skipped.
+    (See <<buffers#debug-buffers,`:doc buffers debug-buffers`>>)
+
+*buffer-previous*::
+    *alias* bp +
+    switch to the previous buffer.
+    Debug buffers are skipped.
+    (See <<buffers#debug-buffers,`:doc buffers debug-buffers`>>)
+
 *change-directory* [<directory>]::
     *alias* cd +
     change the current directory to *directory*, or the home directory if
     unspecified
+
+*delete-buffer[!]* [<name>]::
+    *alias* db +
+    delete current buffer or the buffer <name> if specified
 
 *edit[!]* [<switches>] <filename> [<line> [<column>]]::
     *alias* e +
@@ -57,6 +77,19 @@ of the file onto the filesystem
         buffer down to make the new data visible.
         Otherwise, does nothing.
 
+*quit[!]* [<exit status>]::
+    *alias* q +
+    exit Kakoune, use quit! to force quitting even if there is some
+    unsaved buffer remaining. If specified, the client exit status
+    will be set to <exit status>
+
+*rename-buffer* [-file|-scratch] <name>::
+    set current buffer name, if *-scratch* or *-file* is given, ensure
+    the buffer is set to the corresponding type.
+
+*source* <filename> <param>...::
+    execute commands in <filename>
+    parameters are available in the sourced script as `%arg{0}`, `%arg{1}`, …
 
 *write[!]* [-sync] [-method <writemethod>] [<filename>]::
     *alias* w +
@@ -85,10 +118,9 @@ of the file onto the filesystem
     *alias* wa +
     write all changed buffers that are associated with a file
 
-*quit[!]* [<exit status>]::
-    *alias* q +
-    exit Kakoune, use quit! to force quitting even if there is some
-    unsaved buffer remaining. If specified, the client exit status
+*write-all-quit* [-sync] [-method <writemethod>] [<exit status>]::
+    *alias* waq +
+    write all buffers and quit. If specified, the client exit status
     will be set to <exit status>
 
 *write-quit[!]* [-sync] [-method <writemethod>] [<exit status>]::
@@ -96,50 +128,17 @@ of the file onto the filesystem
     write current buffer and quit current client. If specified, the client
     exit status will be set to <exit status>
 
-*write-all-quit* [-sync] [-method <writemethod>] [<exit status>]::
-    *alias* waq +
-    write all buffers and quit. If specified, the client exit status
-    will be set to <exit status>
-
-*buffer* <name>::
-    *alias* b +
-    switch to buffer <name>
-
-*buffer-next*::
-    *alias* bn +
-    switch to the next buffer.
-    Debug buffers are skipped.
-    (See <<buffers#debug-buffers,`:doc buffers debug-buffers`>>)
-
-*buffer-previous*::
-    *alias* bp +
-    switch to the previous buffer.
-    Debug buffers are skipped.
-    (See <<buffers#debug-buffers,`:doc buffers debug-buffers`>>)
-
-*delete-buffer[!]* [<name>]::
-    *alias* db +
-    delete current buffer or the buffer <name> if specified
-
-*rename-buffer* [-file|-scratch] <name>::
-    set current buffer name, if *-scratch* or *-file* is given, ensure
-    the buffer is set to the corresponding type.
-
-*source* <filename> <param>...::
-    execute commands in <filename>
-    parameters are available in the sourced script as `%arg{0}`, `%arg{1}`, …
-
 == Clients and Sessions
+
+*kill[!]* [<exit status>]::
+    terminate the current session, all the clients as well as the server.
+    If specified, the server and clients exit status will be set to <exit status>
 
 *rename-client* <name>::
     set current client name
 
 *rename-session* <name>::
     set current session name
-
-*kill[!]* [<exit status>]::
-    terminate the current session, all the clients as well as the server.
-    If specified, the server and clients exit status will be set to <exit status>
 
 == Options
 
@@ -168,18 +167,22 @@ of the file onto the filesystem
 
 == Commands and Keys
 
-*define-command* [<switches>] <name> <command>::
-    *alias* def +
-    define a new command (See <<declaring-new-commands,Declaring new commands>>)
-
 *alias* <scope> <name> <command>::
     define a new alias named *name* in *scope*
     (See <<aliases,Using aliases>> and <<scopes#,`:doc scopes`>>)
 
-*unalias* <scope> <name> [<command>]::
-    remove an alias if its current value is the same as the one passed
-    as an optional parameter, remove it unconditionally otherwise
-    (See <<aliases,Using aliases>> and <<scopes#,`:doc scopes`>>)
+*declare-user-mode* <name>::
+    declare a new user keymap mode
+
+*define-command* [<switches>] <name> <command>::
+    *alias* def +
+    define a new command (See <<declaring-new-commands,Declaring new commands>>)
+
+*enter-user-mode* [<switches>] <name>::
+    enable <name> keymap mode for next key
+
+    *-lock*:::
+        stay in mode until `<esc>` is pressed
 
 *evaluate-commands* [<switches>] <command> ...::
     *alias* eval +
@@ -194,18 +197,14 @@ of the file onto the filesystem
     bind a list of keys to a combination (See <<mapping#,`:doc mapping`>>
     and <<scopes#,`:doc scopes`>>)
 
+*unalias* <scope> <name> [<command>]::
+    remove an alias if its current value is the same as the one passed
+    as an optional parameter, remove it unconditionally otherwise
+    (See <<aliases,Using aliases>> and <<scopes#,`:doc scopes`>>)
+
 *unmap* <scope> <mode> <key> [<expected>]::
     unbind a key combination (See <<mapping#,`:doc mapping`>>
     and <<scopes#,`:doc scopes`>>)
-
-*declare-user-mode* <name>::
-    declare a new user keymap mode
-
-*enter-user-mode* [<switches>] <name>::
-    enable <name> keymap mode for next key
-
-    *-lock*:::
-        stay in mode until `<esc>` is pressed
 
 == Hooks
 
@@ -223,6 +222,14 @@ of the file onto the filesystem
     the current context. (See <<hooks#,`:doc hooks`>>)
 
 == Display
+
+*add-highlighter* [<switches>] <highlighter_path> <highlighter_parameters> ...::
+    *alias* addhl +
+    add a highlighter to the current window
+    (See <<highlighters#,`:doc highlighters`>>)
+
+*colorscheme* <name>::
+    load named colorscheme
 
 *echo* [<switches>] <text>::
     show *text* in status line, with the following *switches*:
@@ -252,6 +259,11 @@ of the file onto the filesystem
             also wrap each arguments in single quotes and escape
             embedded quotes in a shell compatible way.
 
+*remove-highlighter* <highlighter_path>::
+    *alias* rmhl +
+    remove the highlighter whose id is *highlighter_id*
+    (See <<highlighters#,`:doc highlighters`>>)
+
 *set-face* <scope> <name> <facespec>::
     *alias* face +
     define a face in *scope*
@@ -261,73 +273,17 @@ of the file onto the filesystem
     Remove a face definition from *scope*
     (See <<faces#,`:doc faces`>> and <<scopes#,`:doc scopes`>>)
 
-*colorscheme* <name>::
-    load named colorscheme
-
-*add-highlighter* [<switches>] <highlighter_path> <highlighter_parameters> ...::
-    *alias* addhl +
-    add a highlighter to the current window
-    (See <<highlighters#,`:doc highlighters`>>)
-
-*remove-highlighter* <highlighter_path>::
-    *alias* rmhl +
-    remove the highlighter whose id is *highlighter_id*
-    (See <<highlighters#,`:doc highlighters`>>)
-
 == Helpers
 
 Kakoune provides some helper commands that can be used to define composite
 commands in scripts. They are also available in the interactive mode,
 but not really useful in that context.
 
-*prompt* [<switches>] <prompt> <command>::
-    prompt the user for a string, when the user validates, executes the
-    command. The entered text is available in the `text` value accessible
-    through `$kak_text` in shells or `%val{text}` in commands.
+*debug* {info,buffers,options,memory,shared-strings,profile-hash-maps,faces,mappings}::
+    print some debug information in the *\*debug** buffer
 
-    The *-init <str>* switch allows setting initial content, the
-    *-password* switch hides the entered text and clears the register
-    after command execution.
-
-    The *-on-change* and *-on-abort* switches, followed by a command
-    will have this command executed whenever the prompt content changes
-    or the prompt is aborted, respectively.
-
-    Completion support can be controlled with the same switches provided
-    by the *define-command* command, see
-    <<declaring-new-commands,Declaring new commands>>.
-
-    For *-shell-script-completion* and *-shell-script-candidates*
-    completions, token_to_complete will always be 1, and the full
-    prompt content will be passed as a single token. In other words,
-    word splitting does not take place.
-
-    NOTE: The prompt is displayed in and receives input from the
-    current client context, so inside a draft context like
-    `evaluate-commands -draft`, it is invisible and only responds to
-    an `execute-keys` command in the same context.
-
-*on-key* <command>::
-    wait for next key from user, then execute <command>, the key is
-    available through the `key` value, accessible through `$kak_key`
-    in shells, or `%val{key}` in commands.
-
-    NOTE: The key press must come from the current client context,
-    so inside a draft context like `evaluate-commands -draft`, it only
-    responds to an `execute-keys` command in the same context.
-
-*menu* [<switches>] <label1> <commands1> <label2> <commands2> ...::
-    display a menu using labels, the selected label’s commands are
-    executed. The *menu* command can take an *-auto-single* argument, to automatically
-    run commands when only one choice is provided, and a *-select-cmds*
-    argument, in which case menu takes three argument per item, the
-    last one being a command to execute when the item is selected (but
-    not validated)
-
-    NOTE: The menu is displayed in and receives input from the
-    current client context, so inside a draft context like
-    `evaluate-commands -draft`, it is invisible and only responds to
-    an `execute-keys` command in the same context.
+*fail* <text>::
+    raise an error, uses <text> as its description
 
 *info* [<switches>] <text>::
     display text in an information box with the following *switches*:
@@ -364,26 +320,57 @@ but not really useful in that context.
     NOTE: The info box is displayed in the current client context,
     so inside a draft context like `eval -draft`, it is invisible.
 
-*try* <commands> [catch <on_error_commands>]...::
-    prevent an error in *commands* from aborting the whole command
-    execution, execute *on_error_commands* instead. If nothing is to be
-    done on error, the catch part can be omitted. If an error is raised
-    in the *on_error_commands*, that error is propagated, except if
-    another *catch* and *on_error_commands* parameter follows, in which
-    case those commands get executed, and so-on. During error commands,
-    the description of the last raised error is available as `$kak_error`
-    in the shell, or `%val{error}` in commands.
+*menu* [<switches>] <label1> <commands1> <label2> <commands2> ...::
+    display a menu using labels, the selected label’s commands are
+    executed. The *menu* command can take an *-auto-single* argument, to automatically
+    run commands when only one choice is provided, and a *-select-cmds*
+    argument, in which case menu takes three argument per item, the
+    last one being a command to execute when the item is selected (but
+    not validated)
+
+    NOTE: The menu is displayed in and receives input from the
+    current client context, so inside a draft context like
+    `evaluate-commands -draft`, it is invisible and only responds to
+    an `execute-keys` command in the same context.
 
 *nop*::
     does nothing, but arguments will be evaluated (e.g. shell expansion)
 
-*fail* <text>::
-    raise an error, uses <text> as its description
+*on-key* <command>::
+    wait for next key from user, then execute <command>, the key is
+    available through the `key` value, accessible through `$kak_key`
+    in shells, or `%val{key}` in commands.
 
-*set-register* <name> <contents>...::
-    *alias* reg +
-    set register *name* to *content*, each content parameter is assigned to
-    a different string in the register. (See <<registers#,`:doc registers`>>)
+    NOTE: The key press must come from the current client context,
+    so inside a draft context like `evaluate-commands -draft`, it only
+    responds to an `execute-keys` command in the same context.
+
+*prompt* [<switches>] <prompt> <command>::
+    prompt the user for a string, when the user validates, executes the
+    command. The entered text is available in the `text` value accessible
+    through `$kak_text` in shells or `%val{text}` in commands.
+
+    The *-init <str>* switch allows setting initial content, the
+    *-password* switch hides the entered text and clears the register
+    after command execution.
+
+    The *-on-change* and *-on-abort* switches, followed by a command
+    will have this command executed whenever the prompt content changes
+    or the prompt is aborted, respectively.
+
+    Completion support can be controlled with the same switches provided
+    by the *define-command* command, see
+    <<declaring-new-commands,Declaring new commands>>.
+
+    For *-shell-script-completion* and *-shell-script-candidates*
+    completions, token_to_complete will always be 1, and the full
+    prompt content will be passed as a single token. In other words,
+    word splitting does not take place.
+
+    NOTE: The prompt is displayed in and receives input from the
+    current client context, so inside a draft context like
+    `evaluate-commands -draft`, it is invisible and only responds to
+    an `execute-keys` command in the same context.
 
 *select* [<switches>] <anchor_line>.<anchor_column>,<cursor_line>.<cursor_column>...::
     replace the current selections with the ones described in the arguments
@@ -401,8 +388,20 @@ but not really useful in that context.
     both *-codepoint* and *-display-column* are only valid if *-timestamp*
     matches the current buffer timestamp (or is not specified).
 
-*debug* {info,buffers,options,memory,shared-strings,profile-hash-maps,faces,mappings}::
-    print some debug information in the *\*debug** buffer
+*set-register* <name> <contents>...::
+    *alias* reg +
+    set register *name* to *content*, each content parameter is assigned to
+    a different string in the register. (See <<registers#,`:doc registers`>>)
+
+*try* <commands> [catch <on_error_commands>]...::
+    prevent an error in *commands* from aborting the whole command
+    execution, execute *on_error_commands* instead. If nothing is to be
+    done on error, the catch part can be omitted. If an error is raised
+    in the *on_error_commands*, that error is propagated, except if
+    another *catch* and *on_error_commands* parameter follows, in which
+    case those commands get executed, and so-on. During error commands,
+    the description of the last raised error is available as `$kak_error`
+    in the shell, or `%val{error}` in commands.
 
 == Module commands
 

--- a/doc/pages/execeval.asciidoc
+++ b/doc/pages/execeval.asciidoc
@@ -22,12 +22,13 @@ when the commands have been executed: */*, *"*, *|*, *^*, *@*.
 
 == Optional switches
 
+*-buffer* <names>::
+    execute in the context of each buffers in the comma separated list
+    *names*. `*` as a name can be used to iterate on all non-debug buffers
+    (See <<buffers#debug-buffers, `:doc buffers`>>)
+
 *-client* <name>::
     execute in the context of the client named *name*
-
-*-try-client* <name>::
-    execute in the context of the client named *name* if such client
-    exists, or else in the current context
 
 *-draft*::
     execute in a copy of the context of the selected client. Modifications
@@ -40,14 +41,13 @@ when the commands have been executed: */*, *"*, *|*, *^*, *@*.
     selection. This permits avoiding cases where the selections may
     get merged
 
-*-buffer* <names>::
-    execute in the context of each buffers in the comma separated list
-    *names*. `*` as a name can be used to iterate on all non-debug buffers
-    (See <<buffers#debug-buffers, `:doc buffers`>>)
-
 *-save-regs* <regs>::
     regs is a string of registers to be restored after execution (overwrites
     the list of registers saved by default, c.f. description)
+
+*-try-client* <name>::
+    execute in the context of the client named *name* if such client
+    exists, or else in the current context
 
 == evaluate-commands specific switches
 

--- a/doc/pages/faces.asciidoc
+++ b/doc/pages/faces.asciidoc
@@ -64,62 +64,62 @@ following format:
 The following default faces are used by color schemes to highlight certain
 areas of the user interface:
 
+*BufferPadding*::
+    face applied on the `~` characters that follow the last line of a buffer
+
 *Default*::
     default colors
-
-*PrimarySelection*::
-    main selection face for every selected character except the cursor
-
-*SecondarySelection*::
-    secondary selection face for every selected character except the cursor
-
-*PrimaryCursor*::
-    cursor of the primary selection
-
-*SecondaryCursor*::
-    cursor of the secondary selection
-
-*PrimaryCursorEol*::
-    cursor of the primary selection when it lies on an end of line character
-
-*SecondaryCursorEol*::
-    cursor of the secondary selection when it lies on an end of line character
-
-*MenuForeground*::
-    face for the selected element in menus
-
-*MenuBackground*::
-    face for the not selected elements in menus
-
-*MenuInfo*::
-    face for additional information for elements in menus
-
-*Information*::
-    face for the informations windows and information messages
 
 *Error*::
     face of error messages
 
-*StatusLine*::
-    face used for the status line
+*Information*::
+    face for the informations windows and information messages
 
-*StatusLineMode*::
-    face used for the current mode except the normal mode
+*MenuBackground*::
+    face for the not selected elements in menus
 
-*StatusLineInfo*::
-    face used for special information
+*MenuForeground*::
+    face for the selected element in menus
 
-*StatusLineValue*::
-    face used for special values (numeric prefixes, registers, etc.)
+*MenuInfo*::
+    face for additional information for elements in menus
 
-*StatusCursor*::
-    face used for the status line cursor
+*PrimaryCursor*::
+    cursor of the primary selection
+
+*PrimaryCursorEol*::
+    cursor of the primary selection when it lies on an end of line character
+
+*PrimarySelection*::
+    main selection face for every selected character except the cursor
 
 *Prompt*::
     face used prompt displayed on the status line
 
-*BufferPadding*::
-    face applied on the `~` characters that follow the last line of a buffer
+*SecondaryCursor*::
+    cursor of the secondary selection
+
+*SecondaryCursorEol*::
+    cursor of the secondary selection when it lies on an end of line character
+
+*SecondarySelection*::
+    secondary selection face for every selected character except the cursor
+
+*StatusCursor*::
+    face used for the status line cursor
+
+*StatusLine*::
+    face used for the status line
+
+*StatusLineInfo*::
+    face used for special information
+
+*StatusLineMode*::
+    face used for the current mode except the normal mode
+
+*StatusLineValue*::
+    face used for special values (numeric prefixes, registers, etc.)
 
 === Builtin highlighters faces
 

--- a/doc/pages/faces.asciidoc
+++ b/doc/pages/faces.asciidoc
@@ -28,31 +28,31 @@ following format:
 
 'attributes'::
     string whose individual letters set an attribute:
-        *u*:::
-            underline
-        *r*:::
-            reverse
         *b*:::
             bold
-        *B*:::
-            blink
         *d*:::
             dim
         *i*:::
             italic
-        *F*:::
-            final, override the previous face instead of merging with it,
-            and this face will only be replaced if another face with
-            the final attribute is applied
+        *r*:::
+            reverse
+        *u*:::
+            underline
+        *B*:::
+            blink
+        *a*:::
+            final attributes, as final but only applies to face's
+            attributes
         *f*:::
             final foreground, as final but only applies to face's
             foreground color
         *g*:::
             final background, as final but only applies to face's
             background color
-        *a*:::
-            final attributes, as final but only applies to face's
-            attributes
+        *F*:::
+            final, override the previous face instead of merging with it,
+            and this face will only be replaced if another face with
+            the final attribute is applied
 
 'base'::
     The base face on which this face applies, which can be any face name,

--- a/doc/pages/highlighters.asciidoc
+++ b/doc/pages/highlighters.asciidoc
@@ -28,6 +28,25 @@ highlighter is replaced with the new one.
 
 == Convenient highlighters
 
+*number-lines* [options]::
+    show line numbers using the `LineNumbers`, `LineNumberCursor` and `LineNumbersWrapped` faces,
+    with the following *options*: 
+
+    *-relative*:::
+        show line numbers relative to the main cursor line
+
+    *-hlcursor*:::
+        highlight the cursor line with a separate face
+
+    *-separator* <separator text>:::
+        specify a string to separate the line numbers column from
+        the rest of the buffer (default is '|')
+
+    *-min-digits* <num>:::
+        always reserve room for at least *num* digits,
+        so text doesn't jump around as lines are added or removed
+        (default is 2)
+
 *show-matching*::
     highlight matching char of the character under the selections' cursor
     using `MatchingChar` face
@@ -51,25 +70,6 @@ highlighter is replaced with the new one.
     *-tabpad* <separator>:::
         a one character long separator that will be appended to tabulations to honor the *tabstop* option
 
-*number-lines* [options]::
-    show line numbers using the `LineNumbers`, `LineNumberCursor` and `LineNumbersWrapped` faces,
-    with the following *options*: 
-
-    *-relative*:::
-        show line numbers relative to the main cursor line
-
-    *-hlcursor*:::
-        highlight the cursor line with a separate face
-
-    *-separator* <separator text>:::
-        specify a string to separate the line numbers column from
-        the rest of the buffer (default is '|')
-
-    *-min-digits* <num>:::
-        always reserve room for at least *num* digits,
-        so text doesn't jump around as lines are added or removed
-        (default is 2)
-
 *wrap* [options]::
     soft wrap buffer text at window width, with the following *options*:
 
@@ -88,11 +88,20 @@ highlighter is replaced with the new one.
 
 == General highlighters
 
-*fill* <face>::
-    fill using the given *face*, mostly useful with regions highlighters
-
 *column* <number> <face>::
     highlight column *number* with face *face*
+
+*dynregex* <expression> <capture_id>:<face> ...::
+    similar to regex, but expand (like a command parameter would) the
+    given expression before building a regex from the result.
+    This highlights all the current search matches in italic:
+
+-----------------------------------------------
+add-highlighter window/ dynregex '%reg{/}' 0:+i
+-----------------------------------------------
+
+*fill* <face>::
+    fill using the given *face*, mostly useful with regions highlighters
 
 *line* <number> <face>::
     highlight line *number* with face *face*
@@ -110,15 +119,6 @@ add-highlighter window/ regex //\h*(TODO:)[^\n]* 0:cyan 1:yellow,red
     capture_id can be either the capture number, or its name if a
     named capture is used in the regex (See
     <<regex#Groups, `:doc regex Groups`>>)
-
-*dynregex* <expression> <capture_id>:<face> ...::
-    similar to regex, but expand (like a command parameter would) the
-    given expression before building a regex from the result.
-    This highlights all the current search matches in italic:
-
------------------------------------------------
-add-highlighter window/ dynregex '%reg{/}' 0:+i
------------------------------------------------
 
 == Specs highlighters
 

--- a/doc/pages/hooks.asciidoc
+++ b/doc/pages/hooks.asciidoc
@@ -45,112 +45,49 @@ hook global WinCreate .*\.cc %{ add-highlighter number-lines }
 The parameter string associated with each hook is described after the hook
 name. Hooks with no description will always use an empty string.
 
-*NormalIdle*::
-    a certain duration has passed since the last keypress in normal mode
+*BufClose* `buffer name`::
+    executed when a buffer is deleted, while it is still valid
 
-*NormalKey* `key`::
-    a key is received in normal mode. This hook will not trigger when the user
-    presses a key on the left-hand side of a normal-mode mapping (see
-    <<mapping#,`:doc mapping`>>), but will trigger for keys on the right-hand
-    side. See also `RawKey` below.
-
-*InsertIdle*::
-    a certain duration has passed since the last keypress in insert mode
-
-*InsertKey* `key`::
-    a key is received in insert mode. This hook will not trigger when the user
-    presses a key on the left-hand side of a insert-mode mapping (see
-    <<mapping#,`:doc mapping`>>), but will trigger for keys on the right-hand
-    side. See also `RawKey` below.
-
-*InsertChar* `char`::
-    a character is received in insert mode
-
-*InsertDelete* `deleted char`::
-    a character is deleted in insert mode
-
-*InsertMove* `move key`::
-    the cursor moved (without inserting) in insert mode
-
-*PromptIdle*::
-    a certain duration has passed since the last keypress in prompt mode
-
-*WinCreate* `buffer name`::
-    a window was created. This hook is executed in draft context, so any
-    changes to selections or input state will be discarded.
-
-*WinClose* `buffer name`::
-    a window was destroyed. This hook is executed in a draft context, so any
-    changes to selections or input state will be discarded.
-
-*WinResize* `<line>.<column>`::
-    a window was resized. This hook is executed in a draft context, so any
-    changes to selections or input state will be discarded.
-
-*WinDisplay* `buffer name`::
-    a client switched to displaying the given buffer.
-
-*WinSetOption* `<option_name>=<new_value>`::
-    an option was set in a window context. This hook is executed in a draft
-    context, so any changes to selections or input state will be discarded.
-
-*GlobalSetOption* `<option_name>=<new_value>`::
-    an option was set at the global scope
-
-*BufSetOption* `<option_name>=<new_value>`::
-    an option was set in a buffer context
-
-*BufNewFile* `filename`::
-    a buffer for a new file has been created
-
-*BufOpenFile* `filename`::
-    a buffer for an existing file has been created
+*BufCloseFifo*::
+    executed when a fifo buffer closes its fifo file descriptor either
+    because the buffer is being deleted or the writing end has been closed
 
 *BufCreate* `filename`::
     a buffer has been created
 
-*BufWritePre* `filename`::
-    executed just before a buffer is written
-
-*BufWritePost* `filename`::
-    executed just after a buffer is written
-
-*BufReload* `filename`::
-    executed after a buffer reload has been triggered by an external
-    modification to its file
-
-*BufClose* `buffer name`::
-    executed when a buffer is deleted, while it is still valid
+*BufNewFile* `filename`::
+    a buffer for a new file has been created
 
 *BufOpenFifo* `buffer name`::
     executed when a buffer opens a fifo
+
+*BufOpenFile* `filename`::
+    a buffer for an existing file has been created
 
 *BufReadFifo* `<start line>.<start column>,<end line>.<end column>`::
     executed after some data has been read from a fifo and inserted in
     the buffer. The hook param contains the range of text that was just
     inserted, in a format compatible with the `select` command.
 
-*BufCloseFifo*::
-    executed when a fifo buffer closes its fifo file descriptor either
-    because the buffer is being deleted or the writing end has been closed
+*BufReload* `filename`::
+    executed after a buffer reload has been triggered by an external
+    modification to its file
 
-*ClientCreate* `client name`::
-    executed when a new client is created.
+*BufSetOption* `<option_name>=<new_value>`::
+    an option was set in a buffer context
+
+*BufWritePost* `filename`::
+    executed just after a buffer is written
+
+*BufWritePre* `filename`::
+    executed just before a buffer is written
 
 *ClientClose* `client name`::
     executed when a client is closed, after it was removed from the client
     list.
 
-*RuntimeError* `error message`::
-    an error was encountered while executing a user command
-
-*ModeChange* `[push|pop]:<old mode>:<new mode>`::
-    Triggered whenever a mode is pushed or removed from the mode stack.
-    The mode name can be things like 'normal' or 'insert' for regular
-    interactive modes, or 'next-key[<name>]' for sub-modes where Kakoune
-    prompts for a key. For example, `g` in normal mode pushes 'next-key[goto]'
-    mode, the `enter-user-mode foo` command pushes 'next-key[user.foo]' mode,
-    and the `on-key -mode-name bar` command pushes 'next-key[bar]' mode.
+*ClientCreate* `client name`::
+    executed when a new client is created.
 
 *KakBegin* `session name`::
     kakoune has started, this hook is called just after reading the user
@@ -165,13 +102,57 @@ name. Hooks with no description will always use an empty string.
 *FocusOut* `client name`::
     on supported clients, triggered when the client gets unfocused
 
-*InsertCompletionShow*::
-    Triggered when the insert completion menu gets displayed
+*GlobalSetOption* `<option_name>=<new_value>`::
+    an option was set at the global scope
+
+*InsertChar* `char`::
+    a character is received in insert mode
 
 *InsertCompletionHide* `completion`::
     Triggered when the insert completion menu gets hidden, the list of
     inserted completions text ranges is passed as filtering text, in the
     same format the `select` command expects.
+
+*InsertCompletionShow*::
+    Triggered when the insert completion menu gets displayed
+
+*InsertDelete* `deleted char`::
+    a character is deleted in insert mode
+
+*InsertIdle*::
+    a certain duration has passed since the last keypress in insert mode
+
+*InsertKey* `key`::
+    a key is received in insert mode. This hook will not trigger when the user
+    presses a key on the left-hand side of a insert-mode mapping (see
+    <<mapping#,`:doc mapping`>>), but will trigger for keys on the right-hand
+    side. See also `RawKey` below.
+
+*InsertMove* `move key`::
+    the cursor moved (without inserting) in insert mode
+
+*ModeChange* `[push|pop]:<old mode>:<new mode>`::
+    Triggered whenever a mode is pushed or removed from the mode stack.
+    The mode name can be things like 'normal' or 'insert' for regular
+    interactive modes, or 'next-key[<name>]' for sub-modes where Kakoune
+    prompts for a key. For example, `g` in normal mode pushes 'next-key[goto]'
+    mode, the `enter-user-mode foo` command pushes 'next-key[user.foo]' mode,
+    and the `on-key -mode-name bar` command pushes 'next-key[bar]' mode.
+
+*ModuleLoaded* `module`::
+    Triggered after a module is evaluated by the first `require-module` call
+
+*NormalIdle*::
+    a certain duration has passed since the last keypress in normal mode
+
+*NormalKey* `key`::
+    a key is received in normal mode. This hook will not trigger when the user
+    presses a key on the left-hand side of a normal-mode mapping (see
+    <<mapping#,`:doc mapping`>>), but will trigger for keys on the right-hand
+    side. See also `RawKey` below.
+
+*PromptIdle*::
+    a certain duration has passed since the last keypress in prompt mode
 
 *RawKey* `key`::
     Triggered whenever a key is pressed by the user, regardless of what mode
@@ -183,12 +164,31 @@ name. Hooks with no description will always use an empty string.
 *RegisterModified* `register`::
     Triggered after a register has been written to.
 
-*ModuleLoaded* `module`::
-    Triggered after a module is evaluated by the first `require-module` call
+*RuntimeError* `error message`::
+    an error was encountered while executing a user command
 
 *User* `param`::
     Triggered  via the `trigger-user-hook` command. Provides a way for plugins
     to introduce custom hooks by specifying what *param* would be.
+
+*WinClose* `buffer name`::
+    a window was destroyed. This hook is executed in a draft context, so any
+    changes to selections or input state will be discarded.
+
+*WinCreate* `buffer name`::
+    a window was created. This hook is executed in draft context, so any
+    changes to selections or input state will be discarded.
+
+*WinDisplay* `buffer name`::
+    a client switched to displaying the given buffer.
+
+*WinResize* `<line>.<column>`::
+    a window was resized. This hook is executed in a draft context, so any
+    changes to selections or input state will be discarded.
+
+*WinSetOption* `<option_name>=<new_value>`::
+    an option was set in a window context. This hook is executed in a draft
+    context, so any changes to selections or input state will be discarded.
 
 Note that some hooks will not consider underlying scopes depending on what
 context they are bound to be run into, e.g. the `BufWritePost` hook is a buffer

--- a/doc/pages/mapping.asciidoc
+++ b/doc/pages/mapping.asciidoc
@@ -14,29 +14,29 @@ The *map* command makes *key* behave as if the *keys* sequence was typed.
 
 *mode* dictates in what context the mapping will be available:
 
+    *goto*::
+        mode entered when the goto key is hit (default: 'g')
+
     *insert*::
         insert mode
-
-    *normal*::
-        normal mode
-
-    *prompt*::
-        prompts, such as when entering a command through *:*, or a regex through */*
 
     *menu*::
         mode entered when a menu is displayed with the 'menu' command
 
-    *user*::
-        mode entered when the user prefix is hit (default: ',')
-
-    *goto*::
-        mode entered when the goto key is hit (default: 'g')
-
-    *view*::
-        mode entered when the view key is hit (default: 'v')
+    *normal*::
+        normal mode
 
     *object*::
         mode entered when an object selection is triggered (e.g. '<a-i>')
+
+    *prompt*::
+        prompts, such as when entering a command through *:*, or a regex through */*
+
+    *user*::
+        mode entered when the user prefix is hit (default: ',')
+
+    *view*::
+        mode entered when the view key is hit (default: 'v')
 
 The context of execution of the above modes is always the current one at the
 time of execution of the mapping, except for *user* mode (always executed

--- a/doc/pages/mapping.asciidoc
+++ b/doc/pages/mapping.asciidoc
@@ -87,11 +87,11 @@ be used:
     Keys can also be wrapped in angle-brackets for consistency
     with the non-alphabetic keys below.
 
-*<c-x>*::
-    Holding down Control while pressing the *x* key.
-
 *<a-x>*::
     Holding down Alt while pressing the *x* key.
+
+*<c-x>*::
+    Holding down Control while pressing the *x* key.
 
 *<s-x>*, *X*, *<X>*, *<s-X>*::
     Holding down Shift while pressing the *x* key.
@@ -103,6 +103,21 @@ be used:
 
 *<c-a-x>*::
     Holding down Control and Alt while pressing the *x* key.
+
+*<backspace>*::
+    The Backspace (delete to the left) key.
+
+*<del>*::
+    The Delete (to the right) key.
+
+*<esc>*::
+    The Escape key.
+
+*<F1>*, *<F2>*, ...*<F12>*::
+    Function keys.
+
+*<ins>*::
+    The Insert key.
 
 *<lt>*, *<gt>*::
     The *<* and *>* characters.
@@ -119,24 +134,9 @@ be used:
 *<tab>*::
     The Tab key.
 
-*<backspace>*::
-    The Backspace (delete to the left) key.
-
-*<del>*::
-    The Delete (to the right) key.
-
-*<esc>*::
-    The Escape key.
-
 *<up>*, *<down>*, *<left>*, *<right>*::
 *<pageup>*, *<pagedown>*, *<home>*, *<end>*::
     The usual cursor-movement keys.
-
-*<ins>*::
-    The Insert key.
-
-*<F1>*, *<F2>*, ...*<F12>*::
-    Function keys.
 
 NOTE: Although Kakoune allows many key combinations to be mapped, not every
 possible combination can be triggered. For example, due to limitations in

--- a/doc/pages/modes.asciidoc
+++ b/doc/pages/modes.asciidoc
@@ -22,16 +22,13 @@ To customize key mappings in various modes, refer to <<mapping#,`:doc mapping`>>
 
 == Builtin modes
 
-=== Normal mode
+=== Goto mode
 
-Normal mode is the default mode. It provides commands to manipulate
-selections, such as general movement, text object selection, searching,
-splitting, and commands to manipulate the text underlying the current
-selections, such as yanking, pasting, deleting…
+Goto mode provides commands dedicated to jumping either inside a buffer
+(such as jumping to buffer start/end, window top/bottom) or to another
+(such as jumping to the file whose path is currently selected).
 
-It also provides commands to enter other modes.
-
-See normal commands <<keys#movement,`:doc keys movement`>>.
+See goto commands <<keys#goto-commands,`:doc keys goto-commands`>>.
 
 === Insert mode
 
@@ -52,25 +49,28 @@ Normal mode for a single command, before returning to Insert mode.
 
 See insert commands <<keys#insert-mode,`:doc keys insert-mode`>>.
 
-=== Goto mode
-
-Goto mode provides commands dedicated to jumping either inside a buffer
-(such as jumping to buffer start/end, window top/bottom) or to another
-(such as jumping to the file whose path is currently selected).
-
-See goto commands <<keys#goto-commands,`:doc keys goto-commands`>>.
-
-=== View mode
-
-View mode provides commands dedicated to controlling the window, such
-as scrolling or centering the main selection cursor.
-
-See view commands <<keys#view-commands,`:doc keys view-commands`>>.
-
 === Menu mode
 
 Menu mode is entered when a menu is displayed with the `menu` command.
 Mappings are used to filter and select intended items.
+
+=== Normal mode
+
+Normal mode is the default mode. It provides commands to manipulate
+selections, such as general movement, text object selection, searching,
+splitting, and commands to manipulate the text underlying the current
+selections, such as yanking, pasting, deleting…
+
+It also provides commands to enter other modes.
+
+See normal commands <<keys#movement,`:doc keys movement`>>.
+
+=== Object mode
+
+Mode entered with `<a-i>`, `<a-a>` and various combinations of `[]{}` keys.
+It aims at crafting semantic selections, often called *text-objects*.
+
+See object commands <<keys#object-commands,`:doc keys object-commands`>>.
 
 === Prompt mode
 
@@ -80,18 +80,18 @@ line of text is edited and then validated with `<ret>` or abandoned with
 
 See prompt commands <<keys#prompt-commands,`:doc keys prompt-commands`>>.
 
-=== Object mode
-
-Mode entered with `<a-i>`, `<a-a>` and various combinations of `[]{}` keys.
-It aims at crafting semantic selections, often called *text-objects*.
-
-See object commands <<keys#object-commands,`:doc keys object-commands`>>.
-
 === User mode
 
 Mode entered with `,` (comma key). The user mode is empty by default and is
 the opportunity to store custom mappings with no risk to shadow builtin ones.
 The context of execution is always the Normal mode.
+
+=== View mode
+
+View mode provides commands dedicated to controlling the window, such
+as scrolling or centering the main selection cursor.
+
+See view commands <<keys#view-commands,`:doc keys view-commands`>>.
 
 == User modes
 

--- a/doc/pages/modes.asciidoc
+++ b/doc/pages/modes.asciidoc
@@ -22,6 +22,13 @@ To customize key mappings in various modes, refer to <<mapping#,`:doc mapping`>>
 
 == Builtin modes
 
+The default mode of operation under which all primitives (see
+<<keys#,`:doc keys`>>) are triggered is the
+<<normal mode,`:doc modes normal-mode`>>.
+
+Writing text into the current buffer is achieved by entering
+<<insert mode,`:doc modes insert-mode`>>.
+
 === Goto mode
 
 Goto mode provides commands dedicated to jumping either inside a buffer

--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -180,71 +180,26 @@ are exclusively available to built-in options.
 
 == Builtin options
 
-*tabstop* `int`::
-    _default_ 8 +
-    width of a tab character
-
-*indentwidth* `int`::
-    _default_ 4 +
-    width (in spaces) used for indentation, 0 means a tab character
-
-*scrolloff* `coord`::
-    _default_ 0,0 +
-    number of lines, columns to keep visible around the cursor when
-    scrolling
-
-*eolformat* `enum(lf|crlf)`::
-    _default_ lf +
-    the format of end of lines when writing a buffer, this is autodetected
-    on load; values of this option assigned to the `window` scope are
-    ignored
-
-*BOM* `enum(none|utf8)`::
-    _default_ none +
-    define if the file should be written with a unicode byte order mark;
-    values of this option assigned to the `window` scope are ignored
-
-*readonly* `bool`::
-    _default_ false +
-    prevent modifications from being saved to disk, all buffers if set
-    to `true` in the `global` scope, or current buffer if set in the
-    `buffer` scope; values of this option assigned to the `window`
-    scope are ignored
-
-*incsearch* `bool`::
-    _default_ true +
-    execute search as it is typed
-
 *aligntab* `bool`::
     _default_ false +
     use tabs for alignment command
-
-*autoinfo* `flags(command|onkey|normal)`::
-    _default_ command|onkey +
-    display automatic information box in the enabled contexts
 
 *autocomplete* `flags(insert|prompt)`::
     _default_ insert|prompt +
     automatically display possible completions in the enabled modes.
 
-*ignored_files* `regex`::
-    filenames matching this regex won't be considered as candidates
-    on filename completion (except if the text being completed already
-    matches it)
+*autoinfo* `flags(command|onkey|normal)`::
+    _default_ command|onkey +
+    display automatic information box in the enabled contexts
 
-*disabled_hooks* `regex`::
-    hooks whose group matches this regex won't be executed. For example
-    indentation hooks can be disabled with `.*-indent`.
-    (See <<hooks#disabling-hooks,`:doc hooks`>>)
+*autoreload* `enum(yes|no|ask)`::
+    _default_ ask +
+    auto reload the buffers when an external modification is detected
 
-*filetype* `str`::
-    arbitrary string defining the type of the file. Filetype dependent
-    actions should hook on this option changing for activation/deactivation
-
-*path* `str-list`::
-    _default_ ./ %/ /usr/include +
-    directories to search for *gf* command and filenames completion
-    `%/` represents the current buffer directory
+*BOM* `enum(none|utf8)`::
+    _default_ none +
+    define if the file should be written with a unicode byte order mark;
+    values of this option assigned to the `window` scope are ignored
 
 *completers* `completer-list`::
     _default_ filename word=all +
@@ -267,43 +222,56 @@ are exclusively available to built-in options.
         where *opt-name* is an option of type 'completions' whose
         contents will be used
 
-*static_words* `str-list`::
-    list of words that are always added to completion candidates
-    when completing words in insert mode
+*debug* `flags(hooks|shell|profile|keys|commands)`::
+    dump various debug information in the '\*debug*' buffer
+
+*disabled_hooks* `regex`::
+    hooks whose group matches this regex won't be executed. For example
+    indentation hooks can be disabled with `.*-indent`.
+    (See <<hooks#disabling-hooks,`:doc hooks`>>)
+
+*eolformat* `enum(lf|crlf)`::
+    _default_ lf +
+    the format of end of lines when writing a buffer, this is autodetected
+    on load; values of this option assigned to the `window` scope are
+    ignored
 
 *extra_word_chars* `codepoint-list`::
     a list of all additional codepoints that should be considered
     as word character. This must be set on the buffer, not the window,
     for word completion to offer words containing these codepoints.
 
-*matching_pairs* `codepoint-list`::
-    _default_ ( ) { } [ ] < > +
-    a list of codepoints that are to be treated as matching pairs
-    for the *m* command.
+*filetype* `str`::
+    arbitrary string defining the type of the file. Filetype dependent
+    actions should hook on this option changing for activation/deactivation
 
-*autoreload* `enum(yes|no|ask)`::
-    _default_ ask +
-    auto reload the buffers when an external modification is detected
-
-*writemethod* `enum(overwrite|replace)`::
-    _default_ overwrite +
-    method used to write buffers to file, `overwrite` will open the
-    existing file and write on top of the previous data, `replace`
-    will open a temporary file next to the target file, write it and
-    then rename it to the target file.
-
-*debug* `flags(hooks|shell|profile|keys|commands)`::
-    dump various debug information in the '\*debug*' buffer
+*fs_check_timeout* `int`::
+    _default_ 500 +
+    timeout, in milliseconds, between checks in normal mode of modifications
+    of the file associated with the current buffer on the filesystem.
 
 *idle_timeout* `int`::
     _default_ 50 +
     timeout, in milliseconds, with no user input that will trigger the
     *PromptIdle*, *InsertIdle* and *NormalIdle* hooks, and autocompletion.
 
-*fs_check_timeout* `int`::
-    _default_ 500 +
-    timeout, in milliseconds, between checks in normal mode of modifications
-    of the file associated with the current buffer on the filesystem.
+*ignored_files* `regex`::
+    filenames matching this regex won't be considered as candidates
+    on filename completion (except if the text being completed already
+    matches it)
+
+*incsearch* `bool`::
+    _default_ true +
+    execute search as it is typed
+
+*indentwidth* `int`::
+    _default_ 4 +
+    width (in spaces) used for indentation, 0 means a tab character
+
+*matching_pairs* `codepoint-list`::
+    _default_ ( ) { } [ ] < > +
+    a list of codepoints that are to be treated as matching pairs
+    for the *m* command.
 
 *modelinefmt* `string`::
     A format string used to generate the mode line, that string is
@@ -322,6 +290,38 @@ are exclusively available to built-in options.
             in face Information.
 
     The default value is '%val{bufname} %val{cursor_line}:%val{cursor_char_column} {{context_info}} {{mode_info}} - %val{client}@[%val{session}]'
+
+*path* `str-list`::
+    _default_ ./ %/ /usr/include +
+    directories to search for *gf* command and filenames completion
+    `%/` represents the current buffer directory
+
+*readonly* `bool`::
+    _default_ false +
+    prevent modifications from being saved to disk, all buffers if set
+    to `true` in the `global` scope, or current buffer if set in the
+    `buffer` scope; values of this option assigned to the `window`
+    scope are ignored
+
+*scrolloff* `coord`::
+    _default_ 0,0 +
+    number of lines, columns to keep visible around the cursor when
+    scrolling
+
+[[startup-info]]
+*startup_info_version* `int`::
+    _default_ 0 +
+    Controls which messages will be displayed in the startup info box, only messages
+    relating to a Kakoune version greater than this value will be displayed. Versions
+    are written as a single number: Like `20180413` for version `2018.04.13`
+
+*static_words* `str-list`::
+    list of words that are always added to completion candidates
+    when completing words in insert mode
+
+*tabstop* `int`::
+    _default_ 8 +
+    width of a tab character
 
 *ui_options* `str-to-str-map`::
     a list of `key=value` pairs that are forwarded to the user
@@ -353,12 +353,12 @@ are exclusively available to built-in options.
             Function key from which shifted function key start, if the
             terminal sends F13 for <s-F1>, this should be set to 12.
 
-[[startup-info]]
-*startup_info_version* `int`::
-    _default_ 0 +
-    Controls which messages will be displayed in the startup info box, only messages
-    relating to a Kakoune version greater than this value will be displayed. Versions
-    are written as a single number: Like `20180413` for version `2018.04.13`
+*writemethod* `enum(overwrite|replace)`::
+    _default_ overwrite +
+    method used to write buffers to file, `overwrite` will open the
+    existing file and write on top of the previous data, `replace`
+    will open a temporary file next to the target file, write it and
+    then rename it to the target file.
 
 == Current values
 

--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -63,34 +63,58 @@ text and their set of valid values.
 Some types are usable for user defined options while some other types
 are exclusively available to built-in options.
 
+*bool*::
+    a boolean value, yes/true or no/false
+
+*completions*::
+    a list of `<text>|<select cmd>|<menu text>` candidates,
+    except for the first element which follows the
+    `<line>.<column>[+<length>]@<timestamp>` format to define where the
+    completion apply in the buffer.
+
+    Select commands are arbitrary Kakoune commands that will be executed
+    each time the element is selected in the menu. The common use case is
+    to display element specific documentation.
+
+    Markup can be used in the menu text.
+    (see <<faces#markup-strings,`:doc faces markup-strings`>>)
+
+    `set -add` adds given completions to the list. +
+    `set -remove` removes given completions from the list. +
+
+*coord*::
+    a line, column pair (separated by a comma)
+    Cannot be used with `declare-option`
+
+*enum(value1|value2|...)*::
+    an enum, taking one of the given values
+    Cannot be used with `declare-option`
+
+*flags(value1|value2|...)*::
+    a set of flags, taking a combination of the given values joined by a
+    '|' character.
+
+    `set -add` adds the given flags to the combination. +
+    `set -remove` removes the given flags to the combination. +
+
+    Cannot be used with `declare-option`
+
 *int*::
     an integer number.
 
     `set -add` performs a math addition. +
     `set -remove` performs a math substraction. +
 
-*bool*::
-    a boolean value, yes/true or no/false
+*line-specs*::
+    a list of a line number and a corresponding flag (`<line>|<flag
+    text>`), except for the first element which is just the timestamp
+    of the buffer. When `update-option` is used on an option of this
+    type, its lines get updated according to all the buffer modifications
+    that happened since its timestamp.
+    See <<highlighters#specs-highlighters,`:doc highlighters specs-highlighters`>>)
 
-*str*::
-    a string, some freeform text
-
-*regex*::
-    as a string but the set commands will complain if the entered text
-    is not a valid regex
-
-*coord*::
-    a line, column pair (separated by a comma)
-    Cannot be used with `declare-option`
-
-*<type>-list*::
-    a list, elements are specified as separate arguments to the command.
-
-    `set -add` appends the new element to the list. +
-    `set -remove` removes each given element from the list. +
-
-    Only `int-list` and `str-list` options can be created with
-    `declare-option`.
+    `set -add` appends the new specs to the list. +
+    `set -remove` removes the given specs from the list. +
 
 *range-specs*::
     a timestamp (like `%val{timestamp}`,
@@ -127,45 +151,21 @@ are exclusively available to built-in options.
 
     See <<highlighters#specs-highlighters,`:doc highlighters specs-highlighters`>>)
 
-*line-specs*::
-    a list of a line number and a corresponding flag (`<line>|<flag
-    text>`), except for the first element which is just the timestamp
-    of the buffer. When `update-option` is used on an option of this
-    type, its lines get updated according to all the buffer modifications
-    that happened since its timestamp.
-    See <<highlighters#specs-highlighters,`:doc highlighters specs-highlighters`>>)
+*regex*::
+    as a string but the set commands will complain if the entered text
+    is not a valid regex
 
-    `set -add` appends the new specs to the list. +
-    `set -remove` removes the given specs from the list. +
+*str*::
+    a string, some freeform text
 
-*completions*::
-    a list of `<text>|<select cmd>|<menu text>` candidates,
-    except for the first element which follows the
-    `<line>.<column>[+<length>]@<timestamp>` format to define where the
-    completion apply in the buffer.
+*<type>-list*::
+    a list, elements are specified as separate arguments to the command.
 
-    Select commands are arbitrary Kakoune commands that will be executed
-    each time the element is selected in the menu. The common use case is
-    to display element specific documentation.
+    `set -add` appends the new element to the list. +
+    `set -remove` removes each given element from the list. +
 
-    Markup can be used in the menu text.
-    (see <<faces#markup-strings,`:doc faces markup-strings`>>)
-
-    `set -add` adds given completions to the list. +
-    `set -remove` removes given completions from the list. +
-
-*enum(value1|value2|...)*::
-    an enum, taking one of the given values
-    Cannot be used with `declare-option`
-
-*flags(value1|value2|...)*::
-    a set of flags, taking a combination of the given values joined by a
-    '|' character.
-
-    `set -add` adds the given flags to the combination. +
-    `set -remove` removes the given flags to the combination. +
-
-    Cannot be used with `declare-option`
+    Only `int-list` and `str-list` options can be created with
+    `declare-option`.
 
 *<type>-to-<type>-map*::
     a list of `key=value` pairs.

--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -206,10 +206,6 @@ are exclusively available to built-in options.
     completion engines to use for insert mode completion (they are tried
     in order until one generates candidates). Existing completers are:
 
-    *word=all*, *word=buffer*:::
-        which complete using words in all buffers (*word=all*)
-        or only the current one (*word=buffer*)
-
     *filename*:::
         which tries to detect when a filename is being entered and
         provides completion based on local filesystem
@@ -221,6 +217,10 @@ are exclusively available to built-in options.
     *option=<opt-name>*:::
         where *opt-name* is an option of type 'completions' whose
         contents will be used
+
+    *word=all*, *word=buffer*:::
+        which complete using words in all buffers (*word=all*)
+        or only the current one (*word=buffer*)
 
 *debug* `flags(hooks|shell|profile|keys|commands)`::
     dump various debug information in the '\*debug*' buffer
@@ -327,31 +327,31 @@ are exclusively available to built-in options.
     a list of `key=value` pairs that are forwarded to the user
     interface implementation. The NCurses UI support the following options:
 
-        *ncurses_set_title*:::
-            if *yes* or *true*, the terminal emulator title will
-            be changed
-
-        *ncurses_status_on_top*:::
-            if *yes*, or *true* the status line will be placed
-            at the top of the terminal rather than at the bottom
-
         *ncurses_assistant*:::
             specify the nice assistant displayed in info boxes,
             can be *clippy* (the default), *cat*, *dilbert* or *none*
-
-        *ncurses_enable_mouse*:::
-            boolean option that enables mouse support
 
         *ncurses_change_colors*:::
             boolean option that can disable color palette changing if the
             terminfo enables it but the terminal does not support it.
 
-        *ncurses_wheel_down_button*, *ncurses_wheel_up_button*:::
-            specify which button send for wheel down/up events
+        *ncurses_enable_mouse*:::
+            boolean option that enables mouse support
+
+        *ncurses_set_title*:::
+            if *yes* or *true*, the terminal emulator title will
+            be changed
 
         *ncurses_shift_function_key*:::
             Function key from which shifted function key start, if the
             terminal sends F13 for <s-F1>, this should be set to 12.
+
+        *ncurses_status_on_top*:::
+            if *yes*, or *true* the status line will be placed
+            at the top of the terminal rather than at the bottom
+
+        *ncurses_wheel_down_button*, *ncurses_wheel_up_button*:::
+            specify which button send for wheel down/up events
 
 *writemethod* `enum(overwrite|replace)`::
     _default_ overwrite +

--- a/doc/pages/registers.asciidoc
+++ b/doc/pages/registers.asciidoc
@@ -25,17 +25,6 @@ in contexts where only alphanumeric identifiers are possible.
 
 All normal-mode commands using a register default to a specific one if not specified:
 
-*"* (dquote)::
-    default delete / copy / paste / replace register, used by:
-    *c*, *d*, *y*, *p*, *<a-p>*, *<P>*, *<a-P>*, *R* and *<a-R>*
-    (see <<keys#changes, `:doc keys changes`>>)
-
-*/* (slash)::
-    default search / regex register, used by:
-    */*, *<a-/>*, *?*, *<a-?>*, *n*, *<a-n>*, *N*, *<a-N>*, ***, *<a-*>*,
-    *s*, *S*, *<a-k>* and *<a-K>*
-    (see <<keys#searching, `:doc keys searching`>>)
-
 *@* (arobase)::
     default macro register, used by:
     *q* and *Q*
@@ -47,18 +36,29 @@ All normal-mode commands using a register default to a specific one if not speci
     (see <<keys#marks, `:doc keys marks`>>
     and <<registers#marks, `:doc registers marks`>>)
 
+*"* (dquote)::
+    default delete / copy / paste / replace register, used by:
+    *c*, *d*, *y*, *p*, *<a-p>*, *<P>*, *<a-P>*, *R* and *<a-R>*
+    (see <<keys#changes, `:doc keys changes`>>)
+
 *|* (pipe)::
     default shell command register, used by commands that spawn a subshell:
     *|*, *<a-|>*, *!* and *<a-!>*
     (see <<keys#changes-through-external-programs, `:doc keys changes-through-external-programs`>>)
+
+*/* (slash)::
+    default search / regex register, used by:
+    */*, *<a-/>*, *?*, *<a-?>*, *n*, *<a-n>*, *N*, *<a-N>*, ***, *<a-*>*,
+    *s*, *S*, *<a-k>* and *<a-K>*
+    (see <<keys#searching, `:doc keys searching`>>)
 
 == Special registers
 
 Some registers are not general purposes, they cannot be written to, but they
 contain some special data
 
-*%* (percent)::
-    current buffer name
+*:* (colon)::
+    last entered command
 
 *.* (dot)::
     current selection contents
@@ -66,11 +66,11 @@ contain some special data
 *#* (hash)::
     selection indices (first selection has 1, second has 2, ...)
 
+*%* (percent)::
+    current buffer name
+
 *_* (underscore)::
     null register, always empty
-
-*:* (colon)::
-    last entered command
 
 == Integer registers
 


### PR DESCRIPTION
Back when those documentation pages were written, names (options, faces, hooks, key names, flags…) were sorted alphabetically first, and then by functionality. It worked fine to have, for example, `NormalIdle` close to `InsertIdle` at the top of the list, because the two modes are the most well known, and beneath them all related information was unrolled.

As time went by, more names came to be documented, and those lists more or less became append-only.

It's reasonably easy to find your way around them when one knows a priori how they are sorted, but confusing to a newcomer leveraging the ubiquitous prefix notation (`Normal*` hooks, `Menu*` faces etc.) or expecting names to be sorted alphabetically (option names).

So despite being well-intentioned originally, the double sorting has become counter productive, especially when names are mindlessly appended to them. This PR sorts all names alphabetically, which should help with the “organisation” complaints that bubbled up in the latest survey.

The keys page was not modified, but I think it'd be worth it to sort as well (somehow), if this PR gets merged.

Related to #3940