### PR TITLE
Check if anything is staged before allowing `:git commit`

### DIFF
--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -267,6 +267,13 @@ define-command -params 1.. \
 			$@
 		EOF
 
+        # Is there anything to commit?
+        staged_files=$(git diff --name-only)
+        if [ "$staged_files" = '' ]; then
+            echo "fail 'Nothing to commit! Please stage some changes first e.g. :git add <some-file>'"
+            exit
+        fi
+
         # fails, and generate COMMIT_EDITMSG
         GIT_EDITOR='' EDITOR='' git commit "$@" > /dev/null 2>&1
         msgfile="$(git rev-parse --git-dir)/COMMIT_EDITMSG"


### PR DESCRIPTION
I seem to run into this issue occasionally: 
- Let us assume I've NOT staged anything for commit into `git`
- I then (mistakenly) issue a `:git commit` in kakoune, write a commit message and then `:w`. This will result in a cryptic kakoune error message `Error running hooks for 'BufWritePost' '/some/path/.git/COMMIT_EDITMSG', see *debug* buffer`

According to me I should not be allowed to proceed to the `:git commit` buffer _if_ I have nothing staged. 

This change simply produces a helpful `fail` message
`Nothing to commit! Please stage some changes first e.g. :git add <some-file>`