### PR TITLE
Update README.asciidoc

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -179,10 +179,11 @@ pacman -S kakoune
 .Gentoo
 ====
 Kakoune is found in portage as
-https://packages.gentoo.org/packages/app-editors/kakoune[app-editors/kakoune]
+https://packages.gentoo.org/packages/app-editors/kakoune[app-editors/kakoune].
 --------------------------------
 emerge kakoune
 --------------------------------
+https://wiki.gentoo.org/wiki/Kakoune[Installation and Gentoo specific documentation] is available.
 ====
 
 [TIP]


### PR DESCRIPTION
Gentoo has a wiki page documenting Kakoune installation. The method given here ("emerge kakoune") will not work on a default Gentoo installation, as Kakoune is currently in the Testing branch rather than in the Stable branch. A link to the documentation explaining how to install Kakoune on Gentoo seems pertinent.