### PR TITLE
rc hare: add highlighting for functions, constants, and operators

### DIFF
--- a/rc/filetype/hare.kak
+++ b/rc/filetype/hare.kak
@@ -47,6 +47,9 @@ provide-module hare %§
     add-highlighter shared/hare/code/ regex "\buse\s.*?(?=;)" 0:module
     add-highlighter shared/hare/code/ regex "\buse\b" 0:meta
 
+    # functions
+    add-highlighter shared/hare/code/ regex "\b([a-zA-Z_]*)\h*\(" 1:function
+
     # attributes
     add-highlighter shared/hare/code/ regex "@(offset|init|fini|test|noreturn|symbol)\b" 0:attribute
 
@@ -86,9 +89,14 @@ provide-module hare %§
     add-highlighter shared/hare/code/ regex "\b[0-9]+([eE][-+]?[0-9]+)?(f32|f64)\b" 0:value
     add-highlighter shared/hare/code/ regex "\b[0-9]+([eE][-+]?[0-9]+)?(?=f)" 0:value
 
+    # constants
+    add-highlighter shared/hare/code/ regex "\b[A-Z0-9_]*\b" 0:value
 
     # control flow
     add-highlighter shared/hare/code/ regex "\b(for|if|else|switch|match|return|break|continue|defer|yield|case|static)\b" 0:keyword
+
+    # operators
+    add-highlighter shared/hare/code/ regex "(=|\+|-|\*|/|<|>|!|\?|&|\||\.\.\.)" 0:operator
 
     # commands
     define-command -hidden hare-indent-on-new-line %{ evaluate-commands -draft -itersel %{

--- a/rc/filetype/hare.kak
+++ b/rc/filetype/hare.kak
@@ -48,7 +48,7 @@ provide-module hare %§
     add-highlighter shared/hare/code/ regex "\buse\b" 0:meta
 
     # functions
-    add-highlighter shared/hare/code/ regex "\b([a-zA-Z_]*)\h*\(" 1:function
+    add-highlighter shared/hare/code/ regex "\b([0-9a-zA-Z_]*)\h*\(" 1:function
 
     # attributes
     add-highlighter shared/hare/code/ regex "@(offset|init|fini|test|noreturn|symbol)\b" 0:attribute
@@ -90,7 +90,7 @@ provide-module hare %§
     add-highlighter shared/hare/code/ regex "\b[0-9]+([eE][-+]?[0-9]+)?(?=f)" 0:value
 
     # constants
-    add-highlighter shared/hare/code/ regex "\b[A-Z0-9_]*\b" 0:value
+    add-highlighter shared/hare/code/ regex "\b[0-9A-Z_]*\b" 0:value
 
     # control flow
     add-highlighter shared/hare/code/ regex "\b(for|if|else|switch|match|return|break|continue|defer|yield|case|static)\b" 0:keyword

--- a/rc/filetype/hare.kak
+++ b/rc/filetype/hare.kak
@@ -96,7 +96,7 @@ provide-module hare %§
     add-highlighter shared/hare/code/ regex "\b(for|if|else|switch|match|return|break|continue|defer|yield|case|static)\b" 0:keyword
 
     # operators
-    add-highlighter shared/hare/code/ regex "(=|\+|-|\*|/|<|>|!|\?|&|\||\.\.\.)" 0:operator
+    add-highlighter shared/hare/code/ regex "(=|\+|-|\*|/|<|>|!|\?|&|\||\.\.(\.)?)" 0:operator
 
     # commands
     define-command -hidden hare-indent-on-new-line %{ evaluate-commands -draft -itersel %{


### PR DESCRIPTION
The Hare syntax highlighting was not enough to be very useful for me - I was having a hard time parsing the code. Function calls were the main missing thing, but I also added highlighting for operators and constants.

The function highlighter is defined before the builtins highlighter, allowing the built-in functions to be highlighted with the `builtin` face instead.

According to the Hare style guide, constants are the only identifiers written in `UPPER_SNAKE_CASE`, so highlighting all words that follow that pattern should be fine.

Color scheme: `one-darker` from [kak-one](https://git.sr.ht/~raiguard/kak-one).

## Before:
![image](https://user-images.githubusercontent.com/3515394/194480659-d5dd2e50-6404-4c16-9137-c3494f8b7a32.png)

## After:
![image](https://user-images.githubusercontent.com/3515394/194481073-9d6a8b42-e6a8-4273-902a-e0f9a0949200.png)
