### PR TITLE
Improve prompt handling.

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -807,7 +807,8 @@ public:
             m_callback(line, PromptEvent::Validate, context());
             return;
         }
-        else if (key == Key::Escape or key == ctrl('c'))
+        else if (key == Key::Escape or key == ctrl('c') or
+                 ((key == Key::Backspace or key == ctrl('h')) and line.empty()))
         {
             history_push(line);
             context().print_status(DisplayLine{});


### PR DESCRIPTION
As a long time vi user I find it highly irritating that
you cannot backspace out of the command prompt.

Similar changes should be made to other prompts such
as the search prompt.