### PR TITLE
rc tools doc: use menu behavior for completion again

### DIFF
--- a/rc/tools/doc.kak
+++ b/rc/tools/doc.kak
@@ -134,7 +134,7 @@ define-command -params 1 -hidden doc-render %{
     map buffer normal <ret> :doc-follow-link<ret>
 }
 
-define-command doc -params 0..2 -menu -docstring %{
+define-command doc -params 0..2 -docstring %{
         doc <topic> [<keyword>]: open a buffer containing documentation about a given topic
         An optional keyword argument can be passed to the function, which will be automatically selected in the documentation
 
@@ -165,7 +165,7 @@ define-command doc -params 0..2 -menu -docstring %{
     }
 }
 
-complete-command doc shell-script-candidates %{
+complete-command -menu doc shell-script-candidates %{
     case "$kak_token_to_complete" in
         0)
             find -L \

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1286,7 +1286,8 @@ void define_command(const ParametersParser& parser, Context& context, const Shel
     if (parser.get_switch("hidden"))
         flags = CommandFlags::Hidden;
 
-    const Completions::Flags completions_flags = parser.get_switch("menu") ?
+    bool menu = (bool)parser.get_switch("menu");
+    const Completions::Flags completions_flags = menu ?
         Completions::Flags::Menu : Completions::Flags::None;
 
     const String& commands = parser[1];
@@ -1323,6 +1324,8 @@ void define_command(const ParametersParser& parser, Context& context, const Shel
     }
 
     CommandCompleter completer = parse_completion_switch(parser, completions_flags);
+    if (menu and not completer) 
+        throw runtime_error(format("menu switch requires a completion switch", cmd_name));
     auto docstring = trim_indent(parser.get_switch("docstring").value_or(StringView{}));
 
     cm.register_command(cmd_name, cmd, docstring, desc, flags, CommandHelper{}, std::move(completer));


### PR DESCRIPTION
A recent commit moved "doc" completions to use the new
"complete-command" but forgot to carry over the "-menu" flag. Fix that.

To prevent similar errors, allow "define-command -menu" only if a completer is passed as well.