### PR TITLE
rc/filetype/go: add new go 1.18 predeclared identifiers

### DIFF
--- a/rc/filetype/go.kak
+++ b/rc/filetype/go.kak
@@ -56,7 +56,7 @@ evaluate-commands %sh{
     keywords='break default func interface select case defer go map struct
               chan else goto package switch const fallthrough if range type
               continue for import return var'
-    types='bool byte chan complex128 complex64 error float32 float64 int int16 int32
+    types='any bool byte chan comparable complex128 complex64 error float32 float64 int int16 int32
            int64 int8 interface intptr map rune string struct uint uint16 uint32 uint64 uint8'
     values='false true nil iota'
     functions='append cap close complex copy delete imag len make new panic print println real recover'

--- a/rc/filetype/go.kak
+++ b/rc/filetype/go.kak
@@ -57,7 +57,7 @@ evaluate-commands %sh{
               chan else goto package switch const fallthrough if range type
               continue for import return var'
     types='any bool byte chan comparable complex128 complex64 error float32 float64 int int16 int32
-           int64 int8 interface intptr map rune string struct uint uint16 uint32 uint64 uint8'
+           int64 int8 interface intptr map rune string struct uint uint16 uint32 uint64 uint8 uintptr'
     values='false true nil iota'
     functions='append cap close complex copy delete imag len make new panic print println real recover'
 


### PR DESCRIPTION
rc/filetype/go: add new go 1.18 predeclared identifiers

Go 1.18 introduces the `any` and `comparable` predeclared identifiers. Modify
the list of identifiers here, so syntax highlighting will catch these new
identifiers. See https://go.dev/ref/spec#Predeclared_identifiers.
