### PR TITLE
src/main.cc: Fix inline assembly syntax error on ARM

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1249,8 +1249,12 @@ int main(int argc, char* argv[])
 }
 
 #if defined(__ELF__)
-asm(R"(
-.pushsection ".debug_gdb_scripts", "MS",@progbits,1
+#ifdef __arm__
+# define PROGBITS "%progbits"
+#else
+# define PROGBITS "@progbits"
+#endif
+asm(".pushsection \".debug_gdb_scripts\", \"MS\"," PROGBITS ",1" R"(
 .byte 4
 .ascii "kakoune-inline-gdb.py\n"
 .ascii "import os.path\n"


### PR DESCRIPTION
ARM uses @ as a comment character, so %progbits must be
used in place of @progbits here.  This change fixes the
build on armv7 FreeBSD 13.0.

Fixes		issue #4385
See also	https://bugs.freebsd.org/259434