### PR TITLE
rc markdown: Fix HTML highlighting in inline code

### DIFF
--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -65,15 +65,13 @@ add-highlighter shared/markdown/listblock/g/ ref markdown/inline
 add-highlighter shared/markdown/listblock/g/marker regex ^\h*([-*])\s 1:bullet
 
 # https://spec.commonmark.org/0.29/#link-destination
-# This repetition is not pretty but shell escaping is worse
 add-highlighter shared/markdown/angle_bracket_url region (?<=<)([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=>)|\n fill link
-add-highlighter shared/markdown/url region -recurse \( ([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=\))|\s fill link
+add-highlighter shared/markdown/inline/url region -recurse \( ([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=\))|\s fill link
 add-highlighter shared/markdown/listblock/angle_bracket_url region (?<=<)([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=>)|\n fill link
-add-highlighter shared/markdown/listblock/url region -recurse \( ([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=\))|\s fill link
 
 try %{
     require-module html
-    add-highlighter shared/markdown/tag region (?i)</?[a-z][a-z0-9-]*\s*([a-z_:]|(?=>)) > ref html/tag
+    add-highlighter shared/markdown/inline/tag region (?i)</?[a-z][a-z0-9-]*\s*([a-z_:]|(?=>)) > ref html/tag
 }
 
 add-highlighter shared/markdown/inline/code region -match-capture (`+) (`+) fill mono


### PR DESCRIPTION
Fixes #4091

Because the HTML highlighter was higher up in the hierarchy than the code highlighter, it took precedence. I fixed it by making HTML an inline region. Using my new knowledge of "inline" I was able to remove one line of code.

The angle_bracket_url region cannot be made inline because otherwise HTML takes precedence and `<http://example.org>` is highlighted as a HTML tag.