### PR TITLE
Fix unterminated string in rc/filetype/php.kak

### DIFF
--- a/rc/filetype/php.kak
+++ b/rc/filetype/php.kak
@@ -85,7 +85,7 @@ define-command -hidden php-indent-on-char %<
 define-command -hidden php-insert-on-new-line %<
     evaluate-commands -draft -itersel %<
         # copy // comments or docblock * prefix and following white spaces
-        try %{ execute-keys -draft s [^/] <ret> k <a-x> s ^\h*\K(?://|[*][^/])\h* <ret> y gh j P
+        try %{ execute-keys -draft s [^/] <ret> k <a-x> s ^\h*\K(?://|[*][^/])\h* <ret> y gh j P }
         # append " * " on lines starting a multiline /** or /* comment
         try %{ execute-keys -draft k <a-x> s ^\h*/[*][* ]? <ret> j gi i <space>*<space> }
     >


### PR DESCRIPTION
Edit a php file and insert a new line to see messages in *debug* buffer regarding unterminated string in rc/filetype/php.kak

This commit fixes that issue, just terminate the %{ ... } string.