### PR TITLE
Add highlighting for CODEOWNERS

### DIFF
--- a/rc/filetype/github.kak
+++ b/rc/filetype/github.kak
@@ -1,0 +1,18 @@
+hook global BufCreate .*/CODEOWNERS %{
+    set-option buffer filetype codeowners
+}
+
+hook global WinSetOption filetype=codeowners %{
+    require-module codeowners
+}
+
+hook -group codeowners-hightlight global WinSetOption filetype=codeowners %{
+    add-highlighter window/codeowners ref codeowners
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/codeowners }
+}
+
+provide-module codeowners %{
+add-highlighter shared/codeowners regions
+add-highlighter shared/codeowners/comments region ^# $ group
+add-highlighter shared/codeowners/comments/ fill comment
+}


### PR DESCRIPTION
Basic highlighting for CODEOWNERS.

This is sort of GitHub specific, although I've seen it adopted elsewhere, so I split the difference and put it in a `github.kak` but did not prefix the filetype.  Maybe that's bad?
