### PR TITLE
Fix OCaml line comments

### DIFF
--- a/rc/tools/comment.kak
+++ b/rc/tools/comment.kak
@@ -1,4 +1,5 @@
 # Line comments
+# If the language has no line comments, set to ''
 declare-option -docstring "characters inserted at the beginning of a commented line" \
     str comment_line '#'
 
@@ -97,6 +98,7 @@ hook global BufSetOption filetype=markdown %{
 }
 
 hook global BufSetOption filetype=(ocaml|coq) %{
+    set-option buffer comment_line ''
     set-option buffer comment_block_begin '(* '
     set-option buffer comment_block_end ' *)'
 }


### PR DESCRIPTION
Hi, when trying the new-ish OCaml support I found that the the default line comment `#` was still enabled.
To my knowledge OCaml does not have explicit line comments, and as far as I can tell neither does Coq.

Based on the markdown and html settings it seems like the pattern is to set `comment_line` to `''` which throws an error when `comment-line` is used.