### PR TITLE
rc toml: fix wrong highlighting of triple quoted strings that have quotes at the end

### DIFF
--- a/rc/filetype/toml.kak
+++ b/rc/filetype/toml.kak
@@ -35,10 +35,10 @@ provide-module toml %{
 add-highlighter shared/toml regions
 add-highlighter shared/toml/code default-region group
 add-highlighter shared/toml/comment region '#'   $           fill comment
-add-highlighter shared/toml/string1 region  '"""' (?<!\\)(\\\\)*""" fill string
-add-highlighter shared/toml/string2 region  "'''" "'''"             fill string
-add-highlighter shared/toml/string3 region  '"'   (?<!\\)(\\\\)*"   fill string
-add-highlighter shared/toml/string4 region  "'"   "'"               fill string
+add-highlighter shared/toml/string1 region  '"""' (?<!\\)(\\\\)*"""(?!") fill string
+add-highlighter shared/toml/string2 region  "'''" "'''(?!')"             fill string
+add-highlighter shared/toml/string3 region  '"'   (?<!\\)(\\\\)*"        fill string
+add-highlighter shared/toml/string4 region  "'"   "'"                    fill string
 
 add-highlighter shared/toml/code/ regex \
     "^\h*\[\[?([A-Za-z0-9._-]*)\]\]?" 1:title


### PR DESCRIPTION
In TOML's triple-quoted strings, it's allowed to place quotes just
next to the triple quotes.

	foo = '''bar''''
		    ^    part of the string contents
		     ^^^ closing sequence

We greedily interpret the first three single quotes as closing
sequence. As a result the remaining single quote wrongly opens a new
string. Fix this by only treating triple quotes as closing if they
are not followed by another quote.
I don't think there is another possible interpretation of quadruple
quotes in TOML, so this should not affect other valid inputs.

Fixes #4143
