### PR TITLE
indent_style should probably not control aligntab in editorconfig.kak

### DIFF
--- a/rc/detection/editorconfig.kak
+++ b/rc/detection/editorconfig.kak
@@ -31,11 +31,9 @@ define-command editorconfig-load -params ..1 -docstring "editorconfig-load [file
                     END {
                         if (indent_style == "tab") {
                             print "set-option buffer indentwidth 0"
-                            print "set-option buffer aligntab true"
                         }
                         if (indent_style == "space") {
                             print "set-option buffer indentwidth " indent_size
-                            print "set-option buffer aligntab false"
                         }
                         if (indent_size || tab_width) {
                             print "set-option buffer tabstop " (tab_width ? tab_width : indent_size)


### PR DESCRIPTION
Currently, `indent_style` in an `.editorconfig` file controls the value of `aligntab`, setting it to true if `indent_style = tab` and to false if `indent_style = space`. I would like to make an argument in favor of removing this behavior. If you fine folks agree with this argument, then here's a PR to implement that (fairly trivial) change.

Meta: This behavior originated in [this commit](https://github.com/mawww/kakoune/commit/d88d0bac42aa447c5635556e4a7c48bce625489b). It seems to have been made as part of an effort to "handle tabs more correctly". It can be overridden by setting `aligntab` after invoking `editorconfig-load` as part of a hook. However, I do not think this should be necessary.

`indent_style` is [tersely described](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#indent_style), but seems to deal strictly with indentation, not alignment. A consequence of the current behavior is that `&` aligns selections with tabs if `indent_style = tab`, which goes against a common mantra when using tabs for indentation: **"indent with tabs, align with spaces"**. Tab-based alignment is very fragile. Many of the arguments against tabs for indentation are more accurately arguments against using tabs for alignment, and are valid in that context. I'd argue it's still fine for `aligntab` to exist for people who know what they're doing, but it should not be set to true just because a project uses EditorConfig to signal that a subset of its files should be *indented* with tabs.

The one benefit I could see for this is that it enables `&` to be used to indent lines. Given its description as an alignment tool (and that Kakoune has `<a-&>`, even though it's clumsier), I'm not sure that's much of a benefit considering that this behavior prevents `&` from being used as an alignment tool in tab-indented space-aligned files without user intervention.

As such, I think it's better for `editorconfig.kak` to not change the value of `aligntab` at all (unless EditorConfig specifically comes out with a universal property for alignment). If an end user wants to replicate the current behavior, they can check the value of `indentwidth` after `editorconfig-load` is invoked and set `aligntab` accordingly.

If there's something I've missed regarding the reasoning for why this behavior was implemented, please do let me know. Have a good day!