### PR TITLE
Add gitignore highlighting

### DIFF
--- a/rc/filetype/git.kak
+++ b/rc/filetype/git.kak
@@ -10,17 +10,26 @@ hook global BufCreate .*(\.gitconfig|git/config) %{
     set-option buffer filetype ini
 }
 
+hook global BufCreate .*\.gitignore %{
+    set-option buffer filetype git-ignore
+}
+
 hook global BufCreate .*git-rebase-todo %{
     set-option buffer filetype git-rebase
 }
 
-hook global WinSetOption filetype=git-(commit|notes|rebase) %{
+hook global WinSetOption filetype=git-(commit|ignore|notes|rebase) %{
     require-module "git-%val{hook_param_capture_1}"
 }
 
 hook -group git-commit-highlight global WinSetOption filetype=git-commit %{
     add-highlighter window/git-commit ref git-commit
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-commit }
+}
+
+hook -group git-ignore-highlight global WinSetOption filetype=git-ignore %{
+    add-highlighter window/git-ignore ref git-ignore
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-ignore }
 }
 
 hook -group git-notes-highlight global WinSetOption filetype=git-notes %{
@@ -33,7 +42,6 @@ hook -group git-rebase-highlight global WinSetOption filetype=git-rebase %{
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/git-rebase }
 }
 
-
 provide-module git-commit %{
 require-module diff
 add-highlighter shared/git-commit regions
@@ -41,6 +49,13 @@ add-highlighter shared/git-commit/diff region '^diff --git' '^(?=diff --git)' re
 add-highlighter shared/git-commit/comments region ^# $ group
 add-highlighter shared/git-commit/comments/ fill comment
 add-highlighter shared/git-commit/comments/ regex "\b(?:(modified)|(deleted)|(new file)|(renamed|copied)):([^\n]*)$" 1:yellow 2:red 3:green 4:blue 5:magenta
+}
+
+provide-module git-ignore %{
+add-highlighter shared/git-ignore group
+add-highlighter shared/git-ignore/glob regex '(?<!\\)\*((?<!\\)\*)?|(?<!\\)\?' 0:operator
+add-highlighter shared/git-ignore/negate regex '^!' 0:operator
+add-highlighter shared/git-ignore/comments regex '^#.*?$' 0:comment
 }
 
 provide-module git-notes %{


### PR DESCRIPTION
Adds highlighting for `.gitignore` files. Features:

- Comments: `#...`
- Globs: `*`, `**`, and `?`
- Negations: `!...`

Closes #4608 