### PR TITLE
zig.kak: fix highlighting of empty doc comment

### DIFF
--- a/rc/filetype/zig.kak
+++ b/rc/filetype/zig.kak
@@ -36,7 +36,7 @@ provide-module zig %§
 add-highlighter shared/zig regions
 add-highlighter shared/zig/code default-region group
 
-add-highlighter shared/zig/doc_comment region '///[^/]' '$' fill documentation
+add-highlighter shared/zig/doc_comment region '///(?=[^/])' '$' fill documentation
 add-highlighter shared/zig/comment region '//' '$' fill comment
 
 # strings and characters


### PR DESCRIPTION
If a line contains three slashes directly followed by a new line, the
next line is also erroneously highlighted as a doc comment currently.
Using a lookahead instead fixes this.