### PR TITLE
Add support for PHP heredoc in syntax highlighting

### DIFF
--- a/rc/filetype/php.kak
+++ b/rc/filetype/php.kak
@@ -39,7 +39,12 @@ add-highlighter shared/php/doc_comment2  region /\*\*  \*/             ref php/d
 add-highlighter shared/php/comment1      region //     '$'             fill comment
 add-highlighter shared/php/comment2      region /\*    \*/             fill comment
 add-highlighter shared/php/comment3      region '#'    '$'             fill comment
-
+# Example PHP heredoc:
+# echo <<<SOMETHING
+#  some text
+#  more text etc.
+# SOMETHING;
+add-highlighter shared/php/heredoc       region -match-capture '<<<(.*?)$' '(.*?);' fill string
 
 
 add-highlighter shared/php/code/ regex &?\$\w* 0:variable


### PR DESCRIPTION
This functionality allows PHP heredocs (the `<<<SOMETHING` ... `SOMETHING;` pattern) to be properly syntax highlighted in Kakoune. Example:

```php
    if (!function_exists('proc_open')) {
        echo <<<NO_PROC_OPEN_ERROR

+-----------------------------------------------------------+
|                       ! ERROR !                           |
| The test-suite requires that proc_open() is available.    |
| Please check if you disabled it in php.ini.               |
+-----------------------------------------------------------+

NO_PROC_OPEN_ERROR;
        exit(1);
    }
```