### PR TITLE
Make sure the ParsedRegex structure has the right size.

### DIFF
--- a/src/regex_impl.cc
+++ b/src/regex_impl.cc
@@ -81,7 +81,8 @@ struct ParsedRegex
         NodeIndex children_end;
         Codepoint value;
         Quantifier quantifier;
-    };
+        uint16_t filler = 0;
+    } __attribute__((packed));
     static_assert(sizeof(Node) == 16, "");
 
     Vector<Node, MemoryDomain::Regex> nodes;

--- a/src/regex_impl.cc
+++ b/src/regex_impl.cc
@@ -14,14 +14,6 @@
 #include <cstring>
 #include <limits>
 
-#ifndef __packed
-#if defined(__GNUC__)
-#define __packed	__attribute__((packed))
-#else
-#define __packed
-#endif
-#endif
-
 namespace Kakoune
 {
 
@@ -82,7 +74,7 @@ struct ParsedRegex
     };
 
     using NodeIndex = uint16_t;
-    struct Node
+    struct [[gnu::packed]] Node
     {
         Op op;
         bool ignore_case;
@@ -90,7 +82,7 @@ struct ParsedRegex
         Codepoint value;
         Quantifier quantifier;
         uint16_t filler = 0;
-    } __packed;
+    };
     static_assert(sizeof(Node) == 16, "");
 
     Vector<Node, MemoryDomain::Regex> nodes;

--- a/src/regex_impl.cc
+++ b/src/regex_impl.cc
@@ -14,6 +14,14 @@
 #include <cstring>
 #include <limits>
 
+#ifndef __packed
+#if defined(__GNUC__)
+#define __packed	__attribute__((packed))
+#else
+#define __packed
+#endif
+#endif
+
 namespace Kakoune
 {
 
@@ -82,7 +90,7 @@ struct ParsedRegex
         Codepoint value;
         Quantifier quantifier;
         uint16_t filler = 0;
-    } __attribute__((packed));
+    } __packed;
     static_assert(sizeof(Node) == 16, "");
 
     Vector<Node, MemoryDomain::Regex> nodes;


### PR DESCRIPTION
Hi,

Thanks a lot for your work on kakoune!

While working on the Debian package, I noticed that 2020.09.01 failed to build on the m68k processor. It turns out that the definition of the ParsedRegex structure does not necessarily guarantee that it will be packed and padded up to 16 bytes. What yo you think about this change that ensures that?

Thanks for your time, and keep up the great work!

G'luck,
Peter
