### PR TITLE
rc markdown restructuredtext: only add language highlighters for actual code blocks in buffer

### DIFF
--- a/rc/filetype/kakrc.kak
+++ b/rc/filetype/kakrc.kak
@@ -90,6 +90,8 @@ add-highlighter shared/kakrc/double_string/escape regex '""' 0:default+b
 add-highlighter shared/kakrc/single_string/fill fill string
 add-highlighter shared/kakrc/single_string/escape regex "''" 0:default+b
 
+add-highlighter shared/kak ref kakrc
+
 # Commands
 # ‾‾‾‾‾‾‾‾
 

--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -54,13 +54,12 @@ evaluate-commands %sh{
     ruby rust sass scala scss sh swift toml tupfile typescript yaml sql
   "
   for lang in ${languages}; do
-    [ "${lang}" = kak ] && ref=kakrc || ref="${lang}"
     printf 'add-highlighter shared/markdown/%s region -match-capture ^(\h*)```\h*(%s\\b|\\{[.=]?%s\\})   ^(\h*)``` regions\n' "${lang}" "${lang}" "${lang}"
     printf 'add-highlighter shared/markdown/%s/ default-region fill meta\n' "${lang}"
-    printf 'add-highlighter shared/markdown/%s/inner region \A\h*```[^\\n]*\K (?=```) ref %s\n' "${lang}" "${ref}"
+    printf 'add-highlighter shared/markdown/%s/inner region \A\h*```[^\\n]*\K (?=```) ref %s\n' "${lang}" "${lang}"
     printf 'add-highlighter shared/markdown/listblock/%s region -match-capture ^(\h*)```\h*(%s\\b|\\{[.=]?%s\\})   ^(\h*)``` regions\n' "${lang}" "${lang}" "${lang}"
     printf 'add-highlighter shared/markdown/listblock/%s/ default-region fill meta\n' "${lang}"
-    printf 'add-highlighter shared/markdown/listblock/%s/inner region \A\h*```[^\\n]*\K (?=```) ref %s\n' "${lang}" "${ref}"
+    printf 'add-highlighter shared/markdown/listblock/%s/inner region \A\h*```[^\\n]*\K (?=```) ref %s\n' "${lang}" "${lang}"
   done
 }
 

--- a/rc/filetype/restructuredtext.kak
+++ b/rc/filetype/restructuredtext.kak
@@ -32,8 +32,7 @@ evaluate-commands %sh{
               julia kak kickstart latex lisp lua makefile moon objc \
               perl pug python ragel ruby rust sass scala scss sh swift \
               tupfile yaml; do
-        if [ "$ft" = kak ]; then ref="kakrc"; else ref="$ft"; fi
-        printf 'add-highlighter shared/restructuredtext/%s region %s %s ref %s\n' "$ft" "\.\.\h*code-block::\h*$ft\h*\n" '^(?=\S)' "$ref"
+        printf 'add-highlighter shared/restructuredtext/%s region %s %s ref %s\n' "$ft" "\.\.\h*code-block::\h*$ft\h*\n" '^(?=\S)' "$ft"
     done
 }
 

--- a/rc/filetype/restructuredtext.kak
+++ b/rc/filetype/restructuredtext.kak
@@ -12,6 +12,15 @@ hook global WinSetOption filetype=restructuredtext %{
     require-module restructuredtext
 }
 
+hook -group restructuredtext-load-languages global WinSetOption filetype=restructuredtext %{
+    restructuredtext-load-languages '%'
+}
+
+hook -group restructuredtext-load-languages global WinSetOption filetype=restructuredtext %{
+    hook -group restructuredtext-load-languages window NormalIdle .* %{restructuredtext-load-languages gtGbGl}
+    hook -group restructuredtext-load-languages window InsertIdle .* %{restructuredtext-load-languages gtGbGl}
+}
+
 hook -group restructuredtext-highlight global WinSetOption filetype=restructuredtext %{
     add-highlighter window/restructuredtext ref restructuredtext
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/restructuredtext }
@@ -25,16 +34,6 @@ provide-module restructuredtext %{
 add-highlighter shared/restructuredtext regions
 add-highlighter shared/restructuredtext/content default-region group
 add-highlighter shared/restructuredtext/code region ::\h*\n ^(?=\S)  fill meta
-
-evaluate-commands %sh{
-    for ft in c cabal clojure coffee cpp css cucumber ddiff dockerfile \
-              fish gas go haml haskell html ini java javascript json \
-              julia kak kickstart latex lisp lua makefile moon objc \
-              perl pug python ragel ruby rust sass scala scss sh swift \
-              tupfile yaml; do
-        printf 'add-highlighter shared/restructuredtext/%s region %s %s ref %s\n' "$ft" "\.\.\h*code-block::\h*$ft\h*\n" '^(?=\S)' "$ft"
-    done
-}
 
 # Setext-style header
 # Valid header characters:
@@ -77,5 +76,17 @@ add-highlighter shared/restructuredtext/content/ regex (\A|\n\n)(~{3,}\n)?[^\n]+
 add-highlighter shared/restructuredtext/content/ regex [^*](\*\*([^\s*]|([^\s*][^*]*[^\s*]))\*\*)[^*] 1:+b
 add-highlighter shared/restructuredtext/content/ regex [^*](\*([^\s*]|([^\s*][^*]*[^\s*]))\*)[^*] 1:+i
 add-highlighter shared/restructuredtext/content/ regex [^`](``([^\s`]|([^\s`][^`]*[^\s`]))``)[^`] 1:mono
+
+define-command restructuredtext-load-languages -params 1 %{
+    evaluate-commands -draft %{ try %{
+        execute-keys "%arg{1}s^\.\.\h*code-block::\h*\K\w+<ret>"
+        evaluate-commands -itersel %{ try %{
+            require-module %val{selection}
+            add-highlighter "shared/restructuredtext/%val{selection}" region "\.\.\h*code-block::\h*%val{selection}\h*\n" '^(?=\S)' regions
+            add-highlighter "shared/restructuredtext/%val{selection}/" default-region fill meta
+            add-highlighter "shared/restructuredtext/%val{selection}/inner" region \A\.\.\h*code-block::[^\n]*\K '^(?=\S)' ref %val{selection}
+        }}
+    }}
+}
 
 }


### PR DESCRIPTION
Depends on https://github.com/mawww/kakoune/pull/4713 (first four commits)