### PR TITLE
rc scheme: Fix an Awk error

### DIFF
--- a/rc/filetype/scheme.kak
+++ b/rc/filetype/scheme.kak
@@ -162,7 +162,7 @@ evaluate-commands %sh{ exec awk -f - <<'EOF'
         # unprefixed decimals
         add_highlighter("(?<![" normal_identifiers "])(\\d+(\\.\\d*)?|\\.\\d+)(?:[esfdlESFDL][-+]?\\d+)?(?![" normal_identifiers "])", "0:value");
         # inf and nan
-        add_highlighter("(?<![" normal_identifiers "])[+-](?:inf|nan)\.0(?![" normal_identifiers "])", "0:value");
+        add_highlighter("(?<![" normal_identifiers "])[+-](?:inf|nan)\\.0(?![" normal_identifiers "])", "0:value");
     }
 EOF
 }


### PR DESCRIPTION
This commit prevents Awk from printing the following error:

```
awk: -:106: warning: escape sequence `\.' treated as plain `.'
```