### PR TITLE
Add `-debug shell-stdout` to see the actual output of the `%sh{}` blocks

### DIFF
--- a/src/option.hh
+++ b/src/option.hh
@@ -74,12 +74,13 @@ using TimestampedList = PrefixedList<size_t, T>;
 
 enum class DebugFlags
 {
-    None     = 0,
-    Hooks    = 1 << 0,
-    Shell    = 1 << 1,
-    Profile  = 1 << 2,
-    Keys     = 1 << 3,
-    Commands = 1 << 4,
+    None        = 0,
+    Hooks       = 1 << 0,
+    Shell       = 1 << 1,
+    Profile     = 1 << 2,
+    Keys        = 1 << 3,
+    Commands    = 1 << 4,
+    ShellStdout = 1 << 5,
 };
 
 constexpr bool with_bit_ops(Meta::Type<DebugFlags>) { return true; }
@@ -89,6 +90,7 @@ constexpr auto enum_desc(Meta::Type<DebugFlags>)
     return make_array<EnumDesc<DebugFlags>>({
         { DebugFlags::Hooks, "hooks" },
         { DebugFlags::Shell, "shell" },
+        { DebugFlags::ShellStdout, "shell-stdout" },
         { DebugFlags::Profile, "profile" },
         { DebugFlags::Keys, "keys" },
         { DebugFlags::Commands, "commands" },

--- a/src/shell_manager.cc
+++ b/src/shell_manager.cc
@@ -396,7 +396,16 @@ std::pair<String, int> ShellManager::eval(
     // Most likely you will want to do `kak -debug 'shell|shell-stdout'` to see _both_ what %sh{} blocks
     // were given to execute (shell option) and what result they got back (shell-stdout) option.
     if (debug_flags & DebugFlags::ShellStdout) {
-        write_to_debug_buffer(format("shell stdout:\n{}\n----\n", stdout_contents));
+        // Enclose stdout contents in a markdown ```kak ``` combo.
+        //
+        // The markdown tag allows us to `:set window/ filetype markdown` on the
+        // *debug* window contents and get syntax higlighting easily.
+        //
+        // Here the assumption is that %sh{} blocks generate kak script code.
+        // This assumption does not _always_ hold true but its OK here because the
+        // at best we get the ability to highlight and at worst we just get visual delimiters
+        // to the shell stdout (which is what we need).
+        write_to_debug_buffer(format("shell stdout:\n```kak{}\n```\n", stdout_contents));
     }
 
     return { std::move(stdout_contents), WIFEXITED(status) ? WEXITSTATUS(status) : -1 };

--- a/src/shell_manager.cc
+++ b/src/shell_manager.cc
@@ -391,6 +391,14 @@ std::pair<String, int> ShellManager::eval(
         context.client().redraw_ifn();
     }
 
+    // Allows us to inspect the actual output of the %sh{} blocks
+    // Invoke `kak -debug shell-stdout` on the command line to see shell output in *debug* buffer.
+    // Most likely you will want to do `kak -debug 'shell|shell-stdout'` to see _both_ what %sh{} blocks
+    // were given to execute (shell option) and what result they got back (shell-stdout) option.
+    if (debug_flags & DebugFlags::ShellStdout) {
+        write_to_debug_buffer(format("shell stdout:\n{}\n----\n", stdout_contents));
+    }
+
     return { std::move(stdout_contents), WIFEXITED(status) ? WEXITSTATUS(status) : -1 };
 }
 


### PR DESCRIPTION
_TL;DR: If you are familiar with `kak -debug shell` then this feature might appeal to you also._

_Note:_ This feature is separate from #4451 and can be merged independently

Most of the time we use `%sh{}` blocks to generate kak script code. This commit
adds a new command line option `-debug shell-stdout` that will allow you to see what
`%sh{}` returned back. This is shown in the `*debug*` buffer and does not
interfere with the operation of kak.

An alternative might be to just add `set -x` at the top of the `%sh{}` block you
want to inspect. When we do that the shell script trace is shown as stderr in
`*debug*`. However that is not always satisfying because that traces
the script execution and does not always expand everything. This shows you
the actual output at an eye's glance.

*Usage*

Invoke `kak -debug shell-stdout` on the command line to see shell output in
`*debug*` buffer. Most likely you will want to do `kak -debug 'shell|shell-stdout'`
to see _both_ what `%sh{}` blocks were given to execute (`shell` option) and what
result they got back (`shell-stdout` option).

---
_There is an optional commit:_

Enclose shell stdout contents in a markdown ` ```kak  ` ` ``` ` combo

The markdown tag allows us to `:set window/ filetype markdown` on the
`*debug*` window contents and get syntax higlighting easily.

Here the assumption is that `%sh{}` blocks generate kak script code.
This assumption does not _always_ hold true but its OK here because the
at best we get the ability to highlight and at worst we just get visual
delimiters to the shell `stdout` (which is what we need).