### PR TITLE
Handle spawning iTerm commands with arguments containing newlines

### DIFF
--- a/rc/windowing/iterm.kak
+++ b/rc/windowing/iterm.kak
@@ -15,11 +15,7 @@ define-command -hidden -params 2.. iterm-terminal-split-impl %{
         # join the arguments as one string for the shell execution (see x11.kak)
         args=$(
             for i in "$@"; do
-                if [ "$i" = '' ]; then
-                    printf "'' "
-                else
-                    printf %s "$i" | sed -e "s|'|'\\\\''|g; s|^|'|; s|$|' |"
-                fi
+                printf "'%s' " "$(printf %s "$i" | sed "s|'|'\\\\''|g")"
             done
         )
 
@@ -69,11 +65,7 @@ The program passed as argument will be executed in the new terminal'\
         # see above
         args=$(
             for i in "$@"; do
-                if [ "$i" = '' ]; then
-                    printf "'' "
-                else
-                    printf %s "$i" | sed -e "s|'|'\\\\''|g; s|^|'|; s|$|' |"
-                fi
+                printf "'%s' " "$(printf %s "$i" | sed "s|'|'\\\\''|g")"
             done
         )
         escaped=$(printf %s "$args" | sed -e 's|\\|\\\\|g; s|"|\\"|g')
@@ -96,11 +88,7 @@ The program passed as argument will be executed in the new terminal'\
         # see above
         args=$(
             for i in "$@"; do
-                if [ "$i" = '' ]; then
-                    printf "'' "
-                else
-                    printf %s "$i" | sed -e "s|'|'\\\\''|g; s|^|'|; s|$|' |"
-                fi
+                printf "'%s' " "$(printf %s "$i" | sed "s|'|'\\\\''|g")"
             done
         )
         escaped=$(printf %s "$args" | sed -e 's|\\|\\\\|g; s|"|\\"|g')

--- a/rc/windowing/screen.kak
+++ b/rc/windowing/screen.kak
@@ -17,11 +17,7 @@ define-command screen-terminal-impl -hidden -params 3.. %{
         # see x11.kak for what this achieves
         args=$(
             for i in "$@"; do
-                if [ "$i" = '' ]; then
-                    printf "'' "
-                else
-                    printf %s "$i" | sed -e "s|'|'\\\\''|g; s|^|'|; s|$|' |"
-                fi
+                printf "'%s' " "$(printf %s "$i" | sed "s|'|'\\\\''|g")"
             done
         )
         screen -X screen sh -c "${args} ; screen -X remove" < "/dev/$tty"


### PR DESCRIPTION
Before, sed would add quotes to every line of the single multiline argument, causing the final quoted argument to "split ... command" to contain unquoted newlines such as this (from kakoune-cr):

	tell application "iTerm"
	    tell current session of current window
	        tell (split vertically with same profile command "env PATH='...' 'sh' '-c' ''
	'    export KAKOUNE_SESSION=$1'
	'    export KAKOUNE_CLIENT=$2'
	'    shift 3'
	''
	'    [ $# = 0 ] && set \"$SHELL\"'
	''
	'    \"sh\"'
	'  ' '--' '51909' 'client0' 'terminal' ") to select
	    end tell
	end tell

Instead of using sed to do this which operates on single lines at a time, simply use printf to insert ' quotes before and after the entire argument.