### PR TITLE
markdown: allow additional highlighters in code blocks

### DIFF
--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -139,7 +139,16 @@ define-command -hidden markdown-indent-on-new-line %{
 define-command -hidden markdown-load-languages %{
     evaluate-commands -draft %{ try %{
         execute-keys 'gtGbGls```\h*\{?[.=]?\K[^}\s]+<ret>'
-        evaluate-commands -itersel %{ require-module %val{selection} }
+        evaluate-commands -itersel %sh{
+          for kv in ${kak_opt_markdown_supported_languages}; do
+            ref=${kv##*=}
+            lang=${kv%%=*}
+            [ -n "$ref" ] || ref=$lang
+            if [ "${kak_selection}" = "${lang}" ]; then
+                printf 'require-module %s\n' "${ref}"
+            fi
+          done
+        }
     }}
 }
 

--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -67,7 +67,7 @@ define-command -hidden markdown-build-fenced-highlighters %{
 }
 
 markdown-build-fenced-highlighters
-hook -group markdown-update-highlighers global GlobalSetOption markdown_supported_languages=.* %{
+hook -group markdown-update-highlighters global GlobalSetOption markdown_supported_languages=.* %{
     markdown-build-fenced-highlighters
 }
 

--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -31,6 +31,15 @@ hook -group markdown-highlight global WinSetOption filetype=markdown %{
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/markdown }
 }
 
+declare-option \
+    -docstring "map of supported languages in fenced code blocks. Keys determine which languages are recognised. The value names the corresponding highligher, if empty the key is used instead." \
+    str-to-str-map markdown_supported_languages \
+    awk= c= cabal= clojure= coffee= cpp= crystal= css= cucumber= d= diff= dockerfile= elixir= erlang= fish= \
+    gas= go= haml= haskell= html= ini= java= javascript= json= julia= kak=kakrc kickstart= \
+    latex= lisp= lua= makefile= markdown= moon= objc= ocaml= perl= pug= python= ragel= \
+    ruby= rust= sass= scala= scss= sh= swift= toml= tupfile= typescript= yaml= sql=
+
+
 
 provide-module markdown %{
 
@@ -42,16 +51,12 @@ add-highlighter shared/markdown/inline default-region regions
 add-highlighter shared/markdown/inline/text default-region group
 
 evaluate-commands %sh{
-  languages="
-    awk c cabal clojure coffee cpp crystal css cucumber d diff dockerfile elixir erlang fish
-    gas go haml haskell html ini java javascript json julia kak kickstart
-    latex lisp lua makefile markdown moon objc ocaml perl pug python ragel
-    ruby rust sass scala scss sh swift toml tupfile typescript yaml sql
-  "
-  for lang in ${languages}; do
+  for kv in ${kak_opt_markdown_supported_languages}; do
+    ref=${kv##*=}
+    lang=${kv%%=*}
+    [ -n "$ref" ] || ref=$lang
     printf 'add-highlighter shared/markdown/%s region -match-capture ^(\h*)```\h*(%s\\b|\\{[.=]?%s\\})   ^(\h*)``` regions\n' "${lang}" "${lang}" "${lang}"
     printf 'add-highlighter shared/markdown/%s/ default-region fill meta\n' "${lang}"
-    [ "${lang}" = kak ] && ref=kakrc || ref="${lang}"
     printf 'add-highlighter shared/markdown/%s/inner region \A```[^\\n]*\K (?=```) ref %s\n' "${lang}" "${ref}"
   done
 }


### PR DESCRIPTION
This PR adds the ability to add additional highlighters for fenced code blocks.

It does so by introducing the option `markdown_supported_languages`. This is a map from identifiers (keys) to highlighters (values). If a value is omitted, the key will be used as the name of a highlighter.

What this does, is enable plugins to register their language by adding a key-value pair to the variable. Any pairs added before the markdown module is required, will be highlighted. 

This is how I intend to use this mechanism in idris2.kak:

```kak
hook global KakBegin .* %{
    set -add global markdown_supported_languages idris=idris
}
```

