### PR TITLE
rc spell: Remove `:spell-replace` default value

### DIFF
--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -148,7 +148,6 @@ define-command \
     -docstring "Suggest replacement words for the current selection, against the last language used by the spell-check command" \
     spell-replace %{
     prompt \
-        -init %val{selection} \
         -shell-script-candidates %{
             options=""
             if [ -n "$kak_opt_spell_last_lang" ]; then


### PR DESCRIPTION
This commit removes the default prompt value from the `spell-replace`
command.

Currently, running the command after selecting a misspelled word
might not allow the editor to propose alternative spellings because
it completes upon whatever is inserted into the prompt. If the words
returned by `aspell` are too different from the currently misspelled
word, no candidates are shown.

For example, selecting “unanymously” and running `:spell-replace`
will not show any candidates under the current implementation (the
‘y’ probably trips the fuzzy-matcher).

The user develops a habit of clearing the prompt every time, because
that's the only way to make sure all suggestions from `aspell` are
visible, so the editor might as well not have any default value for
`:spell-replace`.