### PR TITLE
rc modeline: fix error trying to write readonly global variable

### DIFF
--- a/rc/detection/modeline.kak
+++ b/rc/detection/modeline.kak
@@ -16,9 +16,8 @@ define-command -hidden modeline-parse-impl %{
 
         # Translate a vim option into the corresponding kakoune one
         translate_opt_vim() {
-            key="$1"
-            value="$2"
-            tr=""
+            local key="$1"
+            local value="$2"
 
             case "${key}" in
                 so|scrolloff)
@@ -60,8 +59,8 @@ define-command -hidden modeline-parse-impl %{
 
         # Pass a few whitelisted options to kakoune directly
         translate_opt_kakoune() {
-            readonly key="$1"
-            readonly value="$2"
+            local readonly key="$1"
+            local readonly value="$2"
 
             case "${key}" in
                 scrolloff|tabstop|indentwidth|autowrap_column|eolformat|filetype|BOM|spell_lang);;


### PR DESCRIPTION
When running modeline-parse on this file:

	# kakoune: filetype=ledger:indentwidth=4

I get this error from dash (and a similar one from bash):

	sh: 53: readonly: key: is read only

This is because the readonly variable "key" is used elsewhere, both
times as global. Fix this by making both variables local. While
at it, remove an unused variable.
