### PR TITLE
(breaking-cleanups) Fix new trim-indent commands to use new x key meaning

### DIFF
--- a/rc/filetype/coq.kak
+++ b/rc/filetype/coq.kak
@@ -118,7 +118,7 @@ define-command -hidden coq-copy-indent-on-newline %{
 
 define-command -hidden coq-trim-indent %{
     evaluate-commands -no-hooks -draft -itersel %{
-        execute-keys <a-x>
+        execute-keys x
         # remove trailing white spaces
         try %{ execute-keys -draft s \h + $ <ret> d }
     }

--- a/rc/filetype/elvish.kak
+++ b/rc/filetype/elvish.kak
@@ -39,7 +39,7 @@ add-highlighter shared/elvish/code/metachar regex [*?|&\;<>()[\]{}] 0:operator
 
 define-command -hidden elvish-trim-indent %{
     evaluate-commands -no-hooks -draft -itersel %{
-        execute-keys <a-x>
+        execute-keys x
         # remove trailing white spaces
         try %{ execute-keys -draft s \h + $ <ret> d }
     }

--- a/rc/filetype/fsharp.kak
+++ b/rc/filetype/fsharp.kak
@@ -128,7 +128,7 @@ add-highlighter shared/fsharp/code/ regex "\B(\(\))\B" 0:value
 
 define-command -hidden fsharp-trim-indent %{
     evaluate-commands -no-hooks -draft -itersel %{
-        execute-keys <a-x>
+        execute-keys x
         # remove trailing white spaces
         try %{ execute-keys -draft s \h + $ <ret> d }
     }

--- a/rc/filetype/just.kak
+++ b/rc/filetype/just.kak
@@ -26,7 +26,7 @@ provide-module justfile %{
 
 define-command -hidden justfile-trim-indent %{
     evaluate-commands -no-hooks -draft -itersel %{
-        execute-keys <a-x>
+        execute-keys x
         # remove trailing white spaces
         try %{ execute-keys -draft s \h + $ <ret> d }
     }

--- a/rc/filetype/makefile.kak
+++ b/rc/filetype/makefile.kak
@@ -53,7 +53,7 @@ evaluate-commands %sh{
 
 define-command -hidden makefile-trim-indent %{
     evaluate-commands -no-hooks -draft -itersel %{
-        execute-keys <a-x>
+        execute-keys x
         # remove trailing white spaces
         try %{ execute-keys -draft s \h + $ <ret> d }
     }

--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -102,7 +102,7 @@ add-highlighter shared/markdown/inline/text/ regex "\H( {2,})$" 1:+r@meta
 
 define-command -hidden markdown-trim-indent %{
     evaluate-commands -no-hooks -draft -itersel %{
-        execute-keys <a-x>
+        execute-keys x
         # remove trailing white spaces
         try %{ execute-keys -draft s \h + $ <ret> d }
     }

--- a/rc/filetype/pascal.kak
+++ b/rc/filetype/pascal.kak
@@ -192,7 +192,7 @@ EOF
 
 define-command -hidden pascal-trim-indent %{
     evaluate-commands -no-hooks -draft -itersel %{
-        execute-keys <a-x>
+        execute-keys x
         # remove trailing white spaces
         try %{ execute-keys -draft s \h + $ <ret> d }
     }

--- a/rc/filetype/protobuf.kak
+++ b/rc/filetype/protobuf.kak
@@ -69,7 +69,7 @@ evaluate-commands %sh{
 
 define-command -hidden protobuf-trim-indent %{
     evaluate-commands -no-hooks -draft -itersel %{
-        execute-keys <a-x>
+        execute-keys x
         # remove trailing white spaces
         try %{ execute-keys -draft s \h + $ <ret> d }
     }

--- a/rc/filetype/taskpaper.kak
+++ b/rc/filetype/taskpaper.kak
@@ -43,7 +43,7 @@ add-highlighter shared/taskpaper/ regex (([a-z]+://\S+)|((mailto:)[\w+-]+@\S+)) 
 
 define-command -hidden taskpaper-trim-indent %{
     evaluate-commands -no-hooks -draft -itersel %{
-        execute-keys <a-x>
+        execute-keys x
         # remove trailing white spaces
         try %{ execute-keys -draft s \h + $ <ret> d }
     }


### PR DESCRIPTION
Corrects the behavior of 6f28178b91cbecd1bb8f92b9731c9e85c915abdf for breaking-cleanups. Feel free to just rebase/merge into the main `<a-x>` -> `x` commit (14eaaf2848cb1dddf9f80f9138614d2dd61b9d48) or whatever :P