### PR TITLE
doc keys: Explain `<c-s>` better

### DIFF
--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -552,7 +552,8 @@ to skim through the jump list using:
     jump backward
 
 *<c-s>*::
-    save selections
+    create a jump step, but also save the current selection to have it be
+    restored when the step is subsequently cycled through
 
 == Multiple selections
 


### PR DESCRIPTION
Not sure about this entire section, the pre-amble talks about “push[ing] the previous selections to the client's jump list” which doesn't make the definition of `<c-s>` better with this commit.