### PR TITLE
Make ctags.kak compatible with original awk

### DIFF
--- a/rc/tools/ctags.kak
+++ b/rc/tools/ctags.kak
@@ -72,7 +72,7 @@ define-command ctags-complete -docstring "Complete the current selection" %{
                 eval "set -- $kak_quoted_opt_ctagsfiles"
                 for ctagsfile in "$@"; do
                     ${kak_opt_readtagscmd} -p -t "$ctagsfile" ${kak_selection}
-                done | awk '{ uniq[$1]++ } END { for (elem in uniq) printf " %1$s||%1$s", elem }'
+                done | awk '{ uniq[$1]++ } END { for (elem in uniq) printf " %s||%s", elem, elem }'
             )
             printf %s\\n "evaluate-commands -client ${kak_client} set-option buffer=${kak_bufname} ctags_completions ${header}${compl}" | \
                 kak -p ${kak_session}


### PR DESCRIPTION
Positional arguments in awk’s printf is a feature only available in the GNU implementation of awk (gawk). So the ctags auto-completion feature was broken in Kakoune if the installed version of awk was nawk or mawk. This simple change makes it retro-compatible with those versions.

See https://www.gnu.org/software/gawk/manual/html_node/Printf-Ordering.html

For reference, see what happens when using them with nawk or mawk.

```
$ echo | gawk 'END { printf ("%2$s | %1$s", "first", "second") }'
second | first

$ echo | mawk 'END { printf ("%2$s | %1$s", "first", "second") }'
mawk: run time error: improper conversion(number 1) in printf("%2$s | %1$s")
	FILENAME="-" FNR=1 NR=1

$ echo | nawk 'END { printf ("%2$s | %1$s", "first", "second") }'
nawk: '$' not permitted in awk formats
 input record number 1, file 
 source line number 1
```

And here is a simple example to demonstrate the fix.

```
# with positional arguments
$ readtags -p -t tags ListenAndServe |  awk '{ uniq[$1]++ } END { for (elem in uniq) printf " %1$s||%1$s", elem }'
awk: run time error: improper conversion(number 1) in printf(" %1$s||%1$s")
	FILENAME="-" FNR=4 NR=4

# with the fix that does not use them
$ readtags -p -t tags ListenAndServe |  awk '{ uniq[$1]++ } END { for (elem in uniq) printf " %s||%s", elem, elem }'
 ListenAndServeTLS||ListenAndServeTLS ListenAndServe||ListenAndServe
```