### PR TITLE
Add `markdown` comment region

### DIFF
--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -39,6 +39,7 @@ provide-module markdown %{
 add-highlighter shared/markdown regions
 add-highlighter shared/markdown/inline default-region regions
 add-highlighter shared/markdown/inline/text default-region group
+add-highlighter shared/markdown/comment region '\[//\]: # "' '"' fill comment
 
 evaluate-commands %sh{
   languages="


### PR DESCRIPTION
I saw `comment_block_*` entries are defined for `markdown`, but not the highlight region. This adds that region.

![image](https://user-images.githubusercontent.com/1177508/125071241-b7174e80-e0c1-11eb-83cf-5eebe145ba9c.png)
