### PR TITLE
Add `*-insert` hooks for automatic comment insertion

### DIFF
--- a/colors/greyscale.kak
+++ b/colors/greyscale.kak
@@ -12,7 +12,7 @@ evaluate-commands %sh{
     grey_dark_3="rgb:424242"
     grey_dark_4="rgb:212121"
 
-    cat <<- EOF
+    cat <<EOF
 
     # For Code
     set-face global keyword ${grey_dark_2}

--- a/colors/kaleidoscope-dark.kak
+++ b/colors/kaleidoscope-dark.kak
@@ -70,7 +70,7 @@ evaluate-commands %sh{
     dark_grey="rgb:555555"
 
     # NOTE: Do not use any color that hasn't been defined above (no hardcoding)
-    cat <<- EOF
+    cat <<EOF
 
     # For Code
     set-face global keyword ${vibrant_blue}

--- a/colors/kaleidoscope-light.kak
+++ b/colors/kaleidoscope-light.kak
@@ -70,7 +70,7 @@ evaluate-commands %sh{
     dark_grey="rgb:555555"
 
     # NOTE: Do not use any color that hasn't been defined above (no hardcoding)
-    cat <<- EOF
+    cat <<EOF
 
     # For Code
     set-face global keyword ${muted_indigo}

--- a/colors/solarized-dark.kak
+++ b/colors/solarized-dark.kak
@@ -1,22 +1,22 @@
 # Solarized Dark
 
 evaluate-commands %sh{
-	base03='rgb:002b36'
-	base02='rgb:073642'
-	base01='rgb:586e75'
-	base00='rgb:657b83'
-	base0='rgb:839496'
-	base1='rgb:93a1a1'
-	base2='rgb:eee8d5'
-	base3='rgb:fdf6e3'
-	yellow='rgb:b58900'
-	orange='rgb:cb4b16'
-	red='rgb:dc322f'
-	magenta='rgb:d33682'
-	violet='rgb:6c71c4'
-	blue='rgb:268bd2'
-	cyan='rgb:2aa198'
-	green='rgb:859900'
+        base03='rgb:002b36'
+        base02='rgb:073642'
+        base01='rgb:586e75'
+        base00='rgb:657b83'
+        base0='rgb:839496'
+        base1='rgb:93a1a1'
+        base2='rgb:eee8d5'
+        base3='rgb:fdf6e3'
+        yellow='rgb:b58900'
+        orange='rgb:cb4b16'
+        red='rgb:dc322f'
+        magenta='rgb:d33682'
+        violet='rgb:6c71c4'
+        blue='rgb:268bd2'
+        cyan='rgb:2aa198'
+        green='rgb:859900'
 
    echo "
         # code

--- a/rc/filetype/cabal.kak
+++ b/rc/filetype/cabal.kak
@@ -15,6 +15,7 @@ hook global WinSetOption filetype=cabal %[
     require-module cabal
 
     hook window ModeChange pop:insert:.* -group cabal-trim-indent  cabal-trim-indent
+    hook window InsertChar \n -group cabal-insert cabal-insert-on-new-line
     hook window InsertChar \n -group cabal-indent cabal-indent-on-new-line
     hook window InsertChar \{ -group cabal-indent cabal-indent-on-opening-curly-brace
     hook window InsertChar \} -group cabal-indent cabal-indent-on-closing-curly-brace
@@ -50,10 +51,15 @@ define-command -hidden cabal-trim-indent %{
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
 
-define-command -hidden cabal-indent-on-new-line %[
+define-command -hidden cabal-insert-on-new-line %[
     evaluate-commands -draft -itersel %[
         # copy '--' comment prefix and following white spaces
         try %[ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P ]
+    ]
+]
+
+define-command -hidden cabal-indent-on-new-line %[
+    evaluate-commands -draft -itersel %[
         # preserve previous line indent
         try %[ execute-keys -draft <semicolon> K <a-&> ]
         # filter previous line

--- a/rc/filetype/coffee.kak
+++ b/rc/filetype/coffee.kak
@@ -15,6 +15,7 @@ hook global WinSetOption filetype=coffee %{
     require-module coffee
 
     hook window ModeChange pop:insert:.* -group coffee-trim-indent  coffee-trim-indent
+    hook window InsertChar \n -group coffee-insert coffee-insert-on-new-line
     hook window InsertChar \n -group coffee-indent coffee-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window coffee-.+ }
@@ -70,10 +71,15 @@ define-command -hidden coffee-trim-indent %{
     }
 }
 
-define-command -hidden coffee-indent-on-new-line %{
+define-command -hidden coffee-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s '^\h*\K#\h*' <ret> y gh j P }
+    }
+}
+
+define-command -hidden coffee-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/cucumber.kak
+++ b/rc/filetype/cucumber.kak
@@ -15,6 +15,7 @@ hook global WinSetOption filetype=cucumber %{
     require-module cucumber
 
     hook window ModeChange pop:insert:.* -group cucumber-trim-indent  cucumber-trim-indent
+    hook window InsertChar \n -group cucumber-insert cucumber-insert-on-new-line
     hook window InsertChar \n -group cucumber-indent cucumber-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window cucumber-.+ }
@@ -80,10 +81,15 @@ define-command -hidden cucumber-trim-indent %{
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
 
-define-command -hidden cucumber-indent-on-new-line %{
+define-command -hidden cucumber-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
+    }
+}
+
+define-command -hidden cucumber-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/d.kak
+++ b/rc/filetype/d.kak
@@ -115,8 +115,8 @@ define-command -hidden d-indent-on-new-line %~
         try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
-        # copy // comments prefix
-        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
+        # copy // comments prefix and following white spaces
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # indent after if|else|while|for

--- a/rc/filetype/d.kak
+++ b/rc/filetype/d.kak
@@ -18,6 +18,7 @@ hook global WinSetOption filetype=d %{
 
     # cleanup trailing whitespaces when exiting insert mode
     hook window ModeChange pop:insert:.* -group d-trim-indent %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
+    hook window InsertChar \n -group d-insert d-insert-on-new-line
     hook window InsertChar \n -group d-indent d-indent-on-new-line
     hook window InsertChar \{ -group d-indent d-indent-on-opening-curly-brace
     hook window InsertChar \} -group d-indent d-indent-on-closing-curly-brace
@@ -105,6 +106,13 @@ add-highlighter shared/d/code/ regex "\bmodule\s+([\w_-]+)\b" 1:module
 # Commands
 # ‾‾‾‾‾‾‾‾
 
+define-command -hidden d-insert-on-new-line %~
+    evaluate-commands -draft -itersel %=
+        # copy // comments prefix and following white spaces
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
+    =
+~
+
 define-command -hidden d-indent-on-new-line %~
     evaluate-commands -draft -itersel %=
         # preserve previous line indent
@@ -115,8 +123,6 @@ define-command -hidden d-indent-on-new-line %~
         try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
-        # copy // comments prefix and following white spaces
-        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # indent after if|else|while|for

--- a/rc/filetype/dart.kak
+++ b/rc/filetype/dart.kak
@@ -91,8 +91,8 @@ define-command -hidden dart-indent-on-new-line %~
         try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
-        # copy // comments prefix
-        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
+        # copy // comments prefix and following white spaces
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # indent after if|else|while|for

--- a/rc/filetype/dart.kak
+++ b/rc/filetype/dart.kak
@@ -18,6 +18,7 @@ hook global WinSetOption filetype=dart %{
 
     # cleanup trailing whitespaces when exiting insert mode
     hook window ModeChange pop:insert:.* -group dart-trim-indent %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
+    hook window InsertChar \n -group dart-insert dart-insert-on-new-line
     hook window InsertChar \n -group dart-indent dart-indent-on-new-line
     hook window InsertChar \{ -group dart-indent dart-indent-on-opening-curly-brace
     hook window InsertChar \} -group dart-indent dart-indent-on-closing-curly-brace
@@ -81,6 +82,13 @@ evaluate-commands %sh{
 # Commands
 # ‾‾‾‾‾‾‾‾
 
+define-command -hidden dart-insert-on-new-line %~
+    evaluate-commands -draft -itersel %=
+        # copy // comments prefix and following white spaces
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
+    =
+~
+
 define-command -hidden dart-indent-on-new-line %~
     evaluate-commands -draft -itersel %=
         # preserve previous line indent
@@ -91,8 +99,6 @@ define-command -hidden dart-indent-on-new-line %~
         try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
-        # copy // comments prefix and following white spaces
-        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # indent after if|else|while|for

--- a/rc/filetype/dhall.kak
+++ b/rc/filetype/dhall.kak
@@ -15,6 +15,7 @@ hook global WinSetOption filetype=dhall %{
     require-module dhall
 
     hook window ModeChange pop:insert:.* -group dhall-trim-indent dhall-trim-indent
+    hook window InsertChar \n -group dhall-insert dhall-insert-on-new-line
     hook window InsertChar \n -group dhall-indent dhall-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window dhall-.+ }
@@ -80,10 +81,14 @@ define-command -hidden dhall-trim-indent %{
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
 
-define-command -hidden dhall-indent-on-new-line %{
+define-command -hidden dhall-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy -- comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
+    }
+}
+define-command -hidden dhall-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line

--- a/rc/filetype/elixir.kak
+++ b/rc/filetype/elixir.kak
@@ -98,8 +98,8 @@ define-command -hidden elixir-indent-on-new-line %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # indent after line ending with:
-	# try %{ execute-keys -draft k x <a-k> (\bdo|\belse|->)$ <ret> & }
-	# filter previous line
+        # try %{ execute-keys -draft k x <a-k> (\bdo|\belse|->)$ <ret> & }
+        # filter previous line
         try %{ execute-keys -draft k : elixir-trim-indent <ret> }
         # indent after lines ending with do or ->
         try %{ execute-keys -draft <semicolon> k x <a-k> ^.+(\bdo|->)$ <ret> j <a-gt> }

--- a/rc/filetype/elixir.kak
+++ b/rc/filetype/elixir.kak
@@ -19,6 +19,7 @@ hook global WinSetOption filetype=elixir %{
     require-module elixir
 
     hook window ModeChange pop:insert:.* -group elixir-trim-indent  elixir-trim-indent
+    hook window InsertChar \n -group elixir-insert elixir-insert-on-new-line
     hook window InsertChar \n -group elixir-indent elixir-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window elixir-.+ }
@@ -91,10 +92,15 @@ define-command -hidden elixir-trim-indent %{
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
 
-define-command -hidden elixir-indent-on-new-line %{
+define-command -hidden elixir-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy -- comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
+    }
+}
+
+define-command -hidden elixir-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # indent after line ending with:

--- a/rc/filetype/elm.kak
+++ b/rc/filetype/elm.kak
@@ -15,6 +15,7 @@ hook global WinSetOption filetype=elm %{
     require-module elm
 
     hook window ModeChange pop:insert:.* -group elm-trim-indent  elm-trim-indent
+    hook window InsertChar \n -group elm-insert elm-insert-on-new-line
     hook window InsertChar \n -group elm-indent elm-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window elm-.+ }
@@ -61,10 +62,15 @@ define-command -hidden elm-indent-after "
  execute-keys -draft <semicolon> k x <a-k> ^\\h*if|[=(]$|\\b(case\\h+[\\w']+\\h+of|let|in)$|(\\{\\h+\\w+|\\w+\\h+->)$ <ret> j <a-gt>
 "
 
-define-command -hidden elm-indent-on-new-line %{
+define-command -hidden elm-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy -- comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
+    }
+}
+
+define-command -hidden elm-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # align to first clause

--- a/rc/filetype/fsharp.kak
+++ b/rc/filetype/fsharp.kak
@@ -15,6 +15,7 @@ hook global WinSetOption filetype=fsharp %{
     require-module fsharp
 
     # indent on newline
+    hook window InsertChar \n -group fsharp-insert fsharp-insert-on-new-line
     hook window InsertChar \n -group fsharp-indent fsharp-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window fsharp-.+ }
@@ -124,10 +125,15 @@ add-highlighter shared/fsharp/code/ regex "\B(\(\))\B" 0:value
 # Commands
 # ‾‾‾‾‾‾‾‾
 
+define-command -hidden fsharp-insert-on-new-line %{
+    evaluate-commands -draft -itersel %{
+        # copy // comments prefix and following white spaces
+        try %{ execute-keys -draft k <a-x> s ^\h*//\h* <ret> y jgh P }
+    }
+}
+
 define-command -hidden fsharp-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
-        # copy '//' comment prefix and following white spaces
-        try %{ execute-keys -draft k <a-x> s ^\h*//\h* <ret> y jgh P }
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # cleanup trailing whitespaces from previous line

--- a/rc/filetype/gluon.kak
+++ b/rc/filetype/gluon.kak
@@ -16,6 +16,7 @@ hook global WinSetOption filetype=gluon %{
 
     set-option window extra_word_chars '_' "'"
     hook window ModeChange pop:insert:.* -group gluon-trim-indent gluon-trim-indent
+    hook window InsertChar \n -group gluon-insert gluon-insert-on-new-line
     hook window InsertChar \n -group gluon-indent gluon-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{
@@ -78,10 +79,15 @@ define-command -hidden gluon-trim-indent %{
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
 
-define-command -hidden gluon-indent-on-new-line %~
+define-command -hidden gluon-insert-on-new-line %~
     evaluate-commands -draft -itersel %_
         # copy // and /// comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K///?\h* <ret> y gh j P }
+    _
+~
+
+define-command -hidden gluon-indent-on-new-line %~
+    evaluate-commands -draft -itersel %_
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line

--- a/rc/filetype/go.kak
+++ b/rc/filetype/go.kak
@@ -107,8 +107,8 @@ define-command -hidden go-indent-on-new-line %~
         try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
-        # copy // comments prefix
-        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
+        # copy // comments prefix and following white spaces
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # deindent closing brace(s) when after cursor

--- a/rc/filetype/go.kak
+++ b/rc/filetype/go.kak
@@ -107,8 +107,6 @@ define-command -hidden go-indent-on-new-line %~
         try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
-        # copy // comments prefix and following white spaces
-        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # deindent closing brace(s) when after cursor
@@ -128,6 +126,9 @@ define-command -hidden go-indent-on-closing-curly-brace %[
 
 define-command -hidden go-insert-on-new-line %[
     evaluate-commands -no-hooks -draft -itersel %[
+        # copy // comments prefix and following white spaces
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
+
         # Wisely add '}'.
         evaluate-commands -save-regs x %[
             # Save previous line indent in register x.

--- a/rc/filetype/haml.kak
+++ b/rc/filetype/haml.kak
@@ -15,6 +15,7 @@ hook global WinSetOption filetype=haml %{
     require-module haml
 
     hook window ModeChange pop:insert:.* -group haml-trim-indent  haml-trim-indent
+    hook window InsertChar \n -group haml-insert haml-insert-on-new-line
     hook window InsertChar \n -group haml-indent haml-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window haml-.+ }
@@ -56,10 +57,15 @@ define-command -hidden haml-trim-indent %{
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
 
-define-command -hidden haml-indent-on-new-line %{
+define-command -hidden haml-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '/' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K/\h* <ret> y gh j P }
+    }
+}
+
+define-command -hidden haml-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/haskell.kak
+++ b/rc/filetype/haskell.kak
@@ -16,6 +16,7 @@ hook global WinSetOption filetype=haskell %{
 
     set-option buffer extra_word_chars '_' "'"
     hook window ModeChange pop:insert:.* -group haskell-trim-indent  haskell-trim-indent
+    hook window InsertChar \n -group haskell-insert haskell-insert-on-new-line
     hook window InsertChar \n -group haskell-indent haskell-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window haskell-.+ }
@@ -103,10 +104,15 @@ define-command -hidden haskell-trim-indent %{
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
 
-define-command -hidden haskell-indent-on-new-line %{
+define-command -hidden haskell-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy -- comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
+    }
+}
+
+define-command -hidden haskell-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # align to first clause

--- a/rc/filetype/hbs.kak
+++ b/rc/filetype/hbs.kak
@@ -12,6 +12,7 @@ hook global WinSetOption filetype=hbs %{
     require-module hbs
 
     hook window ModeChange pop:insert:.* -group hbs-trim-indent hbs-trim-indent
+    hook window InsertChar \n -group hbs-insert hbs-insert-on-new-line
     hook window InsertChar \n -group hbs-indent hbs-indent-on-new-line
     hook window InsertChar .* -group hbs-indent hbs-indent-on-char
     hook window InsertChar '>' -group hbs-indent html-indent-on-greater-than
@@ -75,10 +76,15 @@ define-command -hidden hbs-indent-on-char %[
     ]
 ]
 
-define-command -hidden hbs-indent-on-new-line %{
+define-command -hidden hbs-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '/' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K/\h* <ret> y j p }
+    }
+}
+
+define-command -hidden hbs-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/hbs.kak
+++ b/rc/filetype/hbs.kak
@@ -35,10 +35,10 @@ require-module html
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
 add-highlighter shared/hbs regions
-add-highlighter shared/hbs/comment          region \{\{!-- --\}\} fill comment
-add-highlighter shared/hbs/comment_alt      region \{\{!   \}\}   fill comment
-add-highlighter shared/hbs/block-expression region \{\{[#/]   \}\}   regions
-add-highlighter shared/hbs/expression 		region \{\{    \}\}   regions
+add-highlighter shared/hbs/comment          region \{\{!--  --\}\} fill comment
+add-highlighter shared/hbs/comment_alt      region \{\{!      \}\} fill comment
+add-highlighter shared/hbs/block-expression region \{\{[#/]   \}\} regions
+add-highlighter shared/hbs/expression       region \{\{       \}\} regions
 
 define-command -hidden add-mutual-highlighters -params 1 %~
     add-highlighter "shared/hbs/%arg{1}/code" default-region group

--- a/rc/filetype/i3.kak
+++ b/rc/filetype/i3.kak
@@ -10,6 +10,7 @@ hook global WinSetOption filetype=i3 %[
 
     # cleanup trailing whitespaces when exiting insert mode
     hook window ModeChange pop:insert:.* -group i3-trim-indent %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
+    hook window InsertChar \n -group i3-insert i3-insert-on-new-line
     hook window InsertChar \n -group i3-indent i3-indent-on-new-line
     hook window InsertChar \} -group i3-indent i3-indent-on-closing-curly-brace
 
@@ -67,10 +68,15 @@ add-highlighter shared/i3/code/ regex "client\.(focused_inactive|focused|unfocus
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden i3-indent-on-new-line %~
+define-command -hidden i3-insert-on-new-line %~
     evaluate-commands -draft -itersel %=
         # copy # comments prefix
         try %{ execute-keys -draft k<a-x> s ^\h*#\h* <ret> y jgh P }
+    =
+~
+
+define-command -hidden i3-indent-on-new-line %~
+    evaluate-commands -draft -itersel %=
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon>K<a-&> }
         # indent after lines ending with {

--- a/rc/filetype/java.kak
+++ b/rc/filetype/java.kak
@@ -50,8 +50,8 @@ define-command -hidden java-indent-on-new-line %~
         try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
-        # copy // comments prefix
-        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,} <ret> y<c-o>P<esc> }
+        # copy // comments prefix and following white spaces
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # indent after keywords

--- a/rc/filetype/java.kak
+++ b/rc/filetype/java.kak
@@ -10,6 +10,7 @@ hook global WinSetOption filetype=java %{
 
     # cleanup trailing whitespaces when exiting insert mode
     hook window ModeChange pop:insert:.* -group java-trim-indent %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
+    hook window InsertChar \n -group java-insert java-insert-on-new-line
     hook window InsertChar \n -group java-indent java-indent-on-new-line
     hook window InsertChar \{ -group java-indent java-indent-on-opening-curly-brace
     hook window InsertChar \} -group java-indent java-indent-on-closing-curly-brace
@@ -40,6 +41,11 @@ add-highlighter shared/java/code/ regex "(?<!\w)@\w+\b" 0:meta
 # Commands
 # ‾‾‾‾‾‾‾‾
 
+define-command -hidden java-insert-on-new-line %[
+        # copy // comments prefix and following white spaces
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
+]
+
 define-command -hidden java-indent-on-new-line %~
     evaluate-commands -draft -itersel %=
         # preserve previous line indent
@@ -50,8 +56,6 @@ define-command -hidden java-indent-on-new-line %~
         try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
-        # copy // comments prefix and following white spaces
-        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # indent after keywords

--- a/rc/filetype/javascript.kak
+++ b/rc/filetype/javascript.kak
@@ -17,6 +17,7 @@ hook global WinSetOption filetype=(javascript|typescript) %{
 
     hook window ModeChange pop:insert:.* -group "%val{hook_param_capture_1}-trim-indent" javascript-trim-indent
     hook window InsertChar .* -group "%val{hook_param_capture_1}-indent" javascript-indent-on-char
+    hook window InsertChar \n -group "%val{hook_param_capture_1}-insert" javascript-insert-on-new-line
     hook window InsertChar \n -group "%val{hook_param_capture_1}-indent" javascript-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* "
@@ -52,10 +53,15 @@ define-command -hidden javascript-indent-on-char %<
     >
 >
 
-define-command -hidden javascript-indent-on-new-line %<
+define-command -hidden javascript-insert-on-new-line %<
     evaluate-commands -draft -itersel %<
         # copy // comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K/{2,}\h* <ret> y gh j P }
+    >
+>
+
+define-command -hidden javascript-indent-on-new-line %<
+    evaluate-commands -draft -itersel %<
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/javascript.kak
+++ b/rc/filetype/javascript.kak
@@ -55,7 +55,7 @@ define-command -hidden javascript-indent-on-char %<
 define-command -hidden javascript-indent-on-new-line %<
     evaluate-commands -draft -itersel %<
         # copy // comments prefix and following white spaces
-        try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
+        try %{ execute-keys -draft k <a-x> s ^\h*\K/{2,}\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -112,7 +112,7 @@ define-command -hidden lua-indent-on-new-line %{
 define-command -hidden lua-insert-on-new-line %[
     evaluate-commands -no-hooks -draft -itersel %[
         # copy -- comment prefix and following white spaces
-        try %{ execute-keys -draft k<a-x>s^\h*\K--\h*<ret>yghjP }
+        try %{ execute-keys -draft k<a-x>s^\h*\K--\h*<ret> y gh j P }
         # wisely add end structure
         evaluate-commands -save-regs x %[
             try %{ execute-keys -draft k<a-x>s^\h+<ret>"xy } catch %{ reg x '' } # Save previous line indent in register x

--- a/rc/filetype/mercury.kak
+++ b/rc/filetype/mercury.kak
@@ -97,7 +97,7 @@ evaluate-commands %sh{
 define-command -hidden mercury-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '%' comment prefix and following white spaces
-        try %{ execute-keys -draft k <a-x> s ^\h*\%\h* <ret> y jgh P }
+        try %{ execute-keys -draft k <a-x> s ^\h*\%\h* <ret> y gh j P }
     }
 }
 

--- a/rc/filetype/moon.kak
+++ b/rc/filetype/moon.kak
@@ -99,7 +99,7 @@ define-command -hidden moon-indent-on-char %{
 define-command -hidden moon-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy -- comment prefix and following white spaces
-        try %{ execute-keys -draft k <a-x> s ^ \h * \K -- \h * <ret> y gh j P }
+        try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/moon.kak
+++ b/rc/filetype/moon.kak
@@ -16,6 +16,7 @@ hook global WinSetOption filetype=moon %{
 
     hook window ModeChange pop:insert:.* -group moon-trim-indent  moon-trim-indent
     hook window InsertChar .* -group moon-indent moon-indent-on-char
+    hook window InsertChar \n -group moon-insert moon-insert-on-new-line
     hook window InsertChar \n -group moon-indent moon-indent-on-new-line
 
     alias window alt moon-alternative-file
@@ -96,10 +97,15 @@ define-command -hidden moon-indent-on-char %{
     }
 }
 
-define-command -hidden moon-indent-on-new-line %{
+define-command -hidden moon-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy -- comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
+    }
+}
+
+define-command -hidden moon-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/nim.kak
+++ b/rc/filetype/nim.kak
@@ -16,6 +16,7 @@ hook global WinSetOption filetype=nim %{
 
     set-option window static_words %opt{nim_static_words}
 
+    hook window InsertChar \n -group nim-insert nim-insert-on-new-line
     hook window InsertChar \n -group nim-indent nim-indent-on-new-line
     # cleanup trailing whitespaces on current line insert end
     hook window ModeChange pop:insert:.* -group nim-trim-indent %{ try %{ exec -draft <semicolon> <a-x> s ^\h+$ <ret> d } }
@@ -108,10 +109,15 @@ add-highlighter shared/nim/code/ regex %{'(\\([rcnlftvabe\\"']|0*[12]?\d?\d|x[0-
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-define-command -hidden nim-indent-on-new-line %{
+define-command -hidden nim-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ exec -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
+    }
+}
+
+define-command -hidden nim-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ exec -draft <semicolon> K <a-&> }
         # cleanup trailing whitespaces from previous line

--- a/rc/filetype/nim.kak
+++ b/rc/filetype/nim.kak
@@ -108,8 +108,8 @@ add-highlighter shared/nim/code/ regex %{'(\\([rcnlftvabe\\"']|0*[12]?\d?\d|x[0-
 # Commands
 # ‾‾‾‾‾‾‾‾
 
-def -hidden nim-indent-on-new-line %{
-    eval -draft -itersel %{
+define-command -hidden nim-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ exec -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
         # preserve previous line indent

--- a/rc/filetype/ninja.kak
+++ b/rc/filetype/ninja.kak
@@ -17,6 +17,7 @@ hook global WinSetOption filetype=ninja %{
     set-option window static_words %opt{ninja_static_words}
 
     hook window ModeChange pop:insert:.* -group ninja-trim-indent ninja-trim-indent
+    hook window InsertChar \n -group ninja-insert ninja-insert-on-new-line
     hook window InsertChar \n -group ninja-indent ninja-indent-on-new-line
     # cleanup trailing whitespaces on current line insert end
     hook window ModeChange pop:insert:.* -group ninja-trim-indent %{ try %{ execute-keys -draft <semicolon> <a-x> s ^\h+$ <ret> d } }
@@ -84,10 +85,15 @@ define-command -hidden ninja-trim-indent %{
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
 
-define-command -hidden ninja-indent-on-new-line %{
+define-command -hidden ninja-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy -- comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
+    }
+}
+
+define-command -hidden ninja-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft \; K <a-&> }
         # filter previous line

--- a/rc/filetype/nix.kak
+++ b/rc/filetype/nix.kak
@@ -16,6 +16,7 @@ hook global WinSetOption filetype=nix %{
 
     hook window ModeChange pop:insert:.* -group nix-trim-indent  nix-trim-indent
     hook window InsertChar .* -group nix-indent nix-indent-on-char
+    hook window InsertChar \n -group nix-insert nix-insert-on-new-line
     hook window InsertChar \n -group nix-indent nix-indent-on-new-line
 
     set-option buffer extra_word_chars _ -
@@ -100,10 +101,15 @@ define-command -hidden nix-indent-on-char %<
     >
 >
 
-define-command -hidden nix-indent-on-new-line %<
+define-command -hidden nix-insert-on-new-line %<
     evaluate-commands -draft -itersel %<
         # copy // comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
+    >
+>
+
+define-command -hidden nix-indent-on-new-line %<
+    evaluate-commands -draft -itersel %<
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/pascal.kak
+++ b/rc/filetype/pascal.kak
@@ -3,25 +3,25 @@
 
 # Detection, see https://wiki.freepascal.org/file_types
 hook global BufCreate .*\.(p|pp|pas|pascal)$ %{
-	set-option buffer filetype pascal
+    set-option buffer filetype pascal
 }
 hook global BufCreate .*\.(dpr|dpk|dfm)$ %{
-	set-option buffer filetype delphi
+    set-option buffer filetype delphi
 }
 hook global BufCreate .*\.(lpr|lfm)$ %{
-	set-option buffer filetype freepascal
+    set-option buffer filetype freepascal
 }
 
 hook global WinSetOption filetype=((free|object)?pascal|delphi) %[
-	require-module pascal
-	hook window InsertChar \n -group pascal-indent pascal-indent-on-new-line
-	hook -once -always window WinSetOption filetype=.* %{ remove-hooks window pascal-.+ }
-	set-option window static_words %opt{static_words}
+    require-module pascal
+    hook window InsertChar \n -group pascal-indent pascal-indent-on-new-line
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window pascal-.+ }
+    set-option window static_words %opt{static_words}
 ]
 
 hook -group pascal-highlight global WinSetOption filetype=((free|object)?pascal|delphi) %[
-	add-highlighter window/pascal ref pascal
-	hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/pascal }
+    add-highlighter window/pascal ref pascal
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/pascal }
 ]
 
 provide-module pascal %§
@@ -30,174 +30,174 @@ add-highlighter shared/pascal regions
 add-highlighter shared/pascal/code default-region group
 
 evaluate-commands %sh¶
-	# This might seem like a lot of effort to highlight routines and
-	# properties correctly but it is worth it
+    # This might seem like a lot of effort to highlight routines and
+    # properties correctly but it is worth it
 
-	id='([_a-zA-Z][\w]{,126})\s*' # identifier for variables etc.
-	id2="(?:$id\.)?$id(?:<.*?>)?" # (module|type).id
-	id4="(?:$id\.)?(?:$id\.)?(?:$id\.)?$id" # type.type.type.id
-	type=":\s*(specialize\s+)?(?:(array\s+of\s+)?$id2)" # 1:attribute 2:keyword 3:module 4:type
+    id='([_a-zA-Z][\w]{,126})\s*' # identifier for variables etc.
+    id2="(?:$id\.)?$id(?:<.*?>)?" # (module|type).id
+    id4="(?:$id\.)?(?:$id\.)?(?:$id\.)?$id" # type.type.type.id
+    type=":\s*(specialize\s+)?(?:(array\s+of\s+)?$id2)" # 1:attribute 2:keyword 3:module 4:type
 
-	cat <<-EOF
-		# routine without parameters
-		add-highlighter shared/pascal/code/simple_routine regex \
-			"\b(?i)(function|procedure|constructor|destructor|operator)\s+$id4(?:$type)?" \
-			2:type 3:type 4:type 5:function 6:attribute 7:keyword 8:module 9:type
-		add-highlighter shared/pascal/simple_property region \
-			"\b(?i)property\s+$id2:"  ";" group
+    cat <<EOF
+        # routine without parameters
+        add-highlighter shared/pascal/code/simple_routine regex \
+            "\b(?i)(function|procedure|constructor|destructor|operator)\s+$id4(?:$type)?" \
+            2:type 3:type 4:type 5:function 6:attribute 7:keyword 8:module 9:type
+        add-highlighter shared/pascal/simple_property region \
+            "\b(?i)property\s+$id2:"  ";" group
 
-		# routine with parameters
-		add-highlighter shared/pascal/routine region \
-			"\b(?i)(function|procedure|constructor|destructor|operator)(\s+$id4)?\s*(<.*?>)?\s*\("  "\).*?;" regions
-		add-highlighter shared/pascal/property region \
-			"\b(?i)property\s+$id4\["  "\].*?;" regions
+        # routine with parameters
+        add-highlighter shared/pascal/routine region \
+            "\b(?i)(function|procedure|constructor|destructor|operator)(\s+$id4)?\s*(<.*?>)?\s*\("  "\).*?;" regions
+        add-highlighter shared/pascal/property region \
+            "\b(?i)property\s+$id4\["  "\].*?;" regions
 
-		add-highlighter shared/pascal/routine/parameters  region -recurse \( \( \) regions
-		add-highlighter shared/pascal/property/parameters region -recurse \[ \[ \] regions
-	EOF
+        add-highlighter shared/pascal/routine/parameters  region -recurse \( \( \) regions
+        add-highlighter shared/pascal/property/parameters region -recurse \[ \[ \] regions
+    EOF
 
-	# Used to highlight "var1, var2, var3, var4 : type" declarations
-	x="(?:$id,\s*)?"
+    # Used to highlight "var1, var2, var3, var4 : type" declarations
+    x="(?:$id,\s*)?"
 
-	for r in property routine; do
-		cat <<-EOF
-			add-highlighter shared/pascal/$r/parameters/default default-region group
-			add-highlighter shared/pascal/$r/parameters/default/ regex \
-				"(?i)(?:(constref|const|var|out|univ)\s+)?$x$x$x$x$x$id(?:$type)?" \
-				1:attribute 2:variable 3:variable 4:variable 5:variable 6:variable 7:variable 8:attribute 9:keyword 10:module 11:type
-			add-highlighter shared/pascal/$r/default default-region group
-		EOF
-	done
+    for r in property routine; do
+        cat <<EOF
+            add-highlighter shared/pascal/$r/parameters/default default-region group
+            add-highlighter shared/pascal/$r/parameters/default/ regex \
+                "(?i)(?:(constref|const|var|out|univ)\s+)?$x$x$x$x$x$id(?:$type)?" \
+                1:attribute 2:variable 3:variable 4:variable 5:variable 6:variable 7:variable 8:attribute 9:keyword 10:module 11:type
+            add-highlighter shared/pascal/$r/default default-region group
+        EOF
+    done
 
-	cat <<-EOF
-		add-highlighter shared/pascal/routine/default/ regex \
-			"\b(?i)(function|procedure|constructor|destructor|operator)(?:\s+$id4)?" \
-			1:keyword 2:type 3:type 4:type 5:function
-		add-highlighter shared/pascal/routine/default/return_type regex \
-			"(?i)$type" 1:attribute 2:keyword 3:module 4:type
-		add-highlighter shared/pascal/routine/default/ regex \
-			"(?i)(of\s+object|is\s+nested)" 1:keyword
-	EOF
+    cat <<EOF
+        add-highlighter shared/pascal/routine/default/ regex \
+            "\b(?i)(function|procedure|constructor|destructor|operator)(?:\s+$id4)?" \
+            1:keyword 2:type 3:type 4:type 5:function
+        add-highlighter shared/pascal/routine/default/return_type regex \
+            "(?i)$type" 1:attribute 2:keyword 3:module 4:type
+        add-highlighter shared/pascal/routine/default/ regex \
+            "(?i)(of\s+object|is\s+nested)" 1:keyword
+    EOF
 
-	for r in property/default simple_property; do
-		cat <<-EOF
-			add-highlighter shared/pascal/$r/ regex "\b(?i)(property)" 1:keyword
-			add-highlighter shared/pascal/$r/type regex ":\s*$id" 1:type
+    for r in property/default simple_property; do
+        cat <<EOF
+            add-highlighter shared/pascal/$r/ regex "\b(?i)(property)" 1:keyword
+            add-highlighter shared/pascal/$r/type regex ":\s*$id" 1:type
 
-			# https://www.freepascal.org/docs-html/ref/refsu33.html
-			add-highlighter shared/pascal/$r/specifier regex \
-				"\b(?i)(index|read|write|implements|(no)?default|stored)\b" 0:attribute
-		EOF
-	done
+            # https://www.freepascal.org/docs-html/ref/refsu33.html
+            add-highlighter shared/pascal/$r/specifier regex \
+                "\b(?i)(index|read|write|implements|(no)?default|stored)\b" 0:attribute
+        EOF
+    done
 
-	for r in pascal pascal/routine pascal/routine/parameters pascal/property; do
-		cat <<-EOF
-			# Example string: 'You''re welcome!'
-			add-highlighter shared/$r/string region \
-				-recurse %{(?<!')('')+(?!')} %{'} %{'(?!')|\$} group
-			add-highlighter shared/$r/string/ fill string
-			add-highlighter shared/$r/string/escape regex "''" 0:+b
+    for r in pascal pascal/routine pascal/routine/parameters pascal/property; do
+        cat <<EOF
+            # Example string: 'You''re welcome!'
+            add-highlighter shared/$r/string region \
+                -recurse %{(?<!')('')+(?!')} %{'} %{'(?!')|\$} group
+            add-highlighter shared/$r/string/ fill string
+            add-highlighter shared/$r/string/escape regex "''" 0:+b
 
-			add-highlighter shared/$r/directive region \{\\$[a-zA-Z] \} fill meta
+            add-highlighter shared/$r/directive region \{\\$[a-zA-Z] \} fill meta
 
-			# comments (https://www.freepascal.org/docs-html/ref/refse2.html)
-			add-highlighter shared/$r/comment_old region -recurse \(\* \(\* \*\) fill comment
-			add-highlighter shared/$r/comment_new region -recurse \{ \{  \} fill comment
-			add-highlighter shared/$r/comment_oneline region // $ fill comment
-		EOF
-	done
+            # comments (https://www.freepascal.org/docs-html/ref/refse2.html)
+            add-highlighter shared/$r/comment_old region -recurse \(\* \(\* \*\) fill comment
+            add-highlighter shared/$r/comment_new region -recurse \{ \{  \} fill comment
+            add-highlighter shared/$r/comment_oneline region // $ fill comment
+        EOF
+    done
 
 
-	# The types "string" and "file", the value "nil", and the modifiers
-	# "bitpacked" and "packed" are not included.
-	reserved='and array as asm begin case class const constructor cppclass
-	          destructor dispinterface div do downto else end except exports
-	          finalization finally for function goto if implementation in
-	          inherited initialization interface is label library mod not
-	          object of operator or otherwise procedure program property raise
-	          record repeat resourcestring set shl shr then threadvar to try
-	          type unit until uses var while with xor'
+    # The types "string" and "file", the value "nil", and the modifiers
+    # "bitpacked" and "packed" are not included.
+    reserved='and array as asm begin case class const constructor cppclass
+              destructor dispinterface div do downto else end except exports
+              finalization finally for function goto if implementation in
+              inherited initialization interface is label library mod not
+              object of operator or otherwise procedure program property raise
+              record repeat resourcestring set shl shr then threadvar to try
+              type unit until uses var while with xor'
 
-	# These are not reserved words in Free Pascal, but for consistency
-	# with other programming languages are highlighted as reserved words:
-	keywords='Break Continue Exit at on package'
-	# "at" is used in Delphi, e.g. 'raise object at address'
+    # These are not reserved words in Free Pascal, but for consistency
+    # with other programming languages are highlighted as reserved words:
+    keywords='Break Continue Exit at on package'
+    # "at" is used in Delphi, e.g. 'raise object at address'
 
-	# https://www.freepascal.org/docs-html/ref/refsu3.html and
-	# https://wiki.freepascal.org/Reserved_words
-	# "name" and "alias" are not included beacuse they produce too many
-	# false positives. Some modifiers like "index" are only highlighted in
-	# certain places.
-	modifiers='absolute abstract assembler automated bitpacked cdecl contains
-	           cppdecl cvar default deprecated dispid dynamic enumerator
-	           experimental export external far far16 final forward generic
-	           helper inline interrupt iocheck local near noreturn
-	           nostackframe oldfpccall overload override packed pascal
-	           platform private protected public published readonly register
-	           reintroduce requires safecall saveregisters softfloat specialize
-	           static stdcall strict syscall unaligned unimplemented varargs
-	           virtual winapi writeonly'
+    # https://www.freepascal.org/docs-html/ref/refsu3.html and
+    # https://wiki.freepascal.org/Reserved_words
+    # "name" and "alias" are not included beacuse they produce too many
+    # false positives. Some modifiers like "index" are only highlighted in
+    # certain places.
+    modifiers='absolute abstract assembler automated bitpacked cdecl contains
+               cppdecl cvar default deprecated dispid dynamic enumerator
+               experimental export external far far16 final forward generic
+               helper inline interrupt iocheck local near noreturn
+               nostackframe oldfpccall overload override packed pascal
+               platform private protected public published readonly register
+               reintroduce requires safecall saveregisters softfloat specialize
+               static stdcall strict syscall unaligned unimplemented varargs
+               virtual winapi writeonly'
 
-	# https://wiki.freepascal.org/Category:Data_types
-	# not highlighted for consistency with not built-in types
-	types='AnsiChar AnsiString Boolean Boolean16 Boolean32 Boolean64 Buffer
-	       Byte ByteBool Cardinal Char Comp Currency Double DWord Extended
-	       Int16 Int32 Int64 Int8 Integer IUnknown LongBool LongInt Longword
-	       NativeInt NativeUInt OleVariant PAnsiChar PAnsiString PBoolean PByte
-	       PByteArray PCardinal PChar PComp PCurrency PDate PDateTime PDouble
-	       PDWord PExtended PHandle PInt64 PInteger PLongInt PLongWord Pointer
-	       PPointer PQWord PShortInt PShortString PSingle PSmallInt PString
-	       PUnicodeChar PUnicodeString PVariant PWideChar PWideString PWord
-	       PWordArray PWordBool QWord QWordBool RawBytestring Real Real48
-	       ShortInt ShortString Single SmallInt TClass TDate TDateTime Text
-	       TextFile THandle TObject TTime UInt16 UInt32 UInt8 UnicodeChar
-	       UnicodeString UTF16String UTF8String Variant WideChar WideString
-	       Word WordBool file string'
+    # https://wiki.freepascal.org/Category:Data_types
+    # not highlighted for consistency with not built-in types
+    types='AnsiChar AnsiString Boolean Boolean16 Boolean32 Boolean64 Buffer
+           Byte ByteBool Cardinal Char Comp Currency Double DWord Extended
+           Int16 Int32 Int64 Int8 Integer IUnknown LongBool LongInt Longword
+           NativeInt NativeUInt OleVariant PAnsiChar PAnsiString PBoolean PByte
+           PByteArray PCardinal PChar PComp PCurrency PDate PDateTime PDouble
+           PDWord PExtended PHandle PInt64 PInteger PLongInt PLongWord Pointer
+           PPointer PQWord PShortInt PShortString PSingle PSmallInt PString
+           PUnicodeChar PUnicodeString PVariant PWideChar PWideString PWord
+           PWordArray PWordBool QWord QWordBool RawBytestring Real Real48
+           ShortInt ShortString Single SmallInt TClass TDate TDateTime Text
+           TextFile THandle TObject TTime UInt16 UInt32 UInt8 UnicodeChar
+           UnicodeString UTF16String UTF8String Variant WideChar WideString
+           Word WordBool file string'
 
-	constants='False True nil MaxInt Self'
+    constants='False True nil MaxInt Self'
 
-	# Add the language's grammar to the static completion list
-	echo declare-option str-list static_words $reserved $keywords $modifiers \
-		$types $constants name index result constref out read write implements \
-		nodefault stored message
+    # Add the language's grammar to the static completion list
+    echo declare-option str-list static_words $reserved $keywords $modifiers \
+        $types $constants name index result constref out read write implements \
+        nodefault stored message
 
-	# Replace spaces with a pipe
-	join() { eval set -- $1; IFS='|'; echo "$*"; }
+    # Replace spaces with a pipe
+    join() { eval set -- $1; IFS='|'; echo "$*"; }
 
-	cat <<-EOF
-		add-highlighter shared/pascal/code/keywords  regex \
-			(?i)(?<!&)\b($(join "$reserved $keywords")|file\s+of)\b 0:keyword
-		add-highlighter shared/pascal/code/modifiers regex \
-			(?i)(?<!\.)\b($(join "$modifiers"))\b(?!\()|message\s+(?!:) 0:attribute
-		add-highlighter shared/pascal/code/index regex \
-			'\b(?i)(index)\s+\w+\s*;' 1:attribute
-	EOF
+    cat <<EOF
+        add-highlighter shared/pascal/code/keywords  regex \
+            (?i)(?<!&)\b($(join "$reserved $keywords")|file\s+of)\b 0:keyword
+        add-highlighter shared/pascal/code/modifiers regex \
+            (?i)(?<!\.)\b($(join "$modifiers"))\b(?!\()|message\s+(?!:) 0:attribute
+        add-highlighter shared/pascal/code/index regex \
+            '\b(?i)(index)\s+\w+\s*;' 1:attribute
+    EOF
 
-	for r in code routine/parameters/default routine/default property/default simple_property; do
-		cat <<-EOF
-			add-highlighter shared/pascal/$r/ regex '[.:=<>@^*/+-]' 0:operator
-			add-highlighter shared/pascal/$r/constants regex \
-				\b(?i)($(join "$constants"))\b 0:value
+    for r in code routine/parameters/default routine/default property/default simple_property; do
+        cat <<EOF
+            add-highlighter shared/pascal/$r/ regex '[.:=<>@^*/+-]' 0:operator
+            add-highlighter shared/pascal/$r/constants regex \
+                \b(?i)($(join "$constants"))\b 0:value
 
-			# numbers (https://www.freepascal.org/docs-html/ref/refse6.html)
-			add-highlighter shared/pascal/$r/decimal regex \b\d+([eE][+-]?\d+)?\b 0:value
-			add-highlighter shared/pascal/$r/hex     regex \\$[\da-fA-F]+\b 0:value
-			add-highlighter shared/pascal/$r/octal   regex &[0-7]+\b 0:value
-			add-highlighter shared/pascal/$r/binary  regex \%[01]+\b 0:value
-			add-highlighter shared/pascal/$r/char    regex '#\d+\b' 0:value
-		EOF
-	done
+            # numbers (https://www.freepascal.org/docs-html/ref/refse6.html)
+            add-highlighter shared/pascal/$r/decimal regex \b\d+([eE][+-]?\d+)?\b 0:value
+            add-highlighter shared/pascal/$r/hex     regex \\$[\da-fA-F]+\b 0:value
+            add-highlighter shared/pascal/$r/octal   regex &[0-7]+\b 0:value
+            add-highlighter shared/pascal/$r/binary  regex \%[01]+\b 0:value
+            add-highlighter shared/pascal/$r/char    regex '#\d+\b' 0:value
+        EOF
+    done
 ¶
 
 define-command -hidden pascal-indent-on-new-line %{
-	evaluate-commands -no-hooks -draft -itersel %{
-		# preserve previous line indent
-		try %{ execute-keys -draft <semicolon> K <a-&> }
-		# cleanup trailing whitespaces from previous line
-		try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
-		# indent after certain keywords
-		try %{ execute-keys -draft k<a-x><a-k>(?i)(asm|begin|const|else|except|exports|finalization|finally|label|of|otherwise|private|property|public|protected|published|record|repeat|resourcestring|threadvar|try|type|uses|var|:)\h*$<ret>j<a-gt> }
-	}
+    evaluate-commands -no-hooks -draft -itersel %{
+        # preserve previous line indent
+        try %{ execute-keys -draft <semicolon> K <a-&> }
+        # cleanup trailing whitespaces from previous line
+        try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
+        # indent after certain keywords
+        try %{ execute-keys -draft k<a-x><a-k>(?i)(asm|begin|const|else|except|exports|finalization|finally|label|of|otherwise|private|property|public|protected|published|record|repeat|resourcestring|threadvar|try|type|uses|var|:)\h*$<ret>j<a-gt> }
+    }
 }
 §
 

--- a/rc/filetype/perl.kak
+++ b/rc/filetype/perl.kak
@@ -116,8 +116,8 @@ define-command -hidden perl-indent-on-new-line %~
         try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
-        # copy # comments prefix
-        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K# <ret> y<c-o>P<esc> }
+        # copy # comments prefix and following white spaces
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K#\h* <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # indent after if|else|while|for

--- a/rc/filetype/perl.kak
+++ b/rc/filetype/perl.kak
@@ -18,6 +18,7 @@ hook global WinSetOption filetype=perl %{
 
     # cleanup trailing whitespaces when exiting insert mode
     hook window ModeChange pop:insert:.* -group perl-trim-indent %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
+    hook window InsertChar \n -group perl-insert perl-insert-on-new-line
     hook window InsertChar \n -group perl-indent perl-indent-on-new-line
     hook window InsertChar \{ -group perl-indent perl-indent-on-opening-curly-brace
     hook window InsertChar \} -group perl-indent perl-indent-on-closing-curly-brace
@@ -106,6 +107,13 @@ add-highlighter shared/perl/code/ regex \$(LAST_REGEXP_CODE_RESULT|LIST_SEPARATO
 # Commands
 # ‾‾‾‾‾‾‾‾
 
+define-command -hidden perl-insert-on-new-line %~
+    evaluate-commands -draft -itersel %=
+        # copy # comments prefix and following white spaces
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K#\h* <ret> y<c-o>P<esc> }
+    =
+~
+
 define-command -hidden perl-indent-on-new-line %~
     evaluate-commands -draft -itersel %=
         # preserve previous line indent
@@ -116,8 +124,6 @@ define-command -hidden perl-indent-on-new-line %~
         try %{ execute-keys -draft k<a-x> s \h+$ <ret>d }
         # align to opening paren of previous line
         try %{ execute-keys -draft [( <a-k> \A\([^\n]+\n[^\n]*\n?\z <ret> s \A\(\h*.|.\z <ret> '<a-;>' & }
-        # copy # comments prefix and following white spaces
-        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K#\h* <ret> y<c-o>P<esc> }
         # indent after a switch's case/default statements
         try %[ execute-keys -draft k<a-x> <a-k> ^\h*(case|default).*:$ <ret> j<a-gt> ]
         # indent after if|else|while|for

--- a/rc/filetype/php.kak
+++ b/rc/filetype/php.kak
@@ -13,6 +13,7 @@ hook global WinSetOption filetype=php %{
 
     hook window ModeChange pop:insert:.* -group php-trim-indent  php-trim-indent
     hook window InsertChar .* -group php-indent php-indent-on-char
+    hook window InsertChar \n -group php-insert php-insert-on-new-line
     hook window InsertChar \n -group php-indent php-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window php-.+ }
@@ -81,18 +82,23 @@ define-command -hidden php-indent-on-char %<
     >
 >
 
-define-command -hidden php-indent-on-new-line %<
+define-command -hidden php-insert-on-new-line %<
     evaluate-commands -draft -itersel %<
         # copy // comments or docblock * prefix and following white spaces
-        try %{ execute-keys -draft s [^/] <ret> k <a-x> s ^\h*\K(?://|[*][^/])\h* <ret> y gh j P }
+        try %{ execute-keys -draft s [^/] <ret> k <a-x> s ^\h*\K(?://|[*][^/])\h* <ret> y gh j P
+        # append " * " on lines starting a multiline /** or /* comment
+        try %{ execute-keys -draft k <a-x> s ^\h*/[*][* ]? <ret> j gi i <space>*<space> }
+    >
+>
+
+define-command -hidden php-indent-on-new-line %<
+    evaluate-commands -draft -itersel %<
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line
         try %{ execute-keys -draft k : php-trim-indent <ret> }
         # indent after lines beginning / ending with opener token
         try %_ execute-keys -draft k <a-x> <a-k> ^\h*[[{]|[[{]$ <ret> j <a-gt> _
-        # append " * " on lines starting a multiline /** or /* comment
-        try %{ execute-keys -draft k <a-x> s ^\h*/[*][* ]? <ret> j gi i <space>*<space> }
         # deindent closer token(s) when after cursor
         try %_ execute-keys -draft <a-x> <a-k> ^\h*[})] <ret> gh / [})] <ret> m <a-S> 1<a-&> _
     >

--- a/rc/filetype/php.kak
+++ b/rc/filetype/php.kak
@@ -92,9 +92,9 @@ define-command -hidden php-indent-on-new-line %<
         # indent after lines beginning / ending with opener token
         try %_ execute-keys -draft k <a-x> <a-k> ^\h*[[{]|[[{]$ <ret> j <a-gt> _
         # append " * " on lines starting a multiline /** or /* comment
-    	try %{ execute-keys -draft k <a-x> s ^\h*/[*][* ]? <ret> j gi i <space>*<space> }
-    	# deindent closer token(s) when after cursor
-    	try %_ execute-keys -draft <a-x> <a-k> ^\h*[})] <ret> gh / [})] <ret> m <a-S> 1<a-&> _
+        try %{ execute-keys -draft k <a-x> s ^\h*/[*][* ]? <ret> j gi i <space>*<space> }
+        # deindent closer token(s) when after cursor
+        try %_ execute-keys -draft <a-x> <a-k> ^\h*[})] <ret> gh / [})] <ret> m <a-S> 1<a-&> _
     >
 >
 

--- a/rc/filetype/pony.kak
+++ b/rc/filetype/pony.kak
@@ -16,6 +16,7 @@ hook global WinSetOption filetype=pony %{
 
     set-option window static_words %opt{pony_static_words}
 
+    hook window InsertChar \n -group pony-insert pony-insert-on-new-line
     hook window InsertChar \n -group pony-indent pony-indent-on-new-line
     # cleanup trailing whitespaces on current line insert end
     hook window ModeChange pop:insert:.* -group pony-trim-indent %{ try %{ execute-keys -draft <semicolon> <a-x> s ^\h+$ <ret> d } }
@@ -80,14 +81,19 @@ evaluate-commands %sh{
 # Commands
 # ‾‾‾‾‾‾‾‾
 
+define-command -hidden pony-insert-on-new-line %{
+    evaluate-commands -draft -itersel %{
+        # copy // comments prefix and following white spaces
+        try %{ execute-keys -draft k x s ^\h*//\h* <ret> y jgh P }
+    }
+}
+
 define-command -hidden pony-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <space> K <a-&> }
         # cleanup trailing whitespaces from previous line
         try %{ execute-keys -draft k <a-x> s \h+$ <ret> d }
-        # copy '//' comment prefix and following white spaces
-        # try %{ execute-keys -draft k x s ^\h*//\h* <ret> y jgh P }
         # indent after line ending with :
         try %{ execute-keys -draft <space> k x <a-k> (\b(?:do|try|then|else)|:|=>)$ <ret> j <a-gt> }
         # else, end are always de-indented

--- a/rc/filetype/purescript.kak
+++ b/rc/filetype/purescript.kak
@@ -18,6 +18,7 @@ hook global WinSetOption filetype=purescript %{
 
     set-option buffer extra_word_chars '_' "'"
     hook window ModeChange pop:insert:.* -group purescript-trim-indent  purescript-trim-indent
+    hook window InsertChar \n -group purescript-insert purescript-insert-on-new-line
     hook window InsertChar \n -group purescript-indent purescript-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window purescript-.+ }
@@ -96,10 +97,15 @@ define-command -hidden purescript-trim-indent %{
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
 
-define-command -hidden purescript-indent-on-new-line %{
+define-command -hidden purescript-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy -- comments prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K--\h* <ret> y gh j P }
+    }
+}
+
+define-command -hidden purescript-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # align to first clause

--- a/rc/filetype/python.kak
+++ b/rc/filetype/python.kak
@@ -149,6 +149,7 @@ define-command -hidden python-insert-on-new-line %{
         try %{ execute-keys -draft k <a-x> s ^\h*#\h* <ret> y jgh P }
     }
 }
+
 define-command -hidden python-indent-on-new-line %<
     evaluate-commands -draft -itersel %<
         # preserve previous line indent

--- a/rc/filetype/ragel.kak
+++ b/rc/filetype/ragel.kak
@@ -18,6 +18,7 @@ hook global WinSetOption filetype=ragel %{
 
     hook window ModeChange pop:insert:.* -group ragel-trim-indent  ragel-trim-indent
     hook window InsertChar .* -group ragel-indent ragel-indent-on-char
+    hook window InsertChar \n -group ragel-insert ragel-insert-on-new-line
     hook window InsertChar \n -group ragel-indent ragel-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window ragel-.+ }
@@ -60,10 +61,15 @@ define-command -hidden ragel-indent-on-char %<
     >
 >
 
-define-command -hidden ragel-indent-on-new-line %<
+define-command -hidden ragel-insert-on-new-line %<
     evaluate-commands -draft -itersel %<
         # copy _#_ comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
+    >
+>
+
+define-command -hidden ragel-indent-on-new-line %<
+    evaluate-commands -draft -itersel %<
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/sass.kak
+++ b/rc/filetype/sass.kak
@@ -16,6 +16,7 @@ hook global WinSetOption filetype=sass %<
 
     hook window ModeChange pop:insert:.* -group sass-trim-indent  sass-trim-indent
     hook window InsertChar \} -group sass-indent sass-indent-on-closing-brace
+    hook window InsertChar \n -group sass-insert sass-insert-on-new-line
     hook window InsertChar \n -group sass-indent sass-indent-on-new-line
     set-option buffer extra_word_chars '_' '-'
 
@@ -62,10 +63,15 @@ define-command -hidden sass-indent-on-closing-brace %<
     >
 >
 
+define-command -hidden sass-insert-on-new-line %<
+    evaluate-commands -draft -itersel %<
+        # copy // comment prefix and following white spaces
+        try %{ execute-keys -draft k <a-x> s ^\h*\K/{2,}\h* <ret> y gh j P }
+    >
+>
+
 define-command -hidden sass-indent-on-new-line %<
     evaluate-commands -draft -itersel %<
-        # copy '/' comment prefix and following white spaces
-        try %{ execute-keys -draft k <a-x> s ^\h*\K/{2,}\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/sass.kak
+++ b/rc/filetype/sass.kak
@@ -37,7 +37,8 @@ add-highlighter shared/sass regions
 add-highlighter shared/sass/code default-region group
 add-highlighter shared/sass/single_string  region '"' (?<!\\)(\\\\)*" fill string
 add-highlighter shared/sass/double_string  region "'" "'"             fill string
-add-highlighter shared/sass/comment        region '/' '$'             fill comment
+add-highlighter shared/sass/comment        region '//' '$'            fill comment
+add-highlighter shared/sass/css_comment    region /[*] [*]/           fill comment
 
 add-highlighter shared/sass/code/ regex [*]|[#.][A-Za-z][A-Za-z0-9_-]* 0:variable
 add-highlighter shared/sass/code/ regex &|@[A-Za-z][A-Za-z0-9_-]* 0:meta
@@ -64,7 +65,7 @@ define-command -hidden sass-indent-on-closing-brace %<
 define-command -hidden sass-indent-on-new-line %<
     evaluate-commands -draft -itersel %<
         # copy '/' comment prefix and following white spaces
-        try %{ execute-keys -draft k <a-x> s ^\h*\K/\h* <ret> y gh j P }
+        try %{ execute-keys -draft k <a-x> s ^\h*\K/{2,}\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/scala.kak
+++ b/rc/filetype/scala.kak
@@ -15,6 +15,7 @@ hook global WinSetOption filetype=scala %[
     require-module scala
 
     hook window ModeChange pop:insert:.* -group scala-trim-indent  scala-trim-indent
+    hook window InsertChar \n -group scala-insert scala-insert-on-new-line
     hook window InsertChar \n -group scala-indent scala-indent-on-new-line
     hook window InsertChar \} -group scala-indent scala-indent-on-closing-curly-brace
 
@@ -59,10 +60,15 @@ define-command -hidden scala-trim-indent %{
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
 
-define-command -hidden scala-indent-on-new-line %[
+define-command -hidden scala-insert-on-new-line %[
     evaluate-commands -draft -itersel %[
         # copy // comments prefix and following white spaces
-        try %[ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P ]
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K#\h* <ret> y<c-o>P<esc> }
+    ]
+]
+
+define-command -hidden scala-indent-on-new-line %[
+    evaluate-commands -draft -itersel %[
         # preserve previous line indent
         try %[ execute-keys -draft <semicolon> K <a-&> ]
         # filter previous line

--- a/rc/filetype/toml.kak
+++ b/rc/filetype/toml.kak
@@ -15,6 +15,7 @@ hook global WinSetOption filetype=toml %{
     require-module toml
 
     hook window ModeChange pop:insert:.* -group toml-trim-indent toml-trim-indent
+    hook window InsertChar \n -group toml-insert toml-insert-on-new-line
     hook window InsertChar \n -group toml-indent toml-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window toml-.+ }
@@ -56,10 +57,15 @@ define-command -hidden toml-trim-indent %{
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
 
+define-command -hidden toml-insert-on-new-line %{
+    evaluate-commands -draft -itersel %{
+        # copy # comments prefix and following white spaces
+        try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
+    }
+}
+
 define-command -hidden toml-indent-on-new-line %{
     evaluate-commands -draft -itersel %{
-        # copy comment prefix and following white spaces
-        try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/vhdl.kak
+++ b/rc/filetype/vhdl.kak
@@ -2,24 +2,24 @@
 
 # Detection
 hook global BufCreate .*[.](vhd[l]?) %[
-	set-option buffer filetype vhdl
+    set-option buffer filetype vhdl
 ]
 
 # Initialization
 hook global WinSetOption filetype=vhdl %[
-	require-module vhdl
-	set-option window static_words %opt{vhdl_static_words}
-	hook -group vhdl-indent window InsertChar \n  vhdl-indent-on-new-line
-	hook -group vhdl-indent window InsertChar \)  vhdl-indent-on-closing-parenthesis
-	hook -group vhdl-insert window InsertChar \n  vhdl-insert-on-new-line
-	# Cleanup trailing whitespaces on current line insert end.
-	hook -group vhdl-trim-indent window ModeChange pop:insert:.* %[ try %[ execute-keys -draft <semicolon> <a-x> s ^\h+$ <ret> d ] ]
-	hook -once -always window WinSetOption filetype=.* %[ remove-hooks window vhdl-.+ ]
+    require-module vhdl
+    set-option window static_words %opt{vhdl_static_words}
+    hook -group vhdl-indent window InsertChar \n  vhdl-indent-on-new-line
+    hook -group vhdl-indent window InsertChar \)  vhdl-indent-on-closing-parenthesis
+    hook -group vhdl-insert window InsertChar \n  vhdl-insert-on-new-line
+    # Cleanup trailing whitespaces on current line insert end.
+    hook -group vhdl-trim-indent window ModeChange pop:insert:.* %[ try %[ execute-keys -draft <semicolon> <a-x> s ^\h+$ <ret> d ] ]
+    hook -once -always window WinSetOption filetype=.* %[ remove-hooks window vhdl-.+ ]
 ]
 
 hook -group vhdl-highlight global WinSetOption filetype=vhdl %[
-	add-highlighter window/vhdl ref vhdl
-	hook -once -always window WinSetOption filetype=.* %[ remove-highlighter window/vhdl ]
+    add-highlighter window/vhdl ref vhdl
+    hook -once -always window WinSetOption filetype=.* %[ remove-highlighter window/vhdl ]
 ]
 
 provide-module vhdl %§
@@ -43,100 +43,100 @@ add-highlighter shared/vhdl/code/ regex '\b\d+\.' 0:value
 add-highlighter shared/vhdl/code/ regex '\b\d+\+\d+[jJ]\b' 0:value
 
 evaluate-commands %sh[
-	values="true false note warning error failure"
+    values="true false note warning error failure"
 
-	# LRM 5.2.4.1
-	units="fs ps ns us ms sec min Å nm um mm cm m km"
+    # LRM 5.2.4.1
+    units="fs ps ns us ms sec min Å nm um mm cm m km"
 
-	# LRM 16.2
-	predefined_attributes="
-		base left right high low ascending length range reverse_range
-		subtype image pos succ pred leftof rightof value val
-		designated_subtype reflect high low index element delayed
-		stable quiet transaction event active last_event last_active
-		last_value driving driving_value simple_name instance_name
-		path_name record signal converse
-	"
+    # LRM 16.2
+    predefined_attributes="
+        base left right high low ascending length range reverse_range
+        subtype image pos succ pred leftof rightof value val
+        designated_subtype reflect high low index element delayed
+        stable quiet transaction event active last_event last_active
+        last_value driving driving_value simple_name instance_name
+        path_name record signal converse
+    "
 
-	libraries="ieee std"
+    libraries="ieee std"
 
-	packages="
-		math_real math_complex std_logic_1164 std_logic_textio numeric_bit numeric_std
-		numeric_bit_unsigned numeric_std_unsigned fixed_float_types fixed_generic_pkg
-		fixed_pkg float_generic_pkg float_pkg
-		standard textio env
-	"
+    packages="
+        math_real math_complex std_logic_1164 std_logic_textio numeric_bit numeric_std
+        numeric_bit_unsigned numeric_std_unsigned fixed_float_types fixed_generic_pkg
+        fixed_pkg float_generic_pkg float_pkg
+        standard textio env
+    "
 
-	 # LRM 15.10
-	reserved_words="
-		abs access after alias all and architecture array assert assume assume_guarantee attribute
-		begin block body buffer bus
-		case component configuration constant context cover
-		default disconnect downto
-		else elsif end entity exit
-		fairness file for force function
-		generate generic group guarded
-		if impure in inertial inout is
-		label library linkage literal loop
-		map mod
-		nand new next nor not null
-		of on open or others out
-		package parameter port postponed procedure process property protected pure
-		range record register reject release rem report restrict restrict_guarantee return rol ror
-		select sequence severity signal shared sla sll sra srl strong subtype
-		then to transport type
-		unaffected units until use
-		variable view vpkg vmode vprop vunit
-		wait when while with
-		xnor xor
-	"
+     # LRM 15.10
+    reserved_words="
+        abs access after alias all and architecture array assert assume assume_guarantee attribute
+        begin block body buffer bus
+        case component configuration constant context cover
+        default disconnect downto
+        else elsif end entity exit
+        fairness file for force function
+        generate generic group guarded
+        if impure in inertial inout is
+        label library linkage literal loop
+        map mod
+        nand new next nor not null
+        of on open or others out
+        package parameter port postponed procedure process property protected pure
+        range record register reject release rem report restrict restrict_guarantee return rol ror
+        select sequence severity signal shared sla sll sra srl strong subtype
+        then to transport type
+        unaffected units until use
+        variable view vpkg vmode vprop vunit
+        wait when while with
+        xnor xor
+    "
 
-	types="
-		bit bit_vector
-		boolean
-		file_open_state file_origin_kind
-		integer natural positive
-		line line_vector
-		std_logic std_logic_vector
-		std_ulogic std_ulogic_vector
-		side
-		signed unsigned
-		string text
-		time
-	"
+    types="
+        bit bit_vector
+        boolean
+        file_open_state file_origin_kind
+        integer natural positive
+        line line_vector
+        std_logic std_logic_vector
+        std_ulogic std_ulogic_vector
+        side
+        signed unsigned
+        string text
+        time
+    "
 
-	functions="
-		find_leftmost find_rightmost divide reciprocal remainder modulo minimum maximum
-		std_match add_carry scalb
-		resize to_ufixed to_sfixed to_unsigned to_signed to_real to_integer to_slv
-		to_std_logic_vector to_stdlogicvector to_sulv to_std_ulogic_vector to_std_ulogicvector
-		to_01 is_x to_x01 to_ux01 to_x01z
-		ufixed_high ufixed_low sfixed_high sfixed_low to_ufix to_sfix ufix_high ufix_low
-		sfix_high sfix_low
-		write read bwrite binary_write bread binary_read owrite oread octal_write octal_read
-		hwrite hread hex_write hex_read to_string to_bstring to_binary_string to_ostring
-		to_octal_string to_hstring to_hex_string from_string from_bstring from_binary_string
-		from_ostring from_octal_string from_hstring from_hex_string
-		rising_edge falling_edge
-	"
+    functions="
+        find_leftmost find_rightmost divide reciprocal remainder modulo minimum maximum
+        std_match add_carry scalb
+        resize to_ufixed to_sfixed to_unsigned to_signed to_real to_integer to_slv
+        to_std_logic_vector to_stdlogicvector to_sulv to_std_ulogic_vector to_std_ulogicvector
+        to_01 is_x to_x01 to_ux01 to_x01z
+        ufixed_high ufixed_low sfixed_high sfixed_low to_ufix to_sfix ufix_high ufix_low
+        sfix_high sfix_low
+        write read bwrite binary_write bread binary_read owrite oread octal_write octal_read
+        hwrite hread hex_write hex_read to_string to_bstring to_binary_string to_ostring
+        to_octal_string to_hstring to_hex_string from_string from_bstring from_binary_string
+        from_ostring from_octal_string from_hstring from_hex_string
+        rising_edge falling_edge
+    "
 
-	join() { sep=$2; eval set -- $1; IFS="$sep"; echo "$*"; }
+    join() { sep=$2; eval set -- $1; IFS="$sep"; echo "$*"; }
 
-	# Add the language's grammar to the static completion list
-	printf %s\\n "declare-option str-list vhdl_static_words $(join "${values} ${units} ${predefined_attributes} ${libraries} ${packages} ${reserved_words} ${types} ${functions}" ' ')"
+    # Add the language's grammar to the static completion list
+    printf %s\\n "declare-option str-list vhdl_static_words $(join "${values} ${units} ${predefined_attributes} ${libraries} ${packages} ${reserved_words} ${types} ${functions}" ' ')"
 
-	 # Highlight keywords
-	printf %s "
-		add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${values}" '|'))\b' 0:value
-		add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${units}" '|'))\b' 0:meta
-		add-highlighter shared/vhdl/code/ regex \"'(?i)\b($(join "${predefined_attributes}" '|'))\b\" 0:attribute
-		add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${libraries}" '|'))\b' 0:builtin
-		add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${packages}" '|'))\b' 0:builtin
-		add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${reserved_words}" '|'))\b' 0:keyword
-		add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${functions}" '|'))\b\(' 1:builtin
-		add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${types}" '|'))\b' 0:type
-		add-highlighter shared/vhdl/code/ regex '^\h*(@[\w_.]+))' 1:attribute
-	"
+     # Highlight keywords
+    printf %s "
+        add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${values}" '|'))\b' 0:value
+        add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${units}" '|'))\b' 0:meta
+        add-highlighter shared/vhdl/code/ regex \"'(?i)\b($(join "${predefined_attributes}" '|'))\b\" 0:attribute
+        add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${libraries}" '|'))\b' 0:builtin
+        add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${packages}" '|'))\b' 0:builtin
+        add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${reserved_words}" '|'))\b' 0:keyword
+        add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${functions}" '|'))\b\(' 1:builtin
+        add-highlighter shared/vhdl/code/ regex '(?i)\b($(join "${types}" '|'))\b' 0:type
+        add-highlighter shared/vhdl/code/ regex '^\h*(@[\w_.]+))' 1:attribute
+    "
 ]
 
 add-highlighter shared/vhdl/code/ regex \(|\)|\;|\.|,|:|\| 0:attribute
@@ -162,247 +162,247 @@ add-highlighter shared/vhdl/code/ regex '[oO]"[01234567_]*"' 0:value
 add-highlighter shared/vhdl/code/ regex '(?i)x"[0123456789abcdef_]*"' 0:value
 
 define-command -hidden vhdl-insert-on-new-line %[
-	# Handle comment lines.
-	evaluate-commands -itersel %[
-		# Copy '--' comment prefix and following white spaces.
-		try %[
-			# <a-lt> is needed because of "Preserve previous line indent" command.
-			try %[ execute-keys -draft k <a-x> s ^\h*--\h* <ret> y j <a-lt> gh P ]
-		]
-	]
+    # Handle comment lines.
+    evaluate-commands -itersel %[
+        # Copy '--' comment prefix and following white spaces.
+        try %[
+            # <a-lt> is needed because of "Preserve previous line indent" command.
+            try %[ execute-keys -draft k <a-x> s ^\h*--\h* <ret> y j <a-lt> gh P ]
+        ]
+    ]
 
-	evaluate-commands -save-regs x %[
-		# Save previous line indent in register x.
-		try %[ execute-keys -draft k<a-x>s^\h+<ret>"xy ] catch %[ reg x '' ]
+    evaluate-commands -save-regs x %[
+        # Save previous line indent in register x.
+        try %[ execute-keys -draft k<a-x>s^\h+<ret>"xy ] catch %[ reg x '' ]
 
-		# All "wisely add" commands share the same concept.
-		# Only "end if" has extra comments.
-		# Wisely add "end if;".
-		evaluate-commands %[
-			try %[
-				# Validate previous line and that it is not closed yet.
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)((then|(.*:\h*)?if\b.*\bthen)$)<ret> }i<a-x> <a-K>^<c-r>x(?i)end\b<ret>
-				# Don't add for "if ... generate", it requires "end generate;".
-				execute-keys -draft k<a-x> <a-K>(?i)\bgenerate\b<ret>
-				execute-keys -draft o<c-r>xend<space>if<semicolon><esc>
-			]
-		]
-		# Wisely add "end generate;".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i).*\bgenerate$<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
-				# Don't add in case of comment line.
-				execute-keys -draft k<a-x> <a-K>^\h*--<ret>
-				execute-keys -draft o<c-r>xend<space>generate<semicolon><esc>
-			]
-		]
-		# Wisely add "end case;".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)(case|.*\h*:\h*case)\b<ret> }i<a-x> <a-K>^<c-r>x(?i)end<ret>
-				execute-keys -draft o<c-r>xend<space>case<semicolon><esc>
-			]
-		]
-		# Wisely add "begin" and "end block;".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)((block|.*:\h*block)\b)<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
-				execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>block<semicolon><esc>
-			]
-		]
-		# Wisely add "begin" and "end process;".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)(.*:\h*)?(postponed\h+)?process\b<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
-				execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>process<semicolon><esc>
-			]
-		]
-		# Wisely add "end loop;".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)(.*\bloop|.*\h*:\h*(for|loop))$<ret> }i<a-x> <a-K>^<c-r>x(?i)(end)<ret>
-				execute-keys -draft o<c-r>xend<space>loop<semicolon><esc>
-			]
-		]
-		# Wisely add "end protected;".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)(type\b.*\bis\h+protected)$<ret> }i<a-x> <a-K>^<c-r>x(?i)(end)<ret>
-				execute-keys -draft o<c-r>xend<space>protected<semicolon><esc>
-			]
-		]
-		# Wisely add "end record;".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)(type\b.*\bis\h+record\h*)$<ret> }i<a-x> <a-K>^<c-r>x(?i)(end)<ret>
-				execute-keys -draft o<c-r>xend<space>record<semicolon><esc>
-			]
-		]
-		# Wisely add ");" for "type ... is (".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)(type\b.*\bis\h+\(\h*)$<ret> }i<a-x> <a-K>^<c-r>x(\))<ret>
-				execute-keys -draft o<c-r>x)<semicolon><esc>
-			]
-		]
-		# Wisely add "end entity;".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^(?i)\h*entity\b.*\bis$<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
-				execute-keys -draft o<c-r>xend<space>entity<semicolon><esc>
-			]
-		]
-		# Wisely add "begin" and "end function;".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^(?i)(\h*\)?\h*return\b.*\bis$)<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
-				execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>function<semicolon><esc>
-			]
-			try %[
-				execute-keys -draft k<a-x> <a-k>^(?i)(\h*((pure|impure)\h+)?function\b.*\bis$)<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
-				execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>function<semicolon><esc>
-			]
-		]
-		# Wisely add "begin" and "end procedure;".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^(?i)(\h*procedure\b.*\bis$)<ret> }i<a-x> <a-K>^<c-r>x(?i)\b(begin|end)\b<ret>
-				execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>procedure<semicolon><esc>
-			]
-			try %[
-			execute-keys -draft k<a-x> <a-k>^(?i)\h*\)\h*\bis$<ret> }i<a-x> <a-K>^<c-r>x(?i)\b(begin|end)\b<ret>
-			# Verify that line with opening parenthesis contains "procedure" keyword.
-			execute-keys -draft k<a-x> s\)<ret> <a-m><semicolon> <a-x><a-k> (?i)\bprocedure\b<ret>
-			execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>procedure<semicolon><esc>
-			]
-		]
-		# Wisely add "end package;".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^(?i)(package\b)<ret> }i<a-x> <a-K>^<c-r>x(?i)(end)<ret>
-				# Make sure it is not package body.
-				execute-keys -draft k<a-x><a-K>(?i)\bbody\b<ret>
-				execute-keys -draft oend<space>package<semicolon><esc>
-			]
-		]
-		# Wisely add "end package body;".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^(?i)(package\h+body\b)<ret> }i<a-x> <a-K>^<c-r>x(?i)(end)<ret>
-				execute-keys -draft oend<space>package<space>body<semicolon><esc>
-			]
-		]
-		# Wisely add "begin" and "end architecture;".
-		evaluate-commands %[
-			try %[
-			execute-keys -draft k<a-x> <a-k>^(?i)\h*architecture\b<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
-			execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>architecture<semicolon><esc>
-			]
-		]
-		# Wisely add ");" for "port (".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)port\h*\($<ret> }i<a-x> <a-K>^<c-r>x(\)\;)<ret>
-				execute-keys -draft o<c-r>x)<semicolon><esc>
-			]
-		]
-		# Wisely add ");" for "port map (".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)port\h+map\h*\($<ret> }i<a-x> <a-K>^<c-r>x(\)\;)<ret>
-				execute-keys -draft o<c-r>x)<semicolon><esc>
-			]
-		]
-		# Wisely add ");" for "generic (".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)generic\h*\($<ret> }i<a-x> <a-K>^<c-r>x(\)\;)<ret>
-				execute-keys -draft o<c-r>x)<semicolon><esc>
-			]
-		]
-		# Wisely add ")" for "generic map (".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)generic\h+map\h*\($<ret> }i<a-x> <a-K>^<c-r>x(\))<ret>
-				execute-keys -draft o<c-r>x)<esc>
-			]
-		]
-		# Wisely add ") return ;" for "[pure|impure] function ... (".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)(pure\b|impure\b)?\h*function\b.*\h*\($<ret> }i<a-x> <a-K>^<c-r>x(\)\h*return.*)<ret>
-				execute-keys -draft o<c-r>x)<space>return<space><semicolon><esc>
-			]
-		]
-		# Wisely add ");" for "procedure ... (".
-		evaluate-commands %[
-			try %[
-				execute-keys -draft k<a-x> <a-k>^\h*(?i)procedure\b.*\h*\($<ret> }i<a-x> <a-K>^<c-r>x(\)\h*\;)<ret>
-				execute-keys -draft o<c-r>x)<semicolon><esc>
-			]
-		]
-	]
+        # All "wisely add" commands share the same concept.
+        # Only "end if" has extra comments.
+        # Wisely add "end if;".
+        evaluate-commands %[
+            try %[
+                # Validate previous line and that it is not closed yet.
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)((then|(.*:\h*)?if\b.*\bthen)$)<ret> }i<a-x> <a-K>^<c-r>x(?i)end\b<ret>
+                # Don't add for "if ... generate", it requires "end generate;".
+                execute-keys -draft k<a-x> <a-K>(?i)\bgenerate\b<ret>
+                execute-keys -draft o<c-r>xend<space>if<semicolon><esc>
+            ]
+        ]
+        # Wisely add "end generate;".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i).*\bgenerate$<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
+                # Don't add in case of comment line.
+                execute-keys -draft k<a-x> <a-K>^\h*--<ret>
+                execute-keys -draft o<c-r>xend<space>generate<semicolon><esc>
+            ]
+        ]
+        # Wisely add "end case;".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)(case|.*\h*:\h*case)\b<ret> }i<a-x> <a-K>^<c-r>x(?i)end<ret>
+                execute-keys -draft o<c-r>xend<space>case<semicolon><esc>
+            ]
+        ]
+        # Wisely add "begin" and "end block;".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)((block|.*:\h*block)\b)<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
+                execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>block<semicolon><esc>
+            ]
+        ]
+        # Wisely add "begin" and "end process;".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)(.*:\h*)?(postponed\h+)?process\b<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
+                execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>process<semicolon><esc>
+            ]
+        ]
+        # Wisely add "end loop;".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)(.*\bloop|.*\h*:\h*(for|loop))$<ret> }i<a-x> <a-K>^<c-r>x(?i)(end)<ret>
+                execute-keys -draft o<c-r>xend<space>loop<semicolon><esc>
+            ]
+        ]
+        # Wisely add "end protected;".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)(type\b.*\bis\h+protected)$<ret> }i<a-x> <a-K>^<c-r>x(?i)(end)<ret>
+                execute-keys -draft o<c-r>xend<space>protected<semicolon><esc>
+            ]
+        ]
+        # Wisely add "end record;".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)(type\b.*\bis\h+record\h*)$<ret> }i<a-x> <a-K>^<c-r>x(?i)(end)<ret>
+                execute-keys -draft o<c-r>xend<space>record<semicolon><esc>
+            ]
+        ]
+        # Wisely add ");" for "type ... is (".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)(type\b.*\bis\h+\(\h*)$<ret> }i<a-x> <a-K>^<c-r>x(\))<ret>
+                execute-keys -draft o<c-r>x)<semicolon><esc>
+            ]
+        ]
+        # Wisely add "end entity;".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^(?i)\h*entity\b.*\bis$<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
+                execute-keys -draft o<c-r>xend<space>entity<semicolon><esc>
+            ]
+        ]
+        # Wisely add "begin" and "end function;".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^(?i)(\h*\)?\h*return\b.*\bis$)<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
+                execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>function<semicolon><esc>
+            ]
+            try %[
+                execute-keys -draft k<a-x> <a-k>^(?i)(\h*((pure|impure)\h+)?function\b.*\bis$)<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
+                execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>function<semicolon><esc>
+            ]
+        ]
+        # Wisely add "begin" and "end procedure;".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^(?i)(\h*procedure\b.*\bis$)<ret> }i<a-x> <a-K>^<c-r>x(?i)\b(begin|end)\b<ret>
+                execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>procedure<semicolon><esc>
+            ]
+            try %[
+            execute-keys -draft k<a-x> <a-k>^(?i)\h*\)\h*\bis$<ret> }i<a-x> <a-K>^<c-r>x(?i)\b(begin|end)\b<ret>
+            # Verify that line with opening parenthesis contains "procedure" keyword.
+            execute-keys -draft k<a-x> s\)<ret> <a-m><semicolon> <a-x><a-k> (?i)\bprocedure\b<ret>
+            execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>procedure<semicolon><esc>
+            ]
+        ]
+        # Wisely add "end package;".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^(?i)(package\b)<ret> }i<a-x> <a-K>^<c-r>x(?i)(end)<ret>
+                # Make sure it is not package body.
+                execute-keys -draft k<a-x><a-K>(?i)\bbody\b<ret>
+                execute-keys -draft oend<space>package<semicolon><esc>
+            ]
+        ]
+        # Wisely add "end package body;".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^(?i)(package\h+body\b)<ret> }i<a-x> <a-K>^<c-r>x(?i)(end)<ret>
+                execute-keys -draft oend<space>package<space>body<semicolon><esc>
+            ]
+        ]
+        # Wisely add "begin" and "end architecture;".
+        evaluate-commands %[
+            try %[
+            execute-keys -draft k<a-x> <a-k>^(?i)\h*architecture\b<ret> }i<a-x> <a-K>^<c-r>x(?i)(begin|end)<ret>
+            execute-keys -draft o<c-r>xbegin<ret><c-r>xend<space>architecture<semicolon><esc>
+            ]
+        ]
+        # Wisely add ");" for "port (".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)port\h*\($<ret> }i<a-x> <a-K>^<c-r>x(\)\;)<ret>
+                execute-keys -draft o<c-r>x)<semicolon><esc>
+            ]
+        ]
+        # Wisely add ");" for "port map (".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)port\h+map\h*\($<ret> }i<a-x> <a-K>^<c-r>x(\)\;)<ret>
+                execute-keys -draft o<c-r>x)<semicolon><esc>
+            ]
+        ]
+        # Wisely add ");" for "generic (".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)generic\h*\($<ret> }i<a-x> <a-K>^<c-r>x(\)\;)<ret>
+                execute-keys -draft o<c-r>x)<semicolon><esc>
+            ]
+        ]
+        # Wisely add ")" for "generic map (".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)generic\h+map\h*\($<ret> }i<a-x> <a-K>^<c-r>x(\))<ret>
+                execute-keys -draft o<c-r>x)<esc>
+            ]
+        ]
+        # Wisely add ") return ;" for "[pure|impure] function ... (".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)(pure\b|impure\b)?\h*function\b.*\h*\($<ret> }i<a-x> <a-K>^<c-r>x(\)\h*return.*)<ret>
+                execute-keys -draft o<c-r>x)<space>return<space><semicolon><esc>
+            ]
+        ]
+        # Wisely add ");" for "procedure ... (".
+        evaluate-commands %[
+            try %[
+                execute-keys -draft k<a-x> <a-k>^\h*(?i)procedure\b.*\h*\($<ret> }i<a-x> <a-K>^<c-r>x(\)\h*\;)<ret>
+                execute-keys -draft o<c-r>x)<semicolon><esc>
+            ]
+        ]
+    ]
 ]
 
 define-command -hidden vhdl-indent-on-new-line %{
-	evaluate-commands -itersel %{
-		# Align "then" to previous "if|elsif".
-		evaluate-commands -itersel -save-regs x %[
-			try %[
-				execute-keys -draft k <a-x> <a-k> (?i)^\h*then$ <ret>
-				try %[ execute-keys -draft <a-/>(?i)\b(if|elsif)\b<ret><a-x>s^\h+<ret>"xy ] catch %[ reg x '' ]
-				try %[ execute-keys -draft k <a-x>s^\h+<ret>d ] catch %[ ]
-				execute-keys -draft kgh i<c-r>x<esc>
-			]
-		]
+    evaluate-commands -itersel %{
+        # Align "then" to previous "if|elsif".
+        evaluate-commands -itersel -save-regs x %[
+            try %[
+                execute-keys -draft k <a-x> <a-k> (?i)^\h*then$ <ret>
+                try %[ execute-keys -draft <a-/>(?i)\b(if|elsif)\b<ret><a-x>s^\h+<ret>"xy ] catch %[ reg x '' ]
+                try %[ execute-keys -draft k <a-x>s^\h+<ret>d ] catch %[ ]
+                execute-keys -draft kgh i<c-r>x<esc>
+            ]
+        ]
 
-		 # Align "generate" to previous "if|for".
-		evaluate-commands -itersel -save-regs x %[
-			try %[
-				execute-keys -draft k <a-x> <a-k> (?i)^\h*generate$ <ret>
-				try %[ execute-keys -draft <a-/>(?i)\b(if|for)\b<ret><a-x>s^\h+<ret>"xy ] catch %[ reg x '' ]
-				try %[ execute-keys -draft k <a-x>s^\h+<ret>d ] catch %[ ]
-				execute-keys -draft kgh i<c-r>x<esc>
-			]
-		]
+         # Align "generate" to previous "if|for".
+        evaluate-commands -itersel -save-regs x %[
+            try %[
+                execute-keys -draft k <a-x> <a-k> (?i)^\h*generate$ <ret>
+                try %[ execute-keys -draft <a-/>(?i)\b(if|for)\b<ret><a-x>s^\h+<ret>"xy ] catch %[ reg x '' ]
+                try %[ execute-keys -draft k <a-x>s^\h+<ret>d ] catch %[ ]
+                execute-keys -draft kgh i<c-r>x<esc>
+            ]
+        ]
 
-		 # Preserve previous line indent.
-		try %[ execute-keys -draft <semicolon> K <a-&> ]
+         # Preserve previous line indent.
+        try %[ execute-keys -draft <semicolon> K <a-&> ]
 
-		 # Cleanup trailing whitespaces from previous line.
-		try %[ execute-keys -draft k <a-x> s \h+$ <ret> d ]
+         # Cleanup trailing whitespaces from previous line.
+        try %[ execute-keys -draft k <a-x> s \h+$ <ret> d ]
 
-		 # Increase indent after some keywords.
-		try %[
-			execute-keys -draft k<a-x><a-k> (?i)\b(begin|block|else|for|generate|if|is|loop|process|protected|record|select|then)$ <ret>
-			# Does not indent if in comment line.
-			execute-keys -draft k<a-x><a-K>(?i)^\h*--<ret>
-			# Handle case line in a bit different way.
-			execute-keys -draft k<a-x><a-K>(?i)^\h*case\b<ret>
-			execute-keys -draft <semicolon> <a-gt>
-		]
+         # Increase indent after some keywords.
+        try %[
+            execute-keys -draft k<a-x><a-k> (?i)\b(begin|block|else|for|generate|if|is|loop|process|protected|record|select|then)$ <ret>
+            # Does not indent if in comment line.
+            execute-keys -draft k<a-x><a-K>(?i)^\h*--<ret>
+            # Handle case line in a bit different way.
+            execute-keys -draft k<a-x><a-K>(?i)^\h*case\b<ret>
+            execute-keys -draft <semicolon> <a-gt>
+        ]
 
-		# Add "when " and increase indent after "case ... is".
-		try %[
-			execute-keys -draft k<a-x><a-k> (?i)\h*case\b.*\h+is$ <ret>
-			# Don't indent if in comment line.
-			execute-keys -draft k<a-x><a-K>(?i)^\h*--<ret>
-			execute-keys -draft <semicolon>iwhen<space><esc><a-gt>
-		]
+        # Add "when " and increase indent after "case ... is".
+        try %[
+            execute-keys -draft k<a-x><a-k> (?i)\h*case\b.*\h+is$ <ret>
+            # Don't indent if in comment line.
+            execute-keys -draft k<a-x><a-K>(?i)^\h*--<ret>
+            execute-keys -draft <semicolon>iwhen<space><esc><a-gt>
+        ]
 
-		# Copy the indentation of the matching if.
-		try %{ execute-keys -draft <space> k <a-x> <a-k> ^\h*(elsif\b|else$) <ret> gh [c^\h*(\S*\h*:\h*)?if\b,\bend\sif\b <ret> <a-x> <a-S> 1<a-&> <space> j K <a-&> }
+        # Copy the indentation of the matching if.
+        try %{ execute-keys -draft <space> k <a-x> <a-k> ^\h*(elsif\b|else$) <ret> gh [c^\h*(\S*\h*:\h*)?if\b,\bend\sif\b <ret> <a-x> <a-S> 1<a-&> <space> j K <a-&> }
 
-		# Increase indent after some operators.
-		try %[ execute-keys -draft <semicolon> <space> k <a-x> <a-k> (\(|=>|<=|:=)$ <ret> j <a-gt> ]
-	 }
+        # Increase indent after some operators.
+        try %[ execute-keys -draft <semicolon> <space> k <a-x> <a-k> (\(|=>|<=|:=)$ <ret> j <a-gt> ]
+     }
 }
 
 define-command vhdl-indent-on-closing-parenthesis %[
-	evaluate-commands -itersel %[
-		# Decrease indent after ")" at the beginning of line.
-		try %[ execute-keys -draft <a-x> <a-k> (^\h+\)$) <ret> <a-lt> ]
-	]
+    evaluate-commands -itersel %[
+        # Decrease indent after ")" at the beginning of line.
+        try %[ execute-keys -draft <a-x> <a-k> (^\h+\)$) <ret> <a-lt> ]
+    ]
 ]
 
 §

--- a/rc/filetype/yaml.kak
+++ b/rc/filetype/yaml.kak
@@ -15,6 +15,7 @@ hook global WinSetOption filetype=yaml %{
     require-module yaml
 
     hook window ModeChange pop:insert:.* -group yaml-trim-indent yaml-trim-indent
+    hook window InsertChar \n -group yaml-insert yaml-insert-on-new-line
     hook window InsertChar \n -group yaml-indent yaml-indent-on-new-line
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window yaml-.+ }
 }
@@ -49,10 +50,15 @@ define-command -hidden yaml-trim-indent %{
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
 
-define-command -hidden yaml-indent-on-new-line %{
+define-command -hidden yaml-insert-on-new-line %{
     evaluate-commands -draft -itersel %{
         # copy '#' comment prefix and following white spaces
         try %{ execute-keys -draft k <a-x> s ^\h*\K#\h* <ret> y gh j P }
+    }
+}
+
+define-command -hidden yaml-indent-on-new-line %{
+    evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
         # filter previous line

--- a/rc/filetype/zig.kak
+++ b/rc/filetype/zig.kak
@@ -16,6 +16,7 @@ hook global BufCreate .*[.]zig %{
 hook global WinSetOption filetype=zig %<
     require-module zig
     hook window ModeChange pop:insert:.* -group zig-trim-indent zig-trim-indent
+    hook window InsertChar \n -group zig-insert zig-insert-on-new-line
     hook window InsertChar \n -group zig-indent zig-indent-on-new-line
     hook window InsertChar \} -group zig-indent zig-indent-on-closing
 
@@ -99,16 +100,20 @@ define-command -hidden zig-trim-indent %{
     try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
 }
 
+define-command -hidden zig-insert-on-new-line %<
+    evaluate-commands -draft -itersel %<
+        # copy // or /// comments prefix and following whitespace
+        try %< execute-keys -draft k <a-x> s ^\h*\K///?\h* <ret> y gh j P >
+    >
+>
+
 define-command -hidden zig-indent-on-new-line %<
     evaluate-commands -draft -itersel %<
+        # preserve indent level
+        try %< execute-keys -draft <semicolon> K <a-&> >
         try %<
-            # copy // or /// comments prefix and following whitespace
-            execute-keys -draft k <a-x> s ^\h*\K///?\h* <ret> y gh j P
-            # preserve indent level
-            try %< execute-keys -draft <semicolon> K <a-&> >
-        > catch %<
-            # preserve indent level
-            try %< execute-keys -draft <semicolon> K <a-&> >
+            # only if we didn't copy a comment
+            execute-keys -draft <a-x> <a-K> ^\h*// <ret>
             # indent after lines ending in {
             try %< execute-keys -draft k <a-x> <a-k> \{\h*$ <ret> j <a-gt> >
             # deindent closing } when after cursor

--- a/rc/windowing/wayland.kak
+++ b/rc/windowing/wayland.kak
@@ -47,7 +47,7 @@ define-command wayland-focus -params ..1 -client-completion -docstring '
 wayland-focus [<kakoune_client>]: focus a given client''s window
 If no client is passed, then the current client is used' \
 %{
-	fail There is no way to focus another window on Wayland
+    fail There is no way to focus another window on Wayland
 }
 
 alias global focus wayland-focus


### PR DESCRIPTION
Some major filetypes already have the split between *-indent and *-insert hooks.
A separate insertion hook allows to disable the auto-insertion of comments via `%opt{disabled_hooks}`, or by overwriting the appropriate command.

This PR adds *-insert hooks for most filetypes, plus some related fixes.

The only remaining filetype that inserts comments in the indent hook is Rust, which might be complicated, I'm not sure.