### PR TITLE
[Feature] add ncurses options for buffer padding

### DIFF
--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -353,6 +353,15 @@ are exclusively available to built-in options.
             Function key from which shifted function key start, if the
             terminal sends F13 for <s-F1>, this should be set to 12.
 
+        *ncurses_padding_char*:::
+            character used to indicate the area out of the displayed buffer
+            (defaults to '~')
+
+        *ncurses_padding_fill*:::
+            if *yes* or *true*, fill the padding area with the padding character
+            instead of displaying a single character at the beginning of the
+            padding line (defaults to *false*)
+
 [[startup-info]]
 *startup_info_version* `int`::
     _default_ 0 +

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -474,7 +474,14 @@ void NCursesUI::draw(const DisplayBuffer& display_buffer,
     while (line_index < dim.line + line_offset)
     {
         m_window.move_cursor(line_index++);
-        m_window.draw(m_palette, DisplayAtom("~"), face);
+        if (m_padding_fill)
+        {
+            ColumnCount column_index = 0;
+            while (column_index++ < dim.column)
+                m_window.draw(m_palette, m_padding_char, face);
+        }
+        else
+            m_window.draw(m_palette, m_padding_char, face);
     }
 
     m_dirty = true;
@@ -1360,6 +1367,22 @@ void NCursesUI::set_ui_options(const Options& options)
         auto wheel_scroll_amount_it = options.find("ncurses_wheel_scroll_amount"_sv);
         m_wheel_scroll_amount = wheel_scroll_amount_it != options.end() ?
             str_to_int_ifp(wheel_scroll_amount_it->value).value_or(3) : 3;
+    }
+
+    {
+        auto it = options.find("ncurses_padding_char"_sv);
+        if (it == options.end())
+            m_padding_char = DisplayAtom("~");
+        else if (it->value.length() < 1)
+            m_padding_char = DisplayAtom(" ");
+        else
+            m_padding_char = DisplayAtom(it->value);
+    }
+
+    {
+        auto it = options.find("ncurses_padding_fill"_sv);
+        m_padding_fill = it != options.end() and
+            (it->value == "yes" or it->value == "true");
     }
 }
 

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -477,8 +477,11 @@ void NCursesUI::draw(const DisplayBuffer& display_buffer,
         if (m_padding_fill)
         {
             ColumnCount column_index = 0;
-            while (column_index++ < dim.column)
+            while (column_index < dim.column)
+            {
                 m_window.draw(m_palette, m_padding_char, face);
+                column_index += m_padding_char.length();
+            }
         }
         else
             m_window.draw(m_palette, m_padding_char, face);
@@ -1372,8 +1375,10 @@ void NCursesUI::set_ui_options(const Options& options)
     {
         auto it = options.find("ncurses_padding_char"_sv);
         if (it == options.end())
+            // Defaults to tilde.
             m_padding_char = DisplayAtom("~");
-        else if (it->value.length() < 1)
+        else if (it->value.column_length() < 1)
+            // Do not allow empty string, use space instead.
             m_padding_char = DisplayAtom(" ");
         else
             m_padding_char = DisplayAtom(it->value);

--- a/src/ncurses_ui.hh
+++ b/src/ncurses_ui.hh
@@ -169,6 +169,9 @@ private:
 
     bool m_set_title = true;
 
+    DisplayAtom m_padding_char = DisplayAtom("~");
+    bool m_padding_fill = false;
+
     bool m_dirty = false;
 
     bool m_resize_pending = false;


### PR DESCRIPTION
In some cases, it may be difficult to easily spot the area out of the buffer
(bad color scheme, small font, superimposed windows).

This patch adds two ncurses ui_options to bypass this problem:
- `ncurses_padding_char`, to configure the padding character,
- `ncurses_padding_fill`, to indicate whether to fill the padding line
  (or to display a single character).

The default config is the legacy one (a single "~").

Screenshot of an example:
![feat_padding-uioption](https://user-images.githubusercontent.com/285009/113610423-640aa700-964d-11eb-8af8-c97932dde57d.png)
With the following config:
```kak
set-option -add global ui_options ncurses_padding_char=╱ # More fancy examples: ▚ ╳ ╱ ┼
set-option -add global ui_options ncurses_padding_fill=yes
```