### PR TITLE
update IRC channel location

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -7,7 +7,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .asciidoc]
 :cirrus-img: https://api.cirrus-ci.com/github/mawww/kakoune.svg
 :cirrus-url: https://cirrus-ci.com/github/mawww/kakoune
 :irc-img: https://img.shields.io/badge/IRC-%23kakoune-blue.svg
-:irc-url: https://webchat.freenode.net/?channels=kakoune
+:irc-url: https://web.libera.chat/?channels=kakoune
 :icons: font
 :toc: right
 :pp: ++
@@ -57,7 +57,7 @@ and the cursor moves around.
 
 See https://vimeo.com/82711574
 
-Join us on freenode IRC `#Kakoune`
+Join us on libera IRC `#Kakoune`
 
 Features
 ~~~~~~~~


### PR DESCRIPTION
On kaoune.org the IRC link leads to freenode. Currently the topic of the freenode channel is: "This channel is deprecated, please move to liбеrа" indicating that the current kakoune channel is on libera. This pull requests changes the website to directly point to libera chat.