### PR TITLE
Normalize links in navigation banner

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -29,11 +29,12 @@
                 <ul class="navbar-nav">
                     <li class="nav-item">
                         <a class="nav-link text-nowrap" href="https://github.com/mawww/kakoune#2-getting-started">
+                            <i class="fa fa-fw fa-flag"></i>
                             <span tid="navbar:getStarted">Get started!</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link text-nowrap" href="https://github.com/mawww/kakoune/blob/master/README.asciidoc#3-basic-interaction">
+                        <a class="nav-link text-nowrap" href="https://github.com/mawww/kakoune#3-basic-interaction">
                             <i class="fa fa-fw fa-list-alt"></i>
                             <span tid="navbar:documentation">Documentation</span>
                         </a>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link text-nowrap" href="https://github.com/mawww/kakoune/blob/master/README.asciidoc#3-basic-interaction">
+                        <a class="nav-link text-nowrap" href="https://github.com/mawww/kakoune#3-basic-interaction">
                             <i class="fa fa-fw fa-list-alt"></i>
                             <span tid="navbar:documentation">Documentation</span>
                         </a>

--- a/plugins.html
+++ b/plugins.html
@@ -41,7 +41,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link text-nowrap" href="https://github.com/mawww/kakoune/blob/master/README.asciidoc#3-basic-interaction">
+                        <a class="nav-link text-nowrap" href="https://github.com/mawww/kakoune#3-basic-interaction">
                             <i class="fa fa-fw fa-list-alt"></i>
                             <span tid="navbar:documentation">Documentation</span>
                         </a>

--- a/writings.html
+++ b/writings.html
@@ -34,7 +34,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link text-nowrap" href="https://github.com/mawww/kakoune/blob/master/README.asciidoc#3-basic-interaction">
+                        <a class="nav-link text-nowrap" href="https://github.com/mawww/kakoune#3-basic-interaction">
                             <i class="fa fa-fw fa-list-alt"></i>
                             <span tid="navbar:documentation">Documentation</span>
                         </a>


### PR DESCRIPTION
Change the 'Documentation' links to match the URL pattern of the 'Get Started' links (and of the 'Try Kakoune!' button in the homepage).

Also add the missing icon for the 'Get Started' link in the `gallery.html` page.