### PR TITLE
Fix Svelte detection: use `set buffer filetype` instead of `window`

### DIFF
--- a/rc/filetype/svelte.kak
+++ b/rc/filetype/svelte.kak
@@ -1,5 +1,5 @@
-hook global WinCreate .*\.svelte %[
-    set-option window filetype svelte
+hook global BufCreate .*\.svelte %[
+    set-option buffer filetype svelte
 ]
 
 hook global WinSetOption filetype=(svelte) %{


### PR DESCRIPTION
As the title suggests, this fixes the Svelte filetype detector to only set the buffer as a Svelte file.