### PR TITLE
Add brief modules explanation

### DIFF
--- a/doc/pages/commands.asciidoc
+++ b/doc/pages/commands.asciidoc
@@ -423,9 +423,10 @@ but not really useful in that context.
 
 == Module commands
 
-In Kakoune, modules are groups of commands that are evaluated all at once. This allows
-lazy loading of complex configurations with a single invocation of *require-moule*.
-The builtin filetype handling for Kakoune is implemented via modules.
+In Kakoune, modules are a grouping of stored commands to be executed the first time
+they are needed. This allows complex configurations to be evaluated lazily, and allows
+plugins to ensure their dependencies have been loaded before they execute. The builtin
+filetype handling for Kakoune is implemented via modules.
 
 *provide-module* [<switches>] <name> <commands>::
     declares a module *name* that is defined by *commands*. *commands* will be

--- a/doc/pages/commands.asciidoc
+++ b/doc/pages/commands.asciidoc
@@ -423,6 +423,10 @@ but not really useful in that context.
 
 == Module commands
 
+In Kakoune, modules are groups of commands that are evaluated all at once. This allows
+lazy loading of complex configurations with a single invocation of *require-moule*.
+The builtin filetype handling for Kakoune is implemented via modules.
+
 *provide-module* [<switches>] <name> <commands>::
     declares a module *name* that is defined by *commands*. *commands* will be
     evaluated as if by source the first time *require-module <name>* is run.

--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -716,7 +716,7 @@ When pressing `:` in normal mode, Kakoune will open a prompt to enter
 a command.  The executed command line is stored in the *:* register
 (See <<registers#,`:doc registers`>>).
 
-During edition, a transient *clipboard* is available, its content is
+During editing, a transient *clipboard* is available, its content is
 empty at the start of prompt edition, and is not preserved afterwards.
 
 The following keys are recognized by this mode to help with editing

--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -342,7 +342,7 @@ are exclusively available to built-in options.
 
 *ui_options* `str-to-str-map`::
     a list of `key=value` pairs that are forwarded to the user
-    interface implementation. The NCurses UI support the following options:
+    interface implementation. The NCurses UI supports the following options:
 
         *terminal_set_title*:::
             if *yes* or *true*, the terminal emulator title will


### PR DESCRIPTION
In lieu of adding a whole docs page for modules, a brief introduction can
be added above the provide-module and require-module command docs.