### PR TITLE
file.kak: Acknowledge mime type application/x-shellscript

### DIFF
--- a/rc/detection/file.kak
+++ b/rc/detection/file.kak
@@ -10,6 +10,7 @@ hook global BufOpenFile .* %{ evaluate-commands %sh{
             text/x-script.*) filetype="${mime#text/x-script.}" ;;
             text/x-*) filetype="${mime#text/x-}" ;;
             text/*)   filetype="${mime#text/}" ;;
+            application/x-shellscript) filetype="sh" ;;
             application/x-*) filetype="${mime#application/x-}" ;;
             application/*) filetype="${mime#application/}" ;;
             *) exit ;;


### PR DESCRIPTION
On OpenBSD, the `file` utility determines the mime type `application/x-shellscript` instead of `text/x-shellscript`. This also [is recommended in the Debian wiki](https://wiki.debian.org/ShellScript).