### PR TITLE
define `%val{jumplist}` and `%val{jumplist_pos}`

### DIFF
--- a/src/context.hh
+++ b/src/context.hh
@@ -126,6 +126,7 @@ public:
     Flags flags() const { return m_flags; }
 
     JumpList& jump_list() { return m_jump_list; }
+    const JumpList& jump_list_readonly() const { return m_jump_list; }
     void push_jump(bool force = false)
     {
         if (force or not (m_flags & Flags::Draft))

--- a/src/main.cc
+++ b/src/main.cc
@@ -214,6 +214,28 @@ static const EnvVarDesc builtin_env_vars[] = { {
         "history_id", false,
         [](StringView name, const Context& context) -> Vector<String>
         { return {to_string((size_t)context.buffer().current_history_id())}; }
+    },{
+        "jumplist", false,
+        [](StringView name, const Context& context)  -> Vector<String>
+        {
+            Vector<String> vec{};
+            auto jumplist = context.jump_list_readonly().get_as_list();
+            for (auto item = jumplist.begin(); item != jumplist.end(); item++) {
+                vec.push_back(item->buffer().display_name());
+                auto cur = item->main().cursor();
+                vec.push_back(format("{}.{}", cur.line + 1, cur.column + 1));
+            }
+            return vec;
+        }
+    },{
+        "jumplist_pos", false,
+        [](StringView name, const Context& context)  -> Vector<String>
+        {
+            Vector<String> vec;
+            // To be consistent with user facing <c-i> <c-o>, the index is 0 based.
+            auto current = context.jump_list_readonly().current_index();
+            return {format("{}", current)};
+        }
     }, {
         "selection", false,
         [](StringView name, const Context& context) -> Vector<String>


### PR DESCRIPTION
`echo %val{jumplist}` will return a list of jump locations. Fixes #4452

e.g.
```
.git/COMMIT_EDITMSG 7.1 *grep* 1.47 *grep* 1.1 src/main.cc 231.1 *debug* 4.65
```

Each jump location is `<filename> <line>.<column>`

`%val{jumplist_pos}` reports the currently active jumplist position as a 0 based index.

This is consistent with indexing adopted by the user interface messages when doing `<c-i>`, `<c-o>`

*Motivation*
- I am not aware of a way of obtaining a jumplist in Kakoune. This
  information should be exposed by Kakoune so that plugins/scripts can show
  jump history. You would conceivably want to see a jumplist and
  navigate to a particular entry in it. There could be other interesting
  use cases also.
- It is not programmatically possibly to obtain the jumplist even
  if you want. If you try doing `eval -draft %{ exec <c-o> ; echo %val{buffname} }`
  this will give an error. Newly created draft contexts start off
  with an empty jumplist. They don't inherit the jumplist of the
  current client context.
- This is borne out of a user request on #4452