### PR TITLE
rc ledger: don't use region highlighter for simple keywords

### DIFF
--- a/rc/filetype/ledger.kak
+++ b/rc/filetype/ledger.kak
@@ -64,12 +64,14 @@ add-highlighter shared/ledger/other region '^(P|=|~)' '$' fill meta
 # The following highlighters implement
 # https://www.ledger-cli.org/3.0/doc/ledger3.html#Command-Directives
 
+add-highlighter shared/ledger/default default-region group
+
 # Add highlighters for simple one-line command directives
 evaluate-commands %sh{
     # TODO: Is `expr` also a command directive? The documentation confuses me.
     for cmd in 'apply account' 'apply fixed' 'assert' 'bucket' 'check' 'end' \
                'include' 'apply tag' 'test' 'year'; do
-        echo "add-highlighter shared/ledger/ region '^${cmd}' '.' fill function"
+        echo "add-highlighter shared/ledger/default/ regex '^${cmd}\b' 0:function"
     done
 }
 


### PR DESCRIPTION
As reported in
https://github.com/mawww/kakoune/issues/4685#issuecomment-1200530001
ledger.kak defines a region end that matches every character of
the buffer. This causes performance issues for large buffers.
Since the affected regions are only ever filled with a single color,
just use a regex highlighter instead of a region highlighter.
This fixes the most serious performance issues when loading
the file for the first time (slow updating of many selections will
be fixed by a different change).

In general, ledger.kak could use some improvements to use more
idiomatic highlighters.

Speedup on [example.journal.txt](https://github.com/mawww/kakoune/issues/4685#issuecomment-1193243588)

	$ HOME=$PWD hyperfine -w 1 'git checkout HEAD'{~,}' -- :/rc/filetype/ledger.kak && ./kak.opt example.journal.txt -e "modeline-
	parse; hook global NormalIdle .* quit" -ui dummy'
	Benchmark 1: git checkout HEAD~ -- :/rc/filetype/ledger.kak && ./kak.opt example.journal.txt -e "modeline-parse; hook global NormalIdle .* quit" -ui dummy
	  Time (mean ± σ):     947.8 ms ±  35.1 ms    [User: 880.0 ms, System: 72.4 ms]
	  Range (min … max):   895.2 ms … 994.3 ms    10 runs
	 
	Benchmark 2: git checkout HEAD -- :/rc/filetype/ledger.kak && ./kak.opt example.journal.txt -e "modeline-parse; hook global NormalIdle .* quit" -ui dummy
	  Time (mean ± σ):     364.7 ms ±  13.7 ms    [User: 349.0 ms, System: 21.7 ms]
	  Range (min … max):   344.6 ms … 391.9 ms    10 runs
	 
	Summary
	  'git checkout HEAD -- :/rc/filetype/ledger.kak && ./kak.opt example.journal.txt -e "modeline-parse; hook global NormalIdle .* quit" -ui dummy' ran
	    2.60 ± 0.14 times faster than 'git checkout HEAD~ -- :/rc/filetype/ledger.kak && ./kak.opt example.journal.txt -e "modeline-parse; hook global NormalIdle .* quit" -ui dummy'

(The exact numbers depend on other optimizations I'm using.)
