### PR TITLE
Respect KITTY_LISTEN_ON when launching terminal

### DIFF
--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -15,7 +15,7 @@ kitty-terminal <program> [<arguments>]: create a new terminal as a kitty window
 The program passed as argument will be executed in the new terminal' \
 %{
     nop %sh{
-        if [[ -z ${kak_client_env_KITTY_LISTEN_ON:-} ]]; then
+        if [ -z "$kak_client_env_KITTY_LISTEN_ON" ]; then
             kitty @ new-window --no-response --window-type "$kak_opt_kitty_window_type" --cwd "$PWD" "$@"
         else
             kitty @ --to "$kak_client_env_KITTY_LISTEN_ON" new-window --no-response --window-type "$kak_opt_kitty_window_type" --cwd "$PWD" "$@"

--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -15,7 +15,11 @@ kitty-terminal <program> [<arguments>]: create a new terminal as a kitty window
 The program passed as argument will be executed in the new terminal' \
 %{
     nop %sh{
-        kitty @ new-window --no-response --window-type $kak_opt_kitty_window_type --cwd "$PWD" "$@"
+        if [[ -z ${kak_client_env_KITTY_LISTEN_ON:-} ]]; then
+            kitty @ new-window --no-response --window-type "$kak_opt_kitty_window_type" --cwd "$PWD" "$@"
+        else
+            kitty @ --to "$kak_client_env_KITTY_LISTEN_ON" new-window --no-response --window-type "$kak_opt_kitty_window_type" --cwd "$PWD" "$@"
+        fi
     }
 }
 

--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -28,7 +28,11 @@ kitty-terminal-tab <program> [<arguments>]: create a new terminal as kitty tab
 The program passed as argument will be executed in the new terminal' \
 %{
     nop %sh{
-        kitty @ new-window --no-response --new-tab --cwd "$PWD" "$@"
+        if [ -z "$kak_client_env_KITTY_LISTEN_ON" ]; then
+            kitty @ new-window --no-response --new-tab --cwd "$PWD" "$@"
+        else
+            kitty @ --to "$kak_client_env_KITTY_LISTEN_ON" new-window --no-response --new-tab --cwd "$PWD" "$@"
+        fi
     }
 }
 
@@ -40,8 +44,13 @@ If no client is passed then the current one is used' \
         if [ $# -eq 1 ]; then
             printf "evaluate-commands -client '%s' focus" "$1"
         else
-            kitty @ focus-tab --no-response -m=id:$kak_client_env_KITTY_WINDOW_ID
-            kitty @ focus-window --no-response -m=id:$kak_client_env_KITTY_WINDOW_ID
+            if [ -z "$kak_client_env_KITTY_LISTEN_ON" ]; then
+                kitty @ focus-tab --no-response -m=id:$kak_client_env_KITTY_WINDOW_ID
+                kitty @ focus-window --no-response -m=id:$kak_client_env_KITTY_WINDOW_ID
+            else
+                kitty @ --to "$kak_client_env_KITTY_LISTEN_ON" focus-tab --no-response -m=id:$kak_client_env_KITTY_WINDOW_ID
+                kitty @ --to "$kak_client_env_KITTY_LISTEN_ON" focus-window --no-response -m=id:$kak_client_env_KITTY_WINDOW_ID
+            fi
         fi
     }
 }


### PR DESCRIPTION
When connecting to an existing session from another shell and executing `terminal`, new window appears in the original shell, not in the currently working shell.

This PR relaxes this problem by taking account of `KITTY_LISTEN_ON` environment variable of the client side.

----

Here is a background why I want this.

Using `connect` plugin, I often open a shell and connect to the current session by:

```
map global space-terminal a ': $<space>kitty :a<ret>' -docstring 'open new client'
```

I rather do this than letting kitty to open a window in the same shell because I want to let the window manager handle whole layout in a centralized way.

This command works fine but, `terminal` command does not work as expected and targets on the original shell.

I found this can be solved by starting kitty with `--listen-on` and targeting on that socket when remotely controlling.

The line above can be updated as:

```
map global space-terminal a ': $<space>kitty --listen-on "unix:@%sh{date +%s}" :a<ret>' -docstring 'open new client'
```

And with this PR, things will work fine.