### PR TITLE
Avoid "env var" in error message for unknown %val expansion

### DIFF
--- a/src/shell_manager.cc
+++ b/src/shell_manager.cc
@@ -389,7 +389,7 @@ Vector<String> ShellManager::get_val(StringView name, const Context& context) co
     });
 
     if (env_var == m_env_vars.end())
-        throw runtime_error("no such env var: " + name);
+        throw runtime_error("no such variable: " + name);
 
     return env_var->func(name, context);
 }


### PR DESCRIPTION
This meaning is only used in C++ sources. The docs use "env
var"/"environment variable" a few times for actual environment
variables.