### PR TITLE
Rename Go auto-insertion hooks to make it easier to disable them

### DIFF
--- a/rc/filetype/go.kak
+++ b/rc/filetype/go.kak
@@ -21,8 +21,8 @@ hook global WinSetOption filetype=go %{
     hook window InsertChar \n -group go-indent go-indent-on-new-line
     hook window InsertChar \{ -group go-indent go-indent-on-opening-curly-brace
     hook window InsertChar \} -group go-indent go-indent-on-closing-curly-brace
-    hook window InsertChar \n -group go-insert go-insert-on-new-line
-    hook window InsertChar \n -group go-insert-closing-delimiter go-insert-closing-delimiter-on-new-line
+    hook window InsertChar \n -group go-comment-insert go-insert-comment-on-new-line
+    hook window InsertChar \n -group go-closing-delimiter-insert go-insert-closing-delimiter-on-new-line
 
     alias window alt go-alternative-file
 
@@ -131,7 +131,7 @@ define-command -hidden go-indent-on-closing-curly-brace %[
     try %[ execute-keys -itersel -draft <a-h><a-k>^\h+\}$<ret>hms\A|.\z<ret>1<a-&> ]
 ]
 
-define-command -hidden go-insert-on-new-line %[
+define-command -hidden go-insert-comment-on-new-line %[
     evaluate-commands -no-hooks -draft -itersel %[
         # copy // comments prefix and following white spaces
         try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }

--- a/test/indent/go/insert-comment/rc
+++ b/test/indent/go/insert-comment/rc
@@ -1,4 +1,4 @@
 source "%val{runtime}/colors/default.kak"
 source "%val{runtime}/rc/filetype/go.kak"
 set buffer filetype go
-set-option global disabled_hooks go-insert-closing-delimiter
+set-option global disabled_hooks go-closing-delimiter-insert


### PR DESCRIPTION
The canonical way to disable all auto-insertion hooks is

	set-option global disabled_hooks .*-insert

A recent change allowed to disable hooks that insert ) and }
independent of hooks that insert // (a step in the right
direction, we should do it for more filetypes).

Since the new hook ("go-insert-closing-delimiter") doesn't match
.*-insert, it broke the above snippet.  Fix this by renaming it to
"go-closing-delimiter-insert".

This makes it a bit less obvious how to disable only comment insertion.
Not sure if there's interest in that, but make it easier by renaming
"go-insert" to "go-comment-insert".

cc @ttttcrngyblflpp, I missed this in the review.
I'm sure we can improve the UX further but I think this is a good intermediate step.
