### PR TITLE
Match against kitty window id directly when using kitty @ launch

### DIFF
--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -17,7 +17,7 @@ The program passed as argument will be executed in the new terminal' \
     nop %sh{
         match=""
         if [ -n "$kak_client_env_KITTY_WINDOW_ID" ]; then
-            match="--match=id:$kak_client_env_KITTY_WINDOW_ID"
+            match="--match=window_id:$kak_client_env_KITTY_WINDOW_ID"
         fi
 
         listen=""
@@ -37,7 +37,7 @@ The program passed as argument will be executed in the new terminal' \
     nop %sh{
         match=""
         if [ -n "$kak_client_env_KITTY_WINDOW_ID" ]; then
-            match="--match=id:$kak_client_env_KITTY_WINDOW_ID"
+            match="--match=window_id:$kak_client_env_KITTY_WINDOW_ID"
         fi
 
         listen=""

--- a/rc/windowing/repl/kitty.kak
+++ b/rc/windowing/repl/kitty.kak
@@ -20,7 +20,7 @@ define-command -params .. \
 
        match=""
         if [ -n "$kak_client_env_KITTY_WINDOW_ID" ]; then
-            match="--match=id:$kak_client_env_KITTY_WINDOW_ID"
+            match="--match=window_id:$kak_client_env_KITTY_WINDOW_ID"
         fi
 
         listen=""


### PR DESCRIPTION
When launch matches using `id` kitty tries to match against tab id before matching windows. When there are multiple tabs it's likely to match a tab before matching a window.

Use `window_id` directly to avoid any possiblity of matching tabs.

This is only needed for `kitty @ launch` for other commands there is no specific `window_id` field.

Solves #4888 