### PR TITLE
Usability changes to plain colorscheme

### DIFF
--- a/colors/plain.kak
+++ b/colors/plain.kak
@@ -1,3 +1,4 @@
+
 # Kakoune simple colors, mostly default
 
 # For default
@@ -29,14 +30,14 @@ face global PrimarySelection white,blue
 face global SecondarySelection black,blue
 face global PrimaryCursor black,white
 face global SecondaryCursor white,blue
-face global PrimaryCursorEol default
+face global PrimaryCursorEol white,blue
 face global SecondaryCursorEol default
 face global LineNumbers default
 face global LineNumberCursor default
-face global MenuForeground default
-face global MenuBackground default
+face global MenuForeground black,blue
+face global MenuBackground blue,black
 face global MenuInfo default
-face global Information default
+face global Information blue,black
 face global Error default
 face global StatusLine default
 face global StatusLineMode default
@@ -46,3 +47,4 @@ face global StatusCursor default+r
 face global Prompt default
 face global MatchingChar default
 face global BufferPadding default
+ace global BufferPadding default


### PR DESCRIPTION
This commit aims to address two usability issues when using the plain colorscheme. 

**1) Moving over blank lines renders the cursor invisible:**

![kak-plain-cursor](https://user-images.githubusercontent.com/9307830/131213248-4283db49-3458-4ea0-a101-a1d4ff998d6b.gif)

**Fix:** highlight the `PrimaryCursorEol` character to make it visible:

![kak-fix-cursor](https://user-images.githubusercontent.com/9307830/131213290-cba31f0a-21b8-4280-b8f4-592772e20ce1.gif)

**2) It is visually difficult to distinguish autocomplete text from surrounding program text, and selections are hard to see:**

![kak-plain-autocomplete](https://user-images.githubusercontent.com/9307830/131350659-6983185b-20a0-42a4-ae71-51b966837b06.gif)

**Fix:** Change the autocomplete (and accompanying information text) to blue to contrast with regular program text. Invert colors for selected items.

![kak-fix-autocomplete](https://user-images.githubusercontent.com/9307830/131350746-c679e6c5-c449-4db1-82d9-0ccd24df9d9f.gif)


Addresses #4307.