### PR TITLE
rc comment: fix comment-block regression from "Select pasted text on paste"

### DIFF
--- a/rc/tools/comment.kak
+++ b/rc/tools/comment.kak
@@ -162,7 +162,7 @@ define-command comment-block -docstring '(un)comment selections using block comm
         } catch %{
             # Comment the selection
             set-register '"' "%opt{comment_block_begin}"
-            execute-keys P
+            execute-keys -draft P
             set-register '"' "%opt{comment_block_end}"
             execute-keys p
         }


### PR DESCRIPTION
Fixes #4665
