### PR TITLE
Make Color::validate_alpha() a constexpr function.

### DIFF
--- a/src/color.cc
+++ b/src/color.cc
@@ -34,13 +34,6 @@ bool is_color_name(StringView color)
     return contains(color_names, color);
 }
 
-void Color::validate_alpha()
-{
-    static_assert(RGB == 17);
-    if (a < RGB)
-        throw runtime_error("Colors alpha must be > 16");
-}
-
 Color str_to_color(StringView color)
 {
     auto it = find_if(color_names, [&](const char* c){ return color == c; });

--- a/src/color.hh
+++ b/src/color.hh
@@ -1,6 +1,7 @@
 #ifndef color_hh_INCLUDED
 #define color_hh_INCLUDED
 
+#include "exception.hh"
 #include "hash.hh"
 #include "meta.hh"
 #include "assert.hh"
@@ -55,7 +56,11 @@ struct Color
     }
 
 private:
-    void validate_alpha();
+    constexpr void validate_alpha() {
+        static_assert(RGB == 17);
+        if (a < RGB)
+            throw runtime_error("Colors alpha must be > 16");
+    }
 };
 
 constexpr bool operator==(Color lhs, Color rhs)


### PR DESCRIPTION
We call it from a constexpr constructor, so it needs to be constexpr itself.

Fixes #4544.