### PR TITLE
Allow to put switches after :write's positional argument

### DIFF
--- a/src/commands.cc
+++ b/src/commands.cc
@@ -479,7 +479,7 @@ const ParameterDesc write_params = {
         { "method", { true, "explicit writemethod (replace|overwrite)" } },
         { "force", { false, "Allow overwriting existing file with explicit filename" } }
     },
-    ParameterDesc::Flags::SwitchesOnlyAtStart, 0, 1
+    ParameterDesc::Flags::None, 0, 1
 };
 
 const ParameterDesc write_params_except_force = {
@@ -487,7 +487,7 @@ const ParameterDesc write_params_except_force = {
         { "sync", { false, "force the synchronization of the file onto the filesystem" } },
         { "method", { true, "explicit writemethod (replace|overwrite)" } },
     },
-    ParameterDesc::Flags::SwitchesOnlyAtStart, 0, 1
+    ParameterDesc::Flags::None, 0, 1
 };
 
 auto parse_write_method(StringView str)
@@ -2642,7 +2642,7 @@ const CommandDesc enter_user_mode_cmd = {
     "enter-user-mode [<switches>] <name>: enable <name> keymap mode for next key",
     ParameterDesc{
         { { "lock", { false, "stay in mode until <esc> is pressed" } } },
-        ParameterDesc::Flags::SwitchesOnlyAtStart, 1, 1
+        ParameterDesc::Flags::None, 1, 1
     },
     CommandFlags::None,
     CommandHelper{},


### PR DESCRIPTION
After a failed

	:write file-that-already-exists

a user might want to type ":<up> -f<ret>" to force-overwrite.
This doesn't work because :write's switches must precede the filename.
It's dual :edit does not have this restriction.

Some commands require switches to precede positional arguments for a
good reason; for example because positional arguments might start with
"-" (like ":echo 1 - 1").

There seems to be no reason for the :write restriction, so remove
it. Same for :enter-user-mode.

Thanks to alexherbo2 for reporting.
