### PR TITLE
Rename key_to_str() and button_to_str() to to_string()

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -92,8 +92,7 @@ bool Client::process_pending_inputs()
         try
         {
             if (debug_keys)
-                write_to_debug_buffer(format("Client '{}' got key '{}'",
-                                             context().name(), key_to_str(key)));
+                write_to_debug_buffer(format("Client '{}' got key '{}'", context().name(), key));
 
             if (key == Key::FocusIn)
                 context().hooks().run_hook(Hook::FocusIn, context().name(), context());
@@ -102,7 +101,7 @@ bool Client::process_pending_inputs()
             else
                 m_input_handler.handle_key(key);
 
-            context().hooks().run_hook(Hook::RawKey, key_to_str(key), context());
+            context().hooks().run_hook(Hook::RawKey, to_string(key), context());
         }
         catch (Kakoune::runtime_error& error)
         {
@@ -327,7 +326,7 @@ void Client::on_buffer_reload_key(Key key)
     }
     else
     {
-        print_status({ format("'{}' is not a valid choice", key_to_str(key)),
+        print_status({ format("'{}' is not a valid choice", key),
                        context().faces()["Error"] });
         m_input_handler.on_next_key("buffer-reload", KeymapMode::None, [this](Key key, Context&){ on_buffer_reload_key(key); });
         return;

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1562,8 +1562,7 @@ const CommandDesc debug_cmd = {
                 KeymapMode m = parse_keymap_mode(mode, user_modes);
                 for (auto& key : keymaps.get_mapped_keys(m))
                     write_to_debug_buffer(format(" * {} {}: {}",
-                                          mode, key_to_str(key),
-                                          keymaps.get_mapping(key, m).docstring));
+                                          mode, key, keymaps.get_mapping(key, m).docstring));
             }
         }
         else if (parser[0] == "regex")
@@ -1847,7 +1846,7 @@ static Completions map_key_completer(const Context& context, CompletionFlags fla
 
         return { 0_byte, params[2].length(),
                  complete(params[2], pos_in_token,
-                          keys | transform([](Key k) { return key_to_str(k); })
+                          keys | transform([](Key k) { return to_string(k); })
                                | gather<Vector<String>>()) };
     }
     return {};
@@ -2299,7 +2298,7 @@ const CommandDesc on_key_cmd = {
         context.input_handler().on_next_key(
             parser.get_switch("mode-name").value_or("on-key"),
             KeymapMode::None, [=](Key key, Context& context) mutable {
-            sc.env_vars["key"_sv] = key_to_str(key);
+            sc.env_vars["key"_sv] = to_string(key);
             ScopedSetBool disable_history{context.history_disabled()};
 
             CommandManager::instance().execute(command, context, sc);

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -310,7 +310,7 @@ public:
             {
                 auto autoinfo = context().options()["autoinfo"].get<AutoInfo>();
                 if (autoinfo & AutoInfo::Normal and context().has_client())
-                    context().client().info_show(key_to_str(key), command->docstring.str(),
+                    context().client().info_show(to_string(key), command->docstring.str(),
                                                  {}, InfoStyle::Prompt);
 
                 // reset m_params now to be reentrant
@@ -323,7 +323,7 @@ public:
                 m_params = { 0, 0 };
         }
 
-        context().hooks().run_hook(Hook::NormalKey, key_to_str(key), context());
+        context().hooks().run_hook(Hook::NormalKey, to_string(key), context());
         if (enabled() and not transient) // The hook might have changed mode
             m_idle_timer.set_next_date(Clock::now() + get_idle_timeout(context()));
     }
@@ -1403,7 +1403,7 @@ public:
                     if (auto cp = get_raw_codepoint(key))
                     {
                         insert(*cp);
-                        context().hooks().run_hook(Hook::InsertKey, key_to_str(key), context());
+                        context().hooks().run_hook(Hook::InsertKey, to_string(key), context());
                         if (enabled() and not transient)
                             m_idle_timer.set_next_date(Clock::now() + get_idle_timeout(context()));
                     }
@@ -1416,9 +1416,9 @@ public:
             return;
         }
 
-        context().hooks().run_hook(Hook::InsertKey, key_to_str(key), context());
+        context().hooks().run_hook(Hook::InsertKey, to_string(key), context());
         if (moved)
-            context().hooks().run_hook(Hook::InsertMove, key_to_str(key), context());
+            context().hooks().run_hook(Hook::InsertMove, to_string(key), context());
 
         if (update_completions and enabled() and not transient) // Hooks might have disabled us
             m_idle_timer.set_next_date(Clock::now() + get_idle_timeout(context()));
@@ -1723,7 +1723,7 @@ void InputHandler::handle_key(Key key)
     // do not record the key that made us enter or leave recording mode,
     // and the ones that are triggered recursively by previous keys.
     if (was_recording and is_recording() and m_handle_key_level == m_recording_level)
-        m_recorded_keys += key_to_str(key);
+        m_recorded_keys += to_string(key);
 
     if (m_handle_key_level < m_recording_level)
     {

--- a/src/keys.cc
+++ b/src/keys.cc
@@ -181,7 +181,7 @@ Key::MouseButton str_to_button(StringView str)
     throw runtime_error(format("invalid mouse button name {}", str));
 }
 
-String key_to_str(Key key)
+String to_string(Key key)
 {
     const auto coord = key.coord() + DisplayCoord{1,1};
     switch (Key::Modifiers(key.modifiers & ~Key::Modifiers::MouseButtonMask))
@@ -241,7 +241,7 @@ UnitTest test_keys{[]()
     };
     String keys_as_str;
     for (auto& key : keys)
-        keys_as_str += key_to_str(key);
+        keys_as_str += to_string(key);
     auto parsed_keys = parse_keys(keys_as_str);
     kak_assert(keys == parsed_keys);
     kak_assert(ConstArrayView<Key>{parse_keys("a<c-a-b>c")} ==
@@ -257,7 +257,7 @@ UnitTest test_keys{[]()
     kak_assert(parse_keys("<s-tab>") == KeyList{ shift({Key::Tab}) });
     kak_assert(parse_keys("\n") == KeyList{ Key::Return });
 
-    kak_assert(key_to_str(shift({Key::Tab})) == "<s-tab>");
+    kak_assert(to_string(shift({Key::Tab})) == "<s-tab>");
 
     kak_expect_throw(key_parse_error, parse_keys("<-x>"));
     kak_expect_throw(key_parse_error, parse_keys("<xy-z>"));

--- a/src/keys.cc
+++ b/src/keys.cc
@@ -162,7 +162,7 @@ KeyList parse_keys(StringView str)
     return result;
 }
 
-StringView button_to_str(Key::MouseButton button)
+StringView to_string(Key::MouseButton button)
 {
     switch (button)
     {
@@ -189,9 +189,9 @@ String to_string(Key key)
         case Key::Modifiers::MousePos:
             return format("<mouse:move:{}.{}>", coord.line, coord.column);
         case Key::Modifiers::MousePress:
-            return format("<mouse:press:{}:{}.{}>", button_to_str(key.mouse_button()), coord.line, coord.column);
+            return format("<mouse:press:{}:{}.{}>", key.mouse_button(), coord.line, coord.column);
         case Key::Modifiers::MouseRelease:
-            return format("<mouse:release:{}:{}.{}>", button_to_str(key.mouse_button()), coord.line, coord.column);
+            return format("<mouse:release:{}:{}.{}>", key.mouse_button(), coord.line, coord.column);
         case Key::Modifiers::Scroll:
             return format("<scroll:{}>", static_cast<int>(key.key));
         case Key::Modifiers::Resize:

--- a/src/keys.hh
+++ b/src/keys.hh
@@ -102,7 +102,7 @@ class String;
 class StringView;
 
 KeyList parse_keys(StringView str);
-String  key_to_str(Key key);
+String  to_string(Key key);
 StringView button_to_str(Key::MouseButton button);
 Key::MouseButton str_to_button(StringView str);
 

--- a/src/keys.hh
+++ b/src/keys.hh
@@ -103,7 +103,7 @@ class StringView;
 
 KeyList parse_keys(StringView str);
 String  to_string(Key key);
-StringView button_to_str(Key::MouseButton button);
+StringView to_string(Key::MouseButton button);
 Key::MouseButton str_to_button(StringView str);
 
 constexpr Key shift(Key key)

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -179,14 +179,14 @@ String build_autoinfo_for_mapping(const Context& context, KeymapMode mode,
     {
         String keys = join(built_in.keys |
                            filter([&](Key k){ return not keymaps.is_mapped(k, mode); }) |
-                           transform(key_to_str),
+                           transform((String(*)(Key))to_string),
                            ',', false);
         if (not keys.empty())
             descs.emplace_back(std::move(keys), built_in.docstring);
     }
 
     for (auto& key : keymaps.get_mapped_keys(mode))
-        descs.emplace_back(key_to_str(key),
+        descs.emplace_back(to_string(key),
                            keymaps.get_mapping(key, mode).docstring);
 
     auto max_len = 0_col;


### PR DESCRIPTION
This makes the functions easier to find for newcomers because
to_string() is the obvious name. It enables format() to do the
conversion automatically which seems like good idea (since there is
no other obvious representation).

Of course this change makes it a bit harder to grep but that's not
a problem with clang tooling.

We need to add a cast in one place when calling transform() but that's
acceptable.
