### PR TITLE
Don't escape markup strings in modeline expansions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 *.pyc
 *.1-r
 .*.kak.*
-.ccls-cache
-compile_commands.json
 src/kak
 src/kak.debug
 src/kak.opt

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.pyc
 *.1-r
 .*.kak.*
+.ccls-cache
+compile_commands.json
 src/kak
 src/kak.debug
 src/kak.opt

--- a/src/client.cc
+++ b/src/client.cc
@@ -157,8 +157,7 @@ DisplayLine Client::generate_mode_line() const
         HashMap<String, DisplayLine> atoms{{ "mode_info", context().client().input_handler().mode_line() },
                                            { "context_info", {generate_context_info(context()),
                                                               context().faces()["Information"]}}};
-        auto expanded = expand(modelinefmt, context(), ShellContext{},
-                               [](String s) { return escape(s, '{', '\\'); });
+        auto expanded = expand(modelinefmt, context(), ShellContext{});
         modeline = parse_display_line(expanded, context().faces(), atoms);
     }
     catch (runtime_error& err)


### PR DESCRIPTION
Fixes #4507

The documentation for `modelinefmt` states that expansions are processed, then markup strings are applied. This brings the actual behavior in line with the documentation.

**Before**

![image](https://user-images.githubusercontent.com/3515394/149835451-836dce90-9cb4-4e1d-a53b-9699ebe8b3d0.png)

**After**

![image](https://user-images.githubusercontent.com/3515394/149835483-30f54da7-f5c5-4beb-a10f-ae0c528928be.png)


