### PR TITLE
Git blame wrapper: Pass blame flags all at once

### DIFF
--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -109,21 +109,27 @@ define-command -params 1.. \
                       set-option buffer=$kak_bufname git_blame_flags '$kak_timestamp'
                   }" | kak -p ${kak_session}
                   git blame "$@" --incremental ${kak_buffile} | awk '
-                  function send_flags(text, flag, i) {
+                  function send_flags(flush,    text, i) {
                       if (line == "") { return; }
                       text=substr(sha,1,8) " " dates[sha] " " authors[sha]
                       # gsub("|", "\\|", text)
                       gsub("~", "~~", text)
-                      flag="%~" line "|" text "~"
-                      for ( i=1; i < count; i++ ) {
-                          flag=flag " %~" line+i "|" text "~"
+                      for ( i=0; i < count; i++ ) {
+                          flags = flags " %~" line+i "|" text "~"
+                      }
+                      now = systime()
+                      # Send roughly one update per second, to avoid creating too many kak processes.
+                      if (!flush && now - last_sent < 1) {
+                          return
                       }
                       cmd = "kak -p " ENVIRON["kak_session"]
-                      print "set-option -add buffer=" ENVIRON["kak_bufname"] " git_blame_flags " flag | cmd
+                      print "set-option -add buffer=" ENVIRON["kak_bufname"] " git_blame_flags " flags | cmd
                       close(cmd)
+                      flags = ""
+                      last_sent = now
                   }
                   /^([0-9a-f]+) ([0-9]+) ([0-9]+) ([0-9]+)/ {
-                      send_flags()
+                      send_flags(0)
                       sha=$1
                       line=$3
                       count=$4
@@ -134,7 +140,7 @@ define-command -params 1.. \
                        cmd | getline dates[sha]
                        close(cmd)
                   }
-                  END { send_flags(); }'
+                  END { send_flags(1); }'
         ) > /dev/null 2>&1 < /dev/null &
     }
 


### PR DESCRIPTION
The wrapper for `git blame` creates flags for each line of the buffer. It parses the output from git and would send a flag (or a series of flags) each time the commit to blame for a line differs from the previous one. For files that were touched by a large number of commits, this results in a high number of connections to the kakoune session, and may take some time. This is visible in the session through the flags for the different commits appearing on the lines one by one, possibly during several seconds.

Instead, it is faster to build a single series of flags while parsing the output from git, and to send it all at once to kakoune.

[EDIT: Latest version sends one batch of flags every 1s or so, instead of passing them all at once.]