### PR TITLE
JSON UI only shows stdin when connecting to an existing session #4432

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -692,7 +692,11 @@ int run_client(StringView session, StringView name, StringView client_init,
     try
     {
         Optional<int> stdin_fd;
-        if (not isatty(0))
+        // json-ui (or dummy) is not intended to be user interactive.
+        // So only worry about making the tty your stdin if:
+        // (a) ui_type is Terminal, *and*
+        // (b) fd 0 is not interactive.
+        if (ui_type == UIType::Terminal && not isatty(0))
         {
             // move stdin to another fd, and restore tty as stdin
             stdin_fd = dup(0);


### PR DESCRIPTION
Fixes #4432

json-ui is not intended to be a user interactive session
so don't worry about making the tty your stdin if fd 0
is not a tty.

This allows json-rpc commands sent via stdin to be acted up rather
than sent to a fifo (which is the default behavior for kakoune).

Does not change the behavior for non-json ui sessions

cc: @Screwtapello @QuinnFreedman

P.S.  This approach is simple and does the job. There probably are more approaches
