### PR TITLE
rc kitty: Correctly detect the terminal emulator

### DIFF
--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -5,7 +5,7 @@ provide-module kitty %{
 
 # ensure that we're running on kitty
 evaluate-commands %sh{
-    [ -z "${kak_opt_windowing_modules}" ] || [ "$TERM" = "xterm-kitty" ] || echo 'fail Kitty not detected'
+    [ -z "${kak_opt_windowing_modules}" ] || [ "$TERMINAL" = "kitty" ] || echo 'fail Kitty not detected'
 }
 
 declare-option -docstring %{window type that kitty creates on new and repl calls (kitty|os)} str kitty_window_type kitty


### PR DESCRIPTION
This commit checks the (non-standard) `$TERMINAL` environment variable, which Kitty sets to `kitty`.

Using `$TERM` as heuristic is not reliable, for example in the case when a multiplexer (Tmux) runs within Kitty and overrides this variable.