### PR TITLE
make clean: also clean up generated version files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -128,7 +128,7 @@ tags:
 	ctags -R
 
 clean:
-	rm -f $(objects) $(deps)
+	rm -f $(objects) $(deps) .version.cc .version.o
 
 dist:
 	@if ! [ -d ../.git ]; then echo "make dist can only run from a git repo";  false; fi


### PR DESCRIPTION
We also discussed using "git clean -dXf" but that could remove files
that were not generated by make.

Closes #4619
