### PR TITLE
update elixir sigil highlighter to be less error prone

### DIFF
--- a/rc/filetype/elixir.kak
+++ b/rc/filetype/elixir.kak
@@ -74,7 +74,7 @@ add-highlighter shared/elixir/code/ regex '[A-Z][\w_]+\b' 0:module
 add-highlighter shared/elixir/code/ regex '(:[\w_]+)(\.)' 1:module
 add-highlighter shared/elixir/code/ regex '\b_\b' 0:default
 add-highlighter shared/elixir/code/ regex '\b_[\w_]+\b' 0:default
-add-highlighter shared/elixir/code/ regex '~[a-zA-Z]\(.*\)' 0:string
+add-highlighter shared/elixir/code/ regex '~[a-zA-Z]\(.*?[^\\]\)' 0:string
 add-highlighter shared/elixir/code/ regex \b(true|false|nil)\b 0:value
 add-highlighter shared/elixir/code/ regex (->|<-|<<|>>|=>) 0:builtin
 add-highlighter shared/elixir/code/ regex \b(require|alias|use|import)\b 0:keyword


### PR DESCRIPTION
Currently, when writing sigils such as the following:

```elixir
String.at(~s(this is a test including \) in the string), 10)
```

the sigil will extend to the last closing parentheses, in this case the one that closes the function call.

This change updates the regex to non-greedily search for the closing parentheses, and to ignore any that have been escaped with `\`