### PR TITLE
Highlight extra chars in literal

### DIFF
--- a/rc/filetype/kotlin.kak
+++ b/rc/filetype/kotlin.kak
@@ -56,7 +56,7 @@ provide-module kotlin %§
 add-highlighter shared/kotlin regions
 add-highlighter shared/kotlin/code default-region group
 add-highlighter shared/kotlin/string region %{(?<!')"} %{(?<!\\)(\\\\)*"} group
-add-highlighter shared/kotlin/character region %{'} %{(?<!\\)'} fill value
+add-highlighter shared/kotlin/character region %{'} %{(?<!\\)'} group
 add-highlighter shared/kotlin/comment region /\* \*/ fill comment
 add-highlighter shared/kotlin/inline_documentation region /// $ fill documentation
 add-highlighter shared/kotlin/line_comment region // $ fill comment
@@ -68,6 +68,10 @@ add-highlighter shared/kotlin/code/fields      regex \.([A-Za-z_][\w]*)\s*?\. 1:
 # String interpolation
 add-highlighter shared/kotlin/string/ fill string
 add-highlighter shared/kotlin/string/ regex \$\{.*?\} 0:value
+
+# Character
+add-highlighter shared/kotlin/character/ fill value
+add-highlighter shared/kotlin/character/ regex ('.{1})(.+)(') 2:red
 
 # As at 15 March 2021, method see: https://regex101.com/r/Mhy4HG/1
 add-highlighter shared/kotlin/code/methods     regex ::([A-Za-z_][\w]*)|\.([A-Za-z_][\w]*)\s*?[\(\{]|\.([A-Za-z_][\w]*)[\s\)\}>](?=[^\(\{]) 1:function 2:function 3:function


### PR DESCRIPTION
This commit adds highlighting characters other than the first with red color helping to get immediate feedback of the syntax error.
This helps those who come from languagles like JS where single quotes also denote multi-character strings.