### PR TITLE
rc/tools/make.kak: quote "${kak_opt_makecmd}"

### DIFF
--- a/rc/tools/make.kak
+++ b/rc/tools/make.kak
@@ -14,7 +14,7 @@ define-command -params .. \
      } make %{ evaluate-commands %sh{
      output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-make.XXXXXXXX)/fifo
      mkfifo ${output}
-     ( eval ${kak_opt_makecmd} "$@" > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
+     ( eval "${kak_opt_makecmd}" "$@" > ${output} 2>&1 & ) > /dev/null 2>&1 < /dev/null
 
      printf %s\\n "evaluate-commands -try-client '$kak_opt_toolsclient' %{
                edit! -fifo ${output} -scroll *make*


### PR DESCRIPTION
As per man page eval(1p):
> The eval utility shall construct a command by concatenating arguments together,
> separating each with a `<space>` character.  The constructed command shall be
> read and executed by the shell.

When not quoting `$kak_opt_makecmd` in the eval, the variable is split by
newlines and spaces and then joined by spaces to form the command. If there
were newlines in `$kak_opt_makecmd`, the command would be malformed.


To reproduce:
```kak
set-option global makecmd "
echo foo
echo bar"
make a b c
```

Expected output in the `*make*` buffer:
```
foo
bar a b c
```

Actual output:
```
foo echo bar a b c
```

This patch fixes this.