### PR TITLE
Allow empty region end in region highlighter

### DIFF
--- a/doc/pages/highlighters.asciidoc
+++ b/doc/pages/highlighters.asciidoc
@@ -224,6 +224,11 @@ add-highlighter <path>/<name>/<region_name> region \
     A highlighter type, and associated params, as they would be passed
     to `add-highlighter` if they were not applied as a region.
 
+A region spans from the beginning of an *opening* match to the end of the
+next *closing* match that does not overlap with the *opening* match. Hence if
+*closing* is the empty regex, the region will be congruent with the *opening*
+match. If there is no *closing* match the region extends until buffer end.
+
 If the *-match-capture* switch is passed, then region *closing* and *recurse*
 regex matches are considered valid for a given region opening match only if they
 matched the same content for the capture 1 in the *opening* regex.

--- a/rc/filetype/crystal.kak
+++ b/rc/filetype/crystal.kak
@@ -86,7 +86,7 @@ add-highlighter shared/crystal/quoted-symbol region ':"' '(?<!\\)(\\\\)*"' fill 
 # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#modifiers
 add-highlighter shared/crystal/regex region '/' '(?<!\\)(\\\\)*/[imx]*' regions
 # Avoid unterminated regular expression
-add-highlighter shared/crystal/division region ' / ' '.\K' group
+add-highlighter shared/crystal/division region ' / .' '' group
 
 # Percent regex literals
 # https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html#percent-regex-literals

--- a/rc/filetype/erlang.kak
+++ b/rc/filetype/erlang.kak
@@ -33,11 +33,11 @@ add-highlighter shared/erlang/default default-region group
 
 add-highlighter shared/erlang/comment region '(?<!\$)%' '$' fill comment
 add-highlighter shared/erlang/attribute_atom_single_quoted region %{-'} %{(?<!\\)(?:\\\\)*'(?=[\( \.])} fill builtin
-add-highlighter shared/erlang/attribute region '\b-[a-z][\w@]*(?=[\( \.])' '\K' fill builtin
+add-highlighter shared/erlang/attribute region '\b-[a-z][\w@]*(?=[\( \.])' '' fill builtin
 add-highlighter shared/erlang/atom_single_quoted region %{'} %{(?<!\\)(?:\\\\)*'} fill type
 add-highlighter shared/erlang/char_list region %{"} %{(?<!\\)(?:\\\\)*"} fill string
-add-highlighter shared/erlang/dollar_double_quote region %{\$\\?"} '\K' fill value
-add-highlighter shared/erlang/dollar_single_quote region %{\$\\?'} '\K' fill value
+add-highlighter shared/erlang/dollar_double_quote region %{\$\\?"} '' fill value
+add-highlighter shared/erlang/dollar_single_quote region %{\$\\?'} '' fill value
 
 # default-region regex highlighters
 add-highlighter shared/erlang/default/atom regex '\b[a-z][\w@]*\b' 0:type

--- a/rc/filetype/fidl.kak
+++ b/rc/filetype/fidl.kak
@@ -30,7 +30,7 @@ add-highlighter shared/fidl/line_comment region // $ group
 add-highlighter shared/fidl/line_comment/comment fill comment
 add-highlighter shared/fidl/line_comment/todo regex TODO|FIXME: 0:meta
 
-add-highlighter shared/fidl/attributes region @[a-zA-Z] \b fill meta
+add-highlighter shared/fidl/attributes region @[a-zA-Z]\w* '' fill meta
 
 add-highlighter shared/fidl/code/keywords regex \b(as|bits|compose|const|enum|error|flexible|optional|library|protocol|resource|service|strict|struct|table|type|union|using)\b 0:keyword
 add-highlighter shared/fidl/code/types regex \b(array|bool|bytes?|client_end|float(32|64)|server_end|string|u?int(8|16|32|64)|vector)\b 0:type

--- a/rc/filetype/graphql.kak
+++ b/rc/filetype/graphql.kak
@@ -34,13 +34,13 @@ provide-module graphql %§
 
 add-highlighter shared/graphql regions
 add-highlighter shared/graphql/code default-region group
-add-highlighter shared/graphql/line-description region '#' '\n' fill comment
+add-highlighter shared/graphql/line-description region '#' '$' fill comment
 add-highlighter shared/graphql/block-description region '"""' '"""' fill comment
-add-highlighter shared/graphql/description region '"' '"\s*\n' fill comment
+add-highlighter shared/graphql/description region '"' '"\s*$' fill comment
 add-highlighter shared/graphql/object region -recurse \{ [{] [}] regions
 
 # Objects
-add-highlighter shared/graphql/object/line-description region '#' '\n' fill comment
+add-highlighter shared/graphql/object/line-description region '#' '$' fill comment
 add-highlighter shared/graphql/object/block-description region '"""' '"""' fill comment
 add-highlighter shared/graphql/object/field default-region group
 add-highlighter shared/graphql/object/field/ regex ([A-Za-z][A-Za-z0-9_-]*)(?:\([^)]*\))?\h*[:{] 1:attribute

--- a/rc/filetype/latex.kak
+++ b/rc/filetype/latex.kak
@@ -39,7 +39,7 @@ add-highlighter shared/latex/content default-region group
 # - at word boundaries not preceded nor followed by @ : \ { } [ ] *, or
 # - after an unescaped }
 add-highlighter shared/latex/cs region '(?<!\\)(?:\\\\)*\K\\[@\w]' '/\n|(?<![@:\\{}\[\]*])(?![@:\\{}\[\]*])\b|(?<!\\)(?:\\\\)*\K\}\K' group
-add-highlighter shared/latex/comment region '(?<!\\)(?:\\\\)*\K%' '\n' fill comment
+add-highlighter shared/latex/comment region '(?<!\\)(?:\\\\)*\K%' '$' fill comment
 
 # Document and LaTeX2e control sequence
 add-highlighter shared/latex/cs/ regex '(?:\\[a-zA-Z@]+)' 0:keyword

--- a/rc/filetype/markdown.kak
+++ b/rc/filetype/markdown.kak
@@ -63,9 +63,9 @@ add-highlighter shared/markdown/listblock/codeblock/ default-region fill meta
 add-highlighter shared/markdown/codeline region "^( {4}|\t)" "$" fill meta
 
 # https://spec.commonmark.org/0.29/#link-destination
-add-highlighter shared/markdown/angle_bracket_url region (?<=<)([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=>)|\n fill link
-add-highlighter shared/markdown/inline/url region -recurse \( ([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=\))|\s fill link
-add-highlighter shared/markdown/listblock/angle_bracket_url region (?<=<)([a-z]+://|(mailto|magnet|xmpp):) (?!\\).(?=>)|\n fill link
+add-highlighter shared/markdown/angle_bracket_url region (?<=<)([a-z]+://|(mailto|magnet|xmpp):)([^\s()]*(?:\([^\s()]*(?:\([^\s()]*(?:\([^\s()]*\))?\))?\))?)+(?=>) '' fill link
+add-highlighter shared/markdown/inline/url region ([a-z]+://|(mailto|magnet|xmpp):)([^\s()]*(?:\([^\s()]*(?:\([^\s()]*(?:\([^\s()]*\))?\))?\))?)+ '' fill link
+add-highlighter shared/markdown/listblock/angle_bracket_url region (?<=<)([a-z]+://|(mailto|magnet|xmpp):)([^\s()]*(?:\([^\s()]*(?:\([^\s()]*(?:\([^\s()]*\))?\))?\))?)+(?=>) '' fill link
 
 try %{
     require-module html

--- a/rc/filetype/perl.kak
+++ b/rc/filetype/perl.kak
@@ -43,8 +43,8 @@ add-highlighter shared/perl/double_string  region (?<!\$)"          (?<!\\)(\\\\
 add-highlighter shared/perl/single_string  region (?<!\$)(?<!\\\\)' (?<!\\)(\\\\)*' fill string
 add-highlighter shared/perl/comment        region (?<!\$)(?<!\\)#   $               fill comment
 
-add-highlighter shared/perl/regex          region m?(?<!/)(?<!qr)/[^/\n]+(?=/)  /\w*   fill meta
-add-highlighter shared/perl/sregex         region s/[^/\n]+/[^/\n]+(?=/)        /\w*   fill meta
+add-highlighter shared/perl/regex          region m?(?<!/)(?<!qr)/[^/\n]+/\w*   ''     fill meta
+add-highlighter shared/perl/sregex         region s/[^/\n]+/[^/\n]+/\w*         ''     fill meta
 add-highlighter shared/perl/bregex         region s\{[^\}\n]+\}\{[^\}\n]*(?=\}) \}\w*  fill meta
 
 add-highlighter shared/perl/quote_brace    region -recurse \{ \bq[qrwx]?\{ \}          fill string

--- a/rc/filetype/ruby.kak
+++ b/rc/filetype/ruby.kak
@@ -65,7 +65,7 @@ add-highlighter shared/ruby/              region -match-capture '%[qwQW]?([^\s0-
 add-highlighter shared/ruby/              region -match-capture '%[isIS]([^\s0-9A-Za-z\(\{\[<>\]\}\)])' ([^\s0-9A-Za-z\(\{\[<>\]\}\)]) fill variable
 add-highlighter shared/ruby/              region -match-capture '%[rxRX]([^\s0-9A-Za-z\(\{\[<>\]\}\)])' ([^\s0-9A-Za-z\(\{\[<>\]\}\)]) fill meta
 add-highlighter shared/ruby/heredoc region -match-capture '<<[-~]?(?!self)(\w+)'      '^\h*(\w+)$' fill string
-add-highlighter shared/ruby/division region '[\w\)\]]\K(/|(\h+/\h+))' '\w' group # Help Kakoune to better detect /…/ literals
+add-highlighter shared/ruby/division region '[\w\)\]]\K(/|(\h+/\h+))[^\n]*\w' '' group # Help Kakoune to better detect /…/ literals
 
 # Regular expression flags are: i → ignore case, m → multi-lines, o → only interpolate #{} blocks once, x → extended mode (ignore white spaces)
 # Literals are: i → array of symbols, q → string, r → regular expression, s → symbol, w → array of words, x → capture shell result

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -1855,7 +1855,7 @@ const HighlighterDesc region_desc = {
     "Parameters:  [-match-capture] [-recurse <recurse>] <opening> <closing> <type> <params>...\n"
     "Define a region for a regions highlighter, and apply the given delegate\n"
     "highlighter as defined by <type> and eventual <params>...\n"
-    "The region starts at <begin> match and ends at the first <end>",
+    "The region spans from the beginning of an <opening> match until the end of the next <closing> match",
     { {
         { "match-capture", { false, "only consider region ending/recurse delimiters whose first capture group match the region beginning delimiter" } },
         { "recurse",       { true, "make the region end on the first ending delimiter that does not close the given parameter" } } },


### PR DESCRIPTION
Some of our highlighters abuse the regions highlighter by using one
of these patterns as region end:

	'\K'
	'.\K'
	(?!\\).(?=>)|\n
	(?!\\).(?=\))|\s
	\b

These highlighters should be regex highlighters (because they have
no children) but are probably required to be region highlighters to
compete with other region highlighters.

A region highlighter works by first computing *all* matches of both
region start and region end (which faciliates caching).  Unfortunately
this means that these oddball region-end-patterns create loads of
matches, most of which are useless.

Let's standardize these hacks by allowing the region end to be empty.
This allows us to match the entire region in the region begin pattern,
and do no extra work if the region end is empty.

It's still hacky (the region highlighter feels like the wrong tool
for some of these cases) but I don't think we have a good alternative
today.

On the [5MB Markdown file] this gives a decent speedup for the initial
highlighting pass:

	$ HOME=$PWD hyperfine -w 1 'git checkout HEAD'{~,}' -- :/rc/filetype/markdown.kak && ./kak.opt big_markdown.md -e "hook global NormalIdle .* quit" -ui dummy'
	Benchmark 1: git checkout HEAD~ -- :/rc/filetype/markdown.kak && ./kak.opt big_markdown.md -e "hook global NormalIdle .* quit" -ui dummy
	  Time (mean ± σ):      1.969 s ±  0.033 s    [User: 1.935 s, System: 0.035 s]
	  Range (min … max):    1.906 s …  2.036 s    10 runs
	 
	Benchmark 2: git checkout HEAD -- :/rc/filetype/markdown.kak && ./kak.opt big_markdown.md -e "hook global NormalIdle .* quit" -ui dummy
	  Time (mean ± σ):      1.111 s ±  0.022 s    [User: 1.093 s, System: 0.020 s]
	  Range (min … max):    1.079 s …  1.145 s    10 runs
	 
	Summary
	  'git checkout HEAD -- :/rc/filetype/markdown.kak && ./kak.opt big_markdown.md -e "hook global NormalIdle .* quit" -ui dummy' ran
	    1.77 ± 0.05 times faster than 'git checkout HEAD~ -- :/rc/filetype/markdown.kak && ./kak.opt big_markdown.md -e "hook global NormalIdle .* quit" -ui dummy'

(The numbers depend on a other optimizations I'm using.)

---

Regarding markdown.kak :

To avoid the empty-region-end hack I considered using regex
highlighters (instead of region highlighters) for Markdown
URLs.  However, we probably want to keep highlighting bare
URLs (without enclosing <>).  This violates the [CommonMark
spec](https://spec.commonmark.org/0.29/#example-607) but both GitHub
Markdown and editors like VSCode and Emacs highlight bare URLs here.

The problem with highlighting bare URLs is that
they may contain Markdown metacharacters, see
https://spec.commonmark.org/dingus/?text=https%3A%2F%2Fexample.com%2F(1)_2_(3)

So unless we keep using a region highlighter, it will be very difficult
to avoid spurious Markdown highlighting in bare URLs.

So for the above performance improvement we need the empty-region-end hack.
This means we need to match the entire URL in the region-start pattern.
This is slightly challenging because a URL can contain balanced
parentheses but we must not match a trailing ")".
CommonMark [mandates](https://spec.commonmark.org/0.30/#link-destination)
support for at least 3 levels of nested parentheses, so let's just
unroll the regex to implement that.

---

[5MB Markdown file]: https://github.com/mawww/kakoune/issues/4685#issuecomment-1208129806
