### PR TITLE
rc restructuredtext: don't highlight first character of next line as …

### DIFF
--- a/rc/filetype/restructuredtext.kak
+++ b/rc/filetype/restructuredtext.kak
@@ -24,7 +24,7 @@ provide-module restructuredtext %{
 
 add-highlighter shared/restructuredtext regions
 add-highlighter shared/restructuredtext/content default-region group
-add-highlighter shared/restructuredtext/code region ::\h*\n ^[^\s]  fill meta
+add-highlighter shared/restructuredtext/code region ::\h*\n ^(?=\S)  fill meta
 
 evaluate-commands %sh{
     for ft in c cabal clojure coffee cpp css cucumber ddiff dockerfile \
@@ -33,7 +33,7 @@ evaluate-commands %sh{
               perl pug python ragel ruby rust sass scala scss sh swift \
               tupfile yaml; do
         if [ "$ft" = kak ]; then ref="kakrc"; else ref="$ft"; fi
-        printf 'add-highlighter shared/restructuredtext/%s region %s %s ref %s\n' "$ft" '\.\.\h*'$ft'::\h*c\h*\n' '^\S' "$ref"
+        printf 'add-highlighter shared/restructuredtext/%s region %s %s ref %s\n' "$ft" '\.\.\h*'$ft'::\h*c\h*\n' '^(?=\S)' "$ref"
     done
 }
 


### PR DESCRIPTION
Reproduce by creating a *.rst buffer with the text below. The "N" used to
be highlighted as code.

```rest
::

    code

Not code
```