### PR TITLE
sh filetype: do not highlight an empty array as a function

### DIFF
--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -61,7 +61,7 @@ evaluate-commands %sh{
 add-highlighter shared/sh/code/operators regex [\[\]\(\)&|]{1,2} 0:operator
 add-highlighter shared/sh/code/variable regex ((?<![-:])\b\w+)= 1:variable
 add-highlighter shared/sh/code/alias regex \balias(\h+[-+]\w)*\h+([\w-.]+)= 2:variable
-add-highlighter shared/sh/code/function regex ^\h*(\S+)\h*\(\) 1:function
+add-highlighter shared/sh/code/function regex ^\h*(\S+(?<!=))\h*\(\) 1:function
 
 add-highlighter shared/sh/code/unscoped_expansion regex (?<!\\)(?:\\\\)*\K\$(\w+|#|@|\?|\$|!|-|\*) 0:value
 add-highlighter shared/sh/double_string/expansion regex (?<!\\)(?:\\\\)*\K\$(\w+|#|@|\?|\$|!|-|\*|\{.+?\}) 0:value


### PR DESCRIPTION
`x=` and `x+=` should not be highlighted as a function.
```
x=()
x+=()
```