### PR TITLE
Add option to set maximum info box width

### DIFF
--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -377,6 +377,10 @@ are exclusively available to built-in options.
             reduce terminal output with sequences that could trigger flickering
             if unsynchronized (defaults to *false*)
 
+        *terminal_info_max_width*:::
+            set the maximum allowable width of an info box. set to zero for
+            no limit.
+
 [[startup-info]]
 *startup_info_version* `int`::
     _default_ 0 +

--- a/src/main.cc
+++ b/src/main.cc
@@ -567,7 +567,8 @@ void register_options()
                        "    terminal_wheel_scroll_amount   int\n"
                        "    terminal_shift_function_key    int\n"
                        "    terminal_padding_char          codepoint\n"
-                       "    terminal_padding_fill          bool\n",
+                       "    terminal_padding_fill          bool\n"
+                       "    terminal_info_max_width        int\n",
                        UserInterface::Options{});
     reg.declare_option("modelinefmt", "format string used to generate the modeline",
                        "%val{bufname} %val{cursor_line}:%val{cursor_char_column} {{context_info}} {{mode_info}} - %val{client}@[%val{session}]"_str);

--- a/src/terminal_ui.cc
+++ b/src/terminal_ui.cc
@@ -1264,7 +1264,9 @@ void TerminalUI::info_show(const DisplayLine& title, const DisplayLineList& cont
     else if (style != InfoStyle::Modal)
         max_size.line -= m_menu.size.line;
 
-    const auto max_content_width = max_size.column - (framed ? 4 : 2) - (assisted ? m_assistant[0].column_length() : 0);
+    const auto max_content_width = (m_info_max_width > 0 ? std::min(max_size.column, m_info_max_width) : max_size.column) -
+                                   (framed ? 4 : 2) -
+                                   (assisted ? m_assistant[0].column_length() : 0);
     if (max_content_width <= 0)
         return;
 
@@ -1495,6 +1497,8 @@ void TerminalUI::set_ui_options(const Options& options)
 
     m_padding_char = find("terminal_padding_char").map([](StringView s) { return s.column_length() < 1 ? ' ' : s[0_char]; }).value_or(Codepoint{'~'});
     m_padding_fill = find("terminal_padding_fill").map(to_bool).value_or(false);
+
+    m_info_max_width = find("terminal_info_max_width").map(str_to_int_ifp).value_or(0);
 }
 
 }

--- a/src/terminal_ui.hh
+++ b/src/terminal_ui.hh
@@ -170,6 +170,7 @@ private:
     void set_resize_pending();
 
     ColumnCount m_status_len = 0;
+    ColumnCount m_info_max_width = 0;
 };
 
 }


### PR DESCRIPTION
Some plugins (*cough* kak-lsp) and help texts tend to have immensely long content in a single line. This generates info boxes that span the entire terminal width. This is made especially worse on widescreen monitors or at small text size.

This grants user control over how wide these boxes are.

I deliberately avoid pushing this change to `kak-lsp` because it's not the only plugin that this could help--see the `hook` help text for an example of this problem in vanilla Kakoune. I would also suggest that since this is a rendering concern, it be handled by the terminal rendering logic.

Here's some screenshots (with `set option global ui_options terminal_info_max_width=80`)

<details> 
  <summary>menu</summary>
<p>

![image](https://user-images.githubusercontent.com/57697428/219252286-60b22e66-ad5f-4c51-9b1c-3a36c36a9381.png)

</p>
</details>

<details> 
  <summary>inline</summary>
<p>

![image](https://user-images.githubusercontent.com/57697428/219252532-fa50a323-ef63-4ad8-ae46-1df11203afc5.png)

</p>
</details>

<details> 
  <summary>modal</summary>
<p>

![image](https://user-images.githubusercontent.com/57697428/219252872-6c7f53ec-86d4-4726-acec-ae2e4c07c8fc.png)

</p>
</details>
