### PR TITLE
markdown: Add inline typescript highlighting with ```ts construction

### DIFF
--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -45,12 +45,16 @@ evaluate-commands %sh{
     awk c cabal clojure coffee cpp crystal css cucumber d diff dockerfile elixir erlang fish
     gas go haml haskell html ini java javascript json julia kak kickstart
     latex lisp lua makefile markdown moon objc ocaml perl pug python ragel
-    ruby rust sass scala scss sh swift toml tupfile typescript yaml sql
+    ruby rust sass scala scss sh swift toml ts tupfile typescript yaml sql
   "
   for lang in ${languages}; do
     printf 'add-highlighter shared/markdown/%s region -match-capture ^(\h*)```\h*(%s\\b|\\{[.=]?%s\\})   ^(\h*)``` regions\n' "${lang}" "${lang}" "${lang}"
     printf 'add-highlighter shared/markdown/%s/ default-region fill meta\n' "${lang}"
-    [ "${lang}" = kak ] && ref=kakrc || ref="${lang}"
+    case "${lang}" in
+      kak) ref="kakrc" ;;
+      ts)  ref="typescript" ;;
+      *)   ref="${lang}" ;;
+    esac
     printf 'add-highlighter shared/markdown/%s/inner region \A```[^\\n]*\K (?=```) ref %s\n' "${lang}" "${ref}"
   done
 }

--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -45,13 +45,24 @@ evaluate-commands %sh{
     awk c cabal clojure coffee cpp crystal css cucumber d diff dockerfile elixir erlang fish
     gas go haml haskell html ini java javascript json julia kak kickstart
     latex lisp lua makefile markdown moon objc ocaml perl pug python ragel
-    ruby rust sass scala scss sh swift toml ts tupfile typescript yaml sql
+    ruby rust sass scala scheme scss sh swift toml ts tupfile typescript yaml sql
   "
   for lang in ${languages}; do
     printf 'add-highlighter shared/markdown/%s region -match-capture ^(\h*)```\h*(%s\\b|\\{[.=]?%s\\})   ^(\h*)``` regions\n' "${lang}" "${lang}" "${lang}"
     printf 'add-highlighter shared/markdown/%s/ default-region fill meta\n' "${lang}"
     case "${lang}" in
+      clj) ref="clojure" ;;
+      js)  ref="javascript" ;;
+      cr)  ref="crystal" ;;
+      c++) ref="cpp" ;;
+      ex)  ref="elixir" ;;
+      exs) ref="elixir" ;;
       kak) ref="kakrc" ;;
+      pl)  ref="perl" ;;
+      py)  ref="python" ;;
+      py3) ref="python" ;;
+      python3) ref="python" ;;
+      scm) ref="scheme" ;;
       ts)  ref="typescript" ;;
       *)   ref="${lang}" ;;
     esac


### PR DESCRIPTION
Currently only ` ```typescript ` gets inline highlighted when viewing typescript code in a markdown file in Kakoune.

GitHub for instance accepts both ` ````ts ` and ` ````typescript `

For usage in the wild, see https://github.com/denoland/deno/blob/main/README.md which uses ` ```ts ` . This will fail to inline highlight in Kakoune without this PR.

