### PR TITLE
Print OS error when ":write -force" fails to change permissions

### DIFF
--- a/src/file.cc
+++ b/src/file.cc
@@ -345,11 +345,11 @@ void write_buffer_to_file(Buffer& buffer, StringView filename,
     }
 
     if (force and ::chmod(zfilename, st.st_mode | S_IWUSR) < 0)
-        throw runtime_error("unable to change file permissions");
+        throw runtime_error(format("unable to change file permissions: {}", strerror(errno)));
 
     auto restore_mode = on_scope_end([&]{
         if ((force or replace) and ::chmod(zfilename, st.st_mode) < 0)
-            throw runtime_error("unable to restore file permissions");
+            throw runtime_error(format("unable to restore file permissions: {}", strerror(errno)));
     });
 
     char temp_filename[PATH_MAX];


### PR DESCRIPTION
When the file system runs out of space, "write -force" will fail but
doesn't print "No space left on device".
Let's fix this by including such an underlying error. Untested.

Backstory: I alias "w" to a command that runs "write -force %arg{@}".
so I can overwrite files that already exist outside the editor (I
should probably get used to the new behavior).
