### PR TITLE
Add a %val{selection_count} expansion

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -373,6 +373,10 @@ The following expansions are supported (with required context _in italics_):
     _in window scope_ +
     unquoted list of the lengths (in codepoints) of the selections
 
+*%val{selection_count}*::
+    _in window scope_ +
+    the number of selections
+
 *%val{session}*::
     name of the current session
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -350,6 +350,10 @@ static const EnvVarDesc builtin_env_vars[] = { {
                          return to_string(char_length(context.buffer(), s));
                      }) | gather<Vector<String>>(); }
     }, {
+        "selection_count", false,
+        [](StringView name, const Context& context) -> Vector<String>
+        { return {to_string(context.selections().size())}; }
+    }, {
         "window_width", false,
         [](StringView name, const Context& context) -> Vector<String>
         { return {to_string(context.window().dimensions().column)}; }


### PR DESCRIPTION
Briefly discussed on IRC. 
With the recent addition of `echo -to-shell-script`, this can be useful to know how many values to expect when parsing stdin, especially since many "list" values hold as many elements as there are selections.

For example with:
`echo -quoting kakoune -to-shell-script 'script.sh' %val{selections} %val{selections_desc}`
one has to parse the entire input to know which are selections and which are selections_desc.

whereas with
`echo -quoting kakoune -to-shell-script 'script.sh' %val{selection_count} %val{selections} %val{selections_desc}`
it is trivial to know in advance.

@Screwtapello mentioned that a more general approach to this problem could be worth considering (as the same problem might apply to `buflist`, `client_list`...)
>I'm imagining more general solutions like %val{selections #} to get the number of selections, or %val{selections 1 3 5} to get individual selections by index, but that's probably getting too fancy. 