### PR TITLE
Fix documentation for %val{window_range}

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -417,7 +417,7 @@ The following expansions are supported (with required context _in italics_):
     _in window scope_ +
     list of coordinates and dimensions of the buffer-space
     available on the current window, in the following format:
-    `<coord_x> <coord_y> <width> <height>`
+    `<coord_y> <coord_x> <height> <width>`
 
 Values in the above list that do not mention a context are available
 everywhere.


### PR DESCRIPTION
Makes line and column be the right way around in the docs.