### PR TITLE
Testing harness and compatibility fixes

### DIFF
--- a/src/ranked_match.cc
+++ b/src/ranked_match.cc
@@ -174,7 +174,7 @@ RankedMatch::RankedMatch(StringView candidate, StringView query)
 static bool is_word_boundary(Codepoint prev, Codepoint c)
 {
     return (iswalnum((wchar_t)prev)) != iswalnum((wchar_t)c) or
-           (iswlower((wchar_t)prev) != islower((wchar_t)c));
+           (iswlower((wchar_t)prev) != iswlower((wchar_t)c));
 }
 
 bool RankedMatch::operator<(const RankedMatch& other) const

--- a/test/compose/select-display-columns/enabled
+++ b/test/compose/select-display-columns/enabled
@@ -1,2 +1,2 @@
 #!/bin/sh
-[ $(echo -n "😄😊😉😍" | wc -m) == 4 ] && locale | grep LC_CTYPE | grep -qi 'utf-*8'
+[ $(echo -n "😄😊😉😍" | wc -m) = '4' ] && locale | grep LC_CTYPE | grep -qi 'utf-*8'

--- a/test/normal/keep-cmd-reg/rc
+++ b/test/normal/keep-cmd-reg/rc
@@ -1,1 +1,1 @@
-set-register a %{grep 'foo\|bar'}
+set-register a %{grep -E 'foo|bar'}

--- a/test/normal/keep-cmd/cmd
+++ b/test/normal/keep-cmd/cmd
@@ -1,1 +1,1 @@
-%<a-s>H$grep 'foo\|bar'<ret>
+%<a-s>H$grep -E 'foo|bar'<ret>

--- a/test/regression/3398-readonly-fifo-failure/rc
+++ b/test/regression/3398-readonly-fifo-failure/rc
@@ -1,2 +1,2 @@
-nop %sh{ mkfifo test-fifo; ( printf 'blah' > test-fifo ) </dev/null >/dev/null 2>&1 & }
+nop %sh{ mkfifo test-fifo; ( printf 'blah' > test-fifo & ) </dev/null >/dev/null 2>&1 }
 edit -readonly -fifo test-fifo out

--- a/test/run
+++ b/test/run
@@ -33,7 +33,7 @@ main() {
   for dir in $(find "${@:-.}" -type d | sort); do
     cd $root/$dir;
     mkdir -p $work/$dir
-    for file in in cmd rc; do
+    for file in in cmd rc enabled; do
       [ -f $file ] && cp $file $work/$dir/
     done
     cd $work/$dir;


### PR DESCRIPTION
While trying to get kakoune `make test` to succeed on OpenBSD (See #4417), I found some issues. Here are the bugs and fixes (see commits).

**Some bugs are related to all systems and _not_ only OpenBSD.**

* **Bug fix: use only iswlower() in RankedMatch::is_word_boundary()**
  **Applicability**: All systems.

  This manifests itself in OpenBSD when you try to run kak compiled with debug=yes.

  Symptom:
  ```
  Fatal error: assert failed "RankedMatch{"find(1p)", "find"} < RankedMatch{"findfs(8)", "find"}" at    ranked_match.cc:255
  ...
  ```
  The fix is to simply use `iswlower()` instead of `islower()`. I think it `islower()` was used by mistake as the code around it does use `iswlower()`.

* **Use grep -E as OpenBSD grep does not like | in regexp otherwise**
  **Applicability**: OpenBSD

  This only manifests itself itself in OpenBSD as it does not use gnu grep by default. Fix by using `grep -E`.

* **Bug: The enabled test checks, though they exist are never actually run**
  **Applicability:** All systems
  
  We can check whether we want to run a test or not by executing the `enabled` script. However, the tests are run in the `/tmp` directory and the `enabled` file needs to be copied over in order to run. We were not copying the file so the `enabled` check was never actually carried out. Fix by copying the file over.

* **Bug: A `enabled` script had a bug in it**
  **Applicability:** All systems

  The enabled check was actually was not being run by the test infrastructure.

  Now that it is, we get the following error when trying to execute
`test/compose/select-display-columns`

  ```sh
  ./enabled: 2: [: 4: unexpected operator
  ```
  
  Fix the script

------
**OpenBSD specific issues**

* ```diff
  -MAÏS MÉLANGE BIENTÔT
  +MAïS MéLANGE BIENTôT
  ```
  (and many other test failures)
  **Resolution:**
  ```bash
  # I'm using bash in OpenBSD 7.0
  $ export LC_ALL=C.UTF-8
  # export LC_ALL=en_US.UTF-8
  # export LC_ALL=en_IN.UTF-8 
  # export LC_ALL=<your-favorite-one>.UTF-8
  # All these will work also. Basically ensure you have the suffix UTF-8
  # man locale in OpenBSD is helpful
  ```
* **There is a single test that still fails (more accurately it does not fail but hangs the test suite) on OpenBSD 7.0**. It's probably going to be complicated as its fifo related on openbsd. And that is `test/regression/3398-readonly-fifo-failure`. I didn't have time to investigate.

  **Temporary Workaround**: Pull this branch, (or if this branch is merged to master, the latest master) and then add the following file to the `test/regression/3398-readonly-fifo-failure` directory:
  ```bash
  $ cat > enabled <<-EOT
  #!/bin/sh
  false
  EOT
  $ chmod u+x enabled
  ```
  This will cause the test to be skipped.
 
  **Final Result of `make test` on OpenBSD 7.0** :
  ```
  ...
  3398-readonly-fifo-failure (disabled)
  ...
  Summary: 508 tests, 0 failures
  ``` 
 