### PR TITLE
Find the executable path on the GNU Hurd, too.

### DIFF
--- a/src/file.cc
+++ b/src/file.cc
@@ -597,7 +597,7 @@ FsStatus get_fs_status(StringView filename)
 String get_kak_binary_path()
 {
     char buffer[2048];
-#if defined(__linux__) or defined(__CYGWIN__)
+#if defined(__linux__) or defined(__CYGWIN__) or defined(__gnu_hurd__)
     ssize_t res = readlink("/proc/self/exe", buffer, 2048);
     kak_assert(res != -1);
     buffer[res] = '\0';


### PR DESCRIPTION
Hi,

Thanks for all your work on kakoune!

What do you think about this trivial patch that fixes the build on the GNU Hurd by teaching kakoune to look for /proc/self/exe there, too? Until now, the build failed with the "finding executable path is not implemented on this platform" error.

Of course, if you say that the GNU Hurd is not something that you can support, I can keep this as a local patch in the Debian package.

Thanks again, and keep up the great work!

G'luck,
Peter
