### PR TITLE
Balanced strings cannot be escaped

### DIFF
--- a/doc/pages/command-parsing.asciidoc
+++ b/doc/pages/command-parsing.asciidoc
@@ -51,33 +51,7 @@ delimiter matches that of its opening delimiter (respectively, `)`, `]`,
 `}`, and `>`).
 
 There is no way to escape the opening and closing characters, even if they
-are nested inside some other kind of string. For example, this will **not**
-work, because the `{` in the map command interferes with the delimiters for the
-hook's command block:
-
-----
-# DOES NOT WORK
-hook global WinSetOption filetype=latex %{
-    map window user b 'o\begin{'
-}
-----
-
-You can solve this by using a different outer delimiter:
-
-----
-hook global WinSetOption filetype=latex %[
-    # Note different delimiter used -----^
-    map window user b o\begin{
-]
-----
-
-...or just by including matching delimiters inside comments:
-
-----
-hook global WinSetOption filetype=latex %{
-    map window user b o\begin{ # matched pair to keep Kakoune happy: }
-}
-----
+are nested inside some other kind of string.
 
 === Balanced Strings Examples
 
@@ -88,6 +62,10 @@ hook global WinSetOption filetype=latex %{
 - `foo%{bar}` contains *foo%{bar}*.
 
 - `"foo %{bar}"` is a single word whose content is *foo bar*.
+
+- `%{foo\{}` is a parse error, since the `{}` delimiters are not balanced.
+
+- `%[foo\{]` contains *foo\{*, since it uses different delimiters.
 
 == Non-Quoted words
 

--- a/doc/pages/command-parsing.asciidoc
+++ b/doc/pages/command-parsing.asciidoc
@@ -12,8 +12,9 @@ prompt, are parsed according to the following rules:
 == Quoted Strings
 
 If a word starts with `'`, `"`, or `%X` with `X` a _non-nestable_ punctuation
-character (see below for nestable characters), it is parsed as a quoted
-string whose delimiter is, respectively, `'`, `"`, or `X`.
+character (see <<command-parsing#balanced-strings,Balanced Strings>> below for
+nestable characters), it is parsed as a quoted string whose delimiter is,
+respectively, `'`, `"`, or `X`.
 
 A quoted string contains every character (including whitespaces).  Doubling
 a closing delimiter escapes it.  Thus, for example, entering two closing

--- a/doc/pages/command-parsing.asciidoc
+++ b/doc/pages/command-parsing.asciidoc
@@ -50,7 +50,34 @@ of `(`, `[`, `{` and `<`), it is parsed as a balanced string whose closing
 delimiter matches that of its opening delimiter (respectively, `)`, `]`,
 `}`, and `>`).
 
-Characters may be escaped in the same manner as those for quoted strings.
+There is no way to escape the opening and closing characters, even if they
+are nested inside some other kind of string. For example, this will **not**
+work, because the `{` in the map command interferes with the delimiters for the
+hook's command block:
+
+----
+# DOES NOT WORK
+hook global WinSetOption filetype=latex %{
+    map window user b 'o\begin{'
+}
+----
+
+You can solve this by using a different outer delimiter:
+
+----
+hook global WinSetOption filetype=latex %[
+    # Note different delimiter used -----^
+    map window user b o\begin{
+]
+----
+
+...or just by including matching delimiters inside comments:
+
+----
+hook global WinSetOption filetype=latex %{
+    map window user b o\begin{ # matched pair to keep Kakoune happy: }
+}
+----
 
 === Balanced Strings Examples
 


### PR DESCRIPTION
Originally the page said:

> No other escaping takes place in balanced strings.

...but in the course of a general readability rewrite (56287da) this was
changed to:

> Characters may be escaped in the same manner as those for quoted strings.

...which is not actually true; probably this change made it in because there
were a lot of good changes in those commits and we didn't read them all closely
enough.

Now the documentation is correct again, and I've added some examples covering
the problems people occasionally ask about (see #2760).

Also, as a bonus, I added a link from the Quoted Strings section to Balanced Strings, just to be clear about how far down "below" was.