### PR TITLE
Preserve indentation type when auto-indenting javascript block comments

### DIFF
--- a/rc/filetype/javascript.kak
+++ b/rc/filetype/javascript.kak
@@ -99,7 +99,7 @@ define-command -hidden javascript-insert-on-new-line %<
         # trim trailing whitespace on the previous line
         try %[ execute-keys -draft s\h+$<ret> d ]
         # align the new star with the previous one
-        execute-keys Kx1s^[^*]*(\*)<ret>&
+        execute-keys Kx1s^[^*]*(\*)<ret><a-(><a-&>
     ]
     >
 >


### PR DESCRIPTION
The current implementation uses '&' to auto-indent comments, which always uses spaces. If we use <a-&> it copies the indentation from the previous line instead of just blindly using spaces.