### PR TITLE
Do not record prompt history when executing user mode mappings

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -18,6 +18,8 @@ released versions.
 * History registers `%reg{colon}`, `%reg{slash}` and `%reg{pipe}` now
   have reverse chronological order
 
+* Executing user mode mappings no longer adds to prompt history registers by default.
+
 == Kakoune 2021.11.07
 
 * Support for curly and separately colored underlines (undocumented in 2021.10.28)

--- a/doc/pages/mapping.asciidoc
+++ b/doc/pages/mapping.asciidoc
@@ -59,12 +59,8 @@ It's common to use a normal-mode or user-mode mapping to trigger a command,
 like this:
 
 ----
-map global user n ': make-next-error<ret>'
+map global user n :make-next-error<ret>
 ----
-
-Note the space between the `:` and the command. This prevents Kakoune from
-adding this command to the prompt history, so the user won't have to scroll
-past it to review commands they actually typed.
 
 If you make a normal-mode mapping, you can prefix it with a count or a register
 name like any other normal-mode key. You can forward this information to the

--- a/doc/pages/mapping.asciidoc
+++ b/doc/pages/mapping.asciidoc
@@ -68,7 +68,7 @@ command you invoke with the `%val{count}` and `%val{register}` expansions
 (See <<expansions#`:doc expansions`>>). For example:
 
 ----
-map global normal = ': echo Got count %val{count} and reg %val{register}<ret>'
+map global normal = ':echo Got count %val{count} and reg %val{register}<ret>'
 ----
 
 == Mappable keys

--- a/rc/filetype/diff.kak
+++ b/rc/filetype/diff.kak
@@ -4,7 +4,7 @@ hook global BufCreate .*\.(diff|patch) %{
 
 hook global WinSetOption filetype=diff %{
     require-module diff
-    map buffer normal <ret> %{: diff-jump<ret>}
+    map buffer normal <ret> :diff-jump<ret>
 }
 
 hook -group diff-highlight global WinSetOption filetype=diff %{

--- a/rc/filetype/mail.kak
+++ b/rc/filetype/mail.kak
@@ -4,9 +4,9 @@ hook global BufCreate .+\.eml %{
 
 hook global WinSetOption filetype=mail %{
     require-module mail
-    map buffer normal <ret> %{: diff-jump<ret>}
+    map buffer normal <ret> :diff-jump<ret>
     hook -once -always window WinSetOption filetype=.* %{
-        unmap buffer normal <ret> %{: diff-jump<ret>}
+        unmap buffer normal <ret> :diff-jump<ret>
     }
 }
 

--- a/rc/tools/doc.kak
+++ b/rc/tools/doc.kak
@@ -131,7 +131,7 @@ define-command -params 1 -hidden doc-render %{
     set-option buffer readonly true
     add-highlighter buffer/ ranges doc_render_ranges
     add-highlighter buffer/ wrap -word -indent
-    map buffer normal <ret> ': doc-follow-link<ret>'
+    map buffer normal <ret> :doc-follow-link<ret>
 }
 
 define-command -params 0..2 \

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -104,8 +104,8 @@ define-command -params 1.. \
         # We need to unmap in case an existing buffer changes type,
         # for example if the user runs "git show" and "git status".
         map_diff_goto_source=$([ -n "${map_diff_goto_source}" ] \
-          && printf %s "map buffer normal <ret> %[: git-diff-goto-source<ret>] -docstring 'Jump to source from git diff'" \
-          || printf %s "unmap buffer normal <ret> %[: git-diff-goto-source<ret>]")
+          && printf %s "map buffer normal <ret> :git-diff-goto-source<ret> -docstring 'Jump to source from git diff'" \
+          || printf %s "unmap buffer normal <ret> :git-diff-goto-source<ret>")
 
         printf %s "evaluate-commands -try-client '$kak_opt_docsclient' %{
                   edit! -fifo ${output} *git*

--- a/rc/tools/man.kak
+++ b/rc/tools/man.kak
@@ -14,7 +14,7 @@ hook -group man-highlight global WinSetOption filetype=man %{
     # References to other manpages
     add-highlighter window/man-highlight/ regex [-a-zA-Z0-9_.]+\([a-z0-9]+\) 0:header
 
-    map window normal <ret> ': man-jump<ret>'
+    map window normal <ret> :man-jump<ret>
 
     hook -once -always window WinSetOption filetype=.* %{
       remove-highlighter window/man-highlight
@@ -141,7 +141,7 @@ man-jump %{
 # Suggested keymaps for a user mode
 declare-user-mode man
 
-map global man 'g' -docstring 'Jump to a man page using selected man page link' ': man-jump<ret>'
-map global man 'j' -docstring 'Go to next man page link'                        ': man-link-next<ret>'
-map global man 'k' -docstring 'Go to previous man page link'                    ': man-link-prev<ret>'
-map global man 'm' -docstring 'Look up a man page'                              ':man<space>'
+map global man 'g' -docstring 'Jump to a man page using selected man page link' :man-jump<ret>
+map global man 'j' -docstring 'Go to next man page link'                        :man-link-next<ret>
+map global man 'k' -docstring 'Go to previous man page link'                    :man-link-prev<ret>
+map global man 'm' -docstring 'Look up a man page'                              :man<space>

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -2620,6 +2620,7 @@ void enter_user_mode(Context& context, String mode_name, KeymapMode mode, bool l
 
         auto& mapping = context.keymaps().get_mapping(key, mode);
         ScopedSetBool disable_keymaps(context.keymaps_disabled());
+        ScopedSetBool disable_history(context.history_disabled());
 
         InputHandler::ScopedForceNormal force_normal{context.input_handler(), {}};
 

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -2014,6 +2014,7 @@ void exec_user_mappings(Context& context, NormalParams params)
 
         auto& mapping = context.keymaps().get_mapping(key, KeymapMode::User);
         ScopedSetBool disable_keymaps(context.keymaps_disabled());
+        ScopedSetBool disable_history(context.history_disabled());
 
         InputHandler::ScopedForceNormal force_normal{context.input_handler(), params};
 


### PR DESCRIPTION
<details>

Commit 217dd6a1d (Disable history when executing maps, 2015-11-10)
made it so with

	map global normal X %{:echo 123<ret>}

X does not add to prompt history (%reg{:}).

Unfortunately this behavior was not extended to mappings in the "user"
keymap, nor to mappings in custom user modes.
In my experience, not adding to history is almost always the expected
behavior for mappings. Most users achieve this by adding a leading space:

	map global user X %{: echo 123<ret>}

but that's awkward. We should have good defaults (no nnoremap)
and map should work the same way across all modes.

Fix this by also disabling history when executing user mappings. This
is a breaking change but I think it only breaks exotic use cases.

I found some uses where user mappings add to history but none of them
looks intentional.

## Introduce "map -with-history" to record prompt history

My terminal allows to map `<c-[>` and `<esc>` independently.  I like
to use `<c-[>` as escape so I use

	map global insert <c-[> <esc>
	map global prompt <c-[> <esc>

Unfortunately, the prompt mapping is not equivalent to `<esc>`: since
mappings are run with history disabled, `<c-[>` will not add the
unfinished command to the prompt history.

Enable this by adding a -with-history switch.

This is also useful when mapping something to `<ret>`.

</details>
