### PR TITLE
Add %val{bufstr} with buffer content as a string

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -204,6 +204,10 @@ The following expansions are supported (with required context _in italics_):
     _in buffer, window scope_ +
     name of the current buffer
 
+*%val{bufstr}*::
+    _in buffer, window scope_ +
+    the contents of the entire buffer, as a string
+
 *%val{client_env_X}*::
     _in window scope_ +
     value of the `$X` environment variable in the client displaying the current

--- a/src/main.cc
+++ b/src/main.cc
@@ -190,6 +190,10 @@ static const EnvVarDesc builtin_env_vars[] = { {
         "buffile", false,
         [](StringView name, const Context& context) -> Vector<String>
         { return {context.buffer().name()}; }
+    },  {
+        "bufstr", false,
+        [](StringView name, const Context& context) -> Vector<String>
+        { return {context.buffer().string({0, 0}, context.buffer().end_coord())}; }
     }, {
         "buflist", false,
         [](StringView name, const Context& context) -> Vector<String>


### PR DESCRIPTION
Add the expansion `%val{bufstr}` with buffer content as a string. Having this avoids having to write the roundabouts using `|` or registers, such as:

    eval -save-regs b %{
        exec -draft '%"by'
        eval %sh{
             # something with $kak_reg_b
        }
    }

This is now simply:

	eval %sh{
         # something with $kak_bufstr
	}

For large buffers that are too big to send as an execve environment this `%val{bufstr}` expansion is still useful together with `echo -to-file`.

Included as an example how `spell.kak` can be simplified using this expansion.