### PR TITLE
Treat .cts and .mts as typescript

### DIFF
--- a/rc/filetype/javascript.kak
+++ b/rc/filetype/javascript.kak
@@ -5,7 +5,7 @@ hook global BufCreate .*[.][cm]?(js)x? %{
     set-option buffer filetype javascript
 }
 
-hook global BufCreate .*[.](ts)x? %{
+hook global BufCreate .*[.][cm]?(ts)x? %{
     set-option buffer filetype typescript
 }
 


### PR DESCRIPTION
Follow-up to #4612 that I forgot to do back then.