### PR TITLE
Allow for periods in commands, modes, modules names, and session names

### DIFF
--- a/src/unicode.hh
+++ b/src/unicode.hh
@@ -92,7 +92,7 @@ inline bool is_basic_digit(Codepoint c) noexcept
 inline bool is_identifier(Codepoint c) noexcept
 {
     return is_basic_alpha(c) or is_basic_digit(c) or
-           c == '_' or c == '-';
+           c == '_' or c == '-' or c == '.';
 }
 
 inline ColumnCount codepoint_width(Codepoint c) noexcept


### PR DESCRIPTION
Closes #4381 

This allows for dots in commands, modes, modules, and sessions. The original issue only asked for this feature in session names. I can amend the commit if desired to be limited to only session names.