### PR TITLE
Performance improvements for update-option and set-option

### DIFF
--- a/src/changes.hh
+++ b/src/changes.hh
@@ -53,8 +53,10 @@ void update_forward(ConstArrayView<Buffer::Change> changes, RangeContainer& rang
             changes_tracker.update(*it++);
     };
 
-    for (auto& range : ranges)
-        update_range(changes_tracker, range, advance_while_relevant);
+    auto range_it = std::lower_bound(ranges.begin(), ranges.end(), changes.front(),
+                                     [](auto& range, const Buffer::Change& change) { return get_last(range) < change.begin; });
+    for (auto end = ranges.end(); range_it != end; ++range_it)
+        update_range(changes_tracker, *range_it, advance_while_relevant);
 }
 
 template<typename RangeContainer>

--- a/src/highlighters.hh
+++ b/src/highlighters.hh
@@ -38,6 +38,7 @@ constexpr StringView option_type_name(Meta::Type<RangeAndStringList>)
 }
 void option_update(RangeAndStringList& opt, const Context& context);
 void option_list_postprocess(Vector<RangeAndString, MemoryDomain::Options>& opt);
+bool option_add_from_strings(Vector<RangeAndString, MemoryDomain::Options>& opt, ConstArrayView<String> strs);
 
 }
 


### PR DESCRIPTION
Closes #4084

The use of `std::inplace_merge()` improves the performance of `set-option -add` much more than expected, given that it is theoretically linear, so I suspect the actual implementation binary searches for the insertion place, or checks if the lists are already sorted, or something?

Before this, `set-option` grew to 341548 us per invocation.  After, it stayed under 4000 us per invocation.

Not happy with the abstractions or the duplication of the comparator from the option_list_postprocess(), but I already spent a day on this instead of my Real Job. :D  Perhaps we need some kind of OptionTraits<>?  Let me know and I'll fix.