### PR TITLE
markdown.kak: erlang, elixir and ocaml code should be highlighted in markdown

### DIFF
--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -42,9 +42,9 @@ add-highlighter shared/markdown/inline/text default-region group
 
 evaluate-commands %sh{
   languages="
-    awk c cabal clojure coffee cpp crystal css cucumber d diff dockerfile fish
+    awk c cabal clojure coffee cpp crystal css cucumber d diff dockerfile elixir erlang fish
     gas go haml haskell html ini java javascript json julia kak kickstart
-    latex lisp lua makefile markdown moon objc perl pug python ragel
+    latex lisp lua makefile markdown moon objc ocaml perl pug python ragel
     ruby rust sass scala scss sh swift toml tupfile typescript yaml sql
   "
   for lang in ${languages}; do


### PR DESCRIPTION
markdown.kak: erlang, elixir and ocaml code should be highlighted in markdown

Edit: Added `ocaml` also.