### PR TITLE
expansions: %arg{@:N} (args from N onward)

### DIFF
--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -374,6 +374,16 @@ expand_token(const Token& token, const Context& context, const ShellContext& she
             else
                 return Vector<String>{params.begin(), params.end()};
         }
+        else if (prefix_match(content, "@:")) {
+            const int arg1 = str_to_int(content.substr (2_byte)) - 1;
+            if (arg1 < 0)
+                throw runtime_error("invalid argument index");
+            auto argn = arg1 < params.size() ? params.begin() + arg1 : params.end();
+            if constexpr (single)
+                return join(Vector<String>{argn, params.end()}, ' ', false);
+            else
+                return Vector<String>{argn, params.end()};
+        }
 
         const int arg = str_to_int(content)-1;
         if (arg < 0)


### PR DESCRIPTION
Some extra expansions. For now

### `%arg{@:N}`
```
1-based, like %arg{N}; shell-like syntax
test:
def -params .. echodbg %{ echo -debug -quoting shell -- %arg{@} } -override
def -params .. tst %{ echodbg %arg{@:3} } -override
tst 9 8 7 6 5
tst 1 2 3
tst 1
tst
def -params .. tst %{ echodbg "%arg{@:3}" } -override # and repeat
```

It's costly to call the shell to execute another command with the first N args removed.

Possible enhancement: `%arg{@:N:count}` (again, as already common in shells).