### PR TITLE
Fix assertion error in DisplayLine::trim_front when front < 0

### DIFF
--- a/src/display_buffer.cc
+++ b/src/display_buffer.cc
@@ -256,7 +256,7 @@ bool DisplayLine::trim_from(ColumnCount first_col, ColumnCount front, ColumnCoun
     while (front > 0 and it != end())
     {
         front -= it->trim_begin(front);
-        kak_assert(it->empty() or front == 0);
+        kak_assert(it->empty() or front <= 0);
         if (it->empty())
             ++it;
     }


### PR DESCRIPTION
Commit eb0e98313 (Fix DisplayLine::trim_front quadratic behaviour,
2023-02-03) added an assert that does not hold for an edge case where
front ends up being -1. The behavior in this edge case is unchanged
by the commit so it seems the assertion is too strict. Relax it.
(FWIW I still have gdb attached.)
