### PR TITLE
Add gentoo linux ebuild filetype detection.

### DIFF
--- a/rc/filetype/gentoo-linux.kak
+++ b/rc/filetype/gentoo-linux.kak
@@ -1,0 +1,4 @@
+# portage ebuild file
+hook global BufCreate .*\.ebuild %{
+    set-option buffer filetype sh
+}


### PR DESCRIPTION
Follows convention from rc/filetype/{arch,void}-linux.kak