### PR TITLE
Disable external diff tools when diffing buffer

### DIFF
--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -157,7 +157,7 @@ define-command -params 1.. \
     update_diff() {
         (
             cd_bufdir
-            git --no-pager diff -U0 "$kak_buffile" | perl -e '
+            git --no-pager diff --no-ext-diff -U0 "$kak_buffile" | perl -e '
             $flags = $ENV{"kak_timestamp"};
             foreach $line (<STDIN>) {
                 if ($line =~ /@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))?/) {


### PR DESCRIPTION
There is a bug that causes `:git show-diff` to fail when using an external diff, for example `difftastic`.

This change ensures that we don't use an external diff tool when diffing the current buffer.

To replicate the bug, try changing your difftool to something else (`git config --global diff.external difft
`) and then use `:git show-diff`. Nothing will show.
