### PR TITLE
Kakoune passed environment variables in shell invocations are repeated

### DIFF
--- a/src/shell_manager.cc
+++ b/src/shell_manager.cc
@@ -144,8 +144,9 @@ Vector<String> generate_env(StringView cmdline, const Context& context, const Sh
         StringView name{match[2].first, match[2].second};
 
         auto match_name = [&](const String& s) {
-            return s.substr(0_byte, name.length()) == name and
-                   s.substr(name.length(), 1_byte) == "=";
+            // 4_byte because of the initial `kak_` prefix
+            return s.substr(4_byte, name.length()) == name and
+                   s.substr(4_byte + name.length(), 1_byte) == "=";
         };
         if (any_of(env, match_name))
             continue;

--- a/src/shell_manager.cc
+++ b/src/shell_manager.cc
@@ -142,11 +142,11 @@ Vector<String> generate_env(StringView cmdline, const Context& context, const Sh
     for (auto&& match : RegexIterator{cmdline.begin(), cmdline.end(), re})
     {
         StringView name{match[2].first, match[2].second};
+        StringView shell_name{match[0].first, match[0].second};
 
         auto match_name = [&](const String& s) {
-            // 4_byte because of the initial `kak_` prefix
-            return s.substr(4_byte, name.length()) == name and
-                   s.substr(4_byte + name.length(), 1_byte) == "=";
+            return s.substr(0_byte, shell_name.length()) == shell_name and
+                   s.substr(0_byte + shell_name.length(), 1_byte) == "=";
         };
         if (any_of(env, match_name))
             continue;

--- a/src/shell_manager.cc
+++ b/src/shell_manager.cc
@@ -146,7 +146,7 @@ Vector<String> generate_env(StringView cmdline, const Context& context, const Sh
 
         auto match_name = [&](const String& s) {
             return s.substr(0_byte, shell_name.length()) == shell_name and
-                   s.substr(0_byte + shell_name.length(), 1_byte) == "=";
+                   s.substr(shell_name.length(), 1_byte) == "=";
         };
         if (any_of(env, match_name))
             continue;


### PR DESCRIPTION
```
    Fix: Kakoune passed environment variables in shell invocations are repeated
    
    If a %sh{} script refers to any variables multiple times they are all multiply
    included in the environment. Example: if a %sh{} invocation refers to
    ${kak_buffile} 5 times, the environment will have "kak_buffile=..." repeated 5
    times and so on. This repetition happens for each multiply used variable that
    is passed into the environment.
    
    The variable should, of course, be only passed into the environment once. This
    commit should fix this issue.
```