### PR TITLE
modeline.kak: fix multiple kak options

### DIFF
--- a/rc/detection/modeline.kak
+++ b/rc/detection/modeline.kak
@@ -60,8 +60,8 @@ define-command -hidden modeline-parse-impl %{
 
         # Pass a few whitelisted options to kakoune directly
         translate_opt_kakoune() {
-            readonly key="$1"
-            readonly value="$2"
+            key="$1"
+            value="$2"
 
             case "${key}" in
                 scrolloff|tabstop|indentwidth|autowrap_column|eolformat|filetype|BOM|spell_lang);;


### PR DESCRIPTION
`modeline-parse` fails with the following file:
```
# kak: set indentwidth=0 tabstop=8:
```