### PR TITLE
Python f-strings highlight

### DIFF
--- a/rc/filetype/python.kak
+++ b/rc/filetype/python.kak
@@ -36,11 +36,28 @@ provide-module python %§
 add-highlighter shared/python regions
 add-highlighter shared/python/code default-region group
 add-highlighter shared/python/docstring     region -match-capture ^\h*("""|''') (?<!\\)(?:\\\\)*("""|''') regions
-add-highlighter shared/python/triple_string region -match-capture ("""|''') (?<!\\)(?:\\\\)*("""|''') fill string
-add-highlighter shared/python/double_string region '"'   (?<!\\)(\\\\)*"  fill string
-add-highlighter shared/python/single_string region "'"   (?<!\\)(\\\\)*'  fill string
+
 add-highlighter shared/python/documentation region '##'  '$'              fill documentation
 add-highlighter shared/python/comment       region '#'   '$'              fill comment
+
+# String interpolation
+add-highlighter shared/python/f_triple_string region -match-capture [fF]("""|''') (?<!\\)(?:\\\\)*("""|''') group
+add-highlighter shared/python/f_triple_string/ fill string
+add-highlighter shared/python/f_triple_string/ regex \{.*?\} 0:value
+
+add-highlighter shared/python/f_double_string region '[fF]"'   (?<!\\)(\\\\)*" group
+add-highlighter shared/python/f_double_string/ fill string
+add-highlighter shared/python/f_double_string/ regex \{.*?\} 0:value
+
+add-highlighter shared/python/f_single_string region "[fF]'"   (?<!\\)(\\\\)*' group
+add-highlighter shared/python/f_single_string/ fill string
+add-highlighter shared/python/f_single_string/ regex \{.*?\} 0:value
+
+
+# Regular string
+add-highlighter shared/python/triple_string region -match-capture ("""|''') (?<!\\)(?:\\\\)*("""|''') fill string
+add-highlighter shared/python/double_string region '"'   (?<!\\)(\\\\)*" fill string
+add-highlighter shared/python/single_string region "'"   (?<!\\)(\\\\)*' fill string
 
 # Integer formats
 add-highlighter shared/python/code/ regex '(?i)\b0b[01]+l?\b' 0:value


### PR DESCRIPTION
Python string interpolation highlight regions inside f-strings, e.g. `f"blah_{some_var}"`, `F"blah_{some_var}"`, etc.