### PR TITLE
js: Highlight special variables at start of file

### DIFF
--- a/rc/filetype/javascript.kak
+++ b/rc/filetype/javascript.kak
@@ -91,7 +91,7 @@ define-command -hidden init-javascript-filetype -params 1 %~
     add-highlighter "shared/%arg{1}/literal/"       fill string
     add-highlighter "shared/%arg{1}/literal/"       regex \$\{.*?\} 0:value
 
-    add-highlighter "shared/%arg{1}/code/" regex [^$_]\b(document|false|null|parent|self|this|true|undefined|window)\b 1:value
+    add-highlighter "shared/%arg{1}/code/" regex (?:^|[^$_])\b(document|false|null|parent|self|this|true|undefined|window)\b 1:value
     add-highlighter "shared/%arg{1}/code/" regex "-?\b[0-9]*\.?[0-9]+" 0:value
     add-highlighter "shared/%arg{1}/code/" regex \b(Array|Boolean|Date|Function|Number|Object|RegExp|String|Symbol)\b 0:type
 


### PR DESCRIPTION
Previously using any of the special/keyword variables (idk what they're called) at the start of the file wouldn't highlight them and show them in the default color.