### PR TITLE
 Change freenode links to libera

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -85,7 +85,7 @@
                                 <i class="fa fa-fw fa-reddit"></i>
                                 SubReddit
                             </a>
-                            <a class="dropdown-item text-nowrap" href="https://webchat.freenode.net/?channels=kakoune">
+                            <a class="dropdown-item text-nowrap" href="https://web.libera.chat/?channels=#kakoune">
                                 <i class="fa fa-fw fa-hashtag"></i>
                                 IRC
                             </a>

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
                                 <i class="fa fa-fw fa-reddit"></i>
                                 SubReddit
                             </a>
-                            <a class="dropdown-item text-nowrap" href="https://webchat.freenode.net/?channels=kakoune">
+                            <a class="dropdown-item text-nowrap" href="https://web.libera.chat/?channels=#kakoune">
                                 <i class="fa fa-fw fa-hashtag"></i>
                                 IRC
                             </a>
@@ -331,7 +331,7 @@
                                 requests proposed by the contributors. Users
                                 can also ask their questions and share
                                 their remark with the rest of the community,
-                                on <a href="https://webchat.freenode.net/?channels=kakoune"><b>#kakoune</b></a> @ irc.freenode.net.
+                                on <a href="https://web.libera.chat/?channels=#kakoune"><b>#kakoune</b></a> @ irc.libera.chat.
                             </div>
                             <span tid-fr="feature:activeDevelopmentSupportText" class="d-none">
                                 Le projet est activement développé,
@@ -340,15 +340,15 @@
                                 d'implémentation des contributeurs. Les
                                 utilisateurs peuvent églament poser leurs
                                 questions et partager leurs remarques avec le
-                                reste de la communauté, sur <a href="https://webchat.freenode.net/?channels=kakoune"><b>#kakoune</b></a>
-                                @ irc.freenode.net.
+                                reste de la communauté, sur <a href="https://web.libera.chat/?channels=#kakoune"><b>#kakoune</b></a>
+                                @ irc.libera.chat.
                             </span>
                             <span tid-hu="feature:activeDevelopmentSupportText" class="d-none">
                                 A projekt aktív fejlesztés alatt van, rendszeresen
                                 bővül új funkciókkal, a közreműködők pull request-jei
                                 által is. A felhasználók feltehetik kérdéseiket,
                                 és megoszthatják véleményüket a közösség nagy
-                                részével a <b>#kakoune</b> csatornán az irc.freenode.net
+                                részével a <b>#kakoune</b> csatornán az irc.libera.chat
                                 hálózaton.
                             </span>
                             <span tid-it="feature:activeDevelopmentSupportText" class="d-none">
@@ -357,8 +357,8 @@
                                 e integrate le Pull Request proposte dai collaboratori.
                                 Gli utenti possono anche fare domande e condividere
                                 le proprie osservazioni con il resto della community
-                                sul canale IRC <a href="https://webchat.freenode.net/?channels=kakoune"><b>#kakoune</b></a>
-                                sul server irc.freenode.net.
+                                sul canale IRC <a href="https://web.libera.chat/?channels=#kakoune"><b>#kakoune</b></a>
+                                sul server irc.libera.chat.
                             </span>
                         </div>
                     </div>

--- a/plugins.html
+++ b/plugins.html
@@ -93,7 +93,7 @@
                                 <i class="fa fa-fw fa-reddit"></i>
                                 SubReddit
                             </a>
-                            <a class="dropdown-item text-nowrap" href="https://webchat.freenode.net/?channels=kakoune">
+                            <a class="dropdown-item text-nowrap" href="https://web.libera.chat/?channels=#kakoune">
                                 <i class="fa fa-fw fa-hashtag"></i>
                                 IRC
                             </a>

--- a/writings.html
+++ b/writings.html
@@ -86,7 +86,7 @@
                                 <i class="fa fa-fw fa-reddit"></i>
                                 SubReddit
                             </a>
-                            <a class="dropdown-item text-nowrap" href="https://webchat.freenode.net/?channels=kakoune">
+                            <a class="dropdown-item text-nowrap" href="https://web.libera.chat/?channels=#kakoune">
                                 <i class="fa fa-fw fa-hashtag"></i>
                                 IRC
                             </a>


### PR DESCRIPTION
Since Kakoune has moved to libera, it doesn't make sense for the site's pages to link to or mention freenode - this commit updates them to point to and mention libera / its webchat instead.
