### PR TITLE
Fix elvish highlighter

### DIFF
--- a/rc/filetype/elvish.kak
+++ b/rc/filetype/elvish.kak
@@ -22,7 +22,7 @@ provide-module elvish %§
 add-highlighter shared/elvish regions
 add-highlighter shared/elvish/code default-region group
 add-highlighter shared/elvish/double_string region '"' (?<!\\)(\\\\)*" fill string
-add-highlighter shared/elvish/single_string region "'" (?<!')('')*' fill string
+add-highlighter shared/elvish/single_string region "'" ('')*' fill string
 add-highlighter shared/elvish/comment region '#' $ fill comment
 
 add-highlighter shared/elvish/code/variable regex \$[\w\d-_:~]+ 0:variable
@@ -30,8 +30,9 @@ add-highlighter shared/elvish/code/variable_in_assignment regex (?:^|\{\s|\(|\||
 add-highlighter shared/elvish/code/variable_in_for regex (?:^|\{\s|\(|\||\;)\h*for\h+([\w\d-_:~]*) 1:variable
 add-highlighter shared/elvish/code/variable_in_except regex \}\h+except\h+([\w\d-_:~]*) 1:variable
 
-add-highlighter shared/elvish/code/builtin regex (?:^|\{\s|\(|\||\;)\h*(var|set|tmp|del|and|or|coalesce|if|while|for|try|fn|pragma|!=|!=s|%|\*|\+|-|-gc|-ifaddrs|-log|-override-wcwidth|-stack|/|<|<=|<=s|<s|==|==s|>|>=|>=s|>s|all|assoc|base|bool|break|call|cd|compare|constantly|continue|count|defer|deprecate|dissoc|drop|each|eawk|echo|eq|eval|exact-num|exec|exit|external|fail|fg|float64|from-json|from-lines|from-terminated|get-env|has-env|has-external|has-key|has-value|is|keys|kind-of|make-map|multi-error|nop|not|not-eq|ns|num|one|only-bytes|only-values|order|peach|pprint|print|printf|put|rand|randint|range|read-line|read-upto|repeat|repr|resolve|return|run-parallel|search-external|set-env|show|sleep|slurp|src|styled|styled-segment|take|tilde-abbr|time|to-json|to-lines|to-string|to-terminated|unset-env|use-mod|wcswidth) 1:builtin
-add-highlighter shared/elvish/code/keyword regex \}\h+(elif|else|except|finally) 1:keyword
+add-highlighter shared/elvish/code/builtin regex (?:^|\{\s|\(|\||\;)\h*(!=|!=s|%|\*|\+|-gc|-ifaddrs|-log|-override-wcwidth|-stack|-|/|<|<=|<=s|<s|==|==s|>|>=|>=s|>s|all|assoc|base|bool|break|call|cd|compare|constantly|continue|count|defer|deprecate|dissoc|drop|each|eawk|echo|eq|eval|exact-num|exec|exit|external|fail|fg|float64|from-json|from-lines|from-terminated|get-env|has-env|has-external|has-key|has-value|is|keys|kind-of|make-map|multi-error|nop|not-eq|not|ns|num|one|only-bytes|only-values|order|peach|pprint|print|printf|put|rand|randint|range|read-line|read-upto|repeat|repr|resolve|return|run-parallel|search-external|set-env|show|sleep|slurp|src|styled|styled-segment|take|tilde-abbr|time|to-json|to-lines|to-string|to-terminated|unset-env|use-mod|wcswidth)(?![-:])\b 1:builtin
+add-highlighter shared/elvish/code/keyword regex (?:^|\{\s|\(|\||\;)\h*(use|var|set|tmp|del|and|or|coalesce|pragma|while|for|try|fn|if)(?![-:])\b 1:keyword
+add-highlighter shared/elvish/code/keyword_block regex \}\h+(elif|else|except|finally)(?![-:])\b 1:keyword
 
 add-highlighter shared/elvish/code/metachar regex [*?|&\;<>()[\]{}] 0:operator
 


### PR DESCRIPTION
@xiaq PTAL
adjusted single quote string, to not break on empty string `''`.
highlight keywords as keywords instead of `builtin`.
terminate keyword/builtin detection on `-`/`:`/`\b`, so partial matches dont get highlighted.
misc reordering. 