### PR TITLE
fix highlighting for undetected config files

### DIFF
--- a/rc/filetype/conf.kak
+++ b/rc/filetype/conf.kak
@@ -1,4 +1,4 @@
-hook global BufCreate .+\.(conf|repo|cfg|properties|desktop) %{
+hook global BufCreate .+\.(repo|cfg|properties|desktop) %{
     set-option buffer filetype conf
 }
 

--- a/rc/filetype/conf.kak
+++ b/rc/filetype/conf.kak
@@ -1,4 +1,4 @@
-hook global BufCreate .+\.(repo|cfg|properties|desktop) %{
+hook global BufCreate .+\.(conf|repo|cfg|properties|desktop) %{
     set-option buffer filetype conf
 }
 

--- a/rc/filetype/nginx.kak
+++ b/rc/filetype/nginx.kak
@@ -1,0 +1,30 @@
+hook global BufCreate .*\.(conf) %{
+    set-option buffer filetype nginx
+}
+
+hook global WinCreate .+\.ini %{
+    try %{
+        execute-keys /^\h*#<ret>
+        set-option buffer filetype nginx
+    }
+}
+
+hook global WinSetOption filetype=nginx %{
+    require-module nginx
+}
+
+hook -group nginx-highlight global WinSetOption filetype=nginx %{
+    add-highlighter window/nginx ref nginx
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/nginx }
+}
+
+provide-module nginx %{
+
+add-highlighter shared/nginx regions
+add-highlighter shared/nginx/code default-region group
+add-highlighter shared/nginx/comment region '(^|\h)\K#' $ fill comment
+
+add-highlighter shared/nginx/code/ regex "(?S)^\h*(\[.+?\])\h*$" 1:title
+add-highlighter shared/nginx/code/ regex "^\h*([^\[][^=\n]*)=([^\n]*)" 1:variable 2:value
+
+}

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -2553,9 +2553,7 @@ const CommandDesc change_directory_cmd = {
              return { 0_byte, cursor_pos,
                       complete_filename(prefix,
                                         context.options()["ignored_files"].get<Regex>(),
-                                        cursor_pos, FilenameFlags::OnlyDirectories),
-                      Completions::Flags::Menu };
-        }),
+                                        cursor_pos, FilenameFlags::OnlyDirectories)};}),
     [](const ParametersParser& parser, Context&, const ShellContext&)
     {
         StringView target = parser.positional_count() == 1 ? StringView{parser[0]} : "~";


### PR DESCRIPTION
consider the following

```
# Includes files with directives to load dynamic modules.
include /etc/nginx/modules/*.conf

# Uncomment to include files with config snippets into the root context.
```

anything after and including `*`, except `#` where applicable,, is not commented out. 









