### PR TITLE
Clarify which parts of Kakoune the extra_word_chars option affects.

### DIFF
--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -95,8 +95,9 @@ it when pasting text.
 
 == Movement
 
-'word' is a sequence of alphanumeric characters or underscore, and 'WORD'
-is a sequence of non whitespace characters. Generally, a movement on its own
+'word' is a sequence of alphanumeric characters, or those in the `extra_word_chars`
+option (see <<options#builtin-options,`:doc options builtin-options`>>).
+'WORD' is a sequence of non whitespace characters. Generally, a movement on its own
 will move each selection to cover the text moved over, while holding down
 the Shift modifier and moving will extend each selection instead.
 

--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -273,7 +273,11 @@ are exclusively available to built-in options.
 
 *extra_word_chars* `codepoint-list`::
     a list of all additional codepoints that should be considered
-    as word character. This must be set on the buffer, not the window,
+    part of a word, for the purposes of the `w`, `b`, and `e` commands
+    (See <<keys#movement,`:doc keys movement`>>).
+    If this option is empty, Kakoune pretends it contains an
+    underscore, otherwise the value is used as-is.
+    This must be set on the buffer, not the window,
     for word completion to offer words containing these codepoints.
 
 *matching_pairs* `codepoint-list`::

--- a/doc/pages/regex.asciidoc
+++ b/doc/pages/regex.asciidoc
@@ -56,10 +56,11 @@ characters, the `-` character, and the `+` character.
 
 Supported character class escapes are:
 
-* `\d` which matches all digits.
-* `\w` which matches all word characters.
-* `\s` which matches all whitespace characters.
-* `\h` which matches all horizontal whitespace characters.
+* `\d` which matches digits 0-9.
+* `\w` which matches word characters A-Z, a-z, 0-9 and underscore
+    (ignoring the `extra_word_chars` option).
+* `\s` which matches all Unicode whitespace characters.
+* `\h` which matches whitespace except Vertical Tab and line-breaks.
 
 Using an upper case letter instead of a lower case one will negate
 the character class. For example, `\D` will match every non-digit


### PR DESCRIPTION
Also, document the "empty option implies underscore" quirk. I do wonder why that quirk exists, instead of just making underscore the global default value.