### PR TITLE
src: Catch “kill exceptions”’cleanly

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -792,21 +792,27 @@ int run_server(StringView session, StringView server_init,
                                      "    {}", error.what()));
     }
 
+    {
+        Context empty_context{Context::EmptyContextFlag{}};
+        global_scope.hooks().run_hook(Hook::KakBegin, session, empty_context);
+    }
+
     if (not server_init.empty()) try
     {
         Context init_context{Context::EmptyContextFlag{}};
         command_manager.execute(server_init, init_context);
+    }
+    catch (const kill_session& kill)
+    {
+        Context empty_context{Context::EmptyContextFlag{}};
+        global_scope.hooks().run_hook(Hook::KakEnd, "", empty_context);
+        return kill.exit_status;
     }
     catch (runtime_error& error)
     {
         startup_error = true;
         write_to_debug_buffer(format("error while running server init commands:\n"
                                      "    {}", error.what()));
-    }
-
-    {
-        Context empty_context{Context::EmptyContextFlag{}};
-        global_scope.hooks().run_hook(Hook::KakBegin, session, empty_context);
     }
 
     if (not files.empty()) try


### PR DESCRIPTION
When the `kill` command is called in the `-E` CLI flag, the resulting
exception is not caught and crashes the server.

This commit allows the server to terminate cleanly.

Since `KakEnd` hooks also need to be executed should the user run a
command like `kak -E 'kill 0'`, the execution of `KakBegin` hooks is
now performed *before* the command provided in `-E` is executed. The
documentation for `KakBegin` (executed after the `-E` command prior to
this commit) consequently becomes more truthful, as it states:

	KakBegin session name
		kakoune has started, this hook is called just after
		reading the user configuration files

Fixes #3972