### PR TITLE
Add `-debug shell-trace` to add `set -x` to every shell script kak executes

### DIFF
--- a/src/option.hh
+++ b/src/option.hh
@@ -74,12 +74,13 @@ using TimestampedList = PrefixedList<size_t, T>;
 
 enum class DebugFlags
 {
-    None     = 0,
-    Hooks    = 1 << 0,
-    Shell    = 1 << 1,
-    Profile  = 1 << 2,
-    Keys     = 1 << 3,
-    Commands = 1 << 4,
+    None        = 0,
+    Hooks       = 1 << 0,
+    Shell       = 1 << 1,
+    Profile     = 1 << 2,
+    Keys        = 1 << 3,
+    Commands    = 1 << 4,
+    ShellTrace  = 1 << 5,
 };
 
 constexpr bool with_bit_ops(Meta::Type<DebugFlags>) { return true; }
@@ -89,6 +90,7 @@ constexpr auto enum_desc(Meta::Type<DebugFlags>)
     return make_array<EnumDesc<DebugFlags>>({
         { DebugFlags::Hooks, "hooks" },
         { DebugFlags::Shell, "shell" },
+        { DebugFlags::ShellTrace, "shell-trace" },
         { DebugFlags::Profile, "profile" },
         { DebugFlags::Keys, "keys" },
         { DebugFlags::Commands, "commands" },

--- a/src/shell_manager.cc
+++ b/src/shell_manager.cc
@@ -258,11 +258,21 @@ struct CommandFifos
 }
 
 std::pair<String, int> ShellManager::eval(
-    StringView cmdline, const Context& context, StringView input,
+    StringView initial_cmdline, const Context& context, StringView input,
     Flags flags, const ShellContext& shell_context)
 {
     const DebugFlags debug_flags = context.options()["debug"].get<DebugFlags>();
     const bool profile = debug_flags & DebugFlags::Profile;
+
+    // Check if user wants shell execution to be traced.
+    // Add a `set -x` prelude to each script in that case.
+    String cmdline_with_setx;
+    StringView cmdline{initial_cmdline};
+    if (debug_flags & DebugFlags::ShellTrace) {
+        cmdline_with_setx = "    set -x\n" + initial_cmdline;
+        cmdline = cmdline_with_setx;
+    }
+
     if (debug_flags & DebugFlags::Shell)
         write_to_debug_buffer(format("shell:\n{}\n----\n", cmdline));
 


### PR DESCRIPTION
_Note_: This is a separate feature from #4450 and can be merged independently.

This commit teaches Kakoune to trace every shell script it
executes if you start Kakoune as `kak -debug shell-trace`.
The results of the trace of each script can be seen in the `*debug*`
buffer.

The alternative is to explictly add `set -x` inside `%sh{}` that
we are interested in. However, this just makes things a bit
more convenient.

Most likely you will want to use this with `shell` i.e.
`kak -debug 'shell|shell-trace'`.

(The `shell` option shows the script that Kakoune sent for execution
while the `shell-trace` option traces the execution via `set -x`
feature)