### PR TITLE
Support commands in more submodes

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -226,9 +226,9 @@ The following expansions are supported (with required context _in italics_):
     directory containing the user configuration
 
 *%val{count}*::
-    _in `map` command <keys> parameter and `<a-;>` from object menu_ +
-    current count when the mapping was triggered, defaults to 0 if no
-    count given
+    _in `map` command <keys> parameter, `<a-;>` from the object menu, and
+    `<semicolon>` from the goto and view menus_ +
+    current count when the mapping was triggered, defaults to 0 if no count given
 
 *%val{cursor_byte_offset}*::
     _in window scope_ +
@@ -302,7 +302,8 @@ The following expansions are supported (with required context _in italics_):
     beginning, and `to_end` if the user wants to select to the end
 
 *%val{register}*::
-    _in `map` command <keys> parameter and `<a-;>` from the object menu_ +
+    _in `map` command <keys> parameter, `<a-;>` from the object menu, and
+    `<semicolon>` from the goto and view menus_ +
     current register when the mapping was triggered
 
 *%val{runtime}*::
@@ -310,7 +311,8 @@ The following expansions are supported (with required context _in italics_):
     Kakoune's binary location if `$KAKOUNE_RUNTIME` is not set
 
 *%val{select_mode}*::
-    _for commands executed from the object menu's `<a-;>` only_ +
+    _for commands executed from the object menu's `<a-;>` and the goto menu's
+    `<semicolon>` only_ +
     `replace` if the new selection should replace the existing, `extend`
     otherwise
 

--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -451,6 +451,10 @@ Searches use the */* register by default (See <<registers#,`:doc registers`>>)
     *.*:::
         go to last buffer modification position
 
+    *;*, *<semicolon>*:::
+        run a command with additional expansions describing the selection
+        context (See <<expansions#,`:doc expansions`>>)
+
 == View commands
 
 *v*, *V*::
@@ -481,6 +485,10 @@ Searches use the */* register by default (See <<registers#,`:doc registers`>>)
 
     *l*:::
         scroll the window `count` columns right
+
+    *;*, *<semicolon>*:::
+        run a command with additional expansions describing the selection
+        context (See <<expansions#,`:doc expansions`>>)
 
 == Marks
 


### PR DESCRIPTION
Limited to `goto` and `view` modes, but I'm sure it'd be easy to add to other modes. Ref https://github.com/mawww/kakoune/issues/3999#issuecomment-753874219.

Note: `command()` was moved up for it to be usable within `goto_commands()` and `view_commands()`.

I wonder what would be the best binding. I used `;` for now, but `<a-;>` would also work.