### PR TITLE
rc swift: Highlight multiline string literals

### DIFF
--- a/rc/filetype/swift.kak
+++ b/rc/filetype/swift.kak
@@ -16,6 +16,7 @@ provide-module swift %{
 
 add-highlighter shared/swift regions
 add-highlighter shared/swift/code default-region group
+add-highlighter shared/swift/string_multiline region %{(?<!')"""} %{(?<!\\)(\\\\)*"""} ref swift/string
 add-highlighter shared/swift/string region %{(?<!')"} %{(?<!\\)(\\\\)*"} fill string
 add-highlighter shared/swift/comment region /\* \*/ group
 add-highlighter shared/swift/line_comment region // $ ref swift/comment
@@ -23,7 +24,7 @@ add-highlighter shared/swift/line_comment region // $ ref swift/comment
 add-highlighter shared/swift/comment/ fill comment
 
 add-highlighter shared/swift/code/ regex %{\b(true|false|nil)\b|\b-?(?!\$)\d+[fdiu]?|'((\\.)?|[^'\\])'} 0:value
-add-highlighter shared/swift/code/ regex "\b(let|var|while|in|for|if|else|do|switch|case|default|break|continue|return|try|catch|throw|new|delete|and|or|not|operator|explicit|func|import|return|init|deinit|get|set)\b" 0:keyword
+add-highlighter shared/swift/code/ regex "\b(let|var|while|in|for|if|guard|else|do|switch|case|default|break|continue|return|try|catch|throw|new|delete|and|or|not|operator|explicit|func|import|return|init|deinit|get|set)\b" 0:keyword
 add-highlighter shared/swift/code/ regex "\bas\b[!?]?" 0:keyword
 add-highlighter shared/swift/code/ regex "(\$[0-9])\b" 0:keyword
 add-highlighter shared/swift/code/ regex "\b(const|mutable|auto|namespace|inline|static|volatile|class|struct|enum|union|public|protected|private|typedef|virtual|friend|extern|typename|override|final|required|convenience|dynamic)\b" 0:attribute


### PR DESCRIPTION
This commit adds proper syntax highlighting for multiline strings in swift, like
```swift
let str = """
{
    "annotators": [\(annotators.joined(separtor: ",")]
}
"""
```

That is, `"annotators"` will be highlighted as part of the string even though it's between double quotes too.

Normally, we'd wanto to also highlight the code between `\(` and `)`, but it seems like kakoune does not support this just yet (See #2401).