### PR TITLE
main: add buffilelist variable

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -201,7 +201,7 @@ The following expansions are supported (with required context _in italics_):
     `%val{bufname}`)
 
 *%val{buffilelist}*::
-    quoted list of the full path of currently-open buffers (as seen in
+    quoted list of the full file paths of currently-open buffers (as seen in
     `%val{buffile}`)
 
 *%val{bufname}*::

--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -200,6 +200,10 @@ The following expansions are supported (with required context _in italics_):
     quoted list of the names of currently-open buffers (as seen in
     `%val{bufname}`)
 
+*%val{buffilelist}*::
+    quoted list of the full path of currently-open buffers (as seen in
+    `%val{buffile}`)
+
 *%val{bufname}*::
     _in buffer, window scope_ +
     name of the current buffer

--- a/src/main.cc
+++ b/src/main.cc
@@ -195,6 +195,10 @@ static const EnvVarDesc builtin_env_vars[] = { {
         [](StringView name, const Context& context) -> Vector<String>
         { return BufferManager::instance() | transform(&Buffer::display_name) | gather<Vector>(); }
     }, {
+        "buffilelist", false,
+        [](StringView name, const Context& context) -> Vector<String>
+        { return BufferManager::instance() | transform(&Buffer::name) | gather<Vector>(); }
+    }, {
         "buf_line_count", false,
         [](StringView name, const Context& context) -> Vector<String>
         { return {to_string(context.buffer().line_count())}; }


### PR DESCRIPTION
This makes it easier to script on the list of buffers, especially when
using $kak_hook_param e.g. in a BufClose hook.

---

This helps with my attempt at scripting alternate buffer functionality (might be a bit over-engineered and / or could be done simpler, but...):

<details>

```kak
## bufhist list for better alternate buffer functionality
declare-option str-list bufhist
declare-option str bufhist_last

define-command -hidden last_buf %{
  evaluate-commands %sh{
    source "$kak_opt_prelude_path"

    # populate the previous buffer
    last="$(printf %s "$kak_opt_bufhist" | perl -pe "s@\\Q$kak_buffile\\E@@g" | tr -s ' ')"
    last="${last%% }"
    last="${last##* }"
    [ -n "$last" ] && [ "${kak_buffilelist#*"$last"}" != "$kak_buffilelist" ] && \
      kak_escape set-option global bufhist_last "$last"

    # if current buffer is the "last" buffer, move it to the beginning of
    # the history list (will be recalculated next time a buffer changes,
    # so this shouldn't change much)
    if [ "$kak_opt_bufhist_last" = "$kak_buffile" ]; then
      file="${kak_opt_bufhist##* }"
      last="$(printf %s "$kak_opt_bufhist" | perl -pe "s@\\Q$file\\E@@g" | tr -s ' ')"
      last="${last%% }"
      last="${last## }"
      last="$file $last"
      kak_escape set-option global bufhist "$last"
    fi
  }
}

define-command -hidden bufhist %{
  evaluate-commands %sh{
    source "$kak_opt_prelude_path"

    # populate the list of buffers
    bufhist="$(printf %s "$kak_opt_bufhist" | perl -pe "s@\\Q$kak_buffile\\E@@g" | tr -s ' ')"
    bufhist="${bufhist%% }"
    bufhist="${bufhist## }"
    bufhist="${bufhist:+$bufhist }$kak_buffile"
    kak_escape set-option global bufhist "$bufhist"
  }
}

hook -always global WinDisplay .* %{
  evaluate-commands %{
    # populate the previous buffer
    last_buf

    # populate the list of buffers
    bufhist
  }

  hook -once -always global BufClose .* %{
    evaluate-commands %sh{
      source "$kak_opt_prelude_path"

      # remove closed buffers
      closed="$kak_hook_param"
      if [ -n "$closed" ]; then
        bufhist="$(printf %s "$kak_opt_bufhist" | perl -pe "s@\\Q$closed\\E@@g" | tr -s ' ')"
        bufhist="${bufhist%% }"
        bufhist="${bufhist## }"
        kak_escape set-option global bufhist "$bufhist"
      fi

      # update last buffer now that a buffer has been removed
      printf "%s\n" last_buf
    }
  }
}
```

</details>