### PR TITLE
Add black-on-white colorscheme

### DIFF
--- a/colors/black-on-white.kak
+++ b/colors/black-on-white.kak
@@ -1,0 +1,53 @@
+# Black-on-bright-white colorscheme for minimal distraction & maximal contrast.
+# Works well with e-ink screens.
+
+# For Code
+face global value black
+face global type black
+face global variable black
+face global module black
+face global function black
+face global string black
+face global keyword black
+face global operator black
+face global attribute black
+face global comment black
+face global documentation comment
+face global meta black
+face global builtin black
+
+# For markup
+face global title black
+face global header black
+face global mono black
+face global block black
+face global link black
+face global bullet black
+face global list black
+
+# builtin faces
+face global Default black,bright-white
+face global PrimarySelection black,rgb:cccccc+fg
+face global SecondarySelection black,rgb:e0e0e0+fg
+face global PrimaryCursor bright-white,black+fg
+face global SecondaryCursor bright-white,rgb:777777+fg
+face global PrimaryCursorEol black,rgb:777777+fg
+face global SecondaryCursorEol black,rgb:aaaaaa+fg
+face global LineNumbers black,bright-white
+face global LineNumberCursor bright-white,black
+face global MenuForeground bright-white,black+fg
+face global MenuBackground black,rgb:e0e0e0+fg
+face global MenuInfo black # Overridden by MenuForeground and MenuBackground
+face global Information black,rgb:e0e0e0
+face global Error bright-white,black
+face global DiagnosticError black
+face global DiagnosticWarning black
+face global StatusLine black,bright-white
+face global StatusLineMode black,bright-white
+face global StatusLineInfo black,bright-white
+face global StatusLineValue black,bright-white
+face global StatusCursor bright-white,black
+face global Prompt bright-white,black
+face global MatchingChar black,bright-white+b
+face global Whitespace black,bright-white+fd
+face global BufferPadding black,bright-white


### PR DESCRIPTION
Kakoune doesn't have an equivalent of Vim's ":syntax off". This
colorscheme is as close as it gets: it uses various shades of grey
for cursors, selections and completion/info boxes, and black/white for
everything else.  The high-contrast makes it ideal for bright settings.

I also have the dual white-on-black colorscheme but it's not tested much,
so I left it on my "colorschemes" branch.
