### PR TITLE
Add `ncurses_ascii` to `ui_options`

### DIFF
--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -335,6 +335,10 @@ are exclusively available to built-in options.
             if *yes*, or *true* the status line will be placed
             at the top of the terminal rather than at the bottom
 
+        *ncurses_ascii*:::
+            if *yes*, or *true*, use ASCII instead of Unicode characters
+            for info boxes, assistant, etc.
+
         *ncurses_assistant*:::
             specify the nice assistant displayed in info boxes,
             can be *clippy* (the default), *cat*, *dilbert* or *none*

--- a/src/main.cc
+++ b/src/main.cc
@@ -540,6 +540,7 @@ void register_options()
                        "The ncurses ui supports the following options:\n"
                        "    <key>:                        <value>:\n"
                        "    ncurses_assistant             clippy|cat|dilbert|none|off\n"
+                       "    ncurses_ascii                 bool\n"
                        "    ncurses_status_on_top         bool\n"
                        "    ncurses_set_title             bool\n"
                        "    ncurses_enable_mouse          bool\n"

--- a/src/ncurses_ui.hh
+++ b/src/ncurses_ui.hh
@@ -167,6 +167,8 @@ private:
     static constexpr int default_shift_function_key = 12;
     int m_shift_function_key = default_shift_function_key;
 
+    bool m_ascii = false;
+
     bool m_set_title = true;
 
     bool m_dirty = false;


### PR DESCRIPTION
When set to `yes` or `true`, the NCurses UI uses ASCII characters
instead of Unicode characters in the following places:

* Assistant "drawings" become ASCII art
* Info box uses `+`, `-` and `|` instead of Box-Drawing Unicode
  characters (e.g., `╭───┤foo├───╮` becomes `+---|foo|---+`)
* Menus use 3 dots (`...`) instead of the ellipsis character in
  Unicode (`…`)
* Menus use background/foreground colors to draw their scrollbar,
  instead of Box Elements Unicode characters.

This fixes an issue with certain fonts, where the Box-Drawing Unicode
characters are absent from the font, and aren't rendered with the same
width as other characters. This caused mis-alignment in the UI.

By using only ASCII characters instead, we fix issues when the
characters are missing from the font (at the cost of the UI being a
little bit uglier).

`ncurses_ascii` is disabled by default.

Screenshot with ncurses_ascii=no: https://imgur.com/a/c5dEMGP
Screenshot with ncurses_ascii=yes: https://imgur.com/a/MJEbUZH