### PR TITLE
Fix sentence that was cut short in keys.asciidoc. 

### DIFF
--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -726,7 +726,7 @@ The following keys are recognized by this mode to help with editing
     validate prompt
 
 *<esc>*::
-    abandon without
+    abandon without validating prompt
 
 *<left>*, *<c-b>*::
     move cursor to previous character


### PR DESCRIPTION
Although "abandon without" sounds funny, its not proper English. 