### PR TITLE
Assign janet group to janet.kak global hooks

### DIFF
--- a/rc/filetype/janet.kak
+++ b/rc/filetype/janet.kak
@@ -4,12 +4,11 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*[.](janet|jdn) %{
+hook -group janet global BufCreate .*[.](janet|jdn) %{
     set-option buffer filetype janet
 }
 
-
-hook global WinSetOption filetype=janet %{
+hook -group janet global WinSetOption filetype=janet %{
     require-module janet
 
     hook window ModeChange pop:insert:.* -group janet-trim-indent janet-trim-indent


### PR DESCRIPTION
If groups are assigned to janet.kak global hooks, the hooks can be overridden by third party janet modules.