### PR TITLE
Adjust regex in gopls-def for when filepath contains a dash

### DIFF
--- a/rc/tools/go/gopls.kak
+++ b/rc/tools/go/gopls.kak
@@ -69,7 +69,7 @@ define-command -hidden -params 1 gopls-cmd %{
 define-command -hidden -params 0 gopls-def %{
     evaluate-commands %sh{
         jump=$( gopls definition "${kak_buffile}:${kak_cursor_line}:${kak_cursor_column}" 2> /dev/null \
-            |sed -e 's/-.*//; s/:/ /g; q' )
+            |sed -e 's/-[0-9]\+:.*//; s/:/ /g; q' )
         if [ -n "${jump}" ]; then
             printf %s\\n "evaluate-commands -try-client '${kak_opt_jumpclient}' %{
                 edit ${jump}


### PR DESCRIPTION
There is a bug in the `gopls` kak integration when trying to jump to definition using `:gopls definition`.

Effectively, the LSP server returns a path that looks like the following:

```
$ gopls definition main.go:69:10 2>/dev/null 
/usr/share/go/src/flag/flag.go:740:19-25: defined here as func (*flag.FlagSet).IntVar(p *int, name string, value int, usage string)
IntVar defines an int flag with specified name, default value, and usage string.
The argument p points to an int variable in which to store the value of the flag.
```

The implementation in `gopls.kak` tries to parse this output to something that `:edit` will understand.

https://github.com/mawww/kakoune/blob/91d45a100a39345f06d9789ded9172fe60887c27/rc/tools/go/gopls.kak#L72

So with the above example, it has to transform it to:

```
/usr/share/go/src/flag/flag.go 740 19
```

The bug appears when the path contains a dash (`-`). On that occasion, the `sed` fails to execute as desired and strips everything after the first dash encountered. That is because of the first part of the `sed`: `'s/-.*//;`.

I am using Nix as my package manager, so go is installed at `/nix/store/ywb6qhxxhkjccid0l0fxbb394fwc3a30-go-1.19.3`. The path contains a dash. Here is the result of `gopls definition` for me.

```
/nix/store/ywb6qhxxhkjccid0l0fxbb394fwc3a30-go-1.19.3/share/go/src/flag/flag.go:740:19-25: defined here as func (*flag.FlagSet).IntVar(p *int, name string, value int, usage string)
IntVar defines an int flag with specified name, default value, and usage string.
The argument p points to an int variable in which to store the value of the flag.
```

And so the kak command `:gopls definition` results in trying to open `/nix/store/ywb6qhxxhkjccid0l0fxbb394fwc3a30` which does not exist.

To fix the problem, I have made sure that the dash that is supposed to be removed is followed by numbers and by a colon.

Hope this is enough.