### PR TITLE
Mark .cjs as javascript

### DIFF
--- a/rc/filetype/javascript.kak
+++ b/rc/filetype/javascript.kak
@@ -1,7 +1,7 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*[.]m?(js)x? %{
+hook global BufCreate .*[.][cm]?(js)x? %{
     set-option buffer filetype javascript
 }
 


### PR DESCRIPTION
While `.mjs` is explicit about a file being a module, `.cjs` is explicit about a file being CommonJS instead.