### PR TITLE
{commands,hooks}.asciidoc: Use consistent capitalization for Kakoune

### DIFF
--- a/doc/pages/commands.asciidoc
+++ b/doc/pages/commands.asciidoc
@@ -501,7 +501,7 @@ New commands can be defined using the *define-command* command:
         following string is a shell command which takes parameters as
         positional params and outputs one completion candidate per line.
         The provided shell command will run once at the beginning of each
-        completion session, candidates are cached and then used by kakoune
+        completion session, candidates are cached and then used by Kakoune
         internal fuzzy engine
 
         during the execution of the shell command, the following env vars are

--- a/doc/pages/hooks.asciidoc
+++ b/doc/pages/hooks.asciidoc
@@ -153,11 +153,11 @@ name. Hooks with no description will always use an empty string.
     and the `on-key -mode-name bar` command pushes 'next-key[bar]' mode.
 
 *KakBegin* `session name`::
-    kakoune has started, this hook is called just after reading the user
+    Kakoune has started, this hook is called just after reading the user
     configuration files
 
 *KakEnd*::
-    kakoune is quitting
+    Kakoune is quitting
 
 *FocusIn* `client name`::
     on supported clients, triggered when the client gets focused


### PR DESCRIPTION
Just a nitpick.