### PR TITLE
Add new libexec directory to SPEC file packaging

### DIFF
--- a/contrib/kakoune.spec
+++ b/contrib/kakoune.spec
@@ -6,7 +6,7 @@
 
 Name:           kakoune
 Version:        2020.09.01
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Code editor heavily inspired by Vim
 
 License:        Unlicense
@@ -80,9 +80,13 @@ popd
 %{_bindir}/kak
 %{_datadir}/kak/
 %{_mandir}/man1/*
+%{_libexecdir}/kak/
 
 
 %changelog
+* Fri Jan 1 2021 Jiri Konecny <jkonecny@redhat.com> - 2020.09.01-2
+- Add new libexec dir to the spec file
+
 * Wed Sep 2 2020 Jiri Konecny <jkonecny@redhat.com> - 2020.09.01-1
 - Update to 2020.09.01
 


### PR DESCRIPTION
Without that the build of RPM file will fail.

-------------------------------
The question is if instead we don't want to remove spec file from here completely. I moved daily builds automation to my fork so I don't need upstream spec file anymore, I will instead keep a copy on my fork. However, I don't have a problem to keep this spec file up-to-date for the community.
Do the upstream want the spec file here or you would rather want to remove it completely? 