### PR TITLE
Support dedicated filter text in "completions" options

### DIFF
--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -142,22 +142,22 @@ are exclusively available to built-in options.
     escaped as `\|` or `\\`.
 
 *completions*::
-    a list of `<text>|<select cmd>|<menu text>` candidates,
+    a list of `<text>[|<filter text>]|<select cmd>|<menu text>` candidates,
     except for the first element which follows the
     `<line>.<column>[+<length>]@<timestamp>` format to define where the
     completion apply in the buffer.
     Any `|` or `\` characters that occur within the `<text>`,
-    `<select cmd>`, or `<menu text>` fields should be escaped as `\|`
-    or `\\`.
+    `<filter text>`, `<select cmd>`, or `<menu text>` fields should be
+    escaped as `\|` or `\\`.
 
     Options of this type are are meant to be added to the `completers`
     option to provide insert mode completion. Candidates are shown if the
     text typed by the user (between `<line>.<column>` and the cursor) is a
-    subsequence of `<text>`.
+    subsequence of `<filter text>` (if provided) or `<text>`.
 
-    For each remaining candidate, the completion menu displays
-    `<text>`, followed by `<menu text>`, which is a Markup string (see
-    <<faces#markup-strings,`:doc faces markup-strings`>>).
+    For each remaining candidate, the completion menu displays `<filter text>`
+    (if provided) or `<text>`, followed by `<menu text>`, which is a Markup
+    string (see <<faces#markup-strings,`:doc faces markup-strings`>>).
 
     As the user selects items from the completion menu, the text they typed
     will be replaced with `<text>`, and the Kakoune command in

--- a/src/insert_completer.hh
+++ b/src/insert_completer.hh
@@ -8,6 +8,8 @@
 
 #include "optional.hh"
 
+#include <variant>
+
 namespace Kakoune
 {
 
@@ -45,7 +47,7 @@ inline StringView option_type_name(Meta::Type<InsertCompleterDesc>)
     return "completer";
 }
 
-using CompletionCandidate = std::tuple<String, String, String>;
+using CompletionCandidate = std::variant<std::tuple<String, String, String, String>, std::tuple<String, String, String>>;
 using CompletionList = PrefixedList<String, CompletionCandidate>;
 
 inline StringView option_type_name(Meta::Type<CompletionList>)

--- a/src/option_types.hh
+++ b/src/option_types.hh
@@ -13,6 +13,7 @@
 #include "units.hh"
 
 #include <tuple>
+#include <variant>
 #include <vector>
 
 namespace Kakoune
@@ -248,6 +249,24 @@ std::tuple<Types...> option_from_string(Meta::Type<std::tuple<Types...>>, String
                                    std::make_index_sequence<sizeof...(Types)>());
 }
 
+// TODO Maybe we should lift this to an arbitrary number of arguments already?
+template<typename A, typename B>
+std::variant<A, B> option_from_string(Meta::Type<std::variant<A, B>>, StringView str)
+{
+    try {
+        return option_from_string(Meta::Type<A>{}, str);
+    } catch(runtime_error &e) { // TODO How should we clean this up?
+        return option_from_string(Meta::Type<B>{}, str);
+    }
+}
+
+template<typename A, typename B>
+String option_to_string(const std::variant<A, B>& opt, Quoting quoting)
+{
+    if (std::holds_alternative<A>(opt))
+        return option_to_string(std::get<A>(opt), quoting);
+    return option_to_string(std::get<B>(opt), quoting);
+}
 template<typename RealType, typename ValueType>
 inline String option_to_string(const StronglyTypedNumber<RealType, ValueType>& opt)
 {


### PR DESCRIPTION
This allows to resolve https://github.com/kak-lsp/kak-lsp/issues/444, via https://github.com/kak-lsp/kak-lsp/pull/551.

For other LSP completions it doesn't seem to matter much. For example clangd sends this:

```json
{
        "label": " someFunction() const volatile",
        "filterText": "someFunction",
        "insertText": "someFunction"
}
```

We are supposed to filter by `filterText`, but it's also fine (and more predictable) to use `insertText` here.