### PR TITLE
rc file-detection hook group

### DIFF
--- a/rc/detection/file.kak
+++ b/rc/detection/file.kak
@@ -22,5 +22,5 @@ define-command -hidden file-detection %{ evaluate-commands %sh{
     fi
 } }
 
-hook global BufOpenFile .* file-detection
-hook global BufWritePost .* file-detection
+hook -group file-detection global BufOpenFile .* file-detection
+hook -group file-detection global BufWritePost .* file-detection


### PR DESCRIPTION
Add a group to the `file-detection` hooks.

There's no way to remove hooks without a group. With this patch, you'll be able to remove those
`file-detection` hooks manually. There's no need for two separate groups since if you wanted to
remove only one, you could run `remove-hooks` and then only add one again.


Related: #3670