### PR TITLE
spell.kak: ignore another undocumented control char

### DIFF
--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -53,7 +53,7 @@ define-command -params ..1 -docstring %{
                         # nothing
                     }
 
-                    else if (/^\+/) {
+                    else if (/^[+-]/) {
                         # required to ignore undocumented aspell functionality
                     }
 


### PR DESCRIPTION
From what I can tell, this is very similar to https://github.com/mawww/kakoune/pull/3871

Just like `$ echo "разделе Подзапросы" | aspell -d ru -a` generates a weird `+` symbol, 
`$ echo "hvordån gor det" | aspell -d da -a` generates a weird `-` symbol which currently breaks spell.kak.

This PR simply ignores that symbol too.

```
$ echo "разделе Подзапросы" | aspell -d ru -a
@(#) International Ispell Version 3.1.20 (but really Aspell 0.60.8)
+ раздел
& Подзапросы 2 8: Под запросы, Под-запросы

$ echo "hvordån gor det" | aspell -d da -a
@(#) International Ispell Version 3.1.20 (but really Aspell 0.60.8)
-
& gor 25 8: Gro, gro, Gorm, glor, gror, for, hor, go, Igor, god, Tor, bor, gok, gom, går, gær, gør, kor, mor, nor, ror, vor, gjord, ord, g'er
*
```

Tested with `aspell 0.60.8` and `aspell-da` of both `0.50.1` (currently on AUR) and `1.6.36` (latest one).