### PR TITLE
Fix use of deprecated mallinfo call

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1445,8 +1445,10 @@ const CommandDesc debug_cmd = {
             }
             write_to_debug_buffer({});
             write_to_debug_buffer(format("  Total: {}", total));
-            #if defined(__GLIBC__) || defined(__CYGWIN__)
+            #if defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 33))
             write_to_debug_buffer(format("  Malloced: {}", mallinfo2().uordblks));
+            #else if defined(__GLIBC__) || defined(__CYGWIN__)
+            write_to_debug_buffer(format("  Malloced: {}", mallinfo().uordblks));
             #endif
         }
         else if (parser[0] == "shared-strings")

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1446,7 +1446,7 @@ const CommandDesc debug_cmd = {
             write_to_debug_buffer({});
             write_to_debug_buffer(format("  Total: {}", total));
             #if defined(__GLIBC__) || defined(__CYGWIN__)
-            write_to_debug_buffer(format("  Malloced: {}", mallinfo().uordblks));
+            write_to_debug_buffer(format("  Malloced: {}", mallinfo2().uordblks));
             #endif
         }
         else if (parser[0] == "shared-strings")


### PR DESCRIPTION
Fixes a compiler warning from use of `mallinfo` instead of `mallinfo2`. 

Details here: https://man7.org/linux/man-pages/man3/mallinfo.3.html
```
       The fields of the mallinfo structure that is returned by the
       older mallinfo() function are typed as int.  However, because
       some internal bookkeeping values may be of type long, the
       reported values may wrap around zero and thus be inaccurate.
```
`mallinfo2` returns a similar struct but with `size_t` instead of `int`.