### PR TITLE
Fix m_completions not being reset, causing a crash. 

### DIFF
--- a/src/insert_completer.cc
+++ b/src/insert_completer.cc
@@ -481,7 +481,7 @@ bool InsertCompleter::has_candidate_selected() const
 
 void InsertCompleter::try_accept()
 {
-    if (m_completions.is_valid() and m_context.has_client() and has_candidate_selected())
+    if (m_completions.is_valid() and has_candidate_selected())
         reset();
 }
 


### PR DESCRIPTION
This fixes the crash when kakoune is run as 
```
kak -f '2oK.k<c-n><ret><c-n>' /dev/null
```

This is part of #4472.  I am not absolutely certain that this is the right way to fix this crash.  