### PR TITLE
Filter duplicate completions only if they have the same select cmd

### DIFF
--- a/src/insert_completer.cc
+++ b/src/insert_completer.cc
@@ -322,7 +322,8 @@ InsertCompletion complete_option(const SelectionList& sels,
     candidates.reserve(matches.size());
     while (candidates.size() < max_count and first != last)
     {
-        if (candidates.empty() or candidates.back().completion != first->candidate())
+        if (candidates.empty() or candidates.back().completion != first->candidate()
+            or candidates.back().on_select != first->on_select)
             candidates.push_back({ first->candidate().str(), first->on_select.str(),
                                    std::move(first->menu_entry) });
         std::pop_heap(first, last--, greater);


### PR DESCRIPTION
Given a completer option with two applicable completions

	text|select-cmd1|menu-text1
	text|select-cmd2|menu-text2

Kakoune will only show one of them, because they will insert the
same text.

Some language servers send completions like this, for example if
two different importable modules provide the same name. This can be
reproduced using intelephense in this PHP file (cursor is %())

	<?php
	namespace namespace1;
	class sometype {}
	?>
	<?php
	namespace namespace2;
	class sometype {}
	?>

	<?php
	namespace test;
	some%()
	?>

Both completions insert "sometype". The import statement will be
added in an InsertCompletionHide hook by kak-lsp (it uses select-cmd
to determine which completion was selected).

To support this use case, refine the duplicate detection to not filter
out completions with different select-cmd values.
