### PR TITLE
Some improvements to Lua syntax highlighting

### DIFF
--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -48,12 +48,11 @@ add-highlighter shared/lua/comment       region '--'  $                 fill com
 
 add-highlighter shared/lua/code/function_declaration regex \b(?:function\h+)(?:\w+\h*\.\h*)*([a-zA-Z_]\w*)\( 1:function
 add-highlighter shared/lua/code/function_call regex \b([a-zA-Z_]\w*)\h*(?=[\(\{]) 1:function
-add-highlighter shared/lua/code/keyword regex \b(and|break|do|else|elseif|end|for|function|goto|if|in|not|or|repeat|return|then|until|while)\b 0:keyword
+add-highlighter shared/lua/code/keyword regex \b(and|break|do|else|elseif|end|for|function|goto|if|in|local|not|or|repeat|return|then|until|while)\b 0:keyword
 add-highlighter shared/lua/code/value regex \b(false|nil|true|[0-9]+(:?\.[0-9])?(:?[eE]-?[0-9]+)?|0x[0-9a-fA-F])\b 0:value
 add-highlighter shared/lua/code/operator regex (\+|-|\*|/|%|\^|==?|~=|<=?|>=?|\.\.|\.\.\.|#) 0:operator
 add-highlighter shared/lua/code/builtin regex \b(_G|_ENV)\b 0:builtin
 add-highlighter shared/lua/code/module regex \b(_G|_ENV)\b 0:module
-add-highlighter shared/lua/code/attribute regex \b(local)\b 0:attribute
 
 # Commands
 # ‾‾‾‾‾‾‾‾

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -52,7 +52,6 @@ add-highlighter shared/lua/code/keyword regex \b(break|do|else|elseif|end|for|fu
 add-highlighter shared/lua/code/value regex \b(false|nil|true|[0-9]+(:?\.[0-9])?(:?[eE]-?[0-9]+)?|0x[0-9a-fA-F])\b 0:value
 add-highlighter shared/lua/code/symbolic_operator regex (\+|-|\*|/|%|\^|==?|~=|<=?|>=?|\.\.|\.\.\.|#) 0:operator
 add-highlighter shared/lua/code/keyword_operator regex \b(and|or|not)\b 0:operator
-add-highlighter shared/lua/code/builtin regex \b(_G|_ENV)\b 0:builtin
 add-highlighter shared/lua/code/module regex \b(_G|_ENV)\b 0:module
 add-highlighter shared/lua/code/attribute regex \B(<[a-zA-Z_]\w*>)\B 0:attribute
 

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -50,7 +50,8 @@ add-highlighter shared/lua/code/function_declaration regex \b(?:function\h+)(?:\
 add-highlighter shared/lua/code/function_call regex \b([a-zA-Z_]\w*)\h*(?=[\(\{]) 1:function
 add-highlighter shared/lua/code/keyword regex \b(break|do|else|elseif|end|for|function|goto|if|in|local|repeat|return|then|until|while)\b 0:keyword
 add-highlighter shared/lua/code/value regex \b(false|nil|true|[0-9]+(:?\.[0-9])?(:?[eE]-?[0-9]+)?|0x[0-9a-fA-F])\b 0:value
-add-highlighter shared/lua/code/operator regex (\+|-|\*|/|%|\^|==?|~=|<=?|>=?|\.\.|\.\.\.|#|\band\b|\bor\b|\bnot\b) 0:operator
+add-highlighter shared/lua/code/symbolic_operator regex (\+|-|\*|/|%|\^|==?|~=|<=?|>=?|\.\.|\.\.\.|#) 0:operator
+add-highlighter shared/lua/code/keyword_operator regex \b(and|or|not)\b 0:operator
 add-highlighter shared/lua/code/builtin regex \b(_G|_ENV)\b 0:builtin
 add-highlighter shared/lua/code/module regex \b(_G|_ENV)\b 0:module
 add-highlighter shared/lua/code/attribute regex \B(<[a-zA-Z_]\w*>)\B 0:attribute

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -53,6 +53,7 @@ add-highlighter shared/lua/code/value regex \b(false|nil|true|[0-9]+(:?\.[0-9])?
 add-highlighter shared/lua/code/operator regex (\+|-|\*|/|%|\^|==?|~=|<=?|>=?|\.\.|\.\.\.|#) 0:operator
 add-highlighter shared/lua/code/builtin regex \b(_G|_ENV)\b 0:builtin
 add-highlighter shared/lua/code/module regex \b(_G|_ENV)\b 0:module
+add-highlighter shared/lua/code/attribute regex \B(<[a-zA-Z_]\w*>)\B 0:attribute
 
 # Commands
 # ‾‾‾‾‾‾‾‾

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -48,9 +48,9 @@ add-highlighter shared/lua/comment       region '--'  $                 fill com
 
 add-highlighter shared/lua/code/function_declaration regex \b(?:function\h+)(?:\w+\h*\.\h*)*([a-zA-Z_]\w*)\( 1:function
 add-highlighter shared/lua/code/function_call regex \b([a-zA-Z_]\w*)\h*(?=[\(\{]) 1:function
-add-highlighter shared/lua/code/keyword regex \b(and|break|do|else|elseif|end|for|function|goto|if|in|local|not|or|repeat|return|then|until|while)\b 0:keyword
+add-highlighter shared/lua/code/keyword regex \b(break|do|else|elseif|end|for|function|goto|if|in|local|repeat|return|then|until|while)\b 0:keyword
 add-highlighter shared/lua/code/value regex \b(false|nil|true|[0-9]+(:?\.[0-9])?(:?[eE]-?[0-9]+)?|0x[0-9a-fA-F])\b 0:value
-add-highlighter shared/lua/code/operator regex (\+|-|\*|/|%|\^|==?|~=|<=?|>=?|\.\.|\.\.\.|#) 0:operator
+add-highlighter shared/lua/code/operator regex (\+|-|\*|/|%|\^|==?|~=|<=?|>=?|\.\.|\.\.\.|#|\band\b|\bor\b|\bnot\b) 0:operator
 add-highlighter shared/lua/code/builtin regex \b(_G|_ENV)\b 0:builtin
 add-highlighter shared/lua/code/module regex \b(_G|_ENV)\b 0:module
 add-highlighter shared/lua/code/attribute regex \B(<[a-zA-Z_]\w*>)\B 0:attribute

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -46,14 +46,14 @@ add-highlighter shared/lua/double_string region '"'   (?<!\\)(?:\\\\)*" fill str
 add-highlighter shared/lua/single_string region "'"   (?<!\\)(?:\\\\)*' fill string
 add-highlighter shared/lua/comment       region '--'  $                 fill comment
 
+add-highlighter shared/lua/code/function_declaration regex \b(?:function\h+)(?:\w+\h*\.\h*)*([a-zA-Z_]\w*)\( 1:function
+add-highlighter shared/lua/code/function_call regex \b([a-zA-Z_]\w*)\h*(?=[\(\{]) 1:function
 add-highlighter shared/lua/code/keyword regex \b(and|break|do|else|elseif|end|for|function|goto|if|in|not|or|repeat|return|then|until|while)\b 0:keyword
 add-highlighter shared/lua/code/value regex \b(false|nil|true|[0-9]+(:?\.[0-9])?(:?[eE]-?[0-9]+)?|0x[0-9a-fA-F])\b 0:value
 add-highlighter shared/lua/code/operator regex (\+|-|\*|/|%|\^|==?|~=|<=?|>=?|\.\.|\.\.\.|#) 0:operator
 add-highlighter shared/lua/code/builtin regex \b(_G|_E)\b 0:builtin
 add-highlighter shared/lua/code/module regex \b(_G|_E)\b 0:module
 add-highlighter shared/lua/code/attribute regex \b(local)\b 0:attribute
-add-highlighter shared/lua/code/function_declaration regex \b(?:function\h+)(?:\w+\h*\.\h*)*([a-zA-Z_]\w*)\( 1:function
-add-highlighter shared/lua/code/function_call regex \b([a-zA-Z_]\w*)\h*(?=[\(\{]) 1:function
 
 # Commands
 # ‾‾‾‾‾‾‾‾

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -51,8 +51,8 @@ add-highlighter shared/lua/code/function_call regex \b([a-zA-Z_]\w*)\h*(?=[\(\{]
 add-highlighter shared/lua/code/keyword regex \b(and|break|do|else|elseif|end|for|function|goto|if|in|not|or|repeat|return|then|until|while)\b 0:keyword
 add-highlighter shared/lua/code/value regex \b(false|nil|true|[0-9]+(:?\.[0-9])?(:?[eE]-?[0-9]+)?|0x[0-9a-fA-F])\b 0:value
 add-highlighter shared/lua/code/operator regex (\+|-|\*|/|%|\^|==?|~=|<=?|>=?|\.\.|\.\.\.|#) 0:operator
-add-highlighter shared/lua/code/builtin regex \b(_G|_E)\b 0:builtin
-add-highlighter shared/lua/code/module regex \b(_G|_E)\b 0:module
+add-highlighter shared/lua/code/builtin regex \b(_G|_ENV)\b 0:builtin
+add-highlighter shared/lua/code/module regex \b(_G|_ENV)\b 0:module
 add-highlighter shared/lua/code/attribute regex \b(local)\b 0:attribute
 
 # Commands


### PR DESCRIPTION
In this PR, I correct a couple of mistakes in the Lua syntax highlighting. Each point is in a separate commit.

1. When returning a table literal, highlight the `return` as a keyword. Currently is is highlighted as a function call.

```lua
return { x = 10 }
```

2. Highlight the `local` keyword using the same color as the other keywords. Currently it is highlighted as an "attribute".

```lua
local x = 12
```

3. The special environment variable is called `_ENV`, not `_E`.

```lua
_ENV = { print = print }
```

4. Highlight variable attributes. This is a new language feature, introduced in Lua 5.4.

```lua
local y <const> = 42
```

---------------

5. Highlight `and` and `or` as operators instead of as regular keywords


```lua
while x and y do
end
```