### PR TITLE
Improves Lua auto indent and end insertion

### DIFF
--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -105,7 +105,7 @@ define-command -hidden lua-indent-on-new-line %{
         # preserve previous non-empty line indent
         try %{ execute-keys -draft <space><a-?>^[^\n]+$<ret>s\A|.\z<ret>)<a-&> }
         # indent after start structure
-        try %{ execute-keys -draft <a-?>^[^\n]*\w+[^\n]*$<ret><a-k>^\h*(else|elseif|for|function|if|while)\b<ret><a-:><semicolon><a-gt> }
+        try %{ execute-keys -draft <a-?>^[^\n]*\w+[^\n]*$<ret><a-k>\b(else|elseif|for|function|if|while)\b<ret><a-K>\bend\b<ret><a-:><semicolon><a-gt> }
     }
 }
 
@@ -116,8 +116,9 @@ define-command -hidden lua-insert-on-new-line %[
         # wisely add end structure
         evaluate-commands -save-regs x %[
             try %{ execute-keys -draft k<a-x>s^\h+<ret>"xy } catch %{ reg x '' } # Save previous line indent in register x
-            try %[ execute-keys -draft k<a-x> <a-k>^<c-r>x(for|function|if|while)<ret> J}iJ<a-x> <a-K>^<c-r>x(else|end|elseif)$<ret> # Validate previous line and that it is not closed yet
-                   execute-keys -draft o<c-r>xend<esc> ] # auto insert end
+            try %[ execute-keys -draft k<a-x> <a-k>^<c-r>x\b[^\n]*(for|function|if|while)<ret><a-K>\bend\b<ret> J}iJ<a-x> <a-K>^<c-r>x(else|end|elseif)$<ret> # Validate previous line and that it is not closed yet
+                   execute-keys -draft o<c-r>xend<esc> # auto insert end
+                   execute-keys -draft k<a-x><a-k>\(function\b<ret>jjA)<esc> ] # auto insert ) for anonymous function
         ]
     ]
 ]


### PR DESCRIPTION
Current solution makes it difficult to use common Lua practices of having one-liner if statements and using anonymous functions.

New solution prevents auto-indentation and end insertion if the previous line contains an `end` keyword. 

It does not attempt to match each structure with corresponding end, since using multiple `end` keywords in single line is a very rare occurance in Lua.

Some of the cases that this improvement fixes:
```lua
i_take_function_as_arg(function()
  -- expected indent/end, kakoune does not
  -- this improvement also detects when to append ) after end
end)

function f(x)
  if not x then return end
  -- kakoune currently unnescessarely indents this line
end

anonymous_function = function()
  -- kakoune does not currently indent this and does not add end
end
```