### PR TITLE
Add a workflow to upload Linux build on releases

### DIFF
--- a/.github/workflows/build-releases-linux.yaml
+++ b/.github/workflows/build-releases-linux.yaml
@@ -1,0 +1,29 @@
+name: Build static binaries for Linux
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Prepare
+        run: apk add --no-cache binutils bzip2 g++ git make tar
+      - name: Build
+        run: |
+          mkdir -p kakoune-${{ github.event.release.tag_name }}-linux/
+          make -C src all static=yes
+          make -C src install PREFIX=$(pwd)/kakoune-${{ github.event.release.tag_name }}-linux/
+          strip -s kakoune-${{ github.event.release.tag_name }}-linux/bin/kak
+          tar cvjf kakoune-${{ github.event.release.tag_name }}-linux.tar.bz2 kakoune-${{ github.event.release.tag_name }}-linux/
+      - name: Upload
+        uses: softprops/action-gh-release@v1
+        with:
+          files: kakoune-${{ github.event.release.tag_name }}-linux.tar.bz2


### PR DESCRIPTION
Building static binaries with Alpine Linux's musl libc-based toolchain should make them work on any distros with Linux kernel 2.6.39 and newer.

Fixes https://github.com/mawww/kakoune/issues/4555