### PR TITLE
Recognize ".rockspec" file extension as a Lua file

### DIFF
--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -4,7 +4,7 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*[.](lua) %{
+hook global BufCreate .*[.](lua|rockspec) %{
     set-option buffer filetype lua
 }
 


### PR DESCRIPTION
rockspec files are used by [Luarocks](https://luarocks.org/), the most prominent package manager for Lua. Despite the different file extension, these files are actually Lua files and should be syntax highlighted as such.

For what it is worth, Neovim also does the same thing that I am doing in this commit. They recognize both ".lua" and ".rockspec" as being Lua files (and no other extensions, as far as I know).