### PR TITLE
Add filetype support for Elvish.

### DIFF
--- a/rc/filetype/elvish.kak
+++ b/rc/filetype/elvish.kak
@@ -1,0 +1,57 @@
+# Syntax highlighting and indentation for Elvish (https://elv.sh)
+
+hook global BufCreate .*\.elv %{
+    set-option buffer filetype elvish
+}
+
+hook global WinSetOption filetype=elvish %<
+    require-module elvish
+
+    hook window InsertChar \n -group elvish-insert elvish-indent
+    hook window InsertChar [\]})] -group elvish-insert elvish-deindent
+    hook -once -always window WinSetOption filetype=.* %{ remove-hooks window elvish-.+ }
+>
+
+hook -group elvish-highlight global WinSetOption filetype=elvish %{
+    add-highlighter window/elvish ref elvish
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/elvish }
+}
+
+provide-module elvish %§
+
+add-highlighter shared/elvish regions
+add-highlighter shared/elvish/code default-region group
+add-highlighter shared/elvish/double_string region '"' (?<!\\)(\\\\)*" fill string
+add-highlighter shared/elvish/single_string region "'" (?<!')('')*' fill string
+add-highlighter shared/elvish/comment region '#' $ fill comment
+
+add-highlighter shared/elvish/code/variable regex \$[\w\d-_:~]+ 0:variable
+add-highlighter shared/elvish/code/variable_in_assignment regex (?:^|\{\s|\(|\||\;)\h*(?:var|set|tmp|del)((?:\h+[\w\d-_:~]+)*) 1:variable
+add-highlighter shared/elvish/code/variable_in_for regex (?:^|\{\s|\(|\||\;)\h*for\h+([\w\d-_:~]*) 1:variable
+add-highlighter shared/elvish/code/variable_in_except regex \}\h+except\h+([\w\d-_:~]*) 1:variable
+
+add-highlighter shared/elvish/code/builtin regex (?:^|\{\s|\(|\||\;)\h*(var|set|tmp|del|and|or|coalesce|if|while|for|try|fn|pragma|!=|!=s|%|\*|\+|-|-gc|-ifaddrs|-log|-override-wcwidth|-stack|/|<|<=|<=s|<s|==|==s|>|>=|>=s|>s|all|assoc|base|bool|break|call|cd|compare|constantly|continue|count|defer|deprecate|dissoc|drop|each|eawk|echo|eq|eval|exact-num|exec|exit|external|fail|fg|float64|from-json|from-lines|from-terminated|get-env|has-env|has-external|has-key|has-value|is|keys|kind-of|make-map|multi-error|nop|not|not-eq|ns|num|one|only-bytes|only-values|order|peach|pprint|print|printf|put|rand|randint|range|read-line|read-upto|repeat|repr|resolve|return|run-parallel|search-external|set-env|show|sleep|slurp|src|styled|styled-segment|take|tilde-abbr|time|to-json|to-lines|to-string|to-terminated|unset-env|use-mod|wcswidth) 1:builtin
+add-highlighter shared/elvish/code/keyword regex \}\h+(elif|else|except|finally) 1:keyword
+
+add-highlighter shared/elvish/code/metachar regex [*?|&\;<>()[\]{}] 0:operator
+
+define-command -hidden elvish-indent %< evaluate-commands -draft -itersel %<
+    execute-keys <semicolon>
+    try %<
+        # if the previous line is a comment, copy indent, # and whitespace
+        execute-keys -draft k <a-x> s^\h*#\h*<ret> yjP
+    > catch %<
+        # copy indent
+        execute-keys -draft K <a-&>
+        # indent after { [ ( |
+        try %< execute-keys -draft k <a-x> <a-k>[[{(|]\h*$<ret> j <a-gt> >
+    >
+>>
+
+define-command -hidden elvish-deindent %< evaluate-commands -draft -itersel %<
+    try %<
+        # Deindent only when there is a lone closing character
+        execute-keys -draft <a-x> <a-k>^\h*[^\h]$<ret> <a-lt>
+    >
+>>
+§


### PR DESCRIPTION
Loosely based on sh.kak and c-family.kak.

See https://elv.sh for information on the Elvish language. In particular,
see https://elv.sh/ref/language.html for the language syntax and
https://elv.sh/ref/builtin.html for builtin commands.