### PR TITLE
Fix hare new line insert indentation after comments

### DIFF
--- a/rc/filetype/hare.kak
+++ b/rc/filetype/hare.kak
@@ -118,7 +118,7 @@ provide-module hare %§
             execute-keys -save-regs '' k x s ^\h*\K//\h* <ret> y
             try %{
                 # paste the comment prefix
-                execute-keys x j x s ^\h* <ret>P
+                execute-keys x j x s ^\h* <ret>p
             }
         } }
         try %{


### PR DESCRIPTION
At the moment, inserting a new line while being in a comment result in a `//<indentation>` instead of `<indentation>//`.

To fix this, we just re-ordre both InsertChar hooks.

![before](https://dav.missbanal.net/578c659e-2803-4d2c-a0cf-0761a101dbf8.png)
![after](https://dav.missbanal.net/9098754a-4e14-4e71-9377-99130414f701.png)