### PR TITLE
Restore prompt completion for "%opt{"

### DIFF
--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -245,8 +245,9 @@ Token parse_percent_token(ParseState& state, bool throw_on_unterminated)
         ++state.pos;
     StringView type_name{type_start, state.pos};
 
+    bool at_end = state.pos == state.str.end();
     const Codepoint opening_delimiter = utf8::read_codepoint(state.pos, state.str.end());
-    if (not state or iswalpha(opening_delimiter))
+    if (at_end or iswalpha(opening_delimiter))
     {
         if (throw_on_unterminated)
             throw parse_error{format("expected a string delimiter after '%{}'",


### PR DESCRIPTION
Commit 2289f350 ("Remove command parsing Reader and just track a
ParserState") introduced a small regression in parse_percent_token()
because we failed to recognize a token like %val{ as percent-expansion.

I tried to add a test case but a UI test doesn't seem possible, e.g.

	kak -ui json -e "exec ':echo %opt{<tab>}<ret>'"

prints: 'exec': option not found: ''