### PR TITLE
Support keypad keys

### DIFF
--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -726,6 +726,7 @@ Optional<Key> NCursesUI::get_next_key()
         case 'B': return masked_key(Key::Down);
         case 'C': return masked_key(Key::Right);
         case 'D': return masked_key(Key::Left);
+        case 'E': return masked_key('5');        // Numeric keypad 5
         case 'F': return masked_key(Key::End);   // PC/xterm style
         case 'H': return masked_key(Key::Home);  // PC/xterm style
         case 'P': return masked_key(Key::F1);
@@ -792,19 +793,46 @@ Optional<Key> NCursesUI::get_next_key()
         return {};
     };
 
-    auto parse_ss3 = []() -> Optional<Key> {
-        switch (get_char().value_or((unsigned char)0xff))
+    auto parse_ss3 = [&parse_mask]() -> Optional<Key> {
+        int raw_mask = 0;
+        char code = '0';
+        do {
+            raw_mask = raw_mask * 10 + (code - '0');
+            code = get_char().value_or((unsigned char)0xff);
+        } while (code >= '0' and code <= '9');
+
+        switch (code)
         {
-        case 'A': return Key{Key::Up};
-        case 'B': return Key{Key::Down};
-        case 'C': return Key{Key::Right};
-        case 'D': return Key{Key::Left};
-        case 'F': return Key{Key::End};
-        case 'H': return Key{Key::Home};
-        case 'P': return Key{Key::F1};
-        case 'Q': return Key{Key::F2};
-        case 'R': return Key{Key::F3};
-        case 'S': return Key{Key::F4};
+        case ' ': return Key{parse_mask(raw_mask), ' '};
+        case 'A': return Key{parse_mask(raw_mask), Key::Up};
+        case 'B': return Key{parse_mask(raw_mask), Key::Down};
+        case 'C': return Key{parse_mask(raw_mask), Key::Right};
+        case 'D': return Key{parse_mask(raw_mask), Key::Left};
+        case 'F': return Key{parse_mask(raw_mask), Key::End};
+        case 'H': return Key{parse_mask(raw_mask), Key::Home};
+        case 'I': return Key{parse_mask(raw_mask), Key::Tab};
+        case 'M': return Key{parse_mask(raw_mask), Key::Return};
+        case 'P': return Key{parse_mask(raw_mask), Key::F1};
+        case 'Q': return Key{parse_mask(raw_mask), Key::F2};
+        case 'R': return Key{parse_mask(raw_mask), Key::F3};
+        case 'S': return Key{parse_mask(raw_mask), Key::F4};
+        case 'X': return Key{parse_mask(raw_mask), '='};
+        case 'j': return Key{parse_mask(raw_mask), '*'};
+        case 'k': return Key{parse_mask(raw_mask), '+'};
+        case 'l': return Key{parse_mask(raw_mask), ','};
+        case 'm': return Key{parse_mask(raw_mask), '-'};
+        case 'n': return Key{parse_mask(raw_mask), '.'};
+        case 'o': return Key{parse_mask(raw_mask), '/'};
+        case 'p': return Key{parse_mask(raw_mask), '0'};
+        case 'q': return Key{parse_mask(raw_mask), '1'};
+        case 'r': return Key{parse_mask(raw_mask), '2'};
+        case 's': return Key{parse_mask(raw_mask), '3'};
+        case 't': return Key{parse_mask(raw_mask), '4'};
+        case 'u': return Key{parse_mask(raw_mask), '5'};
+        case 'v': return Key{parse_mask(raw_mask), '6'};
+        case 'w': return Key{parse_mask(raw_mask), '7'};
+        case 'x': return Key{parse_mask(raw_mask), '8'};
+        case 'y': return Key{parse_mask(raw_mask), '9'};
         default: return {};
         }
     };


### PR DESCRIPTION
Kakoune now knows about all the keypad keys listed in:

https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-PC-Style-Function-Keys
https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-VT220-Style-Function-Keys

The VT220-style encodings are used to for modified numeric keys when NumLock is off. For example, consider the 8/Up key:

| Modifiers       | Sequence    | Notes             |
|-----------------|-------------|-------------------|
| Unmodified      | CSI A       | Ordinary up arrow |
| Shift           | SS3 2 x     | Shift-8           |
| NumLock         | 8           | Ordinary 8        |
| Shift + NumLock | CSI 1 ; 2 A | Shift-Up          |

Note that even though the terminal distinguishes between keypad and regular keys, Kakoune maps keypad keys onto regular keys - keypad Enter is still <ret>, it just supports more modifiers than the regular Enter key.

Since I worked from the xterm docs, unsurprisingly this works best in xterm.

gnome-terminal never sends modified SS3 sequences when NumLock is on: it only ever sends plain ASCII, CSI sequences (with modifiers where appropriate),  or nothing at all. When NumLock is off, it sends SS3 sequences when the `+`, `-`, `*`, `/` or Enter keys are pressed with a modifier, otherwise it's still plain ASCII, CSI sequences (with modifiers) or nothing.

st sends SS3 x instead of CSI A, so you can't type `<up>` on the keypad at all. It also doesn't support modifiers, except that adding Shift sends `<8>`, adding Shift+Alt sends `<a-8>`, and adding Ctrl+Shift sends `<backspace>`.

Konsole does not seem to send SS3 sequences at all, with the exception that Shift+Enter (the regular Enter, not the keypad Enter) send SS3 M which is supposed to mean unmodified keypad Enter (see #4118). This patch makes Shift+Enter indistinguishable from Enter in Konsole, but previously it opened a new line above the cursor and typed M, which wasn't very useful behaviour either.

With putty's default settings, it only ever sends SS3 sequences, regardless of Shift or NumLock. The only modifier supported is Alt (by Esc-prefixing), except that Numpad Plus sends SS3 l (the code for Numpad Comma) while Shift+Numpad Plus sends SS3 m (the code for Numpad Minus). Numlock, Numpad Slash, Numpad Star and Numpad Minus send SS3 P, SS3 Q, SS3 R, and SS3 S respectively, the codes for F1-F4. It kind of makes sense, that's where those keys are placed on a VT100. You can configure Putty to use "Xterm R6" encoding for the keypad, in which case it behaves a little more like xterm, but doesn't support all the modifiers.

rxvt has an entirely different encoding, as usual, and I can't quickly find documentation about it, so I haven't implemented it.

