### PR TITLE
rc repl all: new 2nd arg controls sending of newline

### DIFF
--- a/rc/windowing/repl/x11.kak
+++ b/rc/windowing/repl/x11.kak
@@ -26,7 +26,7 @@ define-command x11-send-text -params 0..1 -docstring %{
         If no text is passed, then the selection is used
         } %{
     evaluate-commands %sh{
-        ([ "$#" -gt 0 ] && printf "%s\\n" "$1" || printf "%s\\n" "${kak_selection}" ) | xsel -i ||
+        ([ "$#" -gt 0 ] && printf "%s" "$1" || printf "%s" "${kak_selection}" ) | xsel -i ||
         echo 'fail x11-send-text: failed to run xsel, see *debug* buffer for details' &&
         kak_winid=$(xdotool getactivewindow) &&
         xdotool windowactivate "${kak_opt_x11_repl_id}" key --clearmodifiers Shift+Insert &&


### PR DESCRIPTION
The consistency of the x11 / kitty / tmux repl's is not great.

Both kitty and tmux send selections and text as specified, however x11 always
appends a new line.

They should be consistent, or at least allow consistency. This patch adds
another argument to `repl-send-text` so that:

	x11 - repl-send-text "hi" 1: sends `hi\n`
	x11 - repl-send-text "hi" 0: sends `hi`
	x11 - repl-send-text "" 1: sends `[SELECTION]\n`
	x11 - repl-send-text "" 0: sends `[SELECTION]`
	x11 - repl-send-text: sends `[SELECTION]\n` (current inconsistent behaviour)

	tmux - repl-send-text "hi" 1: sends `hi\n`
	tmux - repl-send-text "hi" 0: sends `hi`
	tmux - repl-send-text "" 1: sends `[SELECTION]\n`
	tmux - repl-send-text "" 0: sends `[SELECTION]`
	tmux - repl-send-text: sends `[SELECTION]` (current inconsistent behaviour)

	kitty - repl-send-text "hi" 1: sends `hi\n`
	kitty - repl-send-text "hi" 0: sends `hi`
	kitty - repl-send-text "" 1: sends `[SELECTION]\n`
	kitty - repl-send-text "" 0: sends `[SELECTION]`
	kitty - repl-send-text: sends `[SELECTION]` (current inconsistent behaviour)