### PR TITLE
Markdown: Add HTML and improve URL highlighting

### DIFF
--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -59,9 +59,17 @@ add-highlighter shared/markdown/codeblock region -match-capture \
     ^(\h*)```\h*$ \
     fill meta
 
-add-highlighter shared/markdown/listblock region ^\h*[-*]\s ^\h*((?=[-*])|$) group
-add-highlighter shared/markdown/listblock/ ref markdown/inline
-add-highlighter shared/markdown/listblock/marker regex ^\h*([-*])\s 1:bullet
+add-highlighter shared/markdown/listblock region ^\h*[-*]\s ^\h*((?=[-*])|$) regions
+add-highlighter shared/markdown/listblock/g default-region group
+add-highlighter shared/markdown/listblock/g/ ref markdown/inline
+add-highlighter shared/markdown/listblock/g/marker regex ^\h*([-*])\s 1:bullet
+
+# https://spec.commonmark.org/0.29/#link-destination
+# This repetition is not pretty but shell escaping is worse
+add-highlighter shared/markdown/angle_bracket_url region (?<=<)([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=>)|\n fill link
+add-highlighter shared/markdown/url region -recurse \( ([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=\))|\s fill link
+add-highlighter shared/markdown/listblock/angle_bracket_url region (?<=<)([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=>)|\n fill link
+add-highlighter shared/markdown/listblock/url region -recurse \( ([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=\))|\s fill link
 
 add-highlighter shared/markdown/inline/code region -match-capture (`+) (`+) fill mono
 
@@ -76,8 +84,6 @@ add-highlighter shared/markdown/inline/text/ regex (?<!\*)(\*([^\s*]|([^\s*](\n?
 add-highlighter shared/markdown/inline/text/ regex (?<!_)(_([^\s_]|([^\s_](\n?[^\n_])*[^\s_]))_)(?!_) 1:+i
 add-highlighter shared/markdown/inline/text/ regex (?<!\*)(\*\*([^\s*]|([^\s*](\n?[^\n*])*[^\s*]))\*\*)(?!\*) 1:+b
 add-highlighter shared/markdown/inline/text/ regex (?<!_)(__([^\s_]|([^\s_](\n?[^\n_])*[^\s_]))__)(?!_) 1:+b
-add-highlighter shared/markdown/inline/text/ regex <(([a-z]+://.*?)|((mailto:)?[\w+-]+@[a-z]+[.][a-z]+))> 0:link
-add-highlighter shared/markdown/inline/text/ regex ^\[[^\]\n]*\]:\h*([^\n]*) 1:link
 add-highlighter shared/markdown/inline/text/ regex ^\h*(>\h*)+ 0:comment
 add-highlighter shared/markdown/inline/text/ regex "\H( {2,})$" 1:+r@meta
 

--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -71,6 +71,11 @@ add-highlighter shared/markdown/url region -recurse \( ([a-z]+://|(mailto|magnet
 add-highlighter shared/markdown/listblock/angle_bracket_url region (?<=<)([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=>)|\n fill link
 add-highlighter shared/markdown/listblock/url region -recurse \( ([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=\))|\s fill link
 
+try %{
+    require-module html
+    add-highlighter shared/markdown/tag region (?i)</?[a-z][a-z0-9-]*\s*([a-z_:]|(?=>)) > ref html/tag
+}
+
 add-highlighter shared/markdown/inline/code region -match-capture (`+) (`+) fill mono
 
 # Setext-style header


### PR DESCRIPTION
Closes #3979:
-  Prevent underscores in URLs and HTML tags cause italic highlighting
- Add highlighting for inline links and HTML tags

Relative links (i.e. all links without a URI scheme like `http://` or `mailto:`) are not highlighted—and underscores in them can still cause problems—but the full [CommonMark link spec](https://spec.commonmark.org/0.29/#links) is just too complex.

Before:
<pre>
http://example.org#lorum_<i>ipsum not emphasized</i>_
<a href="http://example.org#lorum ipsum_dolor">&lt;http://example.org#lorum ipsum_<i>dolor></i></a> <i>not emphasized</i>_
&lt;a target="_<i>blank">not emphasized</i>_</a>
[Wikipedia](https://en.wikipedia.org/wiki/Element_<i>(software)) not emphasized</i>_
</pre>

After:
<pre>
<a href="http://example.org#lorum_ipsum">http://example.org#lorum_ipsum</a> not emphasized_
&lt;<a href="http://example.org#lorum ipsum_dolor">http://example.org#lorum ipsum_dolor</a>> not emphasized_
&lt;<b>a</b> target="_blank">not emphasized_</a>
[Wikipedia](<a href="https://en.wikipedia.org/wiki/Element_(software)">https://en.wikipedia.org/wiki/Element_(software)</a>) not emphasized_
</pre>