### PR TITLE
cirrus-ci: Update FreeBSD release

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 freebsd_task:
     freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
     gmake_script: pkg install -y gmake
     matrix:
         - name: freebsd_clang


### PR DESCRIPTION
Unlike Linux distros where every release has a separate set of packages, FreeBSD's ports system has just one set of packages that's used with every release. The ports system is only guaranteed to be compatible with the latest stable and development releases; if you have an older release installed and you try to update ports before you've updated the base OS, things can break in weird ways.

Apparently FreeBSD 12.2 was recently released, so our 12.1-based CI runs started breaking. Bumping the images to 12.2 should fix things.
