### PR TITLE
Permit usage on wayland environments.

### DIFF
--- a/rc/windowing/detection.kak
+++ b/rc/windowing/detection.kak
@@ -23,7 +23,7 @@ declare-option -docstring \
 "Ordered list of windowing modules to try and load. An empty list disables
 both automatic module loading and environment detection, enabling complete
 manual control of the module loading." \
-str-list windowing_modules 'tmux' 'screen' 'kitty' 'iterm' 'x11'
+str-list windowing_modules 'tmux' 'screen' 'kitty' 'iterm' 'x11' 'wayland'
 
 hook -group windowing global KakBegin .* %{
 

--- a/rc/windowing/wayland.kak
+++ b/rc/windowing/wayland.kak
@@ -1,0 +1,56 @@
+# wayland
+
+provide-module wayland %{
+
+# ensure that we're running in the right environment
+evaluate-commands %sh{
+    [ -z "${kak_opt_windowing_modules}" ] || [ -n "$WAYLAND_DISPLAY" ] || echo 'fail WAYLAND_DISPLAY is not set'
+}
+
+# termcmd should be set such as the next argument is the whole
+# command line to execute
+declare-option -docstring %{shell command run to spawn a new terminal
+A shell command is appended to the one set in this option at runtime} \
+    str termcmd %sh{
+    for termcmd in 'alacritty      -e sh -c' \
+                   'kitty             sh -c' \
+                   'termite        -e      ' \
+                   'wterm          -e sh -c' \
+                   'gnome-terminal -e      ' \
+                   'xfce4-terminal -e      ' \
+                   'konsole        -e      '; do
+        terminal=${termcmd%% *}
+        if command -v $terminal >/dev/null 2>&1; then
+            printf %s\\n "$termcmd"
+            exit
+        fi
+    done
+}
+
+define-command wayland-terminal -params 1.. -shell-completion -docstring '
+wayland-terminal <program> [<arguments>]: create a new terminal as an wayland window
+The program passed as argument will be executed in the new terminal' \
+%{
+    evaluate-commands -save-regs 'a' %{
+        set-register a %arg{@}
+        evaluate-commands %sh{
+            if [ -z "${kak_opt_termcmd}" ]; then
+                echo "fail 'termcmd option is not set'"
+                exit
+            fi
+            setsid ${kak_opt_termcmd} "$kak_quoted_reg_a" < /dev/null > /dev/null 2>&1 &
+        }
+    }
+}
+
+define-command wayland-focus -params ..1 -client-completion -docstring '
+wayland-focus [<kakoune_client>]: focus a given client''s window
+If no client is passed, then the current client is used' \
+%{
+	fail There is no way to focus another window on Wayland
+}
+
+alias global focus wayland-focus
+alias global terminal wayland-terminal
+
+}


### PR DESCRIPTION
Some wayland wm will not setup a DISPLAY environment variable. Kakoune
should allow x11 windowing toolkit for those wm also.