### PR TITLE
rc filetype: add trim-indent hooks to all languages that have indent hooks

### DIFF
--- a/rc/filetype/cabal.kak
+++ b/rc/filetype/cabal.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](cabal) %{
 hook global WinSetOption filetype=cabal %[
     require-module cabal
 
-    hook window ModeChange pop:insert:.* -group cabal-trim-indent  cabal-trim-indent
+    hook window ModeChange pop:insert:.* -group cabal-trim-indent cabal-trim-indent
     hook window InsertChar \n -group cabal-insert cabal-insert-on-new-line
     hook window InsertChar \n -group cabal-indent cabal-indent-on-new-line
     hook window InsertChar \{ -group cabal-indent cabal-indent-on-opening-curly-brace

--- a/rc/filetype/clojure.kak
+++ b/rc/filetype/clojure.kak
@@ -181,7 +181,7 @@ EOF
 define-command -hidden clojure-configure-window %{
     set-option window static_words %opt{clojure_static_words}
 
-    hook window ModeChange pop:insert:.* -group clojure-trim-indent  clojure-trim-indent
+    hook window ModeChange pop:insert:.* -group clojure-trim-indent clojure-trim-indent
     hook window InsertChar \n -group clojure-indent clojure-indent-on-new-line
 
     set-option buffer extra_word_chars '_' . / * ? + - < > ! : "'"

--- a/rc/filetype/coffee.kak
+++ b/rc/filetype/coffee.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](coffee) %{
 hook global WinSetOption filetype=coffee %{
     require-module coffee
 
-    hook window ModeChange pop:insert:.* -group coffee-trim-indent  coffee-trim-indent
+    hook window ModeChange pop:insert:.* -group coffee-trim-indent coffee-trim-indent
     hook window InsertChar \n -group coffee-insert coffee-insert-on-new-line
     hook window InsertChar \n -group coffee-indent coffee-indent-on-new-line
 

--- a/rc/filetype/coq.kak
+++ b/rc/filetype/coq.kak
@@ -11,6 +11,7 @@ hook global BufCreate .*\.v %{
 
 hook global WinSetOption filetype=coq %{
     require-module coq
+    hook window ModeChange pop:insert:.* -group coq-trim-indent coq-trim-indent
     hook window InsertChar \n -group coq-indent coq-copy-indent-on-newline
 
     set-option window static_words %opt{coq_static_words}
@@ -112,6 +113,14 @@ evaluate-commands %sh{
 define-command -hidden coq-copy-indent-on-newline %{
     evaluate-commands -draft -itersel %{
         try %{ execute-keys -draft k <a-x> s ^\h+ <ret> y gh j P }
+    }
+}
+
+define-command -hidden coq-trim-indent %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        execute-keys <a-x>
+        # remove trailing white spaces
+        try %{ execute-keys -draft s \h + $ <ret> d }
     }
 }
 

--- a/rc/filetype/coq.kak
+++ b/rc/filetype/coq.kak
@@ -27,81 +27,81 @@ provide-module coq %{
 # Syntax
 # ------
 
-    # This is a `looks sensible' keyword syntax highlighting, far from being correct.
-    # Note that only the core language and the proof language is supported,
-    # the Ltac language is not (for now).
+# This is a `looks sensible' keyword syntax highlighting, far from being correct.
+# Note that only the core language and the proof language is supported,
+# the Ltac language is not (for now).
      
-    add-highlighter shared/coq regions
+add-highlighter shared/coq regions
 
-    add-highlighter shared/coq/comment region -recurse \Q(* \Q(* \Q*) fill comment
-    add-highlighter shared/coq/string region (?<!")" (?<!")("")*" fill string
+add-highlighter shared/coq/comment region -recurse \Q(* \Q(* \Q*) fill comment
+add-highlighter shared/coq/string region (?<!")" (?<!")("")*" fill string
 
-    add-highlighter shared/coq/command default-region group
+add-highlighter shared/coq/command default-region group
 
-    # This is not any lexical convention of coq, simply highlighting used to make
-    # proofs look better, based on how people usually use notations
-    add-highlighter shared/coq/command/ regex [`!@#$%^&*-=+\\:\;|<>/]+ 0:operator
-    add-highlighter shared/coq/command/ regex \(dfs\)|\(bfs\)          0:operator
-    add-highlighter shared/coq/command/ regex [()\[\]{}]               0:operator
+# This is not any lexical convention of coq, simply highlighting used to make
+# proofs look better, based on how people usually use notations
+add-highlighter shared/coq/command/ regex [`!@#$%^&*-=+\\:\;|<>/]+ 0:operator
+add-highlighter shared/coq/command/ regex \(dfs\)|\(bfs\)          0:operator
+add-highlighter shared/coq/command/ regex [()\[\]{}]               0:operator
 
-    # numeral literals
-    add-highlighter shared/coq/command/ regex [-]?[0-9][0-9_]*(\.[0-9_]+)?([eE][+-][0-9_]+)? 0:value
+# numeral literals
+add-highlighter shared/coq/command/ regex [-]?[0-9][0-9_]*(\.[0-9_]+)?([eE][+-][0-9_]+)? 0:value
 
-    evaluate-commands %sh{
-        # These are builtin keywords of the Gallina language (without tactics)
-        keywords="_ IF Prop SProp Set Type as at by cofix discriminated else end exists exists2 fix for"
-        keywords="${keywords} forall fun if in lazymatch let match multimatch return then using where with"
-        keywords="${keywords} inside outside"
+evaluate-commands %sh{
+    # These are builtin keywords of the Gallina language (without tactics)
+    keywords="_ IF Prop SProp Set Type as at by cofix discriminated else end exists exists2 fix for"
+    keywords="${keywords} forall fun if in lazymatch let match multimatch return then using where with"
+    keywords="${keywords} inside outside"
 
-        # These are (part of) coq top level commands
-        commands="Abort About Add Admitted All Arguments Axiom Back BackTo"
-        commands="${commands} Canonical Cd Check Coercion CoFixpoint Collection Compute Conjecture Context Contextual Corollary"
-        commands="${commands} Declare Defined Definition Delimit Drop End Eval Example Existential Export"
-        commands="${commands} Fact Fail File Fixpoint Focus From Function Generalizable Global Goal Grab"
-        commands="${commands} Hint Hypotheses Hypothesis Immediate Implicit Import Include Inductive"
-        commands="${commands} Lemma Let Library Load LoadPath Local Locate Module No Notation Opaque"
-        commands="${commands} Parameter Parameters Primitive Print Proof Property Proposition Pwd Qed Quit"
-        commands="${commands} Rec Record Redirect Register Remark Remove Require Reset"
-        commands="${commands} Section Search SearchAbout SearchHead SearchPattern SearchRewrite Show Strategy"
-        commands="${commands} Test Theorem Time Timeout Transparent Types Universes Undo Unfocus Unfocused Unset Variable Variables"
+    # These are (part of) coq top level commands
+    commands="Abort About Add Admitted All Arguments Axiom Back BackTo"
+    commands="${commands} Canonical Cd Check Coercion CoFixpoint Collection Compute Conjecture Context Contextual Corollary"
+    commands="${commands} Declare Defined Definition Delimit Drop End Eval Example Existential Export"
+    commands="${commands} Fact Fail File Fixpoint Focus From Function Generalizable Global Goal Grab"
+    commands="${commands} Hint Hypotheses Hypothesis Immediate Implicit Import Include Inductive"
+    commands="${commands} Lemma Let Library Load LoadPath Local Locate Module No Notation Opaque"
+    commands="${commands} Parameter Parameters Primitive Print Proof Property Proposition Pwd Qed Quit"
+    commands="${commands} Rec Record Redirect Register Remark Remove Require Reset"
+    commands="${commands} Section Search SearchAbout SearchHead SearchPattern SearchRewrite Show Strategy"
+    commands="${commands} Test Theorem Time Timeout Transparent Types Universes Undo Unfocus Unfocused Unset Variable Variables"
 
-        # These are (part of) coq's builtin tactics
-        tactics="abstract absurd admit all apply assert assert_fails"
-        tactics="${tactics} assert_succeeds assumption auto autoapply"
-        tactics="${tactics} autorewrite autounfold btauto by case cbn"
-        tactics="${tactics} cbv change clear clearbody cofix compare"
-        tactics="${tactics} compute congr congruence constructor contradict"
-        tactics="${tactics} cut cutrewrite cycle decide decompose dependent"
-        tactics="${tactics} destruct discriminate do done double"
-        tactics="${tactics} eapply eassert eauto eexact elim elimtype exact exfalso"
-        tactics="${tactics} fail field first firstorder fix fold functional"
-        tactics="${tactics} generalize guard have hnf idtac induction injection"
-        tactics="${tactics} instantiate intro intros intuition inversion"
-        tactics="${tactics} inversion_clear lapply lazy last move omega"
-        tactics="${tactics} pattern pose progress red refine reflexivity"
-        tactics="${tactics} remember rename repeat replace rewrite right ring"
-        tactics="${tactics} set setoid_reflexivity setoid_replace setoid_rewrite"
-        tactics="${tactics} setoid_symmetry setoid_transitivity simpl simple"
-        tactics="${tactics} simplify_eq solve specialize split start stop"
-        tactics="${tactics} subst symmetry tauto transitivity trivial try"
-        tactics="${tactics} under unfold unify unlock"
+    # These are (part of) coq's builtin tactics
+    tactics="abstract absurd admit all apply assert assert_fails"
+    tactics="${tactics} assert_succeeds assumption auto autoapply"
+    tactics="${tactics} autorewrite autounfold btauto by case cbn"
+    tactics="${tactics} cbv change clear clearbody cofix compare"
+    tactics="${tactics} compute congr congruence constructor contradict"
+    tactics="${tactics} cut cutrewrite cycle decide decompose dependent"
+    tactics="${tactics} destruct discriminate do done double"
+    tactics="${tactics} eapply eassert eauto eexact elim elimtype exact exfalso"
+    tactics="${tactics} fail field first firstorder fix fold functional"
+    tactics="${tactics} generalize guard have hnf idtac induction injection"
+    tactics="${tactics} instantiate intro intros intuition inversion"
+    tactics="${tactics} inversion_clear lapply lazy last move omega"
+    tactics="${tactics} pattern pose progress red refine reflexivity"
+    tactics="${tactics} remember rename repeat replace rewrite right ring"
+    tactics="${tactics} set setoid_reflexivity setoid_replace setoid_rewrite"
+    tactics="${tactics} setoid_symmetry setoid_transitivity simpl simple"
+    tactics="${tactics} simplify_eq solve specialize split start stop"
+    tactics="${tactics} subst symmetry tauto transitivity trivial try"
+    tactics="${tactics} under unfold unify unlock"
 
-        echo declare-option str-list coq_static_words ${keywords} ${commands} ${tactics}
+    echo declare-option str-list coq_static_words ${keywords} ${commands} ${tactics}
 
-        keywords_regex=$(echo ${keywords} | tr ' ' '|')
-        printf %s "
-            add-highlighter shared/coq/command/ regex \b(${keywords_regex})\b 0:keyword
-        "
-        commands_regex=$(echo ${commands} | tr ' ' '|')
-        printf %s "
-            add-highlighter shared/coq/command/ regex ^[\h\n]*(${commands_regex})\b 0:variable
-        "
+    keywords_regex=$(echo ${keywords} | tr ' ' '|')
+    printf %s "
+        add-highlighter shared/coq/command/ regex \b(${keywords_regex})\b 0:keyword
+    "
+    commands_regex=$(echo ${commands} | tr ' ' '|')
+    printf %s "
+        add-highlighter shared/coq/command/ regex ^[\h\n]*(${commands_regex})\b 0:variable
+    "
 
-        tactics_regex=$(echo ${tactics} | tr ' ' '|')
-        printf %s "
-            add-highlighter shared/coq/command/ regex \b(${tactics_regex})\b 0:keyword
-        "
-    }
+    tactics_regex=$(echo ${tactics} | tr ' ' '|')
+    printf %s "
+        add-highlighter shared/coq/command/ regex \b(${tactics_regex})\b 0:keyword
+    "
+}
 
 # Indentation
 # -----------
@@ -109,10 +109,10 @@ provide-module coq %{
 # not based on explicit, unique delimiters, like braces in C-family.
 # So it is difficult to properly indent using only regex...
 # Hence here only a simple mechanism of copying indent is done.
-    define-command -hidden coq-copy-indent-on-newline %{
-        evaluate-commands -draft -itersel %{
-            try %{ execute-keys -draft k <a-x> s ^\h+ <ret> y gh j P }
-        }
+define-command -hidden coq-copy-indent-on-newline %{
+    evaluate-commands -draft -itersel %{
+        try %{ execute-keys -draft k <a-x> s ^\h+ <ret> y gh j P }
+    }
 }
 
 }

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -206,7 +206,7 @@ define-command -hidden crystal-indent-on-new-line %{
         # Copy previous line indent
         try %{ execute-keys -draft K <a-&> }
         # Remove previous line's trailing spaces
-        try %{ execute-keys -draft k :ruby-trim-indent <ret> }
+        try %{ execute-keys -draft k :crystal-trim-indent <ret> }
         # Indent after start structure/opening statement
         try %{ execute-keys -draft k <a-x> <a-k> ^\h*(?:begin|case|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|.+\bdo$|.+\bdo\h\|.+(?=\|))[^0-9A-Za-z_!?] <ret> j <a-gt> }
     }

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -17,6 +17,7 @@ hook global WinSetOption filetype=crystal %{
     add-highlighter window/crystal ref crystal
     evaluate-commands set-option window static_words %opt{crystal_keywords} %opt{crystal_attributes} %opt{crystal_objects}
 
+    hook window ModeChange pop:insert:.* -group crystal-trim-indent crystal-trim-indent
     hook window InsertChar .*   -group crystal-indent crystal-indent-on-char
     hook window InsertChar '\n' -group crystal-indent crystal-indent-on-new-line
     hook window InsertChar '\n' -group crystal-insert crystal-insert-on-new-line

--- a/rc/filetype/css.kak
+++ b/rc/filetype/css.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](css) %{
 hook global WinSetOption filetype=css %[
     require-module css
 
-    hook window ModeChange pop:insert:.* -group css-trim-indent  css-trim-indent
+    hook window ModeChange pop:insert:.* -group css-trim-indent css-trim-indent
     hook window InsertChar \n -group css-insert css-insert-on-new-line
     hook window InsertChar \n -group css-indent css-indent-on-new-line
     hook window InsertChar \} -group css-indent css-indent-on-closing-curly-brace

--- a/rc/filetype/cucumber.kak
+++ b/rc/filetype/cucumber.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](feature|story) %{
 hook global WinSetOption filetype=cucumber %{
     require-module cucumber
 
-    hook window ModeChange pop:insert:.* -group cucumber-trim-indent  cucumber-trim-indent
+    hook window ModeChange pop:insert:.* -group cucumber-trim-indent cucumber-trim-indent
     hook window InsertChar \n -group cucumber-insert cucumber-insert-on-new-line
     hook window InsertChar \n -group cucumber-indent cucumber-indent-on-new-line
 

--- a/rc/filetype/elixir.kak
+++ b/rc/filetype/elixir.kak
@@ -18,7 +18,7 @@ hook global BufCreate .*[.]html[.]l?eex %{
 hook global WinSetOption filetype=elixir %{
     require-module elixir
 
-    hook window ModeChange pop:insert:.* -group elixir-trim-indent  elixir-trim-indent
+    hook window ModeChange pop:insert:.* -group elixir-trim-indent elixir-trim-indent
     hook window InsertChar \n -group elixir-indent elixir-indent-on-new-line
     hook window InsertChar \n -group elixir-insert elixir-insert-on-new-line
 

--- a/rc/filetype/elm.kak
+++ b/rc/filetype/elm.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](elm) %{
 hook global WinSetOption filetype=elm %{
     require-module elm
 
-    hook window ModeChange pop:insert:.* -group elm-trim-indent  elm-trim-indent
+    hook window ModeChange pop:insert:.* -group elm-trim-indent elm-trim-indent
     hook window InsertChar \n -group elm-insert elm-insert-on-new-line
     hook window InsertChar \n -group elm-indent elm-indent-on-new-line
 

--- a/rc/filetype/elvish.kak
+++ b/rc/filetype/elvish.kak
@@ -7,6 +7,7 @@ hook global BufCreate .*\.elv %{
 hook global WinSetOption filetype=elvish %<
     require-module elvish
 
+    hook window ModeChange pop:insert:.* -group elvish-trim-indent elvish-trim-indent
     hook window InsertChar \n -group elvish-insert elvish-indent
     hook window InsertChar [\]})] -group elvish-insert elvish-deindent
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window elvish-.+ }
@@ -35,6 +36,14 @@ add-highlighter shared/elvish/code/keyword regex (?:^|\{\s|\(|\||\;)\h*(use|var|
 add-highlighter shared/elvish/code/keyword_block regex \}\h+(elif|else|except|finally)(?![-:])\b 1:keyword
 
 add-highlighter shared/elvish/code/metachar regex [*?|&\;<>()[\]{}] 0:operator
+
+define-command -hidden elvish-trim-indent %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        execute-keys <a-x>
+        # remove trailing white spaces
+        try %{ execute-keys -draft s \h + $ <ret> d }
+    }
+}
 
 define-command -hidden elvish-indent %< evaluate-commands -draft -itersel %<
     execute-keys <semicolon>

--- a/rc/filetype/fish.kak
+++ b/rc/filetype/fish.kak
@@ -14,6 +14,7 @@ hook global BufCreate .*[.](fish) %{
 hook global WinSetOption filetype=fish %{
     require-module fish
 
+    hook window ModeChange pop:insert:.* -group fish-trim-indent fish-trim-indent
     hook window InsertChar .* -group fish-indent fish-indent-on-char
     hook window InsertChar \n -group fish-insert fish-insert-on-new-line
     hook window InsertChar \n -group fish-indent fish-indent-on-new-line

--- a/rc/filetype/fsharp.kak
+++ b/rc/filetype/fsharp.kak
@@ -15,6 +15,7 @@ hook global WinSetOption filetype=fsharp %{
     require-module fsharp
 
     # indent on newline
+    hook window ModeChange pop:insert:.* -group fsharp-trim-indent fsharp-trim-indent
     hook window InsertChar \n -group fsharp-insert fsharp-insert-on-new-line
     hook window InsertChar \n -group fsharp-indent fsharp-indent-on-new-line
 
@@ -124,6 +125,14 @@ add-highlighter shared/fsharp/code/ regex "\B(\(\))\B" 0:value
 
 # Commands
 # ‾‾‾‾‾‾‾‾
+
+define-command -hidden fsharp-trim-indent %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        execute-keys <a-x>
+        # remove trailing white spaces
+        try %{ execute-keys -draft s \h + $ <ret> d }
+    }
+}
 
 define-command -hidden fsharp-insert-on-new-line %{
     evaluate-commands -draft -itersel %{

--- a/rc/filetype/gas.kak
+++ b/rc/filetype/gas.kak
@@ -7,6 +7,7 @@ hook global BufCreate .*\.(s|S|asm)$ %{
 hook global WinSetOption filetype=gas %{
     require-module gas
 
+    hook window ModeChange pop:insert:.* -group gas-trim-indent gas-trim-indent
     hook window InsertChar \n -group gas-indent gas-indent-on-new-line
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window gas-.+ }
 }

--- a/rc/filetype/graphql.kak
+++ b/rc/filetype/graphql.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](graphqls?) %{
 hook global WinSetOption filetype=graphql %{
     require-module graphql
 
-    hook window ModeChange pop:insert:.* -group graphql-trim-indent  graphql-trim-indent
+    hook window ModeChange pop:insert:.* -group graphql-trim-indent graphql-trim-indent
     hook window InsertChar .* -group graphql-indent graphql-indent-on-char
     hook window InsertChar \n -group graphql-indent graphql-indent-on-new-line
 

--- a/rc/filetype/haml.kak
+++ b/rc/filetype/haml.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](haml) %{
 hook global WinSetOption filetype=haml %{
     require-module haml
 
-    hook window ModeChange pop:insert:.* -group haml-trim-indent  haml-trim-indent
+    hook window ModeChange pop:insert:.* -group haml-trim-indent haml-trim-indent
     hook window InsertChar \n -group haml-insert haml-insert-on-new-line
     hook window InsertChar \n -group haml-indent haml-indent-on-new-line
 

--- a/rc/filetype/haskell.kak
+++ b/rc/filetype/haskell.kak
@@ -15,7 +15,7 @@ hook global WinSetOption filetype=haskell %{
     require-module haskell
 
     set-option buffer extra_word_chars '_' "'"
-    hook window ModeChange pop:insert:.* -group haskell-trim-indent  haskell-trim-indent
+    hook window ModeChange pop:insert:.* -group haskell-trim-indent haskell-trim-indent
     hook window InsertChar \n -group haskell-insert haskell-insert-on-new-line
     hook window InsertChar \n -group haskell-indent haskell-indent-on-new-line
 

--- a/rc/filetype/janet.kak
+++ b/rc/filetype/janet.kak
@@ -12,7 +12,7 @@ hook global BufCreate .*[.](janet|jdn) %{
 hook global WinSetOption filetype=janet %{
     require-module janet
 
-    hook window ModeChange pop:insert:.* -group janet-trim-indent  janet-trim-indent
+    hook window ModeChange pop:insert:.* -group janet-trim-indent janet-trim-indent
     hook window InsertChar \n -group janet-indent janet-indent-on-new-line
     set-option buffer extra_word_chars ! @ $ '%' ^ & * - _ + = : < > . ?
 

--- a/rc/filetype/json.kak
+++ b/rc/filetype/json.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](json) %{
 hook global WinSetOption filetype=json %{
     require-module json
 
-    hook window ModeChange pop:insert:.* -group json-trim-indent  json-trim-indent
+    hook window ModeChange pop:insert:.* -group json-trim-indent json-trim-indent
     hook window InsertChar .* -group json-indent json-indent-on-char
     hook window InsertChar \n -group json-indent json-indent-on-new-line
 

--- a/rc/filetype/just.kak
+++ b/rc/filetype/just.kak
@@ -8,6 +8,7 @@ hook global BufCreate .*/?[jJ]ustfile %{
 hook global WinSetOption filetype=justfile %{
     require-module justfile
 
+    hook window ModeChange pop:insert:.* -group justfile-trim-indent justfile-trim-indent
     hook window InsertChar \n -group justfile-indent just-indent-on-new-line
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window justfile-.+ }
 }
@@ -22,6 +23,14 @@ provide-module justfile %{
 
 # Indentation
 # ‾‾‾‾‾‾‾‾‾‾‾
+
+define-command -hidden justfile-trim-indent %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        execute-keys <a-x>
+        # remove trailing white spaces
+        try %{ execute-keys -draft s \h + $ <ret> d }
+    }
+}
 
 define-command -hidden just-indent-on-new-line %{
      evaluate-commands -draft -itersel %{

--- a/rc/filetype/lisp.kak
+++ b/rc/filetype/lisp.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](lisp) %{
 hook global WinSetOption filetype=lisp %{
     require-module lisp
 
-    hook window ModeChange pop:insert:.* -group lisp-trim-indent  lisp-trim-indent
+    hook window ModeChange pop:insert:.* -group lisp-trim-indent lisp-trim-indent
     hook window InsertChar \n -group lisp-indent lisp-indent-on-new-line
     set-option buffer extra_word_chars '_' '+' '-' '*' '/' '@' '$' '%' '^' '&' '_' '=' '<' '>' '~' '.'
 

--- a/rc/filetype/makefile.kak
+++ b/rc/filetype/makefile.kak
@@ -13,6 +13,7 @@ hook global WinSetOption filetype=makefile %{
 
     set-option window static_words %opt{makefile_static_words}
 
+    hook window ModeChange pop:insert:.* -group makefile-trim-indent makefile-trim-indent
     hook window InsertChar \n -group makefile-indent makefile-indent-on-new-line
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window makefile-.+ }
 }
@@ -49,6 +50,14 @@ evaluate-commands %sh{
 
 # Commands
 # ‾‾‾‾‾‾‾‾
+
+define-command -hidden makefile-trim-indent %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        execute-keys <a-x>
+        # remove trailing white spaces
+        try %{ execute-keys -draft s \h + $ <ret> d }
+    }
+}
 
 define-command -hidden makefile-indent-on-new-line %{
     evaluate-commands -draft -itersel %{

--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -14,6 +14,7 @@ hook global BufCreate .*[.](markdown|md|mkd) %{
 hook global WinSetOption filetype=markdown %{
     require-module markdown
 
+    hook window ModeChange pop:insert:.* -group markdown-trim-indent markdown-trim-indent
     hook window InsertChar \n -group markdown-insert markdown-insert-on-new-line
     hook window InsertChar \n -group markdown-indent markdown-indent-on-new-line
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window markdown-.+ }
@@ -98,6 +99,14 @@ add-highlighter shared/markdown/inline/text/ regex "\H( {2,})$" 1:+r@meta
 
 # Commands
 # ‾‾‾‾‾‾‾‾
+
+define-command -hidden markdown-trim-indent %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        execute-keys <a-x>
+        # remove trailing white spaces
+        try %{ execute-keys -draft s \h + $ <ret> d }
+    }
+}
 
 define-command -hidden markdown-insert-on-new-line %{
     try %{ execute-keys -draft -itersel k <a-x> s ^\h*\K((>\h*)+([*+-]\h)?|(>\h*)*[*+-]\h)\h* <ret> y gh j P }

--- a/rc/filetype/moon.kak
+++ b/rc/filetype/moon.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](moon) %{
 hook global WinSetOption filetype=moon %{
     require-module moon
 
-    hook window ModeChange pop:insert:.* -group moon-trim-indent  moon-trim-indent
+    hook window ModeChange pop:insert:.* -group moon-trim-indent moon-trim-indent
     hook window InsertChar .* -group moon-indent moon-indent-on-char
     hook window InsertChar \n -group moon-insert moon-insert-on-new-line
     hook window InsertChar \n -group moon-indent moon-indent-on-new-line

--- a/rc/filetype/nix.kak
+++ b/rc/filetype/nix.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](nix) %{
 hook global WinSetOption filetype=nix %{
     require-module nix
 
-    hook window ModeChange pop:insert:.* -group nix-trim-indent  nix-trim-indent
+    hook window ModeChange pop:insert:.* -group nix-trim-indent nix-trim-indent
     hook window InsertChar .* -group nix-indent nix-indent-on-char
     hook window InsertChar \n -group nix-insert nix-insert-on-new-line
     hook window InsertChar \n -group nix-indent nix-indent-on-new-line

--- a/rc/filetype/pascal.kak
+++ b/rc/filetype/pascal.kak
@@ -14,6 +14,7 @@ hook global BufCreate .*\.(lpr|lfm)$ %{
 
 hook global WinSetOption filetype=((free|object)?pascal|delphi) %[
     require-module pascal
+    hook window ModeChange pop:insert:.* -group pascal-trim-indent pascal-trim-indent
     hook window InsertChar \n -group pascal-indent pascal-indent-on-new-line
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window pascal-.+ }
     set-option window static_words %opt{static_words}
@@ -188,6 +189,14 @@ EOF
 EOF
     done
 ¶
+
+define-command -hidden pascal-trim-indent %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        execute-keys <a-x>
+        # remove trailing white spaces
+        try %{ execute-keys -draft s \h + $ <ret> d }
+    }
+}
 
 define-command -hidden pascal-indent-on-new-line %{
     evaluate-commands -no-hooks -draft -itersel %{

--- a/rc/filetype/php.kak
+++ b/rc/filetype/php.kak
@@ -11,7 +11,7 @@ hook global BufCreate .*[.](phpt?) %{
 hook global WinSetOption filetype=php %{
     require-module php
 
-    hook window ModeChange pop:insert:.* -group php-trim-indent  php-trim-indent
+    hook window ModeChange pop:insert:.* -group php-trim-indent php-trim-indent
     hook window InsertChar .* -group php-indent php-indent-on-char
     hook window InsertChar \n -group php-insert php-insert-on-new-line
     hook window InsertChar \n -group php-indent php-indent-on-new-line

--- a/rc/filetype/protobuf.kak
+++ b/rc/filetype/protobuf.kak
@@ -15,6 +15,7 @@ hook global WinSetOption filetype=protobuf %[
 
     set-option window static_words %opt{protobuf_static_words}
 
+    hook window ModeChange pop:insert:.* -group protobuf-trim-indent protobuf-trim-indent
     hook -group protobuf-indent window InsertChar \n protobuf-indent-on-newline
     hook -group protobuf-indent window InsertChar \{ protobuf-indent-on-opening-curly-brace
     hook -group protobuf-indent window InsertChar \} protobuf-indent-on-closing-curly-brace
@@ -65,6 +66,14 @@ evaluate-commands %sh{
 
 # Commands
 # ‾‾‾‾‾‾‾‾
+
+define-command -hidden protobuf-trim-indent %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        execute-keys <a-x>
+        # remove trailing white spaces
+        try %{ execute-keys -draft s \h + $ <ret> d }
+    }
+}
 
 define-command -hidden protobuf-indent-on-newline %~
     evaluate-commands -draft -itersel %[

--- a/rc/filetype/pug.kak
+++ b/rc/filetype/pug.kak
@@ -18,7 +18,7 @@ hook global BufCreate .*[.](pug|jade) %{
 hook global WinSetOption filetype=pug %{
     require-module pug
 
-    hook window ModeChange pop:insert:.* -group pug-trim-indent  pug-trim-indent
+    hook window ModeChange pop:insert:.* -group pug-trim-indent pug-trim-indent
     hook window InsertChar \n -group pug-indent pug-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window pug-.+ }

--- a/rc/filetype/purescript.kak
+++ b/rc/filetype/purescript.kak
@@ -17,7 +17,7 @@ hook global WinSetOption filetype=purescript %{
     require-module purescript
 
     set-option buffer extra_word_chars '_' "'"
-    hook window ModeChange pop:insert:.* -group purescript-trim-indent  purescript-trim-indent
+    hook window ModeChange pop:insert:.* -group purescript-trim-indent purescript-trim-indent
     hook window InsertChar \n -group purescript-insert purescript-insert-on-new-line
     hook window InsertChar \n -group purescript-indent purescript-indent-on-new-line
 

--- a/rc/filetype/ragel.kak
+++ b/rc/filetype/ragel.kak
@@ -16,7 +16,7 @@ hook global BufCreate .*[.](ragel|rl) %{
 hook global WinSetOption filetype=ragel %{
     require-module ragel
 
-    hook window ModeChange pop:insert:.* -group ragel-trim-indent  ragel-trim-indent
+    hook window ModeChange pop:insert:.* -group ragel-trim-indent ragel-trim-indent
     hook window InsertChar .* -group ragel-indent ragel-indent-on-char
     hook window InsertChar \n -group ragel-insert ragel-insert-on-new-line
     hook window InsertChar \n -group ragel-indent ragel-indent-on-new-line

--- a/rc/filetype/ruby.kak
+++ b/rc/filetype/ruby.kak
@@ -16,6 +16,7 @@ hook global WinSetOption filetype=ruby %{
 
     set-option window static_words %opt{ruby_static_words}
 
+    hook window ModeChange pop:insert:.* -group ruby-trim-indent ruby-trim-indent
     hook window InsertChar .* -group ruby-indent ruby-indent-on-char
     hook window InsertChar \n -group ruby-indent ruby-indent-on-new-line
     hook window InsertChar \n -group ruby-insert ruby-insert-on-new-line

--- a/rc/filetype/sass.kak
+++ b/rc/filetype/sass.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](sass) %{
 hook global WinSetOption filetype=sass %<
     require-module sass
 
-    hook window ModeChange pop:insert:.* -group sass-trim-indent  sass-trim-indent
+    hook window ModeChange pop:insert:.* -group sass-trim-indent sass-trim-indent
     hook window InsertChar \} -group sass-indent sass-indent-on-closing-brace
     hook window InsertChar \n -group sass-insert sass-insert-on-new-line
     hook window InsertChar \n -group sass-indent sass-indent-on-new-line

--- a/rc/filetype/scala.kak
+++ b/rc/filetype/scala.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](scala) %{
 hook global WinSetOption filetype=scala %[
     require-module scala
 
-    hook window ModeChange pop:insert:.* -group scala-trim-indent  scala-trim-indent
+    hook window ModeChange pop:insert:.* -group scala-trim-indent scala-trim-indent
     hook window InsertChar \n -group scala-insert scala-insert-on-new-line
     hook window InsertChar \n -group scala-indent scala-indent-on-new-line
     hook window InsertChar \} -group scala-indent scala-indent-on-closing-curly-brace

--- a/rc/filetype/scheme.kak
+++ b/rc/filetype/scheme.kak
@@ -17,7 +17,7 @@ hook global WinSetOption filetype=scheme %{
     set-option window static_words %opt{scheme_static_words}
 
     set-option buffer extra_word_chars '!' '$' '%' '&' '*' '+' '-' '.' '/' ':' '<' '=' '>' '?' '@' '^' '_' '~'
-    hook window ModeChange pop:insert:.* -group scheme-trim-indent  lisp-trim-indent
+    hook window ModeChange pop:insert:.* -group scheme-trim-indent lisp-trim-indent
     hook window InsertChar \n -group scheme-indent lisp-indent-on-new-line
 
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window scheme-.+ }

--- a/rc/filetype/scss.kak
+++ b/rc/filetype/scss.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](scss) %{
 hook global WinSetOption filetype=scss %[
     require-module scss
 
-    hook window ModeChange pop:insert:.* -group scss-trim-indent  scss-trim-indent
+    hook window ModeChange pop:insert:.* -group scss-trim-indent scss-trim-indent
     hook window InsertChar \n -group scss-indent scss-insert-on-new-line
     hook window InsertChar \n -group scss-indent scss-indent-on-new-line
     hook window InsertChar \} -group scss-indent scss-indent-on-closing-curly-brace

--- a/rc/filetype/taskpaper.kak
+++ b/rc/filetype/taskpaper.kak
@@ -14,6 +14,7 @@ hook global BufCreate .*\.taskpaper %{
 hook global WinSetOption filetype=taskpaper %{
     require-module taskpaper
 
+    hook window ModeChange pop:insert:.* -group taskpaper-trim-indent taskpaper-trim-indent
     hook window InsertChar \n -group taskpaper-indent taskpaper-indent-on-new-line
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window taskpaper-.+ }
 }
@@ -39,6 +40,14 @@ add-highlighter shared/taskpaper/ regex (([a-z]+://\S+)|((mailto:)[\w+-]+@\S+)) 
 
 # Commands
 # ‾‾‾‾‾‾‾‾
+
+define-command -hidden taskpaper-trim-indent %{
+    evaluate-commands -no-hooks -draft -itersel %{
+        execute-keys <a-x>
+        # remove trailing white spaces
+        try %{ execute-keys -draft s \h + $ <ret> d }
+    }
+}
 
 define-command -hidden taskpaper-indent-on-new-line %{
     evaluate-commands -draft -itersel %{

--- a/rc/filetype/twig.kak
+++ b/rc/filetype/twig.kak
@@ -14,7 +14,7 @@ hook global BufCreate .*[.](twig) %{
 hook global WinSetOption filetype=twig %[
     require-module twig
 
-    hook window ModeChange pop:insert:.* -group twig-trim-indent  twig-trim-indent
+    hook window ModeChange pop:insert:.* -group twig-trim-indent twig-trim-indent
     hook window InsertChar \n -group twig-insert twig-insert-on-new-line
     hook window InsertChar \n -group twig-indent twig-indent-on-new-line
     hook window InsertChar '>' -group twig-indent twig-indent-on-greater-than

--- a/test/indent/ruby/do-keyword/out
+++ b/test/indent/ruby/do-keyword/out
@@ -1,7 +1,7 @@
 test do
-    
+
 end
 
 e.map do |element|
-    
+
 end

--- a/test/indent/ruby/following-blocks-should-not-prevent-end/out
+++ b/test/indent/ruby/following-blocks-should-not-prevent-end/out
@@ -1,5 +1,5 @@
 def foo
-    
+
 end
 
 def bar

--- a/test/indent/ruby/indent-after-class/out
+++ b/test/indent/ruby/indent-after-class/out
@@ -1,4 +1,4 @@
 class Test
-    
-    
+
+
 end

--- a/test/indent/ruby/method-definition-shouldnt-duplicate/out
+++ b/test/indent/ruby/method-definition-shouldnt-duplicate/out
@@ -1,5 +1,5 @@
 class Test
     def test
-        
+
     end
 end


### PR DESCRIPTION
An indent hook automatically adds whitespace, so it seems prudent to
add the hook to remove unwanted whitespace again. This is what we do
in most languages already.

Plus related consistency fixes.

The last commit has a semantic conflict with the breaking-cleanups branch.
