### PR TITLE
doc regex: Avoid confusion in relationship with ECMAScript

### DIFF
--- a/doc/pages/regex.asciidoc
+++ b/doc/pages/regex.asciidoc
@@ -2,7 +2,7 @@
 
 == Regex syntax
 
-Kakoune regex syntax is based on ECMAScript syntax, as defined by the
+Kakoune's regex syntax is inspired after ECMAScript, as defined by the
 ECMA-262 standard (see <<regex#compatibility,:doc regex compatibility>>).
 
 Kakoune's regex always runs on Unicode codepoint sequences, not on bytes.

--- a/doc/pages/regex.asciidoc
+++ b/doc/pages/regex.asciidoc
@@ -2,7 +2,7 @@
 
 == Regex syntax
 
-Kakoune's regex syntax is inspired after ECMAScript, as defined by the
+Kakoune's regex syntax is inspired by ECMAScript, as defined by the
 ECMA-262 standard (see <<regex#compatibility,:doc regex compatibility>>).
 
 Kakoune's regex always runs on Unicode codepoint sequences, not on bytes.


### PR DESCRIPTION
The prologue led some users to believe the implementation was compliant with ECMAScript let alone some differences (who *are* documented at the end of the page).