### PR TITLE
Document prompt history registers

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -15,7 +15,7 @@ released versions.
 * User mappings is now bound to `<space>` while keeping/removing main selection
   moved to `,` and `<a-,>`
 
-* History registers `%reg{colon}`, `%reg{slash}` and `%reg{pipe}` now
+* Prompt history registers `%reg{colon}`, `%reg{slash}` and `%reg{pipe}` now
   have reverse chronological order
 
 == Kakoune 2021.11.07

--- a/doc/pages/execeval.asciidoc
+++ b/doc/pages/execeval.asciidoc
@@ -13,7 +13,7 @@ error occurs.
 
 Without the *-save-regs* switch, *execute-keys* saves the following registers, which
 are then restored when the keys have been executed: */*, *"*, *|*, *^*,
-*@*. *evaluate-commands* doesn't save any registers by default.
+*@*, *:*. *evaluate-commands* doesn't save any registers by default.
 (See <<registers#,`:doc registers`>>)
 
 == Switches for both commands

--- a/doc/pages/registers.asciidoc
+++ b/doc/pages/registers.asciidoc
@@ -34,7 +34,9 @@ All normal-mode commands using a register default to a specific one if not speci
     default search / regex register, used by:
     */*, *<a-/>*, *?*, *<a-?>*, *n*, *<a-n>*, *N*, *<a-N>*, ***, *<a-*>*,
     *s*, *S*, *<a-k>* and *<a-K>*
-    (see <<keys#searching, `:doc keys searching`>>)
+    (see <<keys#searching, `:doc keys searching`>>).
+    This is a prompt history register, holding the last 100 commands entered
+    at an interactive regex prompt.
 
 *@* (arobase)::
     default macro register, used by:
@@ -50,7 +52,10 @@ All normal-mode commands using a register default to a specific one if not speci
 *|* (pipe)::
     default shell command register, used by commands that spawn a subshell:
     *|*, *<a-|>*, *!* and *<a-!>*
-    (see <<keys#changes-through-external-programs, `:doc keys changes-through-external-programs`>>)
+    (see <<keys#changes-through-external-programs, `:doc keys changes-through-external-programs`>>).
+    This is a prompt history register, holding the last 100 commands entered
+    at interactive shell command prompts, except for commands starting with
+    a space.
 
 == Special registers
 
@@ -70,7 +75,8 @@ contain some special data
     null register, always empty
 
 *:* (colon)::
-    last entered command
+    prompt history register holding the last 100 commands entered at the
+    interactive prompt, except for commands starting with a space.
 
 == Integer registers
 

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -2100,7 +2100,7 @@ const CommandDesc execute_keys_cmd = {
     {
         context_wrap(parser, context, "/\"|^@:", [](const ParametersParser& parser, Context& context) {
             ScopedSetBool disable_keymaps(context.keymaps_disabled(), not parser.get_switch("with-maps"));
-            ScopedSetBool disable_hoooks(context.hooks_disabled(), not parser.get_switch("with-hooks"));
+            ScopedSetBool disable_hooks(context.hooks_disabled(), not parser.get_switch("with-hooks"));
 
             for (auto& key : parser | transform(parse_keys) | flatten())
                 context.input_handler().handle_key(key);
@@ -2123,7 +2123,7 @@ const CommandDesc evaluate_commands_cmd = {
     {
         context_wrap(parser, context, {}, [&](const ParametersParser& parser, Context& context) {
             const bool no_hooks = context.hooks_disabled() or parser.get_switch("no-hooks");
-            ScopedSetBool disable_hoooks(context.hooks_disabled(), no_hooks);
+            ScopedSetBool disable_hooks(context.hooks_disabled(), no_hooks);
 
             if (parser.get_switch("verbatim"))
                 CommandManager::instance().execute_single_command(parser | gather<Vector>(), context, shell_context);

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1926,7 +1926,6 @@ ParameterDesc make_context_wrap_params_impl(Array<HashItem<String, SwitchDesc>, 
                { "buffer",     { true,  "run in a disposable context for each given buffer in the comma separated list argument" } },
                { "draft",      { false, "run in a disposable context" } },
                { "itersel",    { false, "run once for each selection with that selection as the only one" } },
-               { "save-regs",  { true, "restore all given registers after execution" } },
                std::move(additional_params[P])...},
         ParameterDesc::Flags::SwitchesOnlyAtStart, 1
     };
@@ -2089,7 +2088,8 @@ const CommandDesc execute_keys_cmd = {
     "execute-keys",
     "exec",
     "execute-keys [<switches>] <keys>: execute given keys as if entered by user",
-    make_context_wrap_params<2>({{
+    make_context_wrap_params<3>({{
+        {"save-regs",  {true, "restore all given registers after execution (default: '/\"|^@:')"}},
         {"with-maps",  {false, "use user defined key mapping when executing keys"}},
         {"with-hooks", {false, "trigger hooks while executing keys"}}
     }}),
@@ -2112,7 +2112,8 @@ const CommandDesc evaluate_commands_cmd = {
     "evaluate-commands",
     "eval",
     "evaluate-commands [<switches>] <commands>...: execute commands as if entered by user",
-    make_context_wrap_params<2>({{
+    make_context_wrap_params<3>({{
+        {"save-regs",  {true, "restore all given registers after execution (default: '')"}},
         {"no-hooks", { false, "disable hooks while executing commands" }},
         {"verbatim", { false, "do not reparse argument" }}
     }}),


### PR DESCRIPTION
So far they have only been talked about in source code
(HistoryRegister), not in documentation.

Let's give them an official name so users can find them better;
"prompt history register" seems better than "history register" since
it's easier to grok. OTOH, in future other registers (like @) could
grow into history registers, so I'm not sure.

State that the history registers are only changed by _interactive_
prompts; that's not quite true yet for some edge cases but it will be with
https://github.com/mawww/kakoune/pull/4695
