### PR TITLE
rc: move remaining comment insertion hooks to *-insert group

### DIFF
--- a/rc/filetype/apl.kak
+++ b/rc/filetype/apl.kak
@@ -14,6 +14,7 @@ hook global BufCreate .*\.(apl|aplf|aplo|apln|aplc|apli|dyalog) %{
 hook global WinSetOption filetype=apl %|
     require-module apl
 
+    hook window InsertChar \n -group apl-insert apl-insert-on-new-line
     hook window InsertChar \n -group apl-indent apl-indent-on-new-line
     hook window InsertChar [}⟩\]] -group apl-indent apl-indent-on-closing
 
@@ -57,12 +58,17 @@ declare-user-mode apl
 # Commands
 # ‾‾‾‾‾‾‾‾
 
+define-command -hidden apl-insert-on-new-line %{
+    evaluate-commands -draft -itersel %[
+        # copy # comments prefix
+        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K#+\h* <ret> y<c-o>P<esc> }
+    ]
+}
+
 define-command -hidden apl-indent-on-new-line %`
     evaluate-commands -draft -itersel %_
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon> K <a-&> }
-        # copy # comments prefix
-        try %{ execute-keys -draft <semicolon><c-s>k<a-x> s ^\h*\K#+\h* <ret> y<c-o>P<esc> }
         # indent after lines ending with { [
         try %( execute-keys -draft k<a-x> <a-k> [{\[]\h*$ <ret> j<a-gt> )
         # cleanup trailing white spaces on the previous line

--- a/rc/filetype/just.kak
+++ b/rc/filetype/just.kak
@@ -9,6 +9,7 @@ hook global WinSetOption filetype=justfile %{
     require-module justfile
 
     hook window ModeChange pop:insert:.* -group justfile-trim-indent justfile-trim-indent
+    hook window InsertChar \n -group justfile-insert just-insert-on-new-line
     hook window InsertChar \n -group justfile-indent just-indent-on-new-line
     hook -once -always window WinSetOption filetype=.* %{ remove-hooks window justfile-.+ }
 }
@@ -32,14 +33,17 @@ define-command -hidden justfile-trim-indent %{
     }
 }
 
+define-command -hidden just-insert-on-new-line %{
+    # copy '#' comment prefix and following white spaces
+    try %{ execute-keys -draft k x s ^\h*//\h* <ret> y jgh P }
+}
+
 define-command -hidden just-indent-on-new-line %{
      evaluate-commands -draft -itersel %{
         # preserve previous line indent
         try %{ execute-keys -draft <semicolon>K<a-&> }
         # cleanup trailing white spaces on previous line
         try %{ execute-keys -draft kx s \h+$ <ret>"_d }
-        # copy '#' comment prefix and following white spaces
-        try %{ execute-keys -draft k x s ^\h*//\h* <ret> y jgh P }
     }
 }
 

--- a/rc/filetype/latex.kak
+++ b/rc/filetype/latex.kak
@@ -14,6 +14,7 @@ hook global BufCreate .*\.(tex|cls|sty|dtx) %{
 hook global WinSetOption filetype=latex %(
     require-module latex
 
+    hook window InsertChar \n -group latex-insert %{ latex-insert-on-newline }
     hook window InsertChar \n -group latex-indent %{ latex-indent-newline }
     hook window InsertChar \} -group latex-indent %{ latex-indent-closing-brace }
     hook window ModeChange pop:insert:.* -group latex-indent %{ latex-trim-indent }
@@ -84,10 +85,13 @@ define-command -hidden latex-trim-indent %{
     }
 }
 
+define-command -hidden latex-insert-on-newline %{
+    # copy '%' comment prefix and following white spaces
+    try %{ execute-keys -draft kx s^\h*%\h*<ret> y jgh P }
+}
+
 define-command -hidden latex-indent-newline %(
     evaluate-commands -no-hooks -draft -itersel %(
-        # copy '%' comment prefix and following white spaces
-        try %{ execute-keys -draft kx s^\h*%\h*<ret> y jgh P }
         # preserve previous line indent
         try %{ execute-keys -draft K<a-&> }
         # cleanup trailing whitespaces from previous line

--- a/rc/filetype/protobuf.kak
+++ b/rc/filetype/protobuf.kak
@@ -16,6 +16,7 @@ hook global WinSetOption filetype=protobuf %[
     set-option window static_words %opt{protobuf_static_words}
 
     hook window ModeChange pop:insert:.* -group protobuf-trim-indent protobuf-trim-indent
+    hook -group protobuf-insert window InsertChar \n protobuf-insert-on-newline
     hook -group protobuf-indent window InsertChar \n protobuf-indent-on-newline
     hook -group protobuf-indent window InsertChar \{ protobuf-indent-on-opening-curly-brace
     hook -group protobuf-indent window InsertChar \} protobuf-indent-on-closing-curly-brace
@@ -75,6 +76,13 @@ define-command -hidden protobuf-trim-indent %{
     }
 }
 
+define-command -hidden protobuf-insert-on-new-line %{
+    evaluate-commands -draft -itersel %[
+        # copy // comments prefix
+        try %{ execute-keys -draft <semicolon><c-s>kx s ^\h*\K/{2,}(\h*(?=\S))? <ret> y<c-o>P<esc> }
+    ]
+}
+
 define-command -hidden protobuf-indent-on-newline %~
     evaluate-commands -draft -itersel %[
         # preserve previous line indent
@@ -83,8 +91,6 @@ define-command -hidden protobuf-indent-on-newline %~
         try %[ execute-keys -draft kx <a-k> \{\h*$ <ret> j<a-gt> ]
         # cleanup trailing white spaces on the previous line
         try %{ execute-keys -draft kx s \h+$ <ret>d }
-        # copy // comments prefix
-        try %{ execute-keys -draft <semicolon><c-s>kx s ^\h*\K/{2,}(\h*(?=\S))? <ret> y<c-o>P<esc> }
         # deindent closing brace(s) when after cursor
         try %[ execute-keys -draft x <a-k> ^\h*\} <ret> gh / \} <ret> m <a-S> 1<a-&> ]
     ]


### PR DESCRIPTION
This continues the work started by 0a9c90fec (rc: use a separate
*-insert hook to auto-insert comments, 2021-04-17).
