### PR TITLE
Add detection, intialization and basic syntax highlighting for Erlang

### DIFF
--- a/rc/filetype/erlang.kak
+++ b/rc/filetype/erlang.kak
@@ -1,0 +1,62 @@
+# Erlang/OTP
+# https://erlang.org
+# ----------------------
+
+# Detection and Initialization sections were adapted from rc/filetype/elixir.kak
+
+# Detection
+# ‾‾‾‾‾‾‾‾‾
+hook global BufCreate .*[.](erl|hrl) %{
+    set-option buffer filetype erlang
+}
+
+# Initialization
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+hook global WinSetOption filetype=erlang %{
+    require-module erlang
+
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window erlang-.+ }
+}
+
+hook -group erlang-highlight global WinSetOption filetype=erlang %{
+    add-highlighter window/erlang ref erlang
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/erlang }
+}
+
+provide-module erlang %[
+
+# Highlighters
+# ‾‾‾‾‾‾‾‾‾‾‾‾
+
+add-highlighter shared/erlang regions
+add-highlighter shared/erlang/default default-region group
+
+add-highlighter shared/erlang/comment region '(?<!\$)%' '$' fill comment
+add-highlighter shared/erlang/attribute_atom_single_quoted region %{-'} %{(?<!\\)(?:\\\\)*'(?=[\( \.])} fill builtin
+add-highlighter shared/erlang/attribute region '\b-[a-z][\w@]*(?=[\( \.])' '\K' fill builtin
+add-highlighter shared/erlang/atom_single_quoted region %{'} %{(?<!\\)(?:\\\\)*'} fill type
+add-highlighter shared/erlang/char_list region %{"} %{(?<!\\)(?:\\\\)*"} fill string
+add-highlighter shared/erlang/dollar_double_quote region %{\$\\?"} '\K' fill value
+add-highlighter shared/erlang/dollar_single_quote region %{\$\\?'} '\K' fill value
+
+# default-region regex highlighters
+add-highlighter shared/erlang/default/atom regex '\b[a-z][\w@]*\b' 0:type
+add-highlighter shared/erlang/default/funtion_call regex '\b[a-z][\w@]*(?=\()' 0:function
+add-highlighter shared/erlang/default/keywords regex '\b(after|begin|case|try|catch|end|fun|if|of|receive|when|andalso|orelse|bnot|not|div|rem|band|and|bor|bxor|bsl|bsr|or|xor)\b' 0:keyword
+add-highlighter shared/erlang/default/variable_name regex '\b(?<!\?)[A-Z_][\w@]*\b' 0:variable
+add-highlighter shared/erlang/default/module_prefix regex '\b([a-z][\w_@]+)(?=:)' 1:value
+add-highlighter shared/erlang/default/erlang_ref regex '#Ref' 0:value
+add-highlighter shared/erlang/default/floatish regex '\b(?<!/)(\d+(?:\.\d+)*)\b' 1:value
+add-highlighter shared/erlang/default/base_number regex '\b\d+#[a-zA-Z0-9]+\b' 0:value
+# e.g $\xff
+add-highlighter shared/erlang/default/dollar_hex regex '\$\\x[0-9a-f][0-9a-f]' 0:value
+# e.g. $\^a $\^C
+add-highlighter shared/erlang/default/dollar_ctrl_char regex '\$\\\^[a-zA-Z]' 0:value
+# e.g. $\101, $\70
+add-highlighter shared/erlang/default/dollar_octal regex '\$\\[0-7][0-7][0-7]?' 0:value
+# e.g. $\↕ $\7
+add-highlighter shared/erlang/default/dollar_esc_char regex '\$\\[^x]' 0:value
+# e.g. $↕ $a
+add-highlighter shared/erlang/default/dollar_char regex '\$.' 0:value
+
+]


### PR DESCRIPTION
A notable language for which Kakoune is missing support is Erlang. This PR hopes to remedy that by providing detection, initialization and basic syntax highlighting for Erlang. Erlang has a good language server (erlang_ls) that actually works quite well in Kakoune + kak-lsp. It would be awesome to have Erlang syntax highlighting during development in Kakoune!

**General Comments**
- A recurring issue with regex based syntax highlighting is that it "breaks down" in some situations. This PR provides a robust implementation of syntax highlighting in Erlang. It is robust in the face of erlang literals like `$"` `$'` and in many other situations that may confuse double string / single string detection, atom detection etc. This is one of the strong features of this syntax highlighter. If you find any situations where the syntax highlighting breaks down for you, please bring to my attention
- Atoms, variables, functions, module:function calls, character literals, number literals, keywords, attributes etc. are detected well and highlighted to make Erlang code readable
- The Erlang language is based on just a few (though sometimes idiosyncratic) syntax patterns so this PR while quite basic seems to do a decent job overall 
- I've visually tested syntax highlighting on the https://github.com/ninenines/cowlib and https://github.com/ninenines/cowboy . These libraries do a lot of weird parsing/inspection of HTTP requests and therefore have a lot of complex code that exercises the syntax highlighter well

**Miscellaneous Comments**
- I notice that there is a [link to a gist for erlang support](https://github.com/mawww/kakoune/issues/2720#issuecomment-636875312) by @subsetpark in #2720. This PR was built independently from that gist and is not built off/derived from it
- It would be useful at some point to see if something can be incorporated from that gist into Kakoune. However, I don't think it is possible at this stage as it is not clear if that gist is released in the public domain / is under the Unilicense
- In the [PNG](https://gist.github.com/subsetpark/1dee6a1694d0712068a87d7e5299f5f3#gistcomment-3326129) by @rjcoelho there is a syntax highlighting issue in the block between lines 302-336 (see left hand side). It would be useful to see if the same piece of code highlights properly with this PR 
- This PR can be enhanced in the future by adding support for the automatic indentation etc. However, I would much prefer that if the syntax highlighting works well for people, we merge this PR without more features. Having some support is better than perfect support in the future  

cc: @mawww
 