### PR TITLE
Update tmux.kak

### DIFF
--- a/rc/windowing/repl/tmux.kak
+++ b/rc/windowing/repl/tmux.kak
@@ -36,14 +36,14 @@ define-command tmux-repl-window -params 0.. -command-completion -docstring "Crea
 }
 
 define-command -hidden tmux-send-text -params 0..1 -docstring %{
-        tmux-send-text [text]: Send text(append new line) to the REPL pane.
+        tmux-send-text [text]: Send text to the REPL pane.
         If no text is passed, then the selection is used
     } %{
     nop %sh{
         if [ $# -eq 0 ]; then
-            tmux set-buffer -b kak_selection "${kak_selection}"
+            tmux set-buffer -b kak_selection -- "${kak_selection}"
         else
-            tmux set-buffer -b kak_selection "$1"
+            tmux set-buffer -b kak_selection -- "$1"
         fi
         tmux paste-buffer -b kak_selection -t "$kak_opt_tmux_repl_id"
     }


### PR DESCRIPTION
When $1 or ${kak_selection} start with dash, like "-1", the command will fail, because tmux think it's an argument flag.
-- prevent this.
Also the doc (append new line) is no longer valid.