### PR TITLE
Cleanup session name validation

### DIFF
--- a/src/remote.cc
+++ b/src/remote.cc
@@ -605,8 +605,8 @@ const String& session_directory()
 
 String session_path(StringView session)
 {
-    if (contains(session, '/'))
-        throw runtime_error{"session names cannot have slashes"};
+    if (not all_of(session, is_identifier))
+        throw runtime_error{format("invalid session name: '{}'", session)};
     return format("{}/{}", session_directory(), session);
 }
 
@@ -848,9 +848,6 @@ private:
 Server::Server(String session_name, bool is_daemon)
     : m_session{std::move(session_name)}, m_is_daemon{is_daemon}
 {
-    if (not all_of(m_session, is_identifier))
-        throw runtime_error{format("invalid session name: '{}'", m_session)};
-
     int listen_sock = socket(AF_UNIX, SOCK_STREAM, 0);
     fcntl(listen_sock, F_SETFD, FD_CLOEXEC);
     sockaddr_un addr = session_addr(m_session);
@@ -885,9 +882,6 @@ Server::Server(String session_name, bool is_daemon)
 
 bool Server::rename_session(StringView name)
 {
-    if (not all_of(name, is_identifier))
-        throw runtime_error{format("invalid session name: '{}'", name)};
-
     String old_socket_file = session_path(m_session);
     String new_socket_file = session_path(name);
 

--- a/src/remote.cc
+++ b/src/remote.cc
@@ -614,7 +614,10 @@ static sockaddr_un session_addr(StringView session)
 {
     sockaddr_un addr;
     addr.sun_family = AF_UNIX;
-    strcpy(addr.sun_path, session_path(session).c_str());
+    String path = session_path(session);
+    if (path.length() + 1 > sizeof addr.sun_path)
+        throw runtime_error{format("socket path too long: '{}'", path)};
+    strcpy(addr.sun_path, path.c_str());
     return addr;
 }
 


### PR DESCRIPTION
While investigating #4579 I discovered some minor problems in Kakoune's session name handling code.

Session names were validated in two different ways ("exclude slashes" and "is identifier") in three different places (creating a session, renaming a session, connecting to a session). Now, session names are validated in one place (where the session name is turned into a socket path) in one way ("is identifier", since that's a subset of the other test).

Also, when converting the socket path into a `sockaddr_un` struct, the path was `strcpy()`'d into the fixed-size path buffer without checking if it would fit. Trying to start a session with a ridiculously long name now gives a somewhat helpful error message rather than segfaulting.