### PR TITLE
Allowed for references of strings

### DIFF
--- a/rc/filetype/perl.kak
+++ b/rc/filetype/perl.kak
@@ -39,7 +39,7 @@ provide-module perl %§
 add-highlighter shared/perl regions
 add-highlighter shared/perl/code default-region group
 add-highlighter shared/perl/command        region (?<!\$)(?<!\\)`   (?<!\\)(\\\\)*` fill meta
-add-highlighter shared/perl/double_string  region (?<!\$)(?<!\\)"   (?<!\\)(\\\\)*" fill string
+add-highlighter shared/perl/double_string  region (?<!\$)"          (?<!\\)(\\\\)*" fill string
 add-highlighter shared/perl/single_string  region (?<!\$)(?<!\\\\)' (?<!\\)(\\\\)*' fill string
 add-highlighter shared/perl/comment        region (?<!\$)(?<!\\)#   $               fill comment
 


### PR DESCRIPTION
closes #3967
Perl syntax highlighter mishandled string literals being turned into references.