### PR TITLE
Add the duck assistant discussed on the discourse

### DIFF
--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -337,7 +337,7 @@ are exclusively available to built-in options.
 
         *ncurses_assistant*:::
             specify the nice assistant displayed in info boxes,
-            can be *clippy* (the default), *cat*, *dilbert* or *none*
+            can be *clippy* (the default), *cat*, *dilbert*, *duck* or *none*
 
         *ncurses_enable_mouse*:::
             boolean option that enables mouse support

--- a/src/ncurses_ui.cc
+++ b/src/ncurses_ui.cc
@@ -156,6 +156,14 @@ static constexpr StringView assistant_dilbert[] =
       R"(      @     )",
       R"(            )"};
 
+static constexpr StringView assistant_duck[] =
+   {
+    R"(     __    )",
+    R"( ___( o)> ╮)",
+    R"( \ <_. )  ╰)",
+    R"(  `---'    )",
+    R"(           )"};
+
 template<typename T> T sq(T x) { return x * x; }
 
 constexpr struct { unsigned char r, g, b; } builtin_colors[] = {
@@ -1354,6 +1362,8 @@ void NCursesUI::set_ui_options(const Options& options)
             m_assistant = assistant_cat;
         else if (it->value == "dilbert")
             m_assistant = assistant_dilbert;
+        else if (it->value == "duck")
+            m_assistant = assistant_duck;
         else if (it->value == "none" or it->value == "off")
             m_assistant = ConstArrayView<StringView>{};
     }


### PR DESCRIPTION
Add the duck assistant discussed [here](https://discuss.kakoune.com/t/future-assistants/66/3)

result:

![duck](https://user-images.githubusercontent.com/5412579/116789926-ddad7d80-aab1-11eb-9adf-b56bd9175d61.png)


Best,
C.