### PR TITLE
Fix mode line inconsistency between normal and insert modes

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1443,8 +1443,9 @@ public:
         auto main_index = context().selections().main_index();
         return {AtomList{ { "insert", context().faces()["StatusLineMode"] },
                           { " ", context().faces()["StatusLine"] },
-                          { format( "{} sels ({})", num_sel, main_index + 1),
-                             context().faces()["StatusLineInfo"] } }};
+                          { num_sel == 1 ? format("{} sel", num_sel)
+                              : format("{} sels ({})", num_sel, main_index + 1),
+                            context().faces()["StatusLineInfo"] } }};
     }
 
     KeymapMode keymap_mode() const override { return KeymapMode::Insert; }


### PR DESCRIPTION
This fixes the mode line text in insert mode (which contains "n sels (k)" unconditionally, even when n == 1) to match normal mode, where the mode line contains "1 sel" if there's only one selection.

Fixes #4466 