### PR TITLE
rc format: restore in-client error when formatcmd fails

### DIFF
--- a/rc/tools/format.kak
+++ b/rc/tools/format.kak
@@ -14,7 +14,8 @@ define-command format-selections -docstring "Format the selections individually"
             echo "fail 'The option ''formatcmd'' must be set'"
         fi
     }
-    evaluate-commands -draft -no-hooks -save-regs '|' %{
+    evaluate-commands -draft -no-hooks -save-regs 'e|' %{
+        set-register e nop
         set-register '|' %{
             format_in="$(mktemp "${TMPDIR:-/tmp}"/kak-formatter.XXXXXX)"
             format_out="$(mktemp "${TMPDIR:-/tmp}"/kak-formatter.XXXXXX)"
@@ -24,12 +25,13 @@ define-command format-selections -docstring "Format the selections individually"
             if [ $? -eq 0 ]; then
                 cat "$format_out"
             else
-                printf 'eval -client %s %%{ fail formatter returned an error %s }\n' "$kak_client" "$?" | kak -p "$kak_session"
+                echo "set-register e fail formatter returned an error (exit code $?)" >"$kak_command_fifo"
                 cat "$format_in"
             fi
             rm -f "$format_in" "$format_out"
         }
         execute-keys '|<ret>'
+        %reg{e}
     }
 }
 


### PR DESCRIPTION
Commit 5b1f9255 (rc: Use the standard `fail` command to report errors,
2019-11-14) replaced uses of "echo -markup {Error}" with "fail".
This made format-buffer do

	echo "eval -client $kak_client %{ fail }" | kak -p $kak_session

Unfortunately "fail" fails in the client spawned by "kak -p" and not
in $kak_client where the user would see the message. Correct this.

While at it, clarify the error message, so users immediately know
that the number is the exit code.

Fixes #3254
