### PR TITLE
Lua: insert comment prefix *after* the indent

### DIFF
--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -112,7 +112,7 @@ define-command -hidden lua-indent-on-new-line %{
 define-command -hidden lua-insert-on-new-line %[
     evaluate-commands -no-hooks -draft -itersel %[
         # copy -- comment prefix and following white spaces
-        try %{ execute-keys -draft k<a-x>s^\h*\K--\h*<ret> y gh j P }
+        try %{ execute-keys -draft k<a-x>s^\h*\K--\h*<ret> y gh j <a-x><semicolon> P }
         # wisely add end structure
         evaluate-commands -save-regs x %[
             try %{ execute-keys -draft k<a-x>s^\h+<ret>"xy } catch %{ reg x '' } # Save previous line indent in register x


### PR DESCRIPTION
This fixes a bug in how the Lua scripts handle new comment lines. Currently if we have a comment that is indented, when we add a new line it inserts the `--` prefix before the automatic indentation.

```
  --ABC
--  XYZ
```

After the fix, it correctly inserts the comment prefix after the indentation:

```
  --ABC
  --XYZ
```

The solution I used is inspired by the ruby.kak script.