### PR TITLE
Fix Buffer::advance out of bounds access.

### DIFF
--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -575,9 +575,9 @@ BufferCoord Buffer::advance(BufferCoord coord, ByteCount count) const
         count += coord.column;
         while (count < 0)
         {
-            count += m_lines[--line].length();
-            if (line < 0)
+            if (--line < 0)
                 return {0, 0};
+            count += m_lines[line].length();
         }
         return { line, count };
     }


### PR DESCRIPTION
This commit fixes a bug in Buffer::advance where it would first access m_lines[-1], and then check whether or not that access would have segfaulted.  This commit moves the check to before the segfault would occur.