### PR TITLE
command_manager: only remove last eol in %sh{} expansions

### DIFF
--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -323,14 +323,9 @@ expand_token(const Token& token, const Context& context, const ShellContext& she
             content, context, {}, ShellManager::Flags::WaitForStdout,
             shell_context).first;
 
-        int trailing_eol_count = 0;
-        for (auto c : str | reverse())
-        {
-            if (c != '\n')
-                break;
-            ++trailing_eol_count;
-        }
-        str.resize(str.length() - trailing_eol_count, 0);
+        if (str.back() == '\n')
+            str.resize(str.length() - 1, 0);
+
         return {str};
     }
     case Token::Type::RegisterExpand:


### PR DESCRIPTION
This makes it possible to keep significant EOL in shell expansions (e.g.
for use with clipboard helpers).

---

Fixes #3988.