### PR TITLE
rc/filetype/dockerfile: detect filenames that contain special characters

### DIFF
--- a/rc/filetype/dockerfile.kak
+++ b/rc/filetype/dockerfile.kak
@@ -6,7 +6,7 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*/?Dockerfile(\.\w+)?$ %{
+hook global BufCreate .*/?Dockerfile(\..+)?$ %{
     set-option buffer filetype dockerfile
 }
 


### PR DESCRIPTION
Dockerfiles of the form `Dockerfile.foo-bar` were not detected for syntax
highlighting.

Mainly meaning for this to capture _ and -, but I don't see why we wouldn't
capture any special character.