### PR TITLE
Fix CUE comment options

### DIFF
--- a/rc/tools/comment.kak
+++ b/rc/tools/comment.kak
@@ -106,7 +106,7 @@ hook global BufSetOption filetype=perl %{
     set-option buffer comment_block_end ']'
 }
 
-hook global BufSetOption filetype=(pug|zig) %{
+hook global BufSetOption filetype=(pug|zig|cue) %{
     set-option buffer comment_line '//'
 }
 


### PR DESCRIPTION
CUE uses `//` for line comments.