### PR TITLE
Make Shift+Space insert a space in insert mode

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1003,7 +1003,7 @@ public:
         }
         else
         {
-            if (key == Key::Space and
+            if ((key == Key::Space or key == shift(Key::Space)) and
                 not (m_completions.flags & Completions::Flags::Quoted) and // if token is quoted, this space does not end it
                 can_auto_insert_completion())
                 m_line_editor.insert_from(line.char_count_to(m_completions.start),

--- a/src/keys.cc
+++ b/src/keys.cc
@@ -49,7 +49,7 @@ Optional<Codepoint> Key::codepoint() const
         return '\n';
     if (*this == Key::Tab)
         return '\t';
-    if (*this == Key::Space)
+    if (*this == Key::Space or *this == shift(Key::Space))
         return ' ';
     if (*this == Key::Escape)
         return 0x1B;


### PR DESCRIPTION
Terminals that support CSI u escape codes (like iTerm2, Kitty and foot)
allow us to map `<s-space>` independently of `<space>`.

Users expect that `<s-space>` inputs a space character; make it so.

Fixes #4534
Also reported in https://discuss.kakoune.com/t/shift-space-doesnt-send-space-character/2004
