### PR TITLE
Fix show-whitespaces NNBSP

### DIFF
--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -1049,7 +1049,7 @@ private:
                 {
                     auto coord = it.coord();
                     Codepoint cp = utf8::read_codepoint(it, end);
-                    if (cp == '\t' or cp == ' ' or cp == '\n' or cp == 0xA0)
+                    if (cp == '\t' or cp == ' ' or cp == '\n' or cp == 0xA0 or cp == 0x202F)
                     {
                         if (coord != begin.coord())
                             atom_it = ++line.split(atom_it, coord);
@@ -1067,7 +1067,7 @@ private:
                             atom_it->replace(m_spc);
                         else if (cp == '\n')
                             atom_it->replace(m_lf);
-                        else if (cp == 0xA0)
+                        else if (cp == 0xA0 or cp == 0x202F)
                             atom_it->replace(m_nbsp);
                         atom_it->face = merge_faces(atom_it->face, whitespaceface);
                         break;


### PR DESCRIPTION
The current implementation of the show-whitespace highlighter only take into account the normal Non-Breakable SPace (NBSP) character. However, there is at least one another common character, which is the Narrow NBSP (used in french typography instead of NBSP, for instance). I—for one—often muscle-memory type it along with quotes and interrogation/exclamation marks (AltGr-Shift-space instead of Shift-space). In the current implementation, NBSP is highlighted while NNBSP is not, making the mistake more difficult to spot.

This commit:
– Adds the Narrow No-Break SPace (0x202F, NNBSP) to the list of handled
  spaces in the show-whitespace highlighter.
– Do not add an additional option, just handle it like NBSP, with the same highlight character, for the sake on simplicity.