### PR TITLE
Fix #3957

### DIFF
--- a/rc/tools/lint.kak
+++ b/rc/tools/lint.kak
@@ -209,11 +209,11 @@ define-command \
 
         # A fifo to send the results back to a Kakoune buffer.
         mkfifo "$dir"/fifo
-        printf 'lint-open-output-buffer %s' "$(kakquote "$dir")" | kak -p "$kak_session"
-
-        # We are done here. Send the results to Kakoune,
-        # and clean up.
-        cat "$dir"/result > "$dir"/fifo
+        # Send the results to kakoune if the session is still valid.
+        if printf 'lint-open-output-buffer %s' "$(kakquote "$dir")" | kak -p "$kak_session"; then
+            cat "$dir"/result > "$dir"/fifo
+        fi
+        # Clean up.
         rm -rf "$dir"
 
         } & ) >"$dir"/stderr 2>&1 </dev/null


### PR DESCRIPTION
If the session wasn't valid anymore by the time the linter finishes,
writing to "$dir"/fifo would hang forever leaving temporary files in
/tmp/kak-lint.XXX and the process alive. This commit fixes that by
not writing to the fifo if the session was not valid.

throwawayaccount12345-1 Copyright Waiver

I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.