### PR TITLE
rc autorestore: fix regression due to ! breaking change

### DIFF
--- a/rc/tools/autorestore.kak
+++ b/rc/tools/autorestore.kak
@@ -39,7 +39,7 @@ define-command autorestore-restore-buffer \
             ## Replace the content of the buffer with the content of the backup file
             echo -debug Restoring file: ${newer}
 
-            execute-keys -draft %{ %d!cat<space>\"${newer}\"<ret>d }
+            execute-keys -draft %{%d!cat<space>\"${newer}\"<ret>jd}
 
             ## If the backup file has to be removed, issue the command once
             ## the current buffer has been saved


### PR DESCRIPTION
Commit 85b78dda (src: Select the data inserted by `!` and `<a-!>`,
merged on 2021-03-06) broke autorestore by making it delete the
restored content.  I've been using it for 6 months but never noticed
since I didn't use autorestore

Reproducer:

	HOME=$PWD kak -s foo README.asciidoc -e 'exec iUNSAVED-CONTENT'
	# In another terminal:
	ps aux | awk '/kak -s foo/ {print $2; exit}' | xargs kill -HUP
	HOME=$PWD kak -s foo README.asciidoc

Delete the trailing newline instead of the restored content.

While at it, remove some <space> commands from execute-keys, to make
it work on the breaking-cleanups branch which swaps <space> and ",".

Closes #4335
