### PR TITLE
Expand the `new`/`terminal` API

### DIFF
--- a/rc/windowing/detection.kak
+++ b/rc/windowing/detection.kak
@@ -19,14 +19,13 @@
 #  * focus - focus the specified client, defaulting to the current client
 #
 
-declare-option -docstring \
-"Ordered list of windowing modules to try and load. An empty list disables
-both automatic module loading and environment detection, enabling complete
-manual control of the module loading." \
-str-list windowing_modules 'tmux' 'screen' 'kitty' 'iterm' 'wayland' 'x11'
+declare-option -docstring %{
+    Ordered list of windowing modules to try and load. An empty list disables
+    both automatic module loading and environment detection, enabling complete
+    manual control of the module loading.
+} str-list windowing_modules 'tmux' 'screen' 'kitty' 'iterm' 'wayland' 'x11'
 
 hook -group windowing global KakBegin .* %{
-
     evaluate-commands %sh{
         set -- ${kak_opt_windowing_modules}
         if [ $# -gt 0 ]; then

--- a/rc/windowing/iterm.kak
+++ b/rc/windowing/iterm.kak
@@ -133,6 +133,9 @@ define-command iterm-focus -params ..1 -client-completion -docstring %{
 }
 
 alias global focus iterm-focus
-alias global terminal iterm-terminal-vertical
+alias global terminal            iterm-terminal-vertical
+alias global terminal-window     iterm-terminal-window
+alias global terminal-horizontal iterm-terminal-horizontal
+alias global terminal-vertical   iterm-terminal-vertical
 
 }

--- a/rc/windowing/iterm.kak
+++ b/rc/windowing/iterm.kak
@@ -132,7 +132,7 @@ define-command iterm-focus -params ..1 -client-completion -docstring %{
     }
 }
 
-alias global focus iterm-focus
+alias global focus               iterm-focus
 alias global terminal            iterm-terminal-horizontal
 alias global terminal-window     iterm-terminal-window
 alias global terminal-tab        iterm-terminal-tab

--- a/rc/windowing/iterm.kak
+++ b/rc/windowing/iterm.kak
@@ -36,25 +36,25 @@ define-command -hidden -params 2.. iterm-terminal-split-impl %{
     }
 }
 
-define-command iterm-terminal-vertical -params 1.. -shell-completion -docstring '
-iterm-terminal-vertical <program> [<arguments>]: create a new terminal as an iterm pane
-The current pane is split into two, left and right
-The program passed as argument will be executed in the new terminal'\
-%{
+define-command iterm-terminal-vertical -params 1.. -shell-completion -docstring %{
+    iterm-terminal-vertical <program> [<arguments>]: create a new terminal as an iterm pane
+    The current pane is split into two, left and right
+    The program passed as argument will be executed in the new terminal
+} %{
     iterm-terminal-split-impl 'vertically' %arg{@}
 }
-define-command iterm-terminal-horizontal -params 1.. -shell-completion -docstring '
-iterm-terminal-horizontal <program> [<arguments>]: create a new terminal as an iterm pane
-The current pane is split into two, top and bottom
-The program passed as argument will be executed in the new terminal'\
-%{
+define-command iterm-terminal-horizontal -params 1.. -shell-completion -docstring %{
+    iterm-terminal-horizontal <program> [<arguments>]: create a new terminal as an iterm pane
+    The current pane is split into two, top and bottom
+    The program passed as argument will be executed in the new terminal
+} %{
     iterm-terminal-split-impl 'horizontally' %arg{@}
 }
 
-define-command iterm-terminal-tab -params 1.. -shell-completion -docstring '
-iterm-terminal-tab <program> [<arguments>]: create a new terminal as an iterm tab
-The program passed as argument will be executed in the new terminal'\
-%{
+define-command iterm-terminal-tab -params 1.. -shell-completion -docstring %{
+    iterm-terminal-tab <program> [<arguments>]: create a new terminal as an iterm tab
+    The program passed as argument will be executed in the new terminal
+} %{
     nop %sh{
         # see above
         args=$(
@@ -77,10 +77,10 @@ The program passed as argument will be executed in the new terminal'\
     }
 }
 
-define-command iterm-terminal-window -params 1.. -shell-completion -docstring '
-iterm-terminal-window <program> [<arguments>]: create a new terminal as an iterm window
-The program passed as argument will be executed in the new terminal'\
-%{
+define-command iterm-terminal-window -params 1.. -shell-completion -docstring %{
+    iterm-terminal-window <program> [<arguments>]: create a new terminal as an iterm window
+    The program passed as argument will be executed in the new terminal
+} %{
     nop %sh{
         # see above
         args=$(
@@ -101,10 +101,10 @@ The program passed as argument will be executed in the new terminal'\
     }
 }
 
-define-command iterm-focus -params ..1 -client-completion -docstring '
-iterm-focus [<client>]: focus the given client
-If no client is passed then the current one is used' \
-%{
+define-command iterm-focus -params ..1 -client-completion -docstring %{
+    iterm-focus [<client>]: focus the given client
+    If no client is passed then the current one is used
+} %{
     evaluate-commands %sh{
         if [ $# -eq 1 ]; then
             printf %s\\n "evaluate-commands -client '$1' focus"

--- a/rc/windowing/iterm.kak
+++ b/rc/windowing/iterm.kak
@@ -135,6 +135,7 @@ define-command iterm-focus -params ..1 -client-completion -docstring %{
 alias global focus iterm-focus
 alias global terminal            iterm-terminal-horizontal
 alias global terminal-window     iterm-terminal-window
+alias global terminal-tab        iterm-terminal-tab
 alias global terminal-horizontal iterm-terminal-horizontal
 alias global terminal-vertical   iterm-terminal-vertical
 

--- a/rc/windowing/iterm.kak
+++ b/rc/windowing/iterm.kak
@@ -133,7 +133,7 @@ define-command iterm-focus -params ..1 -client-completion -docstring %{
 }
 
 alias global focus iterm-focus
-alias global terminal            iterm-terminal-vertical
+alias global terminal            iterm-terminal-horizontal
 alias global terminal-window     iterm-terminal-window
 alias global terminal-horizontal iterm-terminal-horizontal
 alias global terminal-vertical   iterm-terminal-vertical

--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -10,10 +10,10 @@ evaluate-commands %sh{
 
 declare-option -docstring %{window type that kitty creates on new and repl calls (window|os-window)} str kitty_window_type window
 
-define-command kitty-terminal -params 1.. -shell-completion -docstring '
-kitty-terminal <program> [<arguments>]: create a new terminal as a kitty window
-The program passed as argument will be executed in the new terminal' \
-%{
+define-command kitty-terminal -params 1.. -shell-completion -docstring %{
+    kitty-terminal <program> [<arguments>]: create a new terminal as a kitty window
+    The program passed as argument will be executed in the new terminal
+} %{
     nop %sh{
         match=""
         if [ -n "$kak_client_env_KITTY_WINDOW_ID" ]; then
@@ -29,10 +29,10 @@ The program passed as argument will be executed in the new terminal' \
     }
 }
 
-define-command kitty-terminal-tab -params 1.. -shell-completion -docstring '
-kitty-terminal-tab <program> [<arguments>]: create a new terminal as kitty tab
-The program passed as argument will be executed in the new terminal' \
-%{
+define-command kitty-terminal-tab -params 1.. -shell-completion -docstring %{
+    kitty-terminal-tab <program> [<arguments>]: create a new terminal as kitty tab
+    The program passed as argument will be executed in the new terminal
+} %{
     nop %sh{
         match=""
         if [ -n "$kak_client_env_KITTY_WINDOW_ID" ]; then
@@ -48,10 +48,10 @@ The program passed as argument will be executed in the new terminal' \
     }
 }
 
-define-command kitty-focus -params ..1 -client-completion -docstring '
-kitty-focus [<client>]: focus the given client
-If no client is passed then the current one is used' \
-%{
+define-command kitty-focus -params ..1 -client-completion -docstring %{
+    kitty-focus [<client>]: focus the given client
+    If no client is passed then the current one is used
+} %{
     evaluate-commands %sh{
         if [ $# -eq 1 ]; then
             printf "evaluate-commands -client '%s' focus" "$1"

--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -73,10 +73,10 @@ define-command kitty-focus -params ..1 -client-completion -docstring %{
 
 alias global terminal            kitty-terminal
 alias global terminal-window     kitty-terminal
+alias global terminal-tab        kitty-terminal-tab
 alias global terminal-horizontal kitty-terminal
 alias global terminal-vertical   kitty-terminal
 
-alias global terminal-tab kitty-terminal-tab
 alias global focus kitty-focus
 
 }

--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -71,12 +71,11 @@ define-command kitty-focus -params ..1 -client-completion -docstring %{
     }
 }
 
+alias global focus               kitty-focus
 alias global terminal            kitty-terminal
 alias global terminal-window     kitty-terminal
 alias global terminal-tab        kitty-terminal-tab
 alias global terminal-horizontal kitty-terminal
 alias global terminal-vertical   kitty-terminal
-
-alias global focus kitty-focus
 
 }

--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -71,7 +71,11 @@ define-command kitty-focus -params ..1 -client-completion -docstring %{
     }
 }
 
-alias global terminal kitty-terminal
+alias global terminal            kitty-terminal
+alias global terminal-window     kitty-terminal
+alias global terminal-horizontal kitty-terminal
+alias global terminal-vertical   kitty-terminal
+
 alias global terminal-tab kitty-terminal-tab
 alias global focus kitty-focus
 

--- a/rc/windowing/new-client.kak
+++ b/rc/windowing/new-client.kak
@@ -1,8 +1,39 @@
 define-command new -params .. -command-completion -docstring %{
-    new [<commands>]: create a new Kakoune client
-    The `terminal` alias is being used to determine the user's preferred terminal emulator
+    new [<commands>]: spawn a new Kakoune client
+    The new window's method of creation and its location are determined by the underlying `terminal` alias, called by this command
     The optional arguments are passed as commands to the new client
 } %{
     terminal kak -c %val{session} -e "%arg{@}"
 }
 
+define-command new-window -params .. -command-completion -docstring %{
+    new-window [<commands>]: spawn a Kakoune client in a new window
+    The new window's method of creation and its location are determined by the underlying `terminal` alias, called by this command
+    The optional arguments are passed as commands to the new client
+} %{
+    terminal-window kak -c %val{session} -e "%arg{@}"
+}
+
+define-command new-tab -params .. -command-completion -docstring %{
+    new-tab [<commands>]: spawn a Kakoune client in a new tab
+    The new tab's method of creation and its location are determined by the underlying `terminal` alias, called by this command
+    The optional arguments are passed as commands to the new client
+} %{
+    terminal-tab kak -c %val{session} -e "%arg{@}"
+}
+
+define-command new-horizontal -params .. -command-completion -docstring %{
+    new-horizontal [<commands>]: spawn a Kakoune client in a new window on the left/right of the current one
+    The new window's method of creation and its location (left/right) are determined by the underlying `terminal` alias, called by this command
+    The optional arguments are passed as commands to the new client
+} %{
+    terminal-horizontal kak -c %val{session} -e "%arg{@}"
+}
+
+define-command new-vertical -params .. -command-completion -docstring %{
+    new-vertical [<commands>]: spawn a Kakoune client in a new window at the top/bottom of the current one
+    The new window's method of creation and its location (up/down) are determined by the underlying `terminal` alias, called by this command
+    The optional arguments are passed as commands to the new client
+} %{
+    terminal-vertical kak -c %val{session} -e "%arg{@}"
+}

--- a/rc/windowing/new-client.kak
+++ b/rc/windowing/new-client.kak
@@ -1,8 +1,8 @@
-define-command new -params .. -command-completion -docstring '
-new [<commands>]: create a new Kakoune client
-The ''terminal'' alias is being used to determine the user''s preferred terminal emulator
-The optional arguments are passed as commands to the new client' \
-%{
+define-command new -params .. -command-completion -docstring %{
+    new [<commands>]: create a new Kakoune client
+    The `terminal` alias is being used to determine the user's preferred terminal emulator
+    The optional arguments are passed as commands to the new client
+} %{
     try %{
         terminal kak -c %val{session} -e "%arg{@}"
     } catch %{

--- a/rc/windowing/new-client.kak
+++ b/rc/windowing/new-client.kak
@@ -3,10 +3,6 @@ define-command new -params .. -command-completion -docstring %{
     The `terminal` alias is being used to determine the user's preferred terminal emulator
     The optional arguments are passed as commands to the new client
 } %{
-    try %{
-        terminal kak -c %val{session} -e "%arg{@}"
-    } catch %{
-        fail "The 'terminal' alias must be defined to use this command"
-    }
+    terminal kak -c %val{session} -e "%arg{@}"
 }
 

--- a/rc/windowing/screen.kak
+++ b/rc/windowing/screen.kak
@@ -68,7 +68,7 @@ define-command screen-focus -params ..1 -client-completion -docstring %{
     }
 }
 
-alias global focus screen-focus
+alias global focus               screen-focus
 alias global terminal            screen-terminal-horizontal
 alias global terminal-window     screen-terminal-window
 alias global terminal-tab        screen-terminal-window

--- a/rc/windowing/screen.kak
+++ b/rc/windowing/screen.kak
@@ -69,6 +69,10 @@ define-command screen-focus -params ..1 -client-completion -docstring %{
 }
 
 alias global focus screen-focus
-alias global terminal screen-terminal-vertical
+alias global terminal            screen-terminal-vertical
+alias global terminal-window     screen-terminal-window
+alias global terminal-horizontal screen-terminal-horizontal
+alias global terminal-vertical   screen-terminal-vertical
+
 
 }

--- a/rc/windowing/screen.kak
+++ b/rc/windowing/screen.kak
@@ -69,7 +69,7 @@ define-command screen-focus -params ..1 -client-completion -docstring %{
 }
 
 alias global focus screen-focus
-alias global terminal            screen-terminal-vertical
+alias global terminal            screen-terminal-horizontal
 alias global terminal-window     screen-terminal-window
 alias global terminal-horizontal screen-terminal-horizontal
 alias global terminal-vertical   screen-terminal-vertical

--- a/rc/windowing/screen.kak
+++ b/rc/windowing/screen.kak
@@ -71,6 +71,7 @@ define-command screen-focus -params ..1 -client-completion -docstring %{
 alias global focus screen-focus
 alias global terminal            screen-terminal-horizontal
 alias global terminal-window     screen-terminal-window
+alias global terminal-tab        screen-terminal-window
 alias global terminal-horizontal screen-terminal-horizontal
 alias global terminal-vertical   screen-terminal-vertical
 

--- a/rc/windowing/screen.kak
+++ b/rc/windowing/screen.kak
@@ -28,34 +28,34 @@ define-command screen-terminal-impl -hidden -params 3.. %{
     }
 }
 
-define-command screen-terminal-vertical -params 1.. -shell-completion -docstring '
-screen-terminal-vertical <program> [<arguments>] [<arguments>]: create a new terminal as a screen pane
-The current pane is split into two, left and right
-The program passed as argument will be executed in the new terminal' \
-%{
+define-command screen-terminal-vertical -params 1.. -shell-completion -docstring %{
+    screen-terminal-vertical <program> [<arguments>] [<arguments>]: create a new terminal as a screen pane
+    The current pane is split into two, left and right
+    The program passed as argument will be executed in the new terminal
+} %{
     screen-terminal-impl 'split -v' 'focus right' %arg{@}
 }
-define-command screen-terminal-horizontal -params 1.. -shell-completion -docstring '
-screen-terminal-horizontal <program> [<arguments>]: create a new terminal as a screen pane
-The current pane is split into two, top and bottom
-The program passed as argument will be executed in the new terminal' \
-%{
+define-command screen-terminal-horizontal -params 1.. -shell-completion -docstring %{
+    screen-terminal-horizontal <program> [<arguments>]: create a new terminal as a screen pane
+    The current pane is split into two, top and bottom
+    The program passed as argument will be executed in the new terminal
+} %{
     screen-terminal-impl 'split -h' 'focus down' %arg{@}
 }
-define-command screen-terminal-window -params 1.. -shell-completion -docstring '
-screen-terminal-window <program> [<arguments>]: create a new terminal as a screen window
-The program passed as argument will be executed in the new terminal' \
-%{
+define-command screen-terminal-window -params 1.. -shell-completion -docstring %{
+    screen-terminal-window <program> [<arguments>]: create a new terminal as a screen window
+    The program passed as argument will be executed in the new terminal
+} %{
     nop %sh{
         tty="$(ps -o tty ${kak_client_pid} | tail -n 1)"
         screen -X screen "$@" < "/dev/$tty"
     }
 }
 
-define-command screen-focus -params ..1 -client-completion -docstring '
-screen-focus [<client>]: focus the given client
-If no client is passed then the current one is used' \
-%{
+define-command screen-focus -params ..1 -client-completion -docstring %{
+    screen-focus [<client>]: focus the given client
+    If no client is passed then the current one is used
+} %{
     evaluate-commands %sh{
         if [ $# -eq 1 ]; then
             printf %s\\n "

--- a/rc/windowing/tmux.kak
+++ b/rc/windowing/tmux.kak
@@ -71,6 +71,9 @@ define-command tmux-focus -params ..1 -client-completion -docstring %{
 
 ## The default behaviour for the `new` command is to open an horizontal pane in a tmux session
 alias global focus tmux-focus
-alias global terminal tmux-terminal-horizontal
+alias global terminal            tmux-terminal-horizontal
+alias global terminal-window     tmux-terminal-window
+alias global terminal-horizontal tmux-terminal-horizontal
+alias global terminal-vertical   tmux-terminal-vertical
 
 }

--- a/rc/windowing/tmux.kak
+++ b/rc/windowing/tmux.kak
@@ -30,31 +30,33 @@ define-command -hidden -params 2.. tmux-terminal-impl %{
     }
 }
 
-define-command tmux-terminal-vertical -params 1.. -shell-completion -docstring '
-tmux-terminal-vertical <program> [<arguments>]: create a new terminal as a tmux pane
-The current pane is split into two, top and bottom
-The program passed as argument will be executed in the new terminal' \
-%{
+define-command tmux-terminal-vertical -params 1.. -shell-completion -docstring %{
+    tmux-terminal-vertical <program> [<arguments>]: create a new terminal as a tmux pane
+    The current pane is split into two, top and bottom
+    The program passed as argument will be executed in the new terminal
+} %{
     tmux-terminal-impl 'split-window -v' %arg{@}
 }
-define-command tmux-terminal-horizontal -params 1.. -shell-completion -docstring '
-tmux-terminal-horizontal <program> [<arguments>]: create a new terminal as a tmux pane
-The current pane is split into two, left and right
-The program passed as argument will be executed in the new terminal' \
-%{
+
+define-command tmux-terminal-horizontal -params 1.. -shell-completion -docstring %{
+    tmux-terminal-horizontal <program> [<arguments>]: create a new terminal as a tmux pane
+    The current pane is split into two, left and right
+    The program passed as argument will be executed in the new terminal
+} %{
     tmux-terminal-impl 'split-window -h' %arg{@}
 }
-define-command tmux-terminal-window -params 1.. -shell-completion -docstring '
-tmux-terminal-window <program> [<arguments>] [<arguments>]: create a new terminal as a tmux window
-The program passed as argument will be executed in the new terminal' \
-%{
+
+define-command tmux-terminal-window -params 1.. -shell-completion -docstring %{
+    tmux-terminal-window <program> [<arguments>] [<arguments>]: create a new terminal as a tmux window
+    The program passed as argument will be executed in the new terminal
+} %{
     tmux-terminal-impl 'new-window' %arg{@}
 }
 
-define-command tmux-focus -params ..1 -client-completion -docstring '
-tmux-focus [<client>]: focus the given client
-If no client is passed then the current one is used' \
-%{
+define-command tmux-focus -params ..1 -client-completion -docstring %{
+    tmux-focus [<client>]: focus the given client
+    If no client is passed then the current one is used
+} %{
     evaluate-commands %sh{
         if [ $# -eq 1 ]; then
             printf "evaluate-commands -client '%s' focus" "$1"

--- a/rc/windowing/tmux.kak
+++ b/rc/windowing/tmux.kak
@@ -70,7 +70,7 @@ define-command tmux-focus -params ..1 -client-completion -docstring %{
 }
 
 ## The default behaviour for the `new` command is to open an horizontal pane in a tmux session
-alias global focus tmux-focus
+alias global focus               tmux-focus
 alias global terminal            tmux-terminal-horizontal
 alias global terminal-window     tmux-terminal-window
 alias global terminal-tab        tmux-terminal-window

--- a/rc/windowing/tmux.kak
+++ b/rc/windowing/tmux.kak
@@ -73,6 +73,7 @@ define-command tmux-focus -params ..1 -client-completion -docstring %{
 alias global focus tmux-focus
 alias global terminal            tmux-terminal-horizontal
 alias global terminal-window     tmux-terminal-window
+alias global terminal-tab        tmux-terminal-window
 alias global terminal-horizontal tmux-terminal-horizontal
 alias global terminal-vertical   tmux-terminal-vertical
 

--- a/rc/windowing/wayland.kak
+++ b/rc/windowing/wayland.kak
@@ -27,10 +27,10 @@ A shell command is appended to the one set in this option at runtime} \
     done
 }
 
-define-command wayland-terminal -params 1.. -shell-completion -docstring '
-wayland-terminal <program> [<arguments>]: create a new terminal as a Wayland window
-The program passed as argument will be executed in the new terminal' \
-%{
+define-command wayland-terminal -params 1.. -shell-completion -docstring %{
+    wayland-terminal <program> [<arguments>]: create a new terminal as a Wayland window
+    The program passed as argument will be executed in the new terminal
+} %{
     evaluate-commands -save-regs 'a' %{
         set-register a %arg{@}
         evaluate-commands %sh{
@@ -43,10 +43,10 @@ The program passed as argument will be executed in the new terminal' \
     }
 }
 
-define-command wayland-focus -params ..1 -client-completion -docstring '
-wayland-focus [<kakoune_client>]: focus a given client''s window
-If no client is passed, then the current client is used' \
-%{
+define-command wayland-focus -params ..1 -client-completion -docstring %{
+    wayland-focus [<kakoune_client>]: focus a given client's window
+    If no client is passed, then the current client is used
+} %{
     fail There is no way to focus another window on Wayland
 }
 

--- a/rc/windowing/wayland.kak
+++ b/rc/windowing/wayland.kak
@@ -50,7 +50,7 @@ define-command wayland-focus -params ..1 -client-completion -docstring %{
     fail There is no way to focus another window on Wayland
 }
 
-alias global focus wayland-focus
+alias global focus               wayland-focus
 alias global terminal            wayland-terminal
 alias global terminal-window     wayland-terminal
 alias global terminal-tab        wayland-terminal

--- a/rc/windowing/wayland.kak
+++ b/rc/windowing/wayland.kak
@@ -53,6 +53,7 @@ define-command wayland-focus -params ..1 -client-completion -docstring %{
 alias global focus wayland-focus
 alias global terminal            wayland-terminal
 alias global terminal-window     wayland-terminal
+alias global terminal-tab        wayland-terminal
 alias global terminal-horizontal wayland-terminal
 alias global terminal-vertical   wayland-terminal
 

--- a/rc/windowing/wayland.kak
+++ b/rc/windowing/wayland.kak
@@ -51,6 +51,10 @@ define-command wayland-focus -params ..1 -client-completion -docstring %{
 }
 
 alias global focus wayland-focus
-alias global terminal wayland-terminal
+alias global terminal            wayland-terminal
+alias global terminal-window     wayland-terminal
+alias global terminal-horizontal wayland-terminal
+alias global terminal-vertical   wayland-terminal
+
 
 }

--- a/rc/windowing/x11.kak
+++ b/rc/windowing/x11.kak
@@ -33,10 +33,10 @@ A shell command is appended to the one set in this option at runtime} \
     done
 }
 
-define-command x11-terminal -params 1.. -shell-completion -docstring '
-x11-terminal <program> [<arguments>]: create a new terminal as an X11 window
-The program passed as argument will be executed in the new terminal' \
-%{
+define-command x11-terminal -params 1.. -shell-completion -docstring %{
+    x11-terminal <program> [<arguments>]: create a new terminal as an X11 window
+    The program passed as argument will be executed in the new terminal
+} %{
     evaluate-commands -save-regs 'a' %{
         set-register a %arg{@}
         evaluate-commands %sh{
@@ -49,10 +49,10 @@ The program passed as argument will be executed in the new terminal' \
     }
 }
 
-define-command x11-focus -params ..1 -client-completion -docstring '
-x11-focus [<kakoune_client>]: focus a given client''s window
-If no client is passed, then the current client is used' \
-%{
+define-command x11-focus -params ..1 -client-completion -docstring %{
+    x11-focus [<kakoune_client>]: focus a given client's window
+    If no client is passed, then the current client is used
+} %{
     evaluate-commands %sh{
         if [ $# -eq 1 ]; then
             printf "evaluate-commands -client '%s' focus" "$1"

--- a/rc/windowing/x11.kak
+++ b/rc/windowing/x11.kak
@@ -63,7 +63,7 @@ define-command x11-focus -params ..1 -client-completion -docstring %{
     }
 }
 
-alias global focus x11-focus
+alias global focus               x11-focus
 alias global terminal            x11-terminal
 alias global terminal-window     x11-terminal
 alias global terminal-tab        x11-terminal

--- a/rc/windowing/x11.kak
+++ b/rc/windowing/x11.kak
@@ -64,6 +64,9 @@ define-command x11-focus -params ..1 -client-completion -docstring %{
 }
 
 alias global focus x11-focus
-alias global terminal x11-terminal
+alias global terminal            x11-terminal
+alias global terminal-window     x11-terminal
+alias global terminal-horizontal x11-terminal
+alias global terminal-vertical   x11-terminal
 
 }

--- a/rc/windowing/x11.kak
+++ b/rc/windowing/x11.kak
@@ -66,6 +66,7 @@ define-command x11-focus -params ..1 -client-completion -docstring %{
 alias global focus x11-focus
 alias global terminal            x11-terminal
 alias global terminal-window     x11-terminal
+alias global terminal-tab        x11-terminal
 alias global terminal-horizontal x11-terminal
 alias global terminal-vertical   x11-terminal
 


### PR DESCRIPTION
This PR allows users to control more accurately where new Kakoune clients are spawned via the `:new` API: `vertical` `horizontal`, `window`.

The `terminal` API had to be extended similarly as a consequence. I also noticed that a `terminal-tab` alias was sneaked into `kitty.kak`, so that’s supported as well, since tabs are a common type of window nowadays. Not all our multiplexer support scripts implement it though.

The other commits are consistency fixes or cosmetics.

Fixes #3943.