### PR TITLE
rc repl x11: Allow send argument for x11-send-text

### DIFF
--- a/rc/windowing/repl/x11.kak
+++ b/rc/windowing/repl/x11.kak
@@ -21,11 +21,16 @@ define-command -docstring %{
     } -- %val{client} %val{session} %arg{@}
 }
 
-define-command x11-send-text -docstring "send the selected text to the repl window" %{
+define-command x11-send-text -params 0..1 -docstring %{
+        x11-send-text [text]: Send text to the REPL window.
+        If no text is passed, then the selection is used
+        } %{
     evaluate-commands %sh{
-        printf %s\\n "${kak_selection}" | xsel -i ||
+        ([ "$#" -gt 0 ] && printf "%s\\n" "$1" || printf "%s\\n" "${kak_selection}" ) | xsel -i ||
         echo 'fail x11-send-text: failed to run xsel, see *debug* buffer for details' &&
-        xdotool windowactivate "${kak_opt_x11_repl_id}" key --clearmodifiers Shift+Insert ||
+        kak_winid=$(xdotool getactivewindow) &&
+        xdotool windowactivate "${kak_opt_x11_repl_id}" key --clearmodifiers Shift+Insert &&
+        xdotool windowactivate "${kak_winid}" ||
         echo 'fail x11-send-text: failed to run xdotool, see *debug* buffer for details'
     }
 }


### PR DESCRIPTION
tmux-send-text allows sending an argument, when supplied the argument
will be sent to the REPL instead of the current selection.

tmux-send-text also keeps kak focussed, which does not happen in the x11
variant as it uses xdotool to switch window.

this patch allows:

 * Passing an argument to x11-send-text, so that value will be sent
 instead of the current selection.
 * We capture the window id of the current (presumably kak window)
 before we use xdotool to switch window. We can therefore switch back to
 kak afterwards (which we do)