### PR TITLE
Remove && from the template parameter given to declval

### DIFF
--- a/src/optional.hh
+++ b/src/optional.hh
@@ -95,7 +95,7 @@ public:
     template<typename U> using DecayOptional = typename DecayOptionalImpl<U>::Type;
 
     template<typename F>
-    auto map(F f) -> Optional<DecayOptional<decltype(f(std::declval<T&&>()))>>
+    auto map(F f) -> Optional<DecayOptional<decltype(f(std::declval<T>()))>>
     {
         if (not m_valid)
             return {};


### PR DESCRIPTION
Change `declval<T&&>` to `declval<T>`.

It seems redundant as `declval` already gives a rvalue reference

According to https://en.cppreference.com/w/cpp/utility/declval

```
template<class T>
typename std::add_rvalue_reference<T>::type declval() noexcept;
		(since C++11)
```

Sorry if I'm misunderstanding something here.