### PR TITLE
Better lua indentation

### DIFF
--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -92,9 +92,12 @@ define-command -hidden lua-trim-indent %[
 
 define-command -hidden lua-indent-on-char %[
     evaluate-commands -no-hooks -draft -itersel %[
-        # align middle and end structures to start and indent when necessary, elseif is already covered by else
-        try %[ execute-keys -draft <a-x><a-k>^\h*(else)$<ret><a-semicolon><a-?>^\h*(if)<ret>s\A|.\z<ret>)<a-&> ]
-        try %[ execute-keys -draft <a-x><a-k>^\h*(end)$<ret><a-semicolon><a-?>^\h*(for|function|if|while)<ret>s\A|.\z<ret>)<a-&> ]
+        # unindent middle and end structures
+        try %[ execute-keys -draft \
+            <a-h><a-k>^\h*(\b(end|else|elseif|until)\b|[)}])$<ret> \
+            :lua-indent-on-new-line<ret> \
+            <a-lt>
+        ]
     ]
 ]
 
@@ -103,9 +106,18 @@ define-command -hidden lua-indent-on-new-line %[
         # remove trailing white spaces from previous line
         try %[ execute-keys -draft k : lua-trim-indent <ret> ]
         # preserve previous non-empty line indent
-        try %[ execute-keys -draft <space><a-?>^[^\n]+$<ret>s\A|.\z<ret>)<a-&> ]
-        # indent after start structure
-        try %[ execute-keys -draft <a-?>^[^\n]*\w+[^\n]*$<ret><a-k>\b(else|elseif|for|function|if|while)\b<ret><a-K>\bend\b<ret><a-:><semicolon><a-gt> ]
+        try %[ execute-keys -draft <space>gh<a-?>^[^\n]+$<ret>s\A|.\z<ret>)<a-&> ]
+        # add one indentation level if the previous line is not a comment and:
+        #     - starts with a block keyword that is not closed on the same line,
+        #     - or contains an unclosed function expression,
+        #     - or ends with an enclosed '(' or '{'
+        try %[ execute-keys -draft \
+            <space> K<a-x> \
+            <a-K>\A\h*--<ret> \
+            <a-K>\A[^\n]*\b(end|until)\b<ret> \
+            <a-k>\A(\h*\b(do|else|elseif|for|function|if|repeat|while)\b|[^\n]*[({]$|[^\n]*\bfunction\b\h*[(])<ret> \
+            <a-:><semicolon><a-gt>
+        ]
     ]
 ]
 

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -127,10 +127,21 @@ define-command -hidden lua-insert-on-new-line %[
         try %[ execute-keys -draft k<a-x>s^\h*\K--\h*<ret> y gh j <a-x><semicolon> P ]
         # wisely add end structure
         evaluate-commands -save-regs x %[
-            try %[ execute-keys -draft k<a-x>s^\h+<ret>"xy ] catch %[ reg x '' ] # Save previous line indent in register x
-            try %[ execute-keys -draft k<a-x> <a-k>^<c-r>x\b[^\n]*(do|for|function|if|while)<ret><a-K>\bend\b<ret> J}iJ<a-x> <a-K>^<c-r>x(else|end|elseif)$<ret> # Validate previous line and that it is not closed yet
-                   execute-keys -draft o<c-r>xend<esc> # auto insert end
-                   execute-keys -draft k<a-x><a-k>\(function\b<ret>jjA)<esc> ] # auto insert ) for anonymous function
+            # save previous line indent in register x
+            try %[ execute-keys -draft k<a-x>s^\h+<ret>"xy ] catch %[ reg x '' ]
+            try %[
+                # check that starts with a block keyword that is not closed on the same line
+                execute-keys -draft \
+                    k<a-x> \
+                    <a-k>^\h*\b(else|elseif|do|for|function|if|while)\b|[^\n]\bfunction\b\h*[(]<ret> \
+                    <a-K>\bend\b<ret>
+                # check that the block is empty and is not closed on a different line
+                execute-keys -draft <a-a>i <a-K>^[^\n]*\n[^\n]*\n<ret> j<a-x> <a-K>^<c-r>x\b(else|elseif|end)\b<ret>
+                # auto insert end
+                execute-keys -draft o<c-r>xend<esc>
+                # auto insert ) for anonymous function
+                execute-keys -draft k<a-x><a-k>\([^)\n]*function\b<ret>jjA)<esc>
+            ]
         ]
     ]
 ]

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -33,7 +33,7 @@ hook -group lua-highlight global WinSetOption filetype=lua %{
 }
 
 
-provide-module lua %[
+provide-module lua %§
 
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
@@ -85,42 +85,42 @@ define-command lua-alternative-file -docstring 'Jump to the alternate file (impl
     printf %s\\n "edit $altfile"
 }}
 
-define-command -hidden lua-trim-indent %{
+define-command -hidden lua-trim-indent %[
     # remove trailing whitespaces
-    try %{ execute-keys -draft -itersel <a-x> s \h+$ <ret> d }
-}
+    try %[ execute-keys -draft -itersel <a-x> s \h+$ <ret> d ]
+]
 
-define-command -hidden lua-indent-on-char %{
-    evaluate-commands -no-hooks -draft -itersel %{
+define-command -hidden lua-indent-on-char %[
+    evaluate-commands -no-hooks -draft -itersel %[
         # align middle and end structures to start and indent when necessary, elseif is already covered by else
-        try %{ execute-keys -draft <a-x><a-k>^\h*(else)$<ret><a-semicolon><a-?>^\h*(if)<ret>s\A|.\z<ret>)<a-&> }
-        try %{ execute-keys -draft <a-x><a-k>^\h*(end)$<ret><a-semicolon><a-?>^\h*(for|function|if|while)<ret>s\A|.\z<ret>)<a-&> }
-    }
-}
+        try %[ execute-keys -draft <a-x><a-k>^\h*(else)$<ret><a-semicolon><a-?>^\h*(if)<ret>s\A|.\z<ret>)<a-&> ]
+        try %[ execute-keys -draft <a-x><a-k>^\h*(end)$<ret><a-semicolon><a-?>^\h*(for|function|if|while)<ret>s\A|.\z<ret>)<a-&> ]
+    ]
+]
 
-define-command -hidden lua-indent-on-new-line %{
-    evaluate-commands -no-hooks -draft -itersel %{
+define-command -hidden lua-indent-on-new-line %[
+    evaluate-commands -no-hooks -draft -itersel %[
         # remove trailing white spaces from previous line
-        try %{ execute-keys -draft k : lua-trim-indent <ret> }
+        try %[ execute-keys -draft k : lua-trim-indent <ret> ]
         # preserve previous non-empty line indent
-        try %{ execute-keys -draft <space><a-?>^[^\n]+$<ret>s\A|.\z<ret>)<a-&> }
+        try %[ execute-keys -draft <space><a-?>^[^\n]+$<ret>s\A|.\z<ret>)<a-&> ]
         # indent after start structure
-        try %{ execute-keys -draft <a-?>^[^\n]*\w+[^\n]*$<ret><a-k>\b(else|elseif|for|function|if|while)\b<ret><a-K>\bend\b<ret><a-:><semicolon><a-gt> }
-    }
-}
+        try %[ execute-keys -draft <a-?>^[^\n]*\w+[^\n]*$<ret><a-k>\b(else|elseif|for|function|if|while)\b<ret><a-K>\bend\b<ret><a-:><semicolon><a-gt> ]
+    ]
+]
 
 define-command -hidden lua-insert-on-new-line %[
     evaluate-commands -no-hooks -draft -itersel %[
         # copy -- comment prefix and following white spaces
-        try %{ execute-keys -draft k<a-x>s^\h*\K--\h*<ret> y gh j <a-x><semicolon> P }
+        try %[ execute-keys -draft k<a-x>s^\h*\K--\h*<ret> y gh j <a-x><semicolon> P ]
         # wisely add end structure
         evaluate-commands -save-regs x %[
-            try %{ execute-keys -draft k<a-x>s^\h+<ret>"xy } catch %{ reg x '' } # Save previous line indent in register x
-            try %[ execute-keys -draft k<a-x> <a-k>^<c-r>x\b[^\n]*(for|function|if|while)<ret><a-K>\bend\b<ret> J}iJ<a-x> <a-K>^<c-r>x(else|end|elseif)$<ret> # Validate previous line and that it is not closed yet
+            try %[ execute-keys -draft k<a-x>s^\h+<ret>"xy ] catch %[ reg x '' ] # Save previous line indent in register x
+            try %[ execute-keys -draft k<a-x> <a-k>^<c-r>x\b[^\n]*(do|for|function|if|while)<ret><a-K>\bend\b<ret> J}iJ<a-x> <a-K>^<c-r>x(else|end|elseif)$<ret> # Validate previous line and that it is not closed yet
                    execute-keys -draft o<c-r>xend<esc> # auto insert end
                    execute-keys -draft k<a-x><a-k>\(function\b<ret>jjA)<esc> ] # auto insert ) for anonymous function
         ]
     ]
 ]
 
-]
+§

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -40,8 +40,8 @@ provide-module lua %[
 
 add-highlighter shared/lua regions
 add-highlighter shared/lua/code default-region group
-add-highlighter shared/lua/raw_string  region -match-capture '\[(=*)\['   '\](=*)\]'       fill string
-add-highlighter shared/lua/raw_comment region -match-capture '--\[(=*)\[' '\](=*)\]'       fill comment
+add-highlighter shared/lua/raw_string  region -match-capture   '\[(=*)\[' '\](=*)\]' fill string
+add-highlighter shared/lua/raw_comment region -match-capture '--\[(=*)\[' '\](=*)\]' fill comment
 add-highlighter shared/lua/double_string region '"'   (?<!\\)(?:\\\\)*" fill string
 add-highlighter shared/lua/single_string region "'"   (?<!\\)(?:\\\\)*' fill string
 add-highlighter shared/lua/comment       region '--'  $                 fill comment

--- a/rc/filetype/lua.kak
+++ b/rc/filetype/lua.kak
@@ -136,7 +136,7 @@ define-command -hidden lua-insert-on-new-line %[
                     <a-k>^\h*\b(else|elseif|do|for|function|if|while)\b|[^\n]\bfunction\b\h*[(]<ret> \
                     <a-K>\bend\b<ret>
                 # check that the block is empty and is not closed on a different line
-                execute-keys -draft <a-a>i <a-K>^[^\n]*\n[^\n]*\n<ret> j<a-x> <a-K>^<c-r>x\b(else|elseif|end)\b<ret>
+                execute-keys -draft <a-a>i <a-K>^[^\n]+\n[^\n]+\n<ret> j<a-x> <a-K>^<c-r>x\b(else|elseif|end)\b<ret>
                 # auto insert end
                 execute-keys -draft o<c-r>xend<esc>
                 # auto insert ) for anonymous function

--- a/test/indent/lua/insert-end-only-when-needed/in
+++ b/test/indent/lua/insert-end-only-when-needed/in
@@ -3,7 +3,19 @@ end
 
 function fun2()%( )
 
-
 function fun3()
     if true then%( )
 end
+
+function fun4()
+    if true then
+        return 10
+    else%( )
+end
+
+function fun5()
+    if true then%( )
+        return 10
+end
+
+local str = "while"%( )

--- a/test/indent/lua/insert-end-only-when-needed/out
+++ b/test/indent/lua/insert-end-only-when-needed/out
@@ -6,9 +6,25 @@ function fun2()
     foo()
 end
 
-
 function fun3()
     if true then
         foo()
     end
 end
+
+function fun4()
+    if true then
+        return 10
+    else
+        foo()
+    end
+end
+
+function fun5()
+    if true then
+        foo()
+        return 10
+end
+
+local str = "while"
+foo()

--- a/test/indent/lua/unindent-after-end/cmd
+++ b/test/indent/lua/unindent-after-end/cmd
@@ -1,0 +1,1 @@
+cend<esc>

--- a/test/indent/lua/unindent-after-end/in
+++ b/test/indent/lua/unindent-after-end/in
@@ -1,0 +1,7 @@
+if A then
+        %( )
+
+if A then
+    while B then
+    end
+    %( )

--- a/test/indent/lua/unindent-after-end/out
+++ b/test/indent/lua/unindent-after-end/out
@@ -1,0 +1,7 @@
+if A then
+end
+
+if A then
+    while B then
+    end
+end

--- a/test/indent/lua/unindent-after-end/rc
+++ b/test/indent/lua/unindent-after-end/rc
@@ -1,0 +1,3 @@
+source "%val{runtime}/colors/default.kak"
+source "%val{runtime}/rc/filetype/lua.kak"
+set buffer filetype lua


### PR DESCRIPTION
Over the last weeks I've been using Kakoune to program in Lua... I felt that some parts of the automatic indentation could be improved, so here is a PR for it :)

## Indentation

- Indent inside **do** **end**
- Indent inside **repeat** **until**
- Indent after a line ending with `{` or `(`
- Do not indent if the keyword is inside a string or comment
- More accurate un-indentation for the **end** keyword

 ```lua
-- Previously, the second "end" was
-- indented at the same level as the "if"
 while true do
      if false then
      end
      end
```

## Automatic insertion of end keyword

- Also insert after **do**, **else** and **elseif**
- Do not insert if the keyword is inside a string or comment
- Do not insert if the block already contains statements

```lua
-- No longer does this:
-- If we open a new line at the start of an unclosed block, adding
-- an "end" right after the cursor is probably not what we want.
if true then
    @
end
    x = 1
    y = 2
```