### PR TITLE
commands: add "registers" subcommand to :debug 

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1392,7 +1392,7 @@ const CommandDesc debug_cmd = {
         [](const Context& context, CompletionFlags flags,
            const String& prefix, ByteCount cursor_pos) -> Completions {
                auto c = {"info", "buffers", "options", "memory", "shared-strings",
-                         "profile-hash-maps", "faces", "mappings", "regex"};
+                         "profile-hash-maps", "faces", "mappings", "regex", "registers"};
                return { 0_byte, cursor_pos, complete(prefix, cursor_pos, c) };
     }),
     [](const ParametersParser& parser, Context& context, const ShellContext&)
@@ -1484,6 +1484,20 @@ const CommandDesc debug_cmd = {
 
             write_to_debug_buffer(format(" * {}:\n{}",
                                   parser[1], dump_regex(compile_regex(parser[1], RegexCompileFlags::Optimize))));
+        }
+        else if (parser[0] == "registers")
+        {
+            write_to_debug_buffer("Register info:");
+            for (auto&& [name, reg] : RegisterManager::instance())
+            {
+                auto content = reg->get(context);
+
+                if (content.size() == 1 and content[0] == "")
+                    continue;
+
+                write_to_debug_buffer(format(" * {} = {}\n", name,
+                    join(content | transform(quote), "\n     = ")));
+            }
         }
         else
             throw runtime_error(format("no such debug command: '{}'", parser[0]));

--- a/src/register_manager.hh
+++ b/src/register_manager.hh
@@ -124,6 +124,9 @@ public:
     void add_register(Codepoint c, std::unique_ptr<Register> reg);
     CandidateList complete_register_name(StringView prefix, ByteCount cursor_pos) const;
 
+    auto begin() const { return m_registers.begin(); }
+    auto end() const { return m_registers.end(); }
+
 protected:
     HashMap<Codepoint, std::unique_ptr<Register>, MemoryDomain::Registers> m_registers;
 };


### PR DESCRIPTION
This prints all non-empty registers and their value(s) to the `*debug*`
buffer.

---

This is definitely not the prettiest code I've ever written. It's been a while since I've written C++, as well, so please point out any unidiomatic / otherwise bad code so I can fix it!

~~My main dissatisfaction with this implementation is how the registers are hardcoded. I was thinking I could iterate through all registers through the `m_registers` HashMap, but that is protected and I can't access it directly. Suggestions greatly appreciated.~~

cc @lenormf for putting me up to this ;)

Closes https://github.com/mawww/kakoune/issues/3978.

---

![image](https://user-images.githubusercontent.com/28582702/102983895-9a1e8380-44c1-11eb-9d5a-7b6a27187263.png)
