### PR TITLE
Improve graphql syntax highlighters

### DIFF
--- a/rc/filetype/graphql.kak
+++ b/rc/filetype/graphql.kak
@@ -4,7 +4,7 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*[.](graphql) %{
+hook global BufCreate .*[.](graphqls?) %{
     set-option buffer filetype graphql
 }
 

--- a/rc/filetype/graphql.kak
+++ b/rc/filetype/graphql.kak
@@ -43,7 +43,7 @@ add-highlighter shared/graphql/object region -recurse \{ [{] [}] regions
 add-highlighter shared/graphql/object/line-description region '#' '\n' fill comment
 add-highlighter shared/graphql/object/block-description region '"""' '"""' fill comment
 add-highlighter shared/graphql/object/field default-region group
-add-highlighter shared/graphql/object/field/ regex ([A-Za-z][A-Za-z0-9_-]*)(?:\([\w\d\h,:$=]*\))?\h*[:{] 1:attribute
+add-highlighter shared/graphql/object/field/ regex ([A-Za-z][A-Za-z0-9_-]*)(?:\([\w\d\h,:$=!"_]*\))?\h*[:{] 1:attribute
 add-highlighter shared/graphql/object/field/ regex ^\h*([A-Za-z][A-Za-z0-9_-]*)\h*$ 1:attribute
 
 # Values

--- a/rc/filetype/graphql.kak
+++ b/rc/filetype/graphql.kak
@@ -49,7 +49,8 @@ add-highlighter shared/graphql/object/field/ regex ^\h*([A-Za-z][A-Za-z0-9_-]*)\
 # Values
 add-highlighter shared/graphql/object/field/values regex \b(true|false|null|\d+(?:\.\d+)?(?:[eE][+-]?\d*)?)\b 0:value
 add-highlighter shared/graphql/object/field/variables regex \$[a-zA-Z0-9]+\b 0:variable
-add-highlighter shared/graphql/object/field/string regex '"[^"]*"' 0:string
+# add-highlighter shared/graphql/object/field/string regex '"([^"]|\\")*"' 0:string
+add-highlighter shared/graphql/object/field/string regex '"(?:[^"\\]|\\.)*"' 0:string
 
 # Meta
 add-highlighter shared/graphql/object/field/directives regex @(?:include|skip) 0:meta

--- a/rc/filetype/graphql.kak
+++ b/rc/filetype/graphql.kak
@@ -34,15 +34,39 @@ provide-module graphql %(
 
 add-highlighter shared/graphql regions
 add-highlighter shared/graphql/code default-region group
-add-highlighter shared/graphql/string region '"' (?<!\\)(\\\\)*" fill string
-add-highlighter shared/graphql/comment region '#' \n fill comment
+add-highlighter shared/graphql/line-description region '#' '\n' fill comment
+add-highlighter shared/graphql/block-description region '"""' '"""' fill comment
+add-highlighter shared/graphql/description region '"' '"\s*\n' fill comment
+add-highlighter shared/graphql/object region -recurse \{ [{] [}] regions
 
-add-highlighter shared/graphql/code/ regex \b(fragment|query|mutation|on)\b 0:keyword
-add-highlighter shared/graphql/code/ regex \b(true|false|null|\d+(?:\.\d+)?(?:[eE][+-]?\d*)?)\b 0:value
-add-highlighter shared/graphql/code/ regex \$[a-zA-Z0-9]+\b 0:value
-add-highlighter shared/graphql/code/ regex @(?:include|skip) 0:meta
-add-highlighter shared/graphql/code/ regex \b(Boolean|Float|ID|Int|String)\b 0:type
-add-highlighter shared/graphql/code/ regex ! 0:operator
+# Objects
+add-highlighter shared/graphql/object/line-description region '#' '\n' fill comment
+add-highlighter shared/graphql/object/block-description region '"""' '"""' fill comment
+add-highlighter shared/graphql/object/field default-region group
+add-highlighter shared/graphql/object/field/ regex ([A-Za-z][A-Za-z0-9_-]*)(?:\([\w\d\h,:$=]*\))?\h*[:{] 1:attribute
+add-highlighter shared/graphql/object/field/ regex ^\h*([A-Za-z][A-Za-z0-9_-]*)\h*$ 1:attribute
+
+# Values
+add-highlighter shared/graphql/object/field/values regex \b(true|false|null|\d+(?:\.\d+)?(?:[eE][+-]?\d*)?)\b 0:value
+add-highlighter shared/graphql/object/field/variables regex \$[a-zA-Z0-9]+\b 0:variable
+add-highlighter shared/graphql/object/field/string regex '"[^"]*"' 0:string
+
+# Meta
+add-highlighter shared/graphql/object/field/directives regex @(?:include|skip) 0:meta
+
+# Attributes
+add-highlighter shared/graphql/object/field/required regex '(?<=[\w\]])(?<bang>!)' bang:operator
+add-highlighter shared/graphql/object/field/assignment regex '=' 0:operator
+
+# Keywords
+add-highlighter shared/graphql/code/top-level regex '\bschema\b' 0:keyword
+add-highlighter shared/graphql/code/keywords regex '\b(?<name>enum|fragment|input|implements|interface|mutation|on|query|scalar|subscription|type|union)\h+(?:[A-Za-z]\w*)' name:keyword
+
+# Types
+add-highlighter shared/graphql/object/field/scalars regex \b(Boolean|Float|ID|Int|String)\b 0:type
+
+# Operators
+add-highlighter shared/graphql/object/field/expand-fragment regex '\.\.\.(?=\w)' 0:operator
 
 # Commands
 # ‾‾‾‾‾‾‾‾

--- a/rc/filetype/graphql.kak
+++ b/rc/filetype/graphql.kak
@@ -27,7 +27,7 @@ hook -group graphql-highlight global WinSetOption filetype=graphql %{
 }
 
 
-provide-module graphql %(
+provide-module graphql %§ 
 
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
@@ -43,7 +43,7 @@ add-highlighter shared/graphql/object region -recurse \{ [{] [}] regions
 add-highlighter shared/graphql/object/line-description region '#' '\n' fill comment
 add-highlighter shared/graphql/object/block-description region '"""' '"""' fill comment
 add-highlighter shared/graphql/object/field default-region group
-add-highlighter shared/graphql/object/field/ regex ([A-Za-z][A-Za-z0-9_-]*)(?:\([\w\d\h,:$=!"_]*\))?\h*[:{] 1:attribute
+add-highlighter shared/graphql/object/field/ regex ([A-Za-z][A-Za-z0-9_-]*)(?:\([^)]*\))?\h*[:{] 1:attribute
 add-highlighter shared/graphql/object/field/ regex ^\h*([A-Za-z][A-Za-z0-9_-]*)\h*$ 1:attribute
 
 # Values
@@ -96,4 +96,4 @@ define-command -hidden graphql-indent-on-new-line %<
     >
 >
 
-)
+§ 


### PR DESCRIPTION
Add more advanced highlighters for graphql syntax. There are still some small issues, however I believe this is mostly due to the use of regexps for syntax highlighting.

### Before
![2021-01-13T21:21:20,304983500-05:00](https://user-images.githubusercontent.com/18397/104536413-0fbfd000-55e6-11eb-9a0b-64bd63f0b6fd.png)

### After
![2021-01-13T21:36:36,912971421-05:00](https://user-images.githubusercontent.com/18397/104537229-8f9a6a00-55e7-11eb-8d47-fcde0958f2fa.png)

