### PR TITLE
iterm.kak: fix for spaces in path

### DIFF
--- a/rc/windowing/iterm.kak
+++ b/rc/windowing/iterm.kak
@@ -22,11 +22,18 @@ define-command -hidden -params 2.. iterm-terminal-split-impl %{
                 fi
             done
         )
+
         # go through another round of escaping for osascript
         # \ -> \\
         # " -> \"
-        escaped=$(printf %s "$args" | sed -e 's|\\|\\\\|g; s|"|\\"|g')
-        cmd="env PATH='${PATH}' TMPDIR='${TMPDIR}' $escaped"
+        do_esc() {
+            printf %s "$*" | sed -e 's|\\|\\\\|g; s|"|\\"|g'
+        }
+
+        escaped=$(do_esc "$args")
+        esc_path=$(do_esc "$PATH")
+        esc_tmp=$(do_esc "$TMPDIR")
+        cmd="env PATH='${esc_path}' TMPDIR='${esc_tmp}' $escaped"
         osascript                                                                             \
         -e "tell application \"iTerm\""                                                       \
         -e "    tell current session of current window"                                       \


### PR DESCRIPTION
Before this commit, if a directory in $PATH contained a space, osascript would complain:

```
shell stderr: <<<
261:262: syntax error: Expected “"” but found unknown token. (-2741)
>>>
```

This commit addresses this by escaping both TMPDIR and PATH before using them in AppleScript