### PR TITLE
Make whitespace dim in default theme

### DIFF
--- a/colors/default.kak
+++ b/colors/default.kak
@@ -46,5 +46,5 @@ face global StatusLineValue green,default
 face global StatusCursor black,cyan
 face global Prompt yellow,default
 face global MatchingChar default,default+b
-face global Whitespace default,default+f
+face global Whitespace default,default+fd
 face global BufferPadding blue,default


### PR DESCRIPTION
Not versed enough in other themes to decide how they should look, but at least in the default theme it would help to dim invisibles so that they don't have the same visual prominence as other characters.