### PR TITLE
Use optimal subsequence match to rank completions

### DIFF
--- a/gdb/kakoune.py
+++ b/gdb/kakoune.py
@@ -235,5 +235,5 @@ def build_pretty_printer():
     pp.add_printer('ByteCount', '^Kakoune::ByteCount$', ByteCount)
     pp.add_printer('Color', '^Kakoune::Color$', Color)
     pp.add_printer('Regex', '^Kakoune::Regex$', Regex)
-    pp.add_printer('SubsequenceDistance', '^Kakoune::SubsequenceDistance$', SubsequenceDistance)
+    pp.add_printer('SubsequenceDistance', '^Kakoune::SubsequenceDistance<true>$', SubsequenceDistance)
     return pp

--- a/gdb/kakoune.py
+++ b/gdb/kakoune.py
@@ -206,6 +206,16 @@ class Regex:
     def to_string(self):
         return "regex%s" % (self.val["m_str"])
 
+class SubsequenceDistance:
+    """Print a SubsequenceDistance"""
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        reference = "*(%s*)%s" % (self.val.type, self.val.address)
+        return gdb.parse_and_eval("Kakoune::to_string(%s)" % reference)
+
 
 def build_pretty_printer():
     pp = gdb.printing.RegexpCollectionPrettyPrinter("kakoune")
@@ -225,4 +235,5 @@ def build_pretty_printer():
     pp.add_printer('ByteCount', '^Kakoune::ByteCount$', ByteCount)
     pp.add_printer('Color', '^Kakoune::Color$', Color)
     pp.add_printer('Regex', '^Kakoune::Regex$', Regex)
+    pp.add_printer('SubsequenceDistance', '^Kakoune::SubsequenceDistance$', SubsequenceDistance)
     return pp

--- a/src/array_view.hh
+++ b/src/array_view.hh
@@ -9,7 +9,7 @@ namespace Kakoune
 
 // An ArrayView provides a typed, non owning view of a memory
 // range with an interface similar to std::vector.
-template<typename T>
+template<typename T, typename SizeType = std::size_t>
 class ArrayView
 {
 public:
@@ -21,7 +21,7 @@ public:
     constexpr ArrayView(T& oneval)
         : m_pointer(&oneval), m_size(1) {}
 
-    constexpr ArrayView(T* pointer, size_t size)
+    constexpr ArrayView(T* pointer, SizeType size)
         : m_pointer(pointer), m_size(size) {}
 
     constexpr ArrayView(T* begin, T* end)
@@ -44,10 +44,10 @@ public:
         : m_pointer(v.begin()), m_size(v.size()) {}
 
     constexpr T* pointer() const { return m_pointer; }
-    constexpr size_t size() const { return m_size; }
+    constexpr SizeType size() const { return m_size; }
 
     [[gnu::always_inline]]
-    constexpr T& operator[](size_t n) const { return *(m_pointer + n); }
+    constexpr T& operator[](SizeType n) const { return *(m_pointer + (size_t)n); }
 
     constexpr T* begin() const { return m_pointer; }
     constexpr T* end()   const { return m_pointer+m_size; }
@@ -61,27 +61,28 @@ public:
 
     constexpr bool empty() const { return m_size == 0; }
 
-    constexpr ArrayView subrange(size_t first, size_t count = -1) const
+    constexpr ArrayView subrange(SizeType first, SizeType count = -1) const
     {
-        auto min = [](size_t a, size_t b) { return a < b ? a : b; };
+        auto min = [](SizeType a, SizeType b) { return a < b ? a : b; };
         return ArrayView(m_pointer + min(first, m_size),
                          min(count, m_size - min(first, m_size)));
     }
 
 private:
     T* m_pointer;
-    size_t m_size;
+    SizeType m_size;
 };
 
 template<typename It>
     requires std::contiguous_iterator<It>
 ArrayView(It begin, It end) -> ArrayView<std::iter_value_t<It>>;
 
-template<typename T>
-using ConstArrayView = ArrayView<const T>;
+template<typename T, typename SizeType = std::size_t>
+using ConstArrayView = ArrayView<const T, SizeType>;
 
-template<typename T>
-bool operator==(ArrayView<T> lhs, ArrayView<T> rhs)
+
+template<typename T, typename SizeType>
+bool operator==(ArrayView<T, SizeType> lhs, ArrayView<T, SizeType> rhs)
 {
     if (lhs.size() != rhs.size())
         return false;

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -166,6 +166,7 @@ static Completions complete_buffer_name(const Context& context, CompletionFlags 
     };
 
     StringView query = prefix.substr(0, cursor_pos);
+    RankedMatchQuery q{query};
     Vector<RankedMatchAndBuffer> filename_matches;
     Vector<RankedMatchAndBuffer> matches;
     for (const auto& buffer : BufferManager::instance())
@@ -176,13 +177,13 @@ static Completions complete_buffer_name(const Context& context, CompletionFlags 
         StringView bufname = buffer->display_name();
         if (buffer->flags() & Buffer::Flags::File)
         {
-            if (RankedMatch match{split_path(bufname).second, query})
+            if (RankedMatch match{split_path(bufname).second, q})
             {
                 filename_matches.emplace_back(match, buffer.get());
                 continue;
             }
         }
-        if (RankedMatch match{bufname, query})
+        if (RankedMatch match{bufname, q})
             matches.emplace_back(match, buffer.get());
     }
     std::sort(filename_matches.begin(), filename_matches.end());
@@ -304,11 +305,11 @@ struct ShellCandidatesCompleter
         }
 
         StringView query = params[token_to_complete].substr(0, pos_in_token);
-        UsedLetters query_letters = used_letters(query);
+        RankedMatchQuery q{query, used_letters(query)};
         Vector<RankedMatch> matches;
         for (const auto& candidate : m_candidates)
         {
-            if (RankedMatch match{candidate.first, candidate.second, query, query_letters})
+            if (RankedMatch match{candidate.first, candidate.second, q})
                 matches.push_back(match);
         }
 

--- a/src/completion.hh
+++ b/src/completion.hh
@@ -75,11 +75,11 @@ CandidateList complete(StringView query, ByteCount cursor_pos,
     static_assert(not std::is_same<decltype(*begin(container)), String>::value,
                   "complete require long lived strings, not temporaries");
 
-    query = query.substr(0, cursor_pos);
+    RankedMatchQuery q{query.substr(0, cursor_pos)};
     Vector<RankedMatch> matches;
     for (const auto& str : container)
     {
-        if (RankedMatch match{str, query})
+        if (RankedMatch match{str, q})
             matches.push_back(match);
     }
     std::sort(matches.begin(), matches.end());

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -983,8 +983,9 @@ public:
                         });
                     else if (key.key == 'w')
                         use_explicit_completer([](const Context& context, StringView token) {
+                            RankedMatchQuery query{token};
                             CandidateList candidates;
-                            for_n_best(get_word_db(context.buffer()).find_matching(token),
+                            for_n_best(get_word_db(context.buffer()).find_matching(query),
                                        100, [](auto& lhs, auto& rhs){ return rhs < lhs; },
                                        [&](RankedMatch& m) {
                                 candidates.push_back(m.candidate().str());

--- a/src/insert_completer.cc
+++ b/src/insert_completer.cc
@@ -123,7 +123,8 @@ InsertCompletion complete_word(const SelectionList& sels,
     };
 
     auto& word_db = get_word_db(buffer);
-    auto matches = word_db.find_matching(prefix)
+    RankedMatchQuery q{prefix};
+    auto matches = word_db.find_matching(q)
                  | transform([&](auto& m) { return RankedMatchAndBuffer{m, &buffer}; })
                  | gather<Vector<RankedMatchAndBuffer>>();
     // Remove words that are being edited
@@ -139,7 +140,7 @@ InsertCompletion complete_word(const SelectionList& sels,
         {
             if (buf.get() == &buffer or buf->flags() & Buffer::Flags::Debug)
                 continue;
-            for (auto& m : get_word_db(*buf).find_matching(prefix) |
+            for (auto& m : get_word_db(*buf).find_matching(q) |
                            // filter out words that are not considered words for the current buffer
                            filter([&](auto& rm) {
                                auto&& c = rm.candidate();
@@ -152,7 +153,7 @@ InsertCompletion complete_word(const SelectionList& sels,
 
     using StaticWords = Vector<String, MemoryDomain::Options>;
     for (auto& word : options["static_words"].get<StaticWords>())
-        if (RankedMatch match{word, prefix})
+        if (RankedMatch match{word, q})
             matches.emplace_back(match, nullptr);
 
     unordered_erase(matches, prefix);
@@ -295,7 +296,7 @@ InsertCompletion complete_option(const SelectionList& sels,
         DisplayLine menu_entry;
     };
 
-    StringView query = buffer.substr(coord, cursor_pos);
+    RankedMatchQuery query{buffer.substr(coord, cursor_pos)};
     Vector<RankedMatchAndInfo> matches;
 
     for (auto& candidate : opt.list)

--- a/src/memory.hh
+++ b/src/memory.hh
@@ -37,6 +37,7 @@ enum class MemoryDomain
     Events,
     Completion,
     Regex,
+    RankedMatch,
     Count
 };
 
@@ -68,6 +69,7 @@ inline const char* domain_name(MemoryDomain domain)
         case MemoryDomain::Events: return "Events";
         case MemoryDomain::Completion: return "Completion";
         case MemoryDomain::Regex: return "Regex";
+        case MemoryDomain::RankedMatch: return "RankedMatch";
         case MemoryDomain::Count: break;
     }
     kak_assert(false);

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -828,7 +828,8 @@ void regex_prompt(Context& context, String prompt, char reg, T func)
             };
 
             const auto word = current_word(regex.substr(0_byte, pos));
-            auto matches = get_word_db(context.buffer()).find_matching(word);
+            RankedMatchQuery query{word};
+            auto matches = get_word_db(context.buffer()).find_matching(query);
             constexpr size_t max_count = 100;
             CandidateList candidates;
             candidates.reserve(std::min(matches.size(), max_count));

--- a/src/ranked_match.cc
+++ b/src/ranked_match.cc
@@ -270,6 +270,19 @@ UnitTest test_ranked_match{[] {
     kak_assert(preferred("", "a", "b"));
     kak_assert(preferred("expresins", "expresions", "expressionism's"));
     kak_assert(preferred("foo_b", "foo/bar/foo_bar.baz", "test/test_foo_bar.baz"));
+    kak_assert(preferred("gre", "*grep*", ".git/rebase-merge/git-rebase-todo"));
+    kak_assert(preferred("CAPRAN", "CAPABILITY_RANGE_FORMATTING", "CAPABILITY_SELECTION_RANGE"));
+    kak_assert(preferred("mal", "malt", "formal"));
+    kak_assert(preferred("fa", "face", "find-apply-changes"));
+    kak_assert(preferred("cne", "cargo-next-error", "comment-line"));
+    kak_assert(preferred("cne", "cargo-next-error", "ccls-navigate"));
+    kak_assert(preferred("cpe", "cargo-previous-error", "cpp-alternative-file"));
+    kak_assert(preferred("server_",  "server_capabilities", "SERVER_CANCELLED"));
+    kak_assert(preferred("server_",  "server_capabilities_capabilities", "SERVER_CANCELLED"));
+    kak_assert(preferred("codegen", "clang/test/CodeGen/asm.c", "clang/test/ASTMerge/codegen-body/test.c"));
+    kak_assert(preferred("cho", "tchou kanaky", "tachou kanay")); // Prefer the leftmost match.
+    kak_assert(preferred("clang-query", "clang/tools/clang-query/ClangQuery.cpp", "clang/test/Tooling/clang-query.cpp"));
+    kak_assert(preferred("clangd", "clang-tools-extra/clangd/README.md", "clang/docs/conf.py"));
 }};
 
 UnitTest test_used_letters{[]()

--- a/src/ranked_match.cc
+++ b/src/ranked_match.cc
@@ -88,28 +88,28 @@ struct SubseqRes
     bool single_word;
 };
 
-static Optional<SubseqRes> subsequence_match_smart_case(StringView str, StringView subseq)
+static Optional<SubseqRes> greedy_subsequence_match(StringView candidate, StringView query)
 {
     bool single_word = true;
     int max_index = -1;
-    auto it = str.begin();
+    auto it = candidate.begin();
     int index = 0;
-    for (auto subseq_it = subseq.begin(); subseq_it != subseq.end();)
+    for (auto query_it = query.begin(); query_it != query.end();)
     {
-        if (it == str.end())
+        if (it == candidate.end())
             return {};
-        const Codepoint c = utf8::read_codepoint(subseq_it, subseq.end());
+        const Codepoint c = utf8::read_codepoint(query_it, query.end());
         while (true)
         {
-            auto str_c = utf8::read_codepoint(it, str.end());
-            if (smartcase_eq(str_c, c))
+            auto candidate_c = utf8::read_codepoint(it, candidate.end());
+            if (smartcase_eq(candidate_c, c))
                 break;
 
-            if (max_index != -1 and single_word and not is_word(str_c))
+            if (max_index != -1 and single_word and not is_word(candidate_c))
                 single_word = false;
 
             ++index;
-            if (it == str.end())
+            if (it == candidate.end())
                 return {};
         }
         max_index = index++;
@@ -133,7 +133,7 @@ RankedMatch::RankedMatch(StringView candidate, StringView query, TestFunc func)
     if (not func())
         return;
 
-    auto res = subsequence_match_smart_case(candidate, query);
+    auto res = greedy_subsequence_match(candidate, query);
     if (not res)
         return;
 

--- a/src/ranked_match.cc
+++ b/src/ranked_match.cc
@@ -50,30 +50,38 @@ static int word_start_factor(Codepoint prev, Codepoint c)
            1 * (iswlower((wchar_t)prev) and iswupper((wchar_t)c));
 }
 
-static bool smartcase_eq(Codepoint candidate, Codepoint query)
+static bool smartcase_eq(Codepoint candidate_c, Codepoint query_c,
+                         const RankedMatchQuery& query, CharCount query_i)
 {
-    return query == (iswlower((wchar_t)query) ? to_lower(candidate) : candidate);
+    return candidate_c == query_c or Optional{candidate_c} == query.smartcase_alternative_match[(size_t)query_i];
 }
 
-static bool greedy_subsequence_match(StringView candidate, StringView query)
+static bool greedy_subsequence_match(StringView candidate, const RankedMatchQuery& query)
 {
     auto it = candidate.begin();
-    for (auto query_it = query.begin(); query_it != query.end();)
+    CharCount query_i = 0;
+    for (auto query_it = query.input.begin(); query_it != query.input.end();)
     {
         if (it == candidate.end())
             return false;
-        const Codepoint c = utf8::read_codepoint(query_it, query.end());
+        const Codepoint c = utf8::read_codepoint(query_it, query.input.end());
         while (true)
         {
             auto candidate_c = utf8::read_codepoint(it, candidate.end());
-            if (smartcase_eq(candidate_c, c))
+            if (smartcase_eq(candidate_c, c, query, query_i))
                 break;
 
             if (it == candidate.end())
                 return false;
         }
+        query_i++;
     }
     return true;
+}
+
+static CharCount query_length(const RankedMatchQuery& query)
+{
+    return query.smartcase_alternative_match.size();
 }
 
 // Below is an implementation of Gotoh's algorithm for optimal sequence
@@ -93,10 +101,10 @@ struct Distance
 class SubsequenceDistance
 {
 public:
-    SubsequenceDistance(StringView query, StringView candidate)
+    SubsequenceDistance(const RankedMatchQuery& query, StringView candidate)
         : query{query}, candidate{candidate},
           stride{candidate.char_length() + 1},
-          m_matrix{(size_t)((query.char_length() + 1) * stride)} {}
+          m_matrix{(size_t)((query_length(query) + 1) * stride)} {}
 
     ArrayView<Distance, CharCount> operator[](CharCount query_i)
     {
@@ -110,7 +118,7 @@ public:
     // The index of the last matched character.
     CharCount max_index = 0;
     // These fields exist to allow pretty-printing in GDB.
-    const StringView query;
+    const RankedMatchQuery& query;
     const StringView candidate;
 private:
     CharCount stride;
@@ -124,7 +132,7 @@ private:
 static constexpr int infinity = std::numeric_limits<int>::max();
 constexpr int max_index_weight = 1;
 
-static SubsequenceDistance subsequence_distance(StringView query, StringView candidate)
+static SubsequenceDistance subsequence_distance(const RankedMatchQuery& query, StringView candidate)
 {
     auto match_bonus = [](int word_start, bool is_same_case) -> int {
         return -75 * word_start
@@ -136,7 +144,6 @@ static SubsequenceDistance subsequence_distance(StringView query, StringView can
 
     SubsequenceDistance distance{query, candidate};
 
-    CharCount query_length = query.char_length();
     CharCount candidate_length = candidate.char_length();
 
     // Compute the distance of skipping a prefix of the candidate.
@@ -145,8 +152,8 @@ static SubsequenceDistance subsequence_distance(StringView query, StringView can
 
     CharCount query_i, candidate_i;
     String::const_iterator query_it, candidate_it;
-    for (query_i = 1, query_it = query.begin();
-         query_i <= query_length;
+    for (query_i = 1, query_it = query.input.begin();
+         query_i <= query_length(query);
          query_i++)
     {
         auto row = distance[query_i];
@@ -161,7 +168,7 @@ static SubsequenceDistance subsequence_distance(StringView query, StringView can
             row[query_i - 1].distance = infinity;
             row[query_i - 1].distance_ending_in_gap = infinity;
         }
-        Codepoint query_c = utf8::read_codepoint(query_it, query.end());
+        Codepoint query_c = utf8::read_codepoint(query_it, query.input.end());
         Codepoint prev_c;
         // Since we don't allow deletions, the candidate must be at least
         // as long as the query. This allows us to skip some cells.
@@ -176,7 +183,7 @@ static SubsequenceDistance subsequence_distance(StringView query, StringView can
             int distance_ending_in_gap = infinity;
             if (auto parent = row[candidate_i - 1]; parent.distance != infinity)
             {
-                bool is_trailing_gap = query_i == query_length;
+                bool is_trailing_gap = query_i == query_length(query);
                 int start_gap = parent.distance + (gap_weight * not is_trailing_gap) + gap_extend_weight;
                 int extend_gap = parent.distance_ending_in_gap == infinity
                                     ? infinity
@@ -186,7 +193,7 @@ static SubsequenceDistance subsequence_distance(StringView query, StringView can
 
             int distance_match = infinity;
             if (Distance parent = prev_row[candidate_i - 1];
-                parent.distance != infinity and smartcase_eq(candidate_c, query_c))
+                parent.distance != infinity and smartcase_eq(candidate_c, query_c, query, query_i - 1))
             {
                 int word_start = word_start_factor(prev_c, candidate_c);
                 bool is_same_case = candidate_c == query_c;
@@ -195,7 +202,7 @@ static SubsequenceDistance subsequence_distance(StringView query, StringView can
 
             row[candidate_i].distance = std::min(distance_match, distance_ending_in_gap);
             row[candidate_i].distance_ending_in_gap = distance_ending_in_gap;
-            if (query_i == query_length and distance_match < distance_ending_in_gap)
+            if (query_i == query_length(query) and distance_match < distance_ending_in_gap)
                 distance.max_index = candidate_i - 1;
             prev_c = candidate_c;
         }
@@ -203,13 +210,23 @@ static SubsequenceDistance subsequence_distance(StringView query, StringView can
     return distance;
 }
 
+RankedMatchQuery::RankedMatchQuery(StringView query) : RankedMatchQuery(query, {}) {}
+
+RankedMatchQuery::RankedMatchQuery(StringView input, UsedLetters used_letters)
+    : input(input), used_letters(used_letters),
+      smartcase_alternative_match(input | transform([](Codepoint c) -> Optional<Codepoint> {
+          if (is_lower(c))
+              return to_upper(c);
+          return {};
+      }) | gather<decltype(smartcase_alternative_match)>()) {}
+
 template<typename TestFunc>
-RankedMatch::RankedMatch(StringView candidate, StringView query, TestFunc func)
+RankedMatch::RankedMatch(StringView candidate, const RankedMatchQuery& query, TestFunc func)
 {
-    if (query.length() > candidate.length())
+    if (query.input.length() > candidate.length())
         return;
 
-    if (query.empty())
+    if (query.input.empty())
     {
         m_candidate = candidate;
         m_matches = true;
@@ -233,19 +250,19 @@ RankedMatch::RankedMatch(StringView candidate, StringView query, TestFunc func)
 
     auto distance = subsequence_distance(query, bounded_candidate);
 
-    m_distance = distance[query.char_length()][bounded_candidate.char_length()].distance
+    m_distance = distance[query_length(query)][bounded_candidate.char_length()].distance
                + (int)distance.max_index * max_index_weight;
 }
 
 RankedMatch::RankedMatch(StringView candidate, UsedLetters candidate_letters,
-                         StringView query, UsedLetters query_letters)
+                         const RankedMatchQuery& query)
     : RankedMatch{candidate, query, [&] {
-        return matches(to_lower(query_letters), to_lower(candidate_letters)) and
-               matches(query_letters & upper_mask, candidate_letters & upper_mask);
+        return matches(to_lower(query.used_letters), to_lower(candidate_letters)) and
+               matches(query.used_letters & upper_mask, candidate_letters & upper_mask);
     }} {}
 
 
-RankedMatch::RankedMatch(StringView candidate, StringView query)
+RankedMatch::RankedMatch(StringView candidate, const RankedMatchQuery& query)
     : RankedMatch{candidate, query, [] { return true; }}
 {
 }
@@ -313,14 +330,13 @@ static_assert(log2(4) == 2);
 // returns a string representation of the distance matrix, for debugging only
 [[maybe_unused]] static String to_string(const SubsequenceDistance& distance)
 {
-    StringView query = distance.query;
+    const RankedMatchQuery& query = distance.query;
     StringView candidate = distance.candidate;
 
-    auto query_length = query.char_length();
     auto candidate_length = candidate.char_length();
 
     int distance_amplitude = 1;
-    for (auto query_i = 0; query_i <= query_length; query_i++)
+    for (auto query_i = 0; query_i <= query_length(query); query_i++)
         for (auto candidate_i = 1; candidate_i <= candidate_length; candidate_i++)
             if (distance[query_i][candidate_i].distance != infinity)
                 distance_amplitude = std::max(distance_amplitude, std::abs(distance[query_i][candidate_i].distance));
@@ -329,11 +345,11 @@ static_assert(log2(4) == 2);
                            + 2; // separator between the numbers, plus one space
 
     String s = "\n";
-    auto query_it = query.begin();
+    auto query_it = query.input.begin();
     s += String{' ', cell_width};
-    for (auto query_i = 0; query_i <= query_length; query_i++)
+    for (auto query_i = 0; query_i <= query_length(query); query_i++)
     {
-        Codepoint query_c = query_i == 0 ? ' ' : utf8::read_codepoint(query_it, query.end());
+        Codepoint query_c = query_i == 0 ? ' ' : utf8::read_codepoint(query_it, query.input.end());
         s += left_pad(to_string(query_c), cell_width);
     }
     s += "\n";
@@ -343,7 +359,7 @@ static_assert(log2(4) == 2);
     {
         Codepoint candidate_c = candidate_i == 0 ? ' ' : utf8::read_codepoint(candidate_it, candidate.end());
         s += left_pad(to_string(candidate_c), cell_width);
-        for (CharCount query_i = 0; query_i <= query_length; query_i++)
+        for (CharCount query_i = 0; query_i <= query_length(query); query_i++)
         {
             auto distance_to_string = [](int d) -> String {
                 return d == infinity ? String{"∞"} : to_string(d);
@@ -361,13 +377,15 @@ static_assert(log2(4) == 2);
 
 UnitTest test_ranked_match{[] {
     // Convenience variables, for debugging only.
+    Optional<RankedMatchQuery> q;
     Optional<SubsequenceDistance> distance_better;
     Optional<SubsequenceDistance> distance_worse;
 
     auto preferred = [&](StringView query, StringView better, StringView worse) -> bool {
-        distance_better = subsequence_distance(query, better);
-        distance_worse = subsequence_distance(query, worse);
-        return RankedMatch{better, query} < RankedMatch{worse, query};
+        q = RankedMatchQuery{query};
+        distance_better = subsequence_distance(*q, better);
+        distance_worse = subsequence_distance(*q, worse);
+        return RankedMatch{better, *q} < RankedMatch{worse, *q};
     };
 
     kak_assert(preferred("so", "source", "source_data"));

--- a/src/ranked_match.hh
+++ b/src/ranked_match.hh
@@ -3,6 +3,7 @@
 
 #include "string.hh"
 #include "meta.hh"
+#include "vector.hh"
 
 #include <cstdint>
 
@@ -19,11 +20,25 @@ inline UsedLetters to_lower(UsedLetters letters)
     return ((letters & upper_mask) >> 26) | (letters & (~upper_mask));
 }
 
+struct RankedMatchQuery
+{
+    const StringView input;
+    const UsedLetters used_letters;
+    // For each lowercase character in the input, this holds the corresponding
+    // uppercase character.
+    const Vector<Optional<Codepoint>> smartcase_alternative_match;
+
+    explicit RankedMatchQuery(StringView query);
+    explicit RankedMatchQuery(StringView query, UsedLetters used_letters);
+};
+
+using Priority = size_t;
+
 struct RankedMatch
 {
-    RankedMatch(StringView candidate, StringView query);
+    RankedMatch(StringView candidate, const RankedMatchQuery& query);
     RankedMatch(StringView candidate, UsedLetters candidate_letters,
-                StringView query, UsedLetters query_letters);
+                const RankedMatchQuery& query);
 
     const StringView& candidate() const { return m_candidate; }
     bool operator<(const RankedMatch& other) const;
@@ -33,7 +48,7 @@ struct RankedMatch
 
 private:
     template<typename TestFunc>
-    RankedMatch(StringView candidate, StringView query, TestFunc test);
+    RankedMatch(StringView candidate, const RankedMatchQuery& query, TestFunc test);
 
     StringView m_candidate{};
     bool m_matches = false;

--- a/src/ranked_match.hh
+++ b/src/ranked_match.hh
@@ -35,25 +35,9 @@ private:
     template<typename TestFunc>
     RankedMatch(StringView candidate, StringView query, TestFunc test);
 
-    enum class Flags : int
-    {
-        None = 0,
-        // Order is important, the highest bit has precedence for comparison
-        FirstCharMatch   = 1 << 0,
-        SingleWord       = 1 << 1,
-        Contiguous       = 1 << 2,
-        OnlyWordBoundary = 1 << 3,
-        Prefix           = 1 << 4,
-        SmartFullMatch   = 1 << 5,
-        FullMatch        = 1 << 6,
-    };
-    friend constexpr bool with_bit_ops(Meta::Type<Flags>) { return true; }
-
     StringView m_candidate{};
     bool m_matches = false;
-    Flags m_flags = Flags::None;
-    int m_word_boundary_match_count = 0;
-    int m_max_index = 0;
+    int m_distance = 0;
 };
 
 }

--- a/src/word_db.cc
+++ b/src/word_db.cc
@@ -193,14 +193,13 @@ int WordDB::get_word_occurences(StringView word) const
     return 0;
 }
 
-RankedMatchList WordDB::find_matching(StringView query)
+RankedMatchList WordDB::find_matching(const RankedMatchQuery& query)
 {
     update_db();
-    const UsedLetters letters = used_letters(query);
     RankedMatchList res;
     for (auto&& word : m_words)
     {
-        if (RankedMatch match{word.key, word.value.letters, query, letters})
+        if (RankedMatch match{word.key, word.value.letters, query})
             res.push_back(match);
     }
 
@@ -227,17 +226,18 @@ UnitTest test_word_db{[]()
     Buffer buffer("test", Buffer::Flags::None,
                   make_lines("tchou mutch\n", "tchou kanaky tchou\n", "\n", "tchaa tchaa\n", "allo\n"));
     WordDB word_db(buffer);
-    auto res = word_db.find_matching("");
+    RankedMatchQuery query{""};
+    auto res = word_db.find_matching(query);
     std::sort(res.begin(), res.end(), cmp_words);
     kak_assert(eq(res, WordList{ "allo", "kanaky", "mutch", "tchaa", "tchou" }));
     kak_assert(word_db.get_word_occurences("tchou") == 3);
     kak_assert(word_db.get_word_occurences("allo") == 1);
     buffer.erase({1, 6}, {4, 0});
-    res = word_db.find_matching("");
+    res = word_db.find_matching(query);
     std::sort(res.begin(), res.end(), cmp_words);
     kak_assert(eq(res, WordList{ "allo", "mutch", "tchou" }));
     buffer.insert({1, 0}, "re");
-    res = word_db.find_matching("");
+    res = word_db.find_matching(query);
     std::sort(res.begin(), res.end(), cmp_words);
     kak_assert(eq(res, WordList{ "allo", "mutch", "retchou", "tchou" }));
 }};

--- a/src/word_db.hh
+++ b/src/word_db.hh
@@ -25,7 +25,7 @@ public:
     WordDB(const WordDB&) = delete;
     WordDB(WordDB&&) noexcept;
 
-    RankedMatchList find_matching(StringView str);
+    RankedMatchList find_matching(const RankedMatchQuery& query);
 
     int get_word_occurences(StringView word) const;
 private:


### PR DESCRIPTION
When using fuzzy completion with candidates from "git ls-files" in
a project with many files I often get unexpected ordering even when
one candidate is clearly the best.
This usually happens if both candidates are the same kind of match
(typically only a subsequence match), which means that the leftmost
match wins (via max_index), which is often wrong.
Also there are some other matching heuristics like FirstCharMatch
that can lead to unexpected ordering by dominating everything else
(for example with query "remcc" we rank "README.asciidoc" over
"src/remote.cc").

Fix these two issues by
1. switching to a restricted variant[*] of the Needleman-Wunsch
algorithm to find an optimal match instead of the leftmost one.
2. Dropping some of the old heuristics in favor of ones based on the
   optimal match.

Optimality is defined by a new matching heuristic which favors longer
subsequences by adding a penalty to each new gap.
On top of this, when comparing two matches, we first compare by the
number of gaps. This makes sure that short queries can prefer long
candidates over short (but worse) candidates. Alternatively, we could
just increase the penalty. I didn't do that yet because I didn't
encounter a real-world use case where the proposed heuristic fails.

Some heuristics are kept because they enable some test cases;
for example "higher number of matched word boundaries is better".
Since we now compute this heuristic based on an optimal match rather
than a greedy match, this metric should be more accurate too -
though we could probably achieve even better matches by including
word boundaries in the optimal-matching heuristic. Again I didn't
do this because I don't have a concrete example to improve.

The algorithm needs quadratic time/space. I believe this should be
mostly okay because we expect small inputs.
Insert completion candidates are usually below max_word_len=50.
The exception is line completion, (which is off in the default
completers).  With lines that are abnormally large, this can cause lag.
For example, if I have a 2 line with 2 million characters and a query
with 5, then `<c-x>l` takes like half a second. No harm I think since
other things are also slow given that line length.

Of course, there's plenty of room to optimize, for example we can
skip matching prefixes.

Every successful match adds a temporary heap allocation.  This feels
bad but it's still much lower than the number of string allocations,
so I didn't optimize that yet.

Closes #3806

[*]: Since we require a (smartcase) subsequence match, we need no
deletions or mismatches, which reduces the search space.

Alternative solution: another fuzzy-matching algorithm
with public domain implementations is described in
https://github.com/tajmone/fuzzy-search/tree/8a0e231f756cccd20f7c57e9593df08fd2bb79ef
but I didn't really look into it.
