### PR TITLE
Fix crash when redrawing after connecting external monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@
 .*.kak.*
 src/kak
 src/kak.debug
+src/kak.debug.san_*
 src/kak.opt
+src/kak.opt.san_*
 src/.version*
 src/.*.json
 doc/kak.1.gz

--- a/src/file.hh
+++ b/src/file.hh
@@ -39,6 +39,7 @@ bool fd_readable(int fd);
 bool fd_writable(int fd);
 String read_fd(int fd, bool text = false);
 String read_file(StringView filename, bool text = false);
+template<bool force_blocking = false>
 void write(int fd, StringView data);
 void write_to_file(StringView filename, StringView data);
 
@@ -121,7 +122,7 @@ CandidateList complete_filename(StringView prefix, const Regex& ignore_regex,
 
 CandidateList complete_command(StringView prefix, ByteCount cursor_pos = -1);
 
-template<int buffer_size = 4096>
+template<bool atomic, int buffer_size = 4096>
 struct BufferedWriter
 {
     BufferedWriter(int fd)
@@ -149,7 +150,7 @@ struct BufferedWriter
 
     void flush()
     {
-        Kakoune::write(m_fd, {m_buffer, m_pos});
+        Kakoune::write<atomic>(m_fd, {m_buffer, m_pos});
         m_pos = 0;
     }
 

--- a/src/terminal_ui.cc
+++ b/src/terminal_ui.cc
@@ -208,7 +208,7 @@ void TerminalUI::Window::draw(DisplayCoord pos,
         lines[(int)pos.line].append({}, size.column - pos.column, default_face);
 }
 
-struct Writer : BufferedWriter<>
+struct Writer : BufferedWriter<true>
 {
     using Writer::BufferedWriter::BufferedWriter;
     ~Writer() noexcept(false) = default;

--- a/test/regression/0-mouse-during-insert/script
+++ b/test/regression/0-mouse-during-insert/script
@@ -10,3 +10,6 @@ ui_in '{ "jsonrpc": "2.0", "method": "mouse_release", "params": [ "left", 0, 4 ]
 sleep .1
 ui_in '{ "jsonrpc": "2.0", "method": "keys", "params": [ "c<esc>" ] }'
 sleep .1
+if [ -n "$CI" ]; then
+	sleep 1
+fi


### PR DESCRIPTION
When Kakoune's terminal is shown on my laptop monitor and I plug in my
external monitor, the terminal's workspace will move to that external
monitor. When this happens, Kakoune segfaults consistently.

The crash happens in "TerminalUI::Screen::output" where we access a
dangling reference

	    auto output_line = [&](const Line& line) {
	        ColumnCount pending_move = 0;
	        for (auto& [text, skip, face] : line.atoms)
	        {
	/->          if (text.empty() and skip == 0)
	|                continue;
	|
	 cannot access memory referenced by "text"

The stack trace is

	Program received signal SIGSEGV, Segmentation fault.
	0x0000555555a5f1ac in Kakoune::String::Data::is_long (this=0x1a) at /home/johannes/git/kakoune/src/string.hh:180
	(gdb) bt
	#0  0x0000555555a5f1ac in Kakoune::String::Data::is_long (this=0x1a) at /home/johannes/git/kakoune/src/string.hh:180
	#1  0x0000555555a5f1d6 in Kakoune::String::Data::size (this=0x1a) at /home/johannes/git/kakoune/src/string.hh:181
	#2  0x0000555555de34e4 in Kakoune::String::length (this=0x1a) at /home/johannes/git/kakoune/src/string.hh:139
	#3  Kakoune::StringOps<Kakoune::String, char>::empty (this=0x1a) at /home/johannes/git/kakoune/src/string.hh:68
	#4  operator() (__closure=0x7fffffffba50, line=...) at terminal_ui.cc:303
	#5  0x0000555555de45aa in Kakoune::TerminalUI::Screen::output (this=0x5555560a7a60, force=true, synchronized=true, writer=...) at terminal_ui.cc:371
	#6  0x0000555555de548a in Kakoune::TerminalUI::redraw (this=0x5555560a7a40, force=true) at terminal_ui.cc:535
	#7  0x0000555555de579e in Kakoune::TerminalUI::refresh (this=0x5555560a7a40, force=true) at terminal_ui.cc:556
	#8  0x0000555555a9ae71 in Kakoune::Client::redraw_ifn (this=0x55555609f9b0) at client.cc:284
	#9  0x0000555555aab3db in Kakoune::ClientManager::redraw_clients (this=0x7fffffffd060) at client_manager.cc:233
	#10 0x0000555555c86ef8 in Kakoune::run_server (session="", server_init="", client_init="", init_buffer="fish-rust/src/ast.rs", init_coord=..., flags=Kakoune::ServerFlags::None, ui_type=Kakoune::UIType::Terminal,
	    debug_flags=Kakoune::DebugFlags::None, files=ArrayView<Kakoune::StringView> = {...}) at main.cc:908
	#11 0x0000555555c8bb76 in main (argc=2, argv=0x7fffffffe7b8) at main.cc:1263

We check for terminal resize in

	TerminalUI::TerminalUI
	TerminalUI::get_next_key
	TerminalUI::draw
	TerminalUI::suspend

I think neither of those happens when the window is moved.

Looks like TerminalUI::refresh relies on up-to-date dimensions,
so add a resize check here too, fixing the crash.
