### PR TITLE
Disable history only for prompts that are never shown in the UI

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1993,7 +1993,7 @@ void context_wrap(const ParametersParser& parser, Context& context, StringView d
                                        Context::Flags::Draft};
             Context& c = input_handler.context();
 
-            ScopedSetBool disable_history(c.history_disabled());
+            ScopedSetBool noninteractive(c.noninteractive());
 
             func(parser, c);
         };
@@ -2044,7 +2044,7 @@ void context_wrap(const ParametersParser& parser, Context& context, StringView d
 
     Context& c = *effective_context;
 
-    ScopedSetBool disable_history(c.history_disabled());
+    ScopedSetBool noninteractive(c.noninteractive());
     ScopedEdition edition{c};
     ScopedSelectionEdition selection_edition{c};
 
@@ -2222,7 +2222,7 @@ const CommandDesc prompt_cmd = {
                     sc.env_vars.erase("text"_sv);
                 });
 
-                ScopedSetBool disable_history{context.history_disabled()};
+                ScopedSetBool noninteractive{context.noninteractive()};
 
                 StringView cmd;
                 switch (event)
@@ -2269,7 +2269,7 @@ const CommandDesc menu_cmd = {
 
         if (count == modulo and parser.get_switch("auto-single"))
         {
-            ScopedSetBool disable_history{context.history_disabled()};
+            ScopedSetBool noninteractive{context.noninteractive()};
 
             CommandManager::instance().execute(parser[1], context);
             return;
@@ -2293,7 +2293,7 @@ const CommandDesc menu_cmd = {
         CapturedShellContext sc{shell_context};
         context.input_handler().menu(std::move(choices),
             [=](int choice, MenuEvent event, Context& context) {
-                ScopedSetBool disable_history{context.history_disabled()};
+                ScopedSetBool noninteractive{context.noninteractive()};
 
                 if (event == MenuEvent::Validate and choice >= 0 and choice < commands.size())
                   CommandManager::instance().execute(commands[choice], context, sc);
@@ -2324,7 +2324,7 @@ const CommandDesc on_key_cmd = {
             parser.get_switch("mode-name").value_or("on-key"),
             KeymapMode::None, [=](Key key, Context& context) mutable {
             sc.env_vars["key"_sv] = to_string(key);
-            ScopedSetBool disable_history{context.history_disabled()};
+            ScopedSetBool noninteractive{context.noninteractive()};
 
             CommandManager::instance().execute(command, context, sc);
         });
@@ -2646,7 +2646,7 @@ void enter_user_mode(Context& context, String mode_name, KeymapMode mode, bool l
             return;
 
         ScopedSetBool disable_keymaps(context.keymaps_disabled());
-        ScopedSetBool disable_history(context.history_disabled());
+        ScopedSetBool noninteractive(context.noninteractive());
 
         InputHandler::ScopedForceNormal force_normal{context.input_handler(), {}};
 

--- a/src/context.hh
+++ b/src/context.hh
@@ -126,8 +126,8 @@ public:
     NestedBool& keymaps_disabled() { return m_keymaps_disabled; }
     const NestedBool& keymaps_disabled() const { return m_keymaps_disabled; }
 
-    NestedBool& history_disabled() { return m_history_disabled; }
-    const NestedBool& history_disabled() const { return m_history_disabled; }
+    NestedBool& noninteractive() { return m_noninteractive; }
+    const NestedBool& noninteractive() const { return m_noninteractive; }
 
     Flags flags() const { return m_flags; }
 
@@ -207,7 +207,7 @@ private:
 
     NestedBool m_hooks_disabled;
     NestedBool m_keymaps_disabled;
-    NestedBool m_history_disabled;
+    NestedBool m_noninteractive;
 };
 
 struct ScopedEdition

--- a/src/hook_manager.cc
+++ b/src/hook_manager.cc
@@ -37,7 +37,7 @@ struct HookManager::HookData
                                   enum_desc(Meta::Type<Hook>{})[to_underlying(hook)].name,
                                   param, group));
 
-        ScopedSetBool disable_history{context.history_disabled()};
+        ScopedSetBool noninteractive{context.noninteractive()};
 
         EnvVarMap env_vars{ {"hook_param", param.str()} };
         for (size_t i = 0; i < captures.size(); ++i)

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1705,7 +1705,7 @@ void InputHandler::prompt(StringView prompt, String initstr, String emptystr,
 
 void InputHandler::set_prompt_face(Face prompt_face)
 {
-    InputModes::Prompt* prompt = dynamic_cast<InputModes::Prompt*>(&current_mode());
+    auto* prompt = dynamic_cast<InputModes::Prompt*>(&current_mode());
     if (prompt)
         prompt->set_prompt_face(prompt_face);
 }

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1197,7 +1197,7 @@ private:
 
     void history_push(StringView entry)
     {
-        if (entry.empty() or context().history_disabled() or
+        if (entry.empty() or context().noninteractive() or
             (m_flags & PromptFlags::DropHistoryEntriesWithBlankPrefix and
              is_horizontal_blank(entry[0_byte])))
             return;
@@ -1772,7 +1772,7 @@ void InputHandler::handle_key(Key key)
     KeymapManager& keymaps = m_context.keymaps();
     if (keymaps.is_mapped(key, keymap_mode) and not m_context.keymaps_disabled())
     {
-        ScopedSetBool disable_history{context().history_disabled()};
+        ScopedSetBool noninteractive{context().noninteractive()};
 
         for (auto& k : keymaps.get_mapping_keys(key, keymap_mode))
             process_key(k);

--- a/src/input_handler.hh
+++ b/src/input_handler.hh
@@ -83,6 +83,7 @@ public:
                 Face prompt_face, PromptFlags flags, char history_register,
                 PromptCompleter completer, PromptCallback callback);
     void set_prompt_face(Face prompt_face);
+    bool history_enabled() const;
 
     // enter menu mode, callback is called on each selection change,
     // abort or validation with corresponding MenuEvent value

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1016,7 +1016,7 @@ void select_regex(Context& context, NormalParams params)
         RegisterManager::instance()[reg].restore(context, saved_reg);
         if (event == PromptEvent::Abort)
             return;
-        if (not context.history_disabled())
+        if (not context.noninteractive())
             RegisterManager::instance()[reg].set(context, ex.str());
 
         auto& selections = context.selections();
@@ -1038,7 +1038,7 @@ void split_regex(Context& context, NormalParams params)
         RegisterManager::instance()[reg].restore(context, saved_reg);
         if (event == PromptEvent::Abort)
             return;
-        if (not context.history_disabled())
+        if (not context.noninteractive())
             RegisterManager::instance()[reg].set(context, ex.str());
 
         auto& selections = context.selections();
@@ -1142,7 +1142,7 @@ void keep(Context& context, NormalParams params)
         RegisterManager::instance()[reg].restore(context, saved_reg);
         if (event == PromptEvent::Abort)
             return;
-        if (not context.history_disabled())
+        if (not context.noninteractive())
             RegisterManager::instance()[reg].set(context, regex.str());
 
         if (regex.empty() or regex.str().empty())
@@ -2049,7 +2049,7 @@ void exec_user_mappings(Context& context, NormalParams params)
             return;
 
         ScopedSetBool disable_keymaps(context.keymaps_disabled());
-        ScopedSetBool disable_history(context.history_disabled());
+        ScopedSetBool noninteractive(context.noninteractive());
 
         InputHandler::ScopedForceNormal force_normal{context.input_handler(), params};
 

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1016,7 +1016,7 @@ void select_regex(Context& context, NormalParams params)
         RegisterManager::instance()[reg].restore(context, saved_reg);
         if (event == PromptEvent::Abort)
             return;
-        if (not context.noninteractive())
+        if (context.input_handler().history_enabled())
             RegisterManager::instance()[reg].set(context, ex.str());
 
         auto& selections = context.selections();
@@ -1038,7 +1038,7 @@ void split_regex(Context& context, NormalParams params)
         RegisterManager::instance()[reg].restore(context, saved_reg);
         if (event == PromptEvent::Abort)
             return;
-        if (not context.noninteractive())
+        if (context.input_handler().history_enabled())
             RegisterManager::instance()[reg].set(context, ex.str());
 
         auto& selections = context.selections();
@@ -1142,7 +1142,7 @@ void keep(Context& context, NormalParams params)
         RegisterManager::instance()[reg].restore(context, saved_reg);
         if (event == PromptEvent::Abort)
             return;
-        if (not context.noninteractive())
+        if (context.input_handler().history_enabled())
             RegisterManager::instance()[reg].set(context, regex.str());
 
         if (regex.empty() or regex.str().empty())


### PR DESCRIPTION
My terminal allows to map `<c-[>` and `<esc>` independently.  I like
to use `<c-[>` as escape key so I have this mapping:

        map global prompt `<c-[>` `<esc>`

Unfortunately, this is not equivalent to `<esc>`.  Since mappings are
run with history disabled, `<c-[>` will not add the command to the
prompt history.

So disabling command history inside mappings is wrong in case the
command prompt was created before mapping execution. The behavior
should be: "a prompt that is both created and closed inside a
noninteractive context does not add to prompt history", where
"noninteractive" means inside a mapping, hook, command, execute-keys
or evaluate-commands.

Implement this behavior, it should better meet user expectations.
Scripts can always use "set-register" to add to history.

Here are my test cases:

1. Basic regression test (needs above mapping):

        :nop should be added to history<c-[>

---

2. Create the prompt in a noninteractive context:

        :exec %{:}

now we're back in the interactive context, so we can type:

        nop should be added to history<ret>

---

3. To check if it works for nested prompts, first set up this mapping.

        map global prompt <c-g> '<a-semicolon>:nop should NOT be added to history<ret>'
        map global prompt <c-h> '<a-semicolon>:nop should be added to history first'

Then type

        :nop should be added to history second<c-g><c-h><ret><ret>

the inner command run by `<c-g>` should not be added to history because
it only existed in a noninteractive context.
