### PR TITLE
kitty command: use launch, simplify, unify

### DIFF
--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -8,23 +8,24 @@ evaluate-commands %sh{
     [ -z "${kak_opt_windowing_modules}" ] || [ "$TERM" = "xterm-kitty" ] || echo 'fail Kitty not detected'
 }
 
-declare-option -docstring %{window type that kitty creates on new and repl calls (kitty|os)} str kitty_window_type kitty
+declare-option -docstring %{window type that kitty creates on new and repl calls (window|os-window)} str kitty_window_type window
 
 define-command kitty-terminal -params 1.. -shell-completion -docstring '
 kitty-terminal <program> [<arguments>]: create a new terminal as a kitty window
 The program passed as argument will be executed in the new terminal' \
 %{
     nop %sh{
-        local match=""
+        match=""
         if [ -n "$kak_client_env_KITTY_WINDOW_ID" ]; then
             match="--match=id:$kak_client_env_KITTY_WINDOW_ID"
         fi
 
-        if [ -z "$kak_client_env_KITTY_LISTEN_ON" ]; then
-            kitty @ new-window --no-response --window-type "$kak_opt_kitty_window_type" --cwd "$PWD" $match "$@"
-        else
-            kitty @ --to "$kak_client_env_KITTY_LISTEN_ON" new-window --no-response --window-type "$kak_opt_kitty_window_type" --cwd "$PWD" $match "$@"
+        listen=""
+        if [ -n "$kak_client_env_KITTY_LISTEN_ON" ]; then
+            listen="--to=$kak_client_env_KITTY_LISTEN_ON"
         fi
+
+        kitty @ $listen launch --no-response --type="$kak_opt_kitty_window_type" --cwd="$PWD" $match "$@"
     }
 }
 
@@ -33,16 +34,17 @@ kitty-terminal-tab <program> [<arguments>]: create a new terminal as kitty tab
 The program passed as argument will be executed in the new terminal' \
 %{
     nop %sh{
-        local match=""
+        match=""
         if [ -n "$kak_client_env_KITTY_WINDOW_ID" ]; then
             match="--match=id:$kak_client_env_KITTY_WINDOW_ID"
         fi
 
-        if [ -z "$kak_client_env_KITTY_LISTEN_ON" ]; then
-            kitty @ new-window --no-response --new-tab --cwd "$PWD" $match "$@"
-        else
-            kitty @ --to "$kak_client_env_KITTY_LISTEN_ON" new-window --no-response --new-tab --cwd "$PWD" $match "$@"
+        listen=""
+        if [ -n "$kak_client_env_KITTY_LISTEN_ON" ]; then
+            listen="--to=$kak_client_env_KITTY_LISTEN_ON"
         fi
+
+        kitty @ $listen launch --no-response --type=tab --cwd="$PWD" $match "$@"
     }
 }
 
@@ -54,13 +56,17 @@ If no client is passed then the current one is used' \
         if [ $# -eq 1 ]; then
             printf "evaluate-commands -client '%s' focus" "$1"
         else
-            if [ -z "$kak_client_env_KITTY_LISTEN_ON" ]; then
-                kitty @ focus-tab --no-response --match=id:$kak_client_env_KITTY_WINDOW_ID
-                kitty @ focus-window --no-response --match=id:$kak_client_env_KITTY_WINDOW_ID
-            else
-                kitty @ --to "$kak_client_env_KITTY_LISTEN_ON" focus-tab --no-response --match=id:$kak_client_env_KITTY_WINDOW_ID
-                kitty @ --to "$kak_client_env_KITTY_LISTEN_ON" focus-window --no-response --match=id:$kak_client_env_KITTY_WINDOW_ID
+            match=""
+            if [ -n "$kak_client_env_KITTY_WINDOW_ID" ]; then
+                match="--match=id:$kak_client_env_KITTY_WINDOW_ID"
             fi
+
+            listen=""
+            if [ -n "$kak_client_env_KITTY_LISTEN_ON" ]; then
+                listen="--to=$kak_client_env_KITTY_LISTEN_ON"
+            fi
+
+            kitty @ $listen focus-window --no-response $match
         fi
     }
 }

--- a/rc/windowing/repl/kitty.kak
+++ b/rc/windowing/repl/kitty.kak
@@ -17,7 +17,18 @@ define-command -params .. -shell-completion \
         else
             cmd="$*"
         fi
-        kitty @ new-window --no-response --window-type $kak_opt_kitty_window_type --title kak_repl_window --cwd "$PWD" $cmd < /dev/null > /dev/null 2>&1 &
+
+       match=""
+        if [ -n "$kak_client_env_KITTY_WINDOW_ID" ]; then
+            match="--match=id:$kak_client_env_KITTY_WINDOW_ID"
+        fi
+
+        listen=""
+        if [ -n "$kak_client_env_KITTY_LISTEN_ON" ]; then
+            listen="--to=$kak_client_env_KITTY_LISTEN_ON"
+        fi
+
+        kitty @ $listen launch --no-response --keep-focus --type="$kak_opt_kitty_window_type" --title=kak_repl_window --cwd="$PWD" $match $cmd
     }
 }
 
@@ -34,7 +45,7 @@ define-command -hidden -params 0..1 \
         else
             text="$1"
         fi
-        kitty @ send-text -m=title:kak_repl_window "$text"
+        kitty @ send-text --match=title:kak_repl_window "$text"
     }
 }
 


### PR DESCRIPTION
`new-window` is a legacy command (see kovidgoyal/kitty#2708) and could be replaced by `launch`.
`KITTY_WINDOW_ID` should be set for any kitty window anyways so a check is redundant.
add `--keep-focus` to repl command