### PR TITLE
readme: update build instructions

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -103,8 +103,8 @@ Building
 
 Kakoune dependencies are:
 
- * A {cpp}17 compliant compiler (GCC >= 8 or clang >= 6) along with its
-   associated {cpp} standard library (libstdc{pp} or libc{pp})
+ * A {cpp}20 compliant compiler (GCC >= 10 or clang >= 11) along with its
+   associated {cpp} standard library (libstdc{pp} >= 10 or libc{pp})
 
 To build, just type *make* in the src directory.
 To generate man pages, type *make man* in the src directory.


### PR DESCRIPTION
After a small hour trying to build Kakoune (mostly due to [`compare`](https://en.cppreference.com/w/cpp/header/compare) being very recent), I think I got the requirements right.

Not sure about the required `libc++`, I couldn't get Kakoune to build with it no matter which version I tried  ¯\\\_(ツ)\_/¯

Also used https://godbolt.org/ to find which version of GCC and Clang managed to compile `#include <compare>`.