### PR TITLE
tmux-focus: Add support for focusing a client on another window.

### DIFF
--- a/rc/windowing/tmux.kak
+++ b/rc/windowing/tmux.kak
@@ -55,7 +55,10 @@ If no client is passed then the current one is used' \
         if [ $# -eq 1 ]; then
             printf "evaluate-commands -client '%s' focus" "$1"
         elif [ -n "${kak_client_env_TMUX}" ]; then
-            TMUX="${kak_client_env_TMUX}" tmux select-pane -t "${kak_client_env_TMUX_PANE}" > /dev/null
+            # select-pane makes the pane active in the window, but does not select the window. Both select-pane
+            # and select-window should be invoked in order to select a pane on a currently not focused window.
+            TMUX="${kak_client_env_TMUX}" tmux select-window -t "${kak_client_env_TMUX_PANE}" \; \
+                                               select-pane   -t "${kak_client_env_TMUX_PANE}" > /dev/null
         fi
     }
 }


### PR DESCRIPTION
Hi,

I found that `focus` command is not working with `alias global terminal tmux-terminal-window`. That's because `tmux select-pane` just makes the target pane active on its window, but does not select the window.

This patch fixes it by invoking both `select-pane` and `select-window`. It also works when someone is mixing using split and window at the same time.