### PR TITLE
Improved installation instructions for Ubuntu

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -205,12 +205,17 @@ sudo zypper install kakoune
 [TIP]
 .Ubuntu
 ====
-Building on Ubuntu 16.04 and 18.04.
-Make sure you have .local/bin in your path to make the kak binary available from your shell.
+Kakoune can be found in the Ubuntu repositories.
+
+----------------------------
+sudo apt install kakoune
+----------------------------
+
+If you want to compile from source on 20.04 or earlier, you must force the build to use GCC 10, which is not the default. Also, make sure you have .local/bin in your path so that kak is available after the installation.
 
 ----------------------------------------------------------------
 git clone https://github.com/mawww/kakoune.git && cd kakoune/src
-make
+CXX=g++-10 make
 PREFIX=$HOME/.local make install
 ----------------------------------------------------------------
 ====


### PR DESCRIPTION
Added information on how to install from the repositories. Also improved the instructions for how to build from source, for those that don't want an ancient version of Kakoune. On Ubuntu 20.04 and earlier, GCC 10 is not the default so we have to explicitly tell `make` to use GCC 10.

See also: https://github.com/mawww/kakoune/issues/4571