### PR TITLE
fix: iterm focus client from different tab or window

### DIFF
--- a/rc/windowing/iterm.kak
+++ b/rc/windowing/iterm.kak
@@ -116,6 +116,12 @@ If no client is passed then the current one is used' \
             -e "        tell aTab to repeat with aSession in sessions"     \
             -e "            tell aSession"                                 \
             -e "                if (unique id = \"${session}\") then"      \
+            -e "                    tell aWin"                             \
+            -e "                        select"                            \
+            -e "                    end tell"                              \
+            -e "                    tell aTab"                             \
+            -e "                        select"                            \
+            -e "                    end tell"                              \
             -e "                    select"                                \
             -e "                end if"                                    \
             -e "            end tell"                                      \


### PR DESCRIPTION
currently focus client doesn't work if target pane of the client is in different tab or window from current one.

**select window, select tab should be triggered in order to select a pane on a currently not focused tab or window.**