### PR TITLE
Pull colorschemes from a list of directories

### DIFF
--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -1,6 +1,11 @@
-def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
+decl -docstring "A list of directories that will be sourced for the `colorscheme` command" \
+    str-list colorscheme_sources "%val{runtime}/colors" "%val{config}/colors"
+
+def -override -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
     -shell-script-candidates %{
-    find -L "${kak_runtime}/colors" "${kak_config}/colors" -type f -name '*\.kak' \
+    # TODO: This don't work!
+    eval set -- "$kak_quoted_opt_colorscheme_sources"
+    find -L "$@" -type f -name '*\.kak' \
         | while read -r filename; do
             basename="${filename##*/}"
             printf %s\\n "${basename%.*}"
@@ -11,18 +16,21 @@ def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
         find -L "${1}" -type f -name "${2}".kak | head -n 1
     }
 
+    scheme_name=$1
     filename=""
-    if [ -d "${kak_config}/colors" ]; then
-        filename=$(find_colorscheme "${kak_config}/colors" "${1}")
-    fi
-    if [ -z "${filename}" ]; then
-        filename=$(find_colorscheme "${kak_runtime}/colors" "${1}")
-    fi
+
+    eval set -- "$kak_quoted_opt_colorscheme_sources"
+    for source; do
+        if [ -d "${source}" ]; then
+            filename=$(find_colorscheme "${source}" "${scheme_name}" || ${filename})
+        fi
+        shift
+    done
 
     if [ -n "${filename}" ]; then
         printf 'source %%{%s}' "${filename}"
     else
-        echo "fail 'No such colorscheme ${1}.kak'"
+        echo "fail 'No such colorscheme ${scheme_name}.kak'"
     fi
 }}
 


### PR DESCRIPTION
I have modified the `colorscheme` command to take a list of directories defined in `colorscheme_sources`. This allows plugin managers such as [cork.kak](https://github.com/topisani/cork.kak) to expose colorschemes provided by plugins without needing to mess with symlinks or copying files around.

The command is probably significantly slower than it was before, but how often do you change your colorscheme?

Created for https://github.com/topisani/cork.kak/pull/6