### PR TITLE
Add support for Tilix terminal

### DIFF
--- a/rc/windowing/detection.kak
+++ b/rc/windowing/detection.kak
@@ -23,7 +23,7 @@ declare-option -docstring \
 "Ordered list of windowing modules to try and load. An empty list disables
 both automatic module loading and environment detection, enabling complete
 manual control of the module loading." \
-str-list windowing_modules 'tmux' 'screen' 'kitty' 'iterm' 'sway' 'wayland' 'x11'
+str-list windowing_modules 'tmux' 'screen' 'kitty' 'iterm' 'tilix' 'sway' 'wayland' 'x11'
 
 hook -group windowing global KakBegin .* %{
 

--- a/rc/windowing/new-client.kak
+++ b/rc/windowing/new-client.kak
@@ -3,7 +3,15 @@ new [<commands>]: create a new Kakoune client
 The ''terminal'' alias is being used to determine the user''s preferred terminal emulator
 The optional arguments are passed as commands to the new client' \
 %{
-    terminal kak -c %val{session} -e "%arg{@}"
+
+    evaluate-commands %sh{
+        if [ $# -gt 0 ]; then
+            echo "echo -debug '$@'"
+            echo "terminal kak -c %val{session} -e \"$@\""
+        else
+            echo "terminal kak -c %val{session}"
+        fi
+    }
 }
 
 complete-command -menu new command

--- a/rc/windowing/tilix.kak
+++ b/rc/windowing/tilix.kak
@@ -1,0 +1,69 @@
+
+provide-module tilix %{
+
+# ensure that we're running on kitty
+evaluate-commands %sh{
+    [ -z "${kak_opt_windowing_modules}" ] || [ -n "$TILIX_ID" ] || echo 'fail Tilix not detected'
+}
+
+define-command -hidden -params 2.. tilix-cmd %{
+    evaluate-commands %sh{
+        if [ -z "$TILIX_ID" ]; then
+            echo "fail 'This command is only available in a Tilix session'"
+            exit
+        fi
+        tilix "$@" < /dev/null > /dev/null 2>&1 &
+    }
+}
+
+define-command tilix-terminal -params 0.. -docstring '
+tilix-terminal-vertical [<program> <arguments>]: create a new Tilix window
+The program, if provided, will be executed in the new terminal' \
+%{
+    tilix-cmd -a app-new-window -e %arg{@}
+}
+complete-command tilix-terminal shell
+
+define-command tilix-terminal-session -params 0.. -docstring '
+tilix-terminal-vertical [<program> <arguments>]: create a new Tilix session in the current window
+The program, if provided, will be executed in the new terminal' \
+%{
+    tilix-cmd -a app-new-session -e %arg{@}
+}
+complete-command tilix-terminal shell
+
+define-command tilix-terminal-vertical -params 0.. -docstring '
+tilix-terminal-vertical [<program> <arguments>]: split tilix terminal vertically
+The program, if provided, will be executed in the new terminal' \
+%{
+    tilix-cmd -a session-add-down -e %arg{@}
+}
+complete-command tilix-terminal-vertical shell
+
+define-command tilix-terminal-horizontal -params 0.. -docstring '
+tilix-terminal-vertical [<program> <arguments>]: split tilix terminal horizontally
+The program, if provided, will be executed in the new terminal' \
+%{
+    tilix-cmd -a session-add-right -e %arg{@}
+}
+complete-command tilix-terminal-horizontal shell
+
+define-command tilix-terminal-focus -params ..1 -docstring '
+tilix-terminal-focus [<kakoune_client>]: focus a given client''s window
+If no client is passed, then the current client is used' \
+%{
+    evaluate-commands %sh{
+        if [ $# -eq 1 ]; then
+            printf "evaluate-commands -client '%s' focus" "$1"
+        else
+            tilix --focus-window > /dev/null ||
+            echo 'fail failed to run x11-focus, see *debug* buffer for details'
+        fi
+    }
+}
+complete-command -menu tilix-terminal-focus client 
+
+alias global focus tilix-terminal-focus
+alias global terminal tilix-terminal-horizontal
+
+}


### PR DESCRIPTION
I can't believe I have been using tilix for all this time without doing this.

I would like a feedback on the commit that patches the `new` command, I did that because an empty `:new` would pass nothing to `kak -e`, making it exit.