### PR TITLE
Fixed grammar; rendered the construction parallel.

### DIFF
--- a/doc/pages/buffers.asciidoc
+++ b/doc/pages/buffers.asciidoc
@@ -59,5 +59,5 @@ for examples.
 When the write end of the fifo is closed, the buffer becomes an ordinary
 <<buffers#scratch-buffers,scratch buffer>>. When the buffer is deleted,
 Kakoune closes the read end of the fifo, so any program writing to it
-will receive `SIGPIPE`. This is useful as it permits to stop the writing
+will receive `SIGPIPE`. This is useful as it permits stopping the writing
 program when the buffer is deleted.


### PR DESCRIPTION
The infinitive "to stop" cannot function as a verb. What follows _permits_ must be an action or state, hence a verb — here, _stopping_.
