### PR TITLE
Add syntax highlighting for `git-revise`

### DIFF
--- a/rc/filetype/git.kak
+++ b/rc/filetype/git.kak
@@ -14,7 +14,11 @@ hook global BufCreate .*git-rebase-todo %{
     set-option buffer filetype git-rebase
 }
 
-hook global WinSetOption filetype=git-(commit|notes|rebase) %{
+hook global BufCreate .*git-revise-todo %{
+  set-option buffer filetype git-revise
+}
+
+hook global WinSetOption filetype=git-(commit|notes|rebase|revise) %{
     require-module "git-%val{hook_param_capture_1}"
 }
 
@@ -33,6 +37,10 @@ hook -group git-rebase-highlight global WinSetOption filetype=git-rebase %{
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-rebase }
 }
 
+hook -group git-revise-highlight global WinSetOption filetype=git-revise %{
+  add-highlighter window/git-revise ref git-revise
+  hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-revise }
+}
 
 provide-module git-commit %{
 add-highlighter shared/git-commit regions
@@ -50,4 +58,10 @@ provide-module git-rebase %{
 add-highlighter shared/git-rebase group
 add-highlighter shared/git-rebase/ regex "^\h*#[^\n]*\n" 0:comment
 add-highlighter shared/git-rebase/ regex "^(?:(pick|p)|(edit|reword|squash|fixup|exec|break|drop|label|reset|merge|[ersfxbdltm])) (\w+)" 1:keyword 2:value 3:meta
+}
+
+provide-module git-revise %{
+add-highlighter shared/git-revise group
+add-highlighter shared/git-revise/ regex "^\h*#[^\n]*\n" 0:comment
+add-highlighter shared/git-revise/ regex "^(?:(pick|index|[pi])|(reword|squash|fixup|cut|[rsfc])) (\w+)" 1:keyword 2:value 3:meta
 }


### PR DESCRIPTION
> `git revise` is a `git` subcommand to efficiently update, split, and rearrange commits. It is heavily inspired by `git rebase`, however it tries to be more efficient and ergonomic for patch-stack oriented workflows.

https://github.com/mystor/git-revise