### PR TITLE
grep selection as a fixed-string when no argument is passed

### DIFF
--- a/rc/tools/grep.kak
+++ b/rc/tools/grep.kak
@@ -7,9 +7,10 @@ declare-option -hidden int grep_current_line 0
 define-command -params .. -docstring %{
     grep [<arguments>]: grep utility wrapper
     All optional arguments are forwarded to the grep utility
+    Passing no argument will perform a literal-string grep for the current selection
 } grep %{ evaluate-commands %sh{
      if [ $# -eq 0 ]; then
-         set -- "${kak_selection}"
+         set -- -F "${kak_selection}"
      fi
 
      output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-grep.XXXXXXXX)/fifo

--- a/rc/tools/grep.kak
+++ b/rc/tools/grep.kak
@@ -9,9 +9,23 @@ define-command -params .. -docstring %{
     All optional arguments are forwarded to the grep utility
     Passing no argument will perform a literal-string grep for the current selection
 } grep %{ evaluate-commands %sh{
-     if [ $# -eq 0 ]; then
-         set -- -F "${kak_selection}"
-     fi
+    if [ $# -eq 0 ]; then
+        IFS=" " greptool=$(
+            set -- $kak_opt_grepcmd
+            echo "$1"
+        )
+        case "$greptool" in
+        ag | grep | rg | ripgrep | ugrep | ug)
+            set -- -F "${kak_selection}"
+            ;;
+        ack )
+            set -- -Q "${kak_selection}"
+            ;;
+        *)
+            set -- "${kak_selection}"
+            ;;
+        esac
+    fi
 
      output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-grep.XXXXXXXX)/fifo
      mkfifo ${output}

--- a/rc/tools/grep.kak
+++ b/rc/tools/grep.kak
@@ -10,15 +10,11 @@ define-command -params .. -docstring %{
     Passing no argument will perform a literal-string grep for the current selection
 } grep %{ evaluate-commands %sh{
     if [ $# -eq 0 ]; then
-        IFS=" " greptool=$(
-            set -- $kak_opt_grepcmd
-            echo "$1"
-        )
-        case "$greptool" in
-        ag | grep | rg | ripgrep | ugrep | ug)
+        case "$kak_opt_grepcmd" in
+        ag\ * | git\ grep\ * | grep\ * | rg\ * | ripgrep\ * | ugrep\ * | ug\ *)
             set -- -F "${kak_selection}"
             ;;
-        ack )
+        ack\ *)
             set -- -Q "${kak_selection}"
             ;;
         *)


### PR DESCRIPTION
Why?
Most users who pass the current selection to grep likely do not intend
to pass the selection as a regex input string.

How?
Check the greptool used in grepcmd, if we recognize the grep tool, and
it has a flag for literal/fixed-string matching, we apply that flag,
otherwise we use the previous behavior and pass the selection as
plain arguments.
