### PR TITLE
rc make: make-next-error to switch toolsclient to *make* buffer

### DIFF
--- a/rc/tools/make.kak
+++ b/rc/tools/make.kak
@@ -72,7 +72,12 @@ define-command make-next-error -docstring 'Jump to the next make error' %{
         execute-keys "%opt{make_current_error_line}ggl" "/^(?:\w:)?[^:\n]+:\d+:(?:\d+:)?%opt{make_error_pattern}<ret>"
         make-jump
     }
-    try %{ evaluate-commands -client %opt{toolsclient} %{ execute-keys %opt{make_current_error_line}g } }
+    try %{
+        evaluate-commands -client %opt{toolsclient} %{
+            buffer '*make*'
+            execute-keys %opt{make_current_error_line}g
+        }
+    }
 }
 
 define-command make-previous-error -docstring 'Jump to the previous make error' %{
@@ -81,5 +86,10 @@ define-command make-previous-error -docstring 'Jump to the previous make error' 
         execute-keys "%opt{make_current_error_line}g" "<a-/>^(?:\w:)?[^:\n]+:\d+:(?:\d+:)?%opt{make_error_pattern}<ret>"
         make-jump
     }
-    try %{ evaluate-commands -client %opt{toolsclient} %{ execute-keys %opt{make_current_error_line}g } }
+    try %{
+        evaluate-commands -client %opt{toolsclient} %{
+            buffer '*make*'
+            execute-keys %opt{make_current_error_line}g
+        }
+    }
 }


### PR DESCRIPTION
This is equivalent to a change to grep.kak in 649e252f7 (bring *grep*
buffer to front in context of toolsclient, 2020-08-14).

If a toolsclient is set, make-next-error (and make-previous-error) will
jump to %opt{make_current_error_line}. This is wrong if the toolsclient
does not show the *make* buffer. In that case make_current_error_line
is undefined and we end up showing the goto menu. This has occasionally
been annoying me for a long time but I never bothered investigating.

Fix this by switching to the *make* buffer. The potential downside
is if make-next-error is run from the toolsclient, where we no longer
jump to the error but that's fine because we can use <ret>.

We can maybe improve this later by extending the logic, see
https://github.com/mawww/kakoune/pull/3656#pullrequestreview-472052285
