### PR TITLE
Do not record selection history in draft context

### DIFF
--- a/src/context.hh
+++ b/src/context.hh
@@ -228,7 +228,7 @@ struct ScopedSelectionEdition
 {
     ScopedSelectionEdition(Context& context)
         : m_context{context},
-          m_buffer{context.has_buffer() ? &context.buffer() : nullptr}
+          m_buffer{not (m_context.flags() & Context::Flags::Draft) and context.has_buffer() ? &context.buffer() : nullptr}
     { if (m_buffer) m_context.m_selection_history.begin_edition(); }
     ScopedSelectionEdition(ScopedSelectionEdition&& other) : m_context{other.m_context}, m_buffer{other.m_buffer}
     { other.m_buffer = nullptr; }


### PR DESCRIPTION
Each draft context gets its own private copy of the selections.
Any selection changes will be thrown away when the draft context
is disposed. Since selection-undo is only supported as top-level
command, it can never be used inside a draft context, so let's stop
recording it.
No functional change.
