### PR TITLE
Remove non-POSIX -r from ln in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -172,7 +172,7 @@ installdirs:
 
 install: kak man installdirs
 	install -m 0755 kak $(bindir)
-	ln -rsf $(bindir)/kak $(libexecdir)/kak
+	ln -sf $(bindir)/kak $(libexecdir)/kak
 	install -m 0644 ../share/kak/kakrc $(sharedir)
 	install -m 0644 ../doc/pages/*.asciidoc $(sharedir)/doc
 	cp -r ../rc/* $(sharedir)/rc


### PR DESCRIPTION
`-r` is not mentioned in [the POSIX standard](https://pubs.opengroup.org/onlinepubs/009695399/utilities/ln.html) and does lead to an error with OpenBSD's `ln`.

I'm not yet really sure what `-r` does, so feel free to correct me here.