### PR TITLE
Add standard DiagnosticError and DiagnosticWarning faces.

### DIFF
--- a/colors/base16.kak
+++ b/colors/base16.kak
@@ -60,6 +60,8 @@ evaluate-commands %sh{
         face global MenuInfo ${cyan_light}
         face global Information ${black_light},${cyan_light}
         face global Error ${grey_light},${magenta_light}
+        face global DiagnosticError ${magenta_light}
+        face global DiagnosticWarning ${cyan_light}
         face global StatusLine ${grey_light},${black_lighterer}
         face global StatusLineMode ${orange_dark}
         face global StatusLineInfo ${cyan_light}

--- a/colors/default.kak
+++ b/colors/default.kak
@@ -39,6 +39,8 @@ face global MenuBackground blue,white
 face global MenuInfo cyan
 face global Information black,yellow
 face global Error black,red
+face global DiagnosticError red
+face global DiagnosticWarning yellow
 face global StatusLine cyan,default
 face global StatusLineMode yellow,default
 face global StatusLineInfo blue,default

--- a/colors/desertex.kak
+++ b/colors/desertex.kak
@@ -54,6 +54,8 @@ face global MenuInfo white,rgb:445599
 face global Information black,yellow
 
 face global Error      white,red
+face global DiagnosticError red
+face global DiagnosticWarning yellow
 face global StatusLine cyan,default
 
 # Status line modes and prompts:

--- a/colors/github.kak
+++ b/colors/github.kak
@@ -41,6 +41,8 @@ face global MenuForeground rgb:434343,rgb:CDCDFD
 face global MenuBackground rgb:F8F8FF,rgb:808080
 face global Information rgb:F8F8FF,rgb:4078C0
 face global Error rgb:F8F8FF,rgb:BD2C00
+face global DiagnosticError rgb:CF222E
+face global DiagnosticWarning rgb:9A6700
 face global StatusLine rgb:434343,rgb:DDDDDD
 face global StatusCursor rgb:434343,rgb:CDCDFD
 face global Prompt rgb:F8F8FF,rgb:4078C0

--- a/colors/greyscale.kak
+++ b/colors/greyscale.kak
@@ -66,6 +66,8 @@ evaluate-commands %sh{
 
     set-face global Information ${grey_light_2},${grey_dark_2}
     set-face global Error ${grey_light_2},${grey_dark_3}
+    set-face global DiagnosticError ${grey_dark_3}
+    set-face global DiagnosticWarning ${grey_dark_2}
     set-face global BufferPadding ${grey_light_1}
 
 EOF

--- a/colors/gruvbox-dark.kak
+++ b/colors/gruvbox-dark.kak
@@ -64,6 +64,8 @@ evaluate-commands %sh{
         face global MenuInfo           ${bg}
         face global Information        ${bg},${fg}
         face global Error              ${bg},${red}
+        face global DiagnosticError    ${red}
+        face global DiagnosticWarning  ${yellow}
         face global StatusLine         ${fg},${bg}
         face global StatusLineMode     ${yellow}+b
         face global StatusLineInfo     ${purple}

--- a/colors/gruvbox-light.kak
+++ b/colors/gruvbox-light.kak
@@ -64,6 +64,8 @@ evaluate-commands %sh{
         face global MenuInfo           ${bg}
         face global Information        ${bg},${fg}
         face global Error              ${bg},${red}
+        face global DiagnosticError    ${red}
+        face global DiagnosticWarning  ${yellow}
         face global StatusLine         ${fg},${bg}
         face global StatusLineMode     ${yellow}+b
         face global StatusLineInfo     ${purple}

--- a/colors/kaleidoscope-dark.kak
+++ b/colors/kaleidoscope-dark.kak
@@ -124,6 +124,8 @@ evaluate-commands %sh{
 
     set-face global Information ${black},${light_yellow}
     set-face global Error ${white},${vibrant_red}
+    set-face global DiagnosticError ${high_contrast_red}
+    set-face global DiagnosticWarning ${high_contrast_yellow}
     set-face global BufferPadding ${dark_grey}
 
 EOF

--- a/colors/kaleidoscope-light.kak
+++ b/colors/kaleidoscope-light.kak
@@ -124,6 +124,8 @@ evaluate-commands %sh{
 
     set-face global Information ${black},${muted_sand}
     set-face global Error ${white},${vibrant_red}
+    set-face global DiagnosticError ${high_contrast_red}
+    set-face global DiagnosticWarning ${high_contrast_yellow}
     set-face global BufferPadding ${vibrant_grey}
 
 EOF

--- a/colors/lucius.kak
+++ b/colors/lucius.kak
@@ -62,6 +62,8 @@ evaluate-commands %sh{
         face global MenuInfo ${lucius_grey}
         face global Information ${lucius_lighter_grey},${lucius_dark_green}
         face global Error ${lucius_light_red},${lucius_dark_red}
+        face global DiagnosticError ${lucius_light_red}
+        face global DiagnosticWarning ${lucius_purple}
         face global StatusLine ${lucius_lighter_grey},${lucius_dark_grey}
         face global StatusLineMode ${lucius_lighter_grey},${lucius_dark_green}+b
         face global StatusLineInfo ${lucius_dark_grey},${lucius_lighter_grey}

--- a/colors/palenight.kak
+++ b/colors/palenight.kak
@@ -77,6 +77,8 @@ evaluate-commands %sh{
     face global Information        $white,$visual_grey
 
     face global Error              $white,$red
+    face global DiagnosticError    $red
+    face global DiagnosticWarning  $yellow
     face global StatusLine         $white,$black
 
     # Status line

--- a/colors/plain.kak
+++ b/colors/plain.kak
@@ -39,6 +39,8 @@ face global MenuBackground blue,black
 face global MenuInfo default
 face global Information blue,black
 face global Error default
+face global DiagnosticError default
+face global DiagnosticWarning default
 face global StatusLine default
 face global StatusLineMode default
 face global StatusLineInfo default

--- a/colors/red-phoenix.kak
+++ b/colors/red-phoenix.kak
@@ -75,6 +75,8 @@ evaluate-commands %sh{
         face global MenuInfo ${gray1}
         face global Information white,${window}
         face global Error white,${gray1}
+        face global DiagnosticError ${orange1}
+        face global DiagnosticWarning ${orange2}
         face global StatusLine ${text},${window}
         face global StatusLineMode ${yellow1}+b
         face global StatusLineInfo ${orange2}

--- a/colors/reeder.kak
+++ b/colors/reeder.kak
@@ -60,6 +60,8 @@ evaluate-commands %sh{
         face global MenuInfo           default,${black}
         face global Information        ${black_light},${brown_lighter}
         face global Error              default,${red}
+        face global DiagnosticError    ${red}
+        face global DiagnosticWarning  ${orange}
         face global StatusLine         ${black},${grey_light}
         face global StatusLineMode     ${orange}
         face global StatusLineInfo     ${black}+b

--- a/colors/solarized-dark-termcolors.kak
+++ b/colors/solarized-dark-termcolors.kak
@@ -41,6 +41,8 @@ face global MenuBackground     bright-cyan,black
 face global MenuInfo           bright-green
 face global Information        black,bright-cyan
 face global Error              red,default+b
+face global DiagnosticError    red
+face global DiagnosticWarning  yellow
 face global StatusLine         bright-cyan,black+b
 face global StatusLineMode     bright-red
 face global StatusLineInfo     cyan

--- a/colors/solarized-dark.kak
+++ b/colors/solarized-dark.kak
@@ -59,6 +59,8 @@ evaluate-commands %sh{
         face global MenuInfo           ${base01}
         face global Information        ${base02},${base1}
         face global Error              ${red},default+b
+        face global DiagnosticError    ${red}
+        face global DiagnosticWarning  ${yellow}
         face global StatusLine         ${base1},${base02}+b
         face global StatusLineMode     ${orange}
         face global StatusLineInfo     ${cyan}

--- a/colors/solarized-light-termcolors.kak
+++ b/colors/solarized-light-termcolors.kak
@@ -41,6 +41,8 @@ face global MenuBackground     bright-green,white
 face global MenuInfo           bright-cyan
 face global Information        white,bright-cyan
 face global Error              red,default+b
+face global DiagnosticError    red
+face global DiagnosticWarning  yellow
 face global StatusLine         bright-green,white+b
 face global StatusLineMode     bright-red
 face global StatusLineInfo     cyan

--- a/colors/solarized-light.kak
+++ b/colors/solarized-light.kak
@@ -59,6 +59,8 @@ evaluate-commands %sh{
         face global MenuInfo           ${base1}
         face global Information        ${base2},${base1}
         face global Error              ${red},default+b
+        face global DiagnosticError    ${red}
+        face global DiagnosticWarning  ${yellow}
         face global StatusLine         ${base01},${base2}+b
         face global StatusLineMode     ${orange}
         face global StatusLineInfo     ${cyan}

--- a/colors/tomorrow-night.kak
+++ b/colors/tomorrow-night.kak
@@ -60,6 +60,8 @@ evaluate-commands %sh{
         face global MenuInfo ${red}
         face global Information ${foreground},${window}
         face global Error ${foreground},${red}
+        face global DiagnosticError ${red}
+        face global DiagnosticWarning ${yellow}
         face global StatusLine ${foreground},${selection}
         face global StatusLineMode ${yellow}+b
         face global StatusLineInfo ${aqua}

--- a/colors/zenburn.kak
+++ b/colors/zenburn.kak
@@ -69,6 +69,8 @@ evaluate-commands %sh{
         face global MenuInfo rgb:cc9393
         face global Information ${zeninfo}
         face global Error default,red
+        face global DiagnosticError red
+        face global DiagnosticWarning yellow
         face global StatusLine ${zenstatus}
         face global StatusLineMode ${zencomment}
         face global StatusLineInfo ${zenspecial}

--- a/doc/pages/faces.asciidoc
+++ b/doc/pages/faces.asciidoc
@@ -103,7 +103,13 @@ areas of the user interface:
     face for the informations windows and information messages
 
 *Error*::
-    face of error messages
+    face of errors reported by Kakoune in the status line
+
+*DiagnosticError*::
+    face of errors reported by external tools in the buffer
+
+*DiagnosticWarning*::
+    face of warnings reported by external tools in the buffer
 
 *StatusLine*::
     face used for the status line

--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -59,7 +59,7 @@ define-command -params ..1 -docstring %{
                     else if (/^[#&]/) {
                         word_len = length($2)
                         word_pos = substr($0, 1, 1) == "&" ? substr($4, 1, length($4) - 1) : $3;
-                        regions = regions " " line_num "." word_pos "+" word_len "|Error"
+                        regions = regions " " line_num "." word_pos "+" word_len "|DiagnosticError"
                     }
 
                     else {

--- a/src/face_registry.cc
+++ b/src/face_registry.cc
@@ -184,6 +184,8 @@ FaceRegistry::FaceRegistry()
         { "MenuInfo", {Face{ Color::Cyan, Color::Default }} },
         { "Information", {Face{ Color::Black, Color::Yellow }} },
         { "Error", {Face{ Color::Black, Color::Red }} },
+        { "DiagnosticError", {Face{ Color::Red, Color::Default }} },
+        { "DiagnosticWarning", {Face{ Color::Yellow, Color::Default }} },
         { "StatusLine", {Face{ Color::Cyan, Color::Default }} },
         { "StatusLineMode", {Face{ Color::Yellow, Color::Default }} },
         { "StatusLineInfo", {Face{ Color::Blue, Color::Default }} },


### PR DESCRIPTION
kak-lsp uses these faces to mark errors inside the buffer, instead of the Error face which is much more jarring, and which does not have an associated warning face. Since the :spell command marks errors inside the buffer, it's also updated
to use this new face.

Adding these faces to Kakoune makes it more likely that colorschemes will automatically do the right thing when used with kak-lsp, and makes it possible to use a subtle appearance (like curly underlines) for in-buffer errors while keeping Kakoune errors bold and jarring as they should be.