### PR TITLE
Fix New gcc errors for missing types

### DIFF
--- a/src/keys.hh
+++ b/src/keys.hh
@@ -9,6 +9,8 @@
 #include "unicode.hh"
 #include "vector.hh"
 
+#include <cstdint>
+
 namespace Kakoune
 {
 

--- a/src/ranked_match.hh
+++ b/src/ranked_match.hh
@@ -4,6 +4,8 @@
 #include "string.hh"
 #include "meta.hh"
 
+#include <cstdint>
+
 namespace Kakoune
 {
 


### PR DESCRIPTION
Fixes #4854 by including the <cstdint> header in keys.hh and ranked_match.hh