### PR TITLE
Implement customizable terminal title

### DIFF
--- a/src/terminal_ui.hh
+++ b/src/terminal_ui.hh
@@ -154,6 +154,7 @@ private:
     int m_shift_function_key = default_shift_function_key;
 
     bool m_set_title = true;
+    String m_title_line;
 
     struct Synchronized
     {


### PR DESCRIPTION
This pull request revives #3829 which in turn revived #2249. It fixes #2217.

The `terminal_set_title` key-value-pair in the `ui_options` option is expanded to allow values beyond booleans. When a non-boolean value is given in the option, that value becomes the terminal title. The documentation is updated to reflect this.