### PR TITLE
src: Make `g` and `v` case sensitive

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -228,7 +228,7 @@ void goto_commands(Context& context, NormalParams params)
             if (not cp or key == Key::Escape)
                 return;
             auto& buffer = context.buffer();
-            switch (to_lower(*cp))
+            switch (*cp)
             {
             case 'g':
             case 'k':
@@ -363,7 +363,7 @@ void view_commands(Context& context, NormalParams params)
 
         const BufferCoord cursor = context.selections().main().cursor();
         Window& window = context.window();
-        switch (to_lower(*cp))
+        switch (*cp)
         {
         case 'v':
         case 'c':


### PR DESCRIPTION
The current implementation allows users to declare mappings in the
`goto` and `view` modes with uppercase letters, but doesn't consider
case to be meaningful.

This quirk is also inconsistent as hitting an unmapped key will quit
the mode menu without complaints, but hitting a key that isn't in it
will work if it has a lowercase mapping equivalent.

Fixes #3976