### PR TITLE
Faces: Allow alpha-blending with non-RGB base colours as well

### DIFF
--- a/src/face.hh
+++ b/src/face.hh
@@ -71,7 +71,7 @@ inline Face merge_faces(const Face& base, const Face& face)
             return base.*color;
         if (face.*color == Color::Default)
             return base.*color;
-        if ((base.*color).isRGB() and (face.*color).isRGB() and (face.*color).a != 255)
+        if ((face.*color).isRGB() and (face.*color).a != 255)
             return alpha_blend(base.*color, face.*color);
         return face.*color;
     };


### PR DESCRIPTION
In `merge_faces()`, we only blend alpha values if the following conditions are met:

```cpp
    if ((base.*color).isRGB() and (face.*color).isRGB() and (face.*color).a != 255)
        return alpha_blend(base.*color, face.*color);
```

The alpha value different from 255 makes sense, otherwise there is nothing to blend. Similarly, if the face is not an `rgba:` (hence RGB) colour, it does not have an alpha value set, so there is no need to proceed.

However, I could find no compelling reason to skip blending if the base colour is not specified as `rgba:`. In that case, blending can still happen, the base colour is simply considered as a plain colour with its alpha value at 255.

The current condition makes it difficult to use a transparent background, since we must have an RGB base first, so we have to proceed in two steps:

```
:set-face global foo ,rgb:ff0000
:add-highlighter global/bar column 80 ,rgba:0000ff44@foo
```

If we allow alpha-blending with all bases, we could instead have something like:

```
:add-highlighter global/bar column 80 ,rgba:ffffff88
```

In particular, this allows merging with the default background. This is useful to blend some background colour (white for a dark background, typically) with the default background colour for the buffer. This is a nice way, for example, to implement a monochrome theme for the different segments of a Powerline modeline, by using a single background colour, and merging it with various level of transparency with the default background.

To achieve this, this PR removes the condition on the base colour being RGB for the alpha-blend.