### PR TITLE
Fix compile error: Compiler refuses to deduce alias template argument

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1473,7 +1473,7 @@ public:
 
     void paste(StringView content) override
     {
-        insert(ConstArrayView{content});
+        insert(ConstArrayView<StringView>{content});
         m_idle_timer.set_next_date(Clock::now() + get_idle_timeout(context()));
     }
 
@@ -1519,7 +1519,7 @@ private:
     void insert(Codepoint key)
     {
         String str{key};
-        insert(ConstArrayView{str});
+        insert(ConstArrayView<String>{str});
         context().hooks().run_hook(Hook::InsertChar, str, context());
     }
 


### PR DESCRIPTION
Happens on `Apple clang version 14.0.3 (clang-1403.0.22.14.1)`

Running on Ventura 13.3.1 so everything is very recent. (By way of comparison, fedora 37 is on clang 15 and fedora 38 is on clang 16).

```
input_handler.cc:1476:16: error: alias template 'ConstArrayView' requires template arguments; argument deduction only allowed for class templates
        insert(ConstArrayView{content});
               ^
input_handler.cc:1522:16: error: alias template 'ConstArrayView' requires template arguments; argument deduction only allowed for class templates
        insert(ConstArrayView{str});
               ^
```