### PR TITLE
Mark gitmodules as ini

### DIFF
--- a/rc/filetype/git.kak
+++ b/rc/filetype/git.kak
@@ -6,7 +6,7 @@ hook global BufCreate .*/NOTES_EDITMSG %{
     set-option buffer filetype git-notes
 }
 
-hook global BufCreate .*(\.gitconfig|git/config) %{
+hook global BufCreate .*(\.git(config|modules)|git/config) %{
     set-option buffer filetype ini
 }
 


### PR DESCRIPTION
Note: `git/modules` is a folder containing the modules, whereas `.gitmodules` is the file configuring them, which is why the former is not included.