### PR TITLE
When reporting an invalid session name, report the correct name.

### DIFF
--- a/src/remote.cc
+++ b/src/remote.cc
@@ -849,7 +849,7 @@ Server::Server(String session_name, bool is_daemon)
     : m_session{std::move(session_name)}, m_is_daemon{is_daemon}
 {
     if (not all_of(m_session, is_identifier))
-        throw runtime_error{format("invalid session name: '{}'", session_name)};
+        throw runtime_error{format("invalid session name: '{}'", m_session)};
 
     int listen_sock = socket(AF_UNIX, SOCK_STREAM, 0);
     fcntl(listen_sock, F_SETFD, FD_CLOEXEC);


### PR DESCRIPTION
At this point, the session name has already been moved from the `session_name` parameter to the `m_session` member variable.