### PR TITLE
website community: add link to Matrix channel (libera.chat IRC bridge)

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -82,6 +82,10 @@
                                 <i class="fa fa-fw fa-comments"></i>
                                 <span tid="navbar:forums">Forums</span>
                             </a>
+                            <a class="dropdown-item text-nowrap" href="https://matrix.to/#/#kakoune:libera.chat">
+                                <i class="fa fa-fw fa-arrows-alt"></i>
+                                Matrix
+                            </a>
                             <a class="dropdown-item text-nowrap" href="https://web.libera.chat/?channels=#kakoune">
                                 <i class="fa fa-fw fa-hashtag"></i>
                                 IRC

--- a/gallery.html
+++ b/gallery.html
@@ -82,13 +82,13 @@
                                 <i class="fa fa-fw fa-comments"></i>
                                 <span tid="navbar:forums">Forums</span>
                             </a>
-                            <a class="dropdown-item text-nowrap" href="https://kakoune.reddit.com/">
-                                <i class="fa fa-fw fa-reddit"></i>
-                                SubReddit
-                            </a>
                             <a class="dropdown-item text-nowrap" href="https://web.libera.chat/?channels=#kakoune">
                                 <i class="fa fa-fw fa-hashtag"></i>
                                 IRC
+                            </a>
+                            <a class="dropdown-item text-nowrap" href="https://kakoune.reddit.com/">
+                                <i class="fa fa-fw fa-reddit"></i>
+                                SubReddit
                             </a>
                         </div>
                     </li>

--- a/index.html
+++ b/index.html
@@ -348,8 +348,8 @@
                                 bővül új funkciókkal, a közreműködők pull request-jei
                                 által is. A felhasználók feltehetik kérdéseiket,
                                 és megoszthatják véleményüket a közösség nagy
-                                részével a <b>#kakoune</b> csatornán az irc.libera.chat
-                                hálózaton.
+                                részével a <a href="https://web.libera.chat/?channels=#kakoune"><b>#kakoune</b></a>
+                                csatornán az irc.libera.chat hálózaton.
                             </span>
                             <span tid-it="feature:activeDevelopmentSupportText" class="d-none">
                                 Il progetto è sviluppato attivamente,

--- a/index.html
+++ b/index.html
@@ -82,13 +82,13 @@
                                 <i class="fa fa-fw fa-comments"></i>
                                 <span tid="navbar:forums">Forums</span>
                             </a>
-                            <a class="dropdown-item text-nowrap" href="https://kakoune.reddit.com/">
-                                <i class="fa fa-fw fa-reddit"></i>
-                                SubReddit
-                            </a>
                             <a class="dropdown-item text-nowrap" href="https://web.libera.chat/?channels=#kakoune">
                                 <i class="fa fa-fw fa-hashtag"></i>
                                 IRC
+                            </a>
+                            <a class="dropdown-item text-nowrap" href="https://kakoune.reddit.com/">
+                                <i class="fa fa-fw fa-reddit"></i>
+                                SubReddit
                             </a>
                         </div>
                     </li>

--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@
                                 implements new features, and integrates pull
                                 requests proposed by the contributors. Users
                                 can also ask their questions and share
-                                their remark with the rest of the community,
+                                their remarks with the rest of the community,
                                 on <a href="https://web.libera.chat/?channels=#kakoune"><b>#kakoune</b></a> @ irc.libera.chat.
                             </div>
                             <span tid-fr="feature:activeDevelopmentSupportText" class="d-none">

--- a/index.html
+++ b/index.html
@@ -82,6 +82,10 @@
                                 <i class="fa fa-fw fa-comments"></i>
                                 <span tid="navbar:forums">Forums</span>
                             </a>
+                            <a class="dropdown-item text-nowrap" href="https://matrix.to/#/#kakoune:libera.chat">
+                                <i class="fa fa-fw fa-arrows-alt"></i>
+                                Matrix
+                            </a>
                             <a class="dropdown-item text-nowrap" href="https://web.libera.chat/?channels=#kakoune">
                                 <i class="fa fa-fw fa-hashtag"></i>
                                 IRC
@@ -331,7 +335,8 @@
                                 requests proposed by the contributors. Users
                                 can also ask their questions and share
                                 their remarks with the rest of the community,
-                                on <a href="https://web.libera.chat/?channels=#kakoune"><b>#kakoune</b></a> @ irc.libera.chat.
+                                on <a href="https://matrix.to/#/#kakoune:libera.chat">#kakoune:libera.chat (Matrix)</a>
+                                or IRC <a href="https://web.libera.chat/?channels=#kakoune"><b>#kakoune</b></a> @ irc.libera.chat.
                             </div>
                             <span tid-fr="feature:activeDevelopmentSupportText" class="d-none">
                                 Le projet est activement développé,
@@ -340,7 +345,9 @@
                                 d'implémentation des contributeurs. Les
                                 utilisateurs peuvent églament poser leurs
                                 questions et partager leurs remarques avec le
-                                reste de la communauté, sur <a href="https://web.libera.chat/?channels=#kakoune"><b>#kakoune</b></a>
+                                reste de la communauté, sur
+                                <a href="https://matrix.to/#/#kakoune:libera.chat">#kakoune:libera.chat (Matrix)</a>
+                                ou canal IRC <a href="https://web.libera.chat/?channels=#kakoune"><b>#kakoune</b></a>
                                 @ irc.libera.chat.
                             </span>
                             <span tid-hu="feature:activeDevelopmentSupportText" class="d-none">
@@ -348,8 +355,9 @@
                                 bővül új funkciókkal, a közreműködők pull request-jei
                                 által is. A felhasználók feltehetik kérdéseiket,
                                 és megoszthatják véleményüket a közösség nagy
-                                részével a <a href="https://web.libera.chat/?channels=#kakoune"><b>#kakoune</b></a>
-                                csatornán az irc.libera.chat hálózaton.
+                                részével a <a href="https://matrix.to/#/#kakoune:libera.chat">#kakoune:libera.chat (Matrix)</a>
+                                vagy <a href="https://web.libera.chat/?channels=#kakoune"><b>#kakoune</b></a>
+                                IRC-csatornán az irc.libera.chat hálózaton.
                             </span>
                             <span tid-it="feature:activeDevelopmentSupportText" class="d-none">
                                 Il progetto è sviluppato attivamente,
@@ -357,7 +365,8 @@
                                 e integrate le Pull Request proposte dai collaboratori.
                                 Gli utenti possono anche fare domande e condividere
                                 le proprie osservazioni con il resto della community
-                                sul canale IRC <a href="https://web.libera.chat/?channels=#kakoune"><b>#kakoune</b></a>
+                                sul <a href="https://matrix.to/#/#kakoune:libera.chat">#kakoune:libera.chat (Matrix)</a>
+                                o canale IRC <a href="https://web.libera.chat/?channels=#kakoune"><b>#kakoune</b></a>
                                 sul server irc.libera.chat.
                             </span>
                         </div>

--- a/plugins.html
+++ b/plugins.html
@@ -89,13 +89,13 @@
                                 <i class="fa fa-fw fa-comments"></i>
                                 <span tid="navbar:forums">Forums</span>
                             </a>
-                            <a class="dropdown-item text-nowrap" href="https://kakoune.reddit.com/">
-                                <i class="fa fa-fw fa-reddit"></i>
-                                SubReddit
-                            </a>
                             <a class="dropdown-item text-nowrap" href="https://web.libera.chat/?channels=#kakoune">
                                 <i class="fa fa-fw fa-hashtag"></i>
                                 IRC
+                            </a>
+                            <a class="dropdown-item text-nowrap" href="https://kakoune.reddit.com/">
+                                <i class="fa fa-fw fa-reddit"></i>
+                                SubReddit
                             </a>
                         </div>
                     </li>

--- a/plugins.html
+++ b/plugins.html
@@ -89,6 +89,10 @@
                                 <i class="fa fa-fw fa-comments"></i>
                                 <span tid="navbar:forums">Forums</span>
                             </a>
+                            <a class="dropdown-item text-nowrap" href="https://matrix.to/#/#kakoune:libera.chat">
+                                <i class="fa fa-fw fa-arrows-alt"></i>
+                                Matrix
+                            </a>
                             <a class="dropdown-item text-nowrap" href="https://web.libera.chat/?channels=#kakoune">
                                 <i class="fa fa-fw fa-hashtag"></i>
                                 IRC

--- a/writings.html
+++ b/writings.html
@@ -82,6 +82,10 @@
                                 <i class="fa fa-fw fa-comments"></i>
                                 <span tid="navbar:forums">Forums</span>
                             </a>
+                            <a class="dropdown-item text-nowrap" href="https://matrix.to/#/#kakoune:libera.chat">
+                                <i class="fa fa-fw fa-arrows-alt"></i>
+                                Matrix
+                            </a>
                             <a class="dropdown-item text-nowrap" href="https://web.libera.chat/?channels=#kakoune">
                                 <i class="fa fa-fw fa-hashtag"></i>
                                 IRC

--- a/writings.html
+++ b/writings.html
@@ -82,13 +82,13 @@
                                 <i class="fa fa-fw fa-comments"></i>
                                 <span tid="navbar:forums">Forums</span>
                             </a>
-                            <a class="dropdown-item text-nowrap" href="https://kakoune.reddit.com/">
-                                <i class="fa fa-fw fa-reddit"></i>
-                                SubReddit
-                            </a>
                             <a class="dropdown-item text-nowrap" href="https://web.libera.chat/?channels=#kakoune">
                                 <i class="fa fa-fw fa-hashtag"></i>
                                 IRC
+                            </a>
+                            <a class="dropdown-item text-nowrap" href="https://kakoune.reddit.com/">
+                                <i class="fa fa-fw fa-reddit"></i>
+                                SubReddit
                             </a>
                         </div>
                     </li>


### PR DESCRIPTION
Kakoune has many users who may not have an IRC bouncer set up. As a
result, they might not have the best experience using IRC.

Let's lower the barrier of entry by linking to the Matrix IRC bridge,
which has a web client with persistent chat history (though for these
bridges, users can only see history from after they joined).

Our peer projects like Neovim and Helix make heavy use of Matrix. They
use proper Matrix channels which may have more features than IRC
bridges.

The icon is fairly random, I didn't find anything resembling the
Matrix logo.

Related: #4766
