### PR TITLE
Use make_array to avoid specifying the array size

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1452,7 +1452,7 @@ KeymapMode parse_keymap_mode(StringView str, const KeymapManager::UserModeList& 
     return (KeymapMode)(std::distance(user_modes.begin(), it) + offset);
 }
 
-static constexpr Array<StringView, 8> modes = { "normal", "insert", "menu", "prompt", "goto", "view", "user", "object" };
+static constexpr auto modes = make_array<StringView>({ "normal", "insert", "menu", "prompt", "goto", "view", "user", "object" });
 
 const CommandDesc debug_cmd = {
     "debug",

--- a/src/register_manager.hh
+++ b/src/register_manager.hh
@@ -34,7 +34,6 @@ protected:
 };
 
 // static value register, which can be modified
-// using operator=, so should be user modifiable
 class StaticRegister : public Register
 {
 public:


### PR DESCRIPTION
Plus some other minor cleanup.
