### PR TITLE
Work around incomplete std::to_chars() support in libstdc++ 10

### DIFF
--- a/src/string_utils.cc
+++ b/src/string_utils.cc
@@ -197,7 +197,13 @@ InplaceString<23> to_string(Hex val)
 
 InplaceString<23> to_string(float val)
 {
+#if defined(__cpp_lib_to_chars)
     return to_string_impl<23>(val, std::chars_format::general);
+#else
+    InplaceString<23> res;
+    res.m_length = sprintf(res.m_data, "%f", val);
+    return res;
+#endif
 }
 
 InplaceString<7> to_string(Codepoint c)


### PR DESCRIPTION
Ubuntu 20.04 ships GCC's libstdc++ 10 from 2020 which implements
std::to_chars() for integers but not for floats. Use the float overload
only if the library advertises support via the feature testing macro.

This can be removed once we require GCC 11 (see
https://www.gnu.org/software/gcc/gcc-11/changes.html).

Closes #4607
