### PR TITLE
Map undo selection change to <a-u>/<a-U>

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -3,6 +3,12 @@
 This changelog contains major and/or breaking changes to Kakoune between
 released versions.
 
+== Development version
+
+* History is now stored linearly instead of in a tree
+* `<a-u>` and `<a-U>` now undo selection history
+* `%exp{...}` expansions provide flexible quoting for expanded strings (as double quoted strings)
+
 == Kakoune 2022.10.31
 
 * `complete-command` (See <<commands#configuring-command-completion,`:doc commands configuring-command-completion`>>)

--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -308,10 +308,10 @@ Yanking (copying) and pasting use the *"* register by default (See <<registers#,
 *U*::
     redo last change
 
-*<c-h>*::
+*<a-u>*::
     undo last selection change
 
-*<c-k>*::
+*<a-U>*::
     redo last selection change
 
 *&*::

--- a/src/main.cc
+++ b/src/main.cc
@@ -46,6 +46,7 @@ struct {
 } constexpr version_notes[] = { {
         0,
         "» History is now stored linearly instead of in a tree\n"
+        "» {+b}<a-u>{} and {+b}<a-U>{} now undo selection history\n"
         "» {+u}%exp\\{...}{} expansions provide flexible quoting for expanded "
         "strings (as double quoted strings)\n"
     }, {

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -2340,8 +2340,8 @@ static constexpr HashMap<Key, NormalCmd, MemoryDomain::Undefined, KeymapBackend>
     { {'u'}, {"undo", undo} },
     { {'U'}, {"redo", redo} },
 
-    { {ctrl('h')}, {"undo selection change", undo_selection_change<Backward>} },
-    { {ctrl('k')}, {"redo selection change", undo_selection_change<Forward>} },
+    { {alt('u')}, {"undo selection change", undo_selection_change<Backward>} },
+    { {alt('U')}, {"redo selection change", undo_selection_change<Forward>} },
 
     { {alt('i')}, {"select inner object", select_object<ObjectFlags::ToBegin | ObjectFlags::ToEnd | ObjectFlags::Inner>} },
     { {alt('a')}, {"select whole object", select_object<ObjectFlags::ToBegin | ObjectFlags::ToEnd>} },

--- a/test/normal/selection-undo/fold-redundant-entries/script
+++ b/test/normal/selection-undo/fold-redundant-entries/script
@@ -1,2 +1,2 @@
 ui_out -ignore 4
-ui_in '{ "jsonrpc": "2.0", "method": "keys", "params": [ "gjgkxd<c-h>ihere<esc>" ] }'
+ui_in '{ "jsonrpc": "2.0", "method": "keys", "params": [ "gjgkxd<a-u>ihere<esc>" ] }'

--- a/test/normal/selection-undo/redo/script
+++ b/test/normal/selection-undo/redo/script
@@ -1,2 +1,2 @@
 ui_out -ignore 4
-ui_in '{ "jsonrpc": "2.0", "method": "keys", "params": [ "2jj<c-h><c-h><c-k>ihere<esc>" ] }'
+ui_in '{ "jsonrpc": "2.0", "method": "keys", "params": [ "2jj<a-u><a-u><a-U>ihere<esc>" ] }'

--- a/test/normal/selection-undo/undo/script
+++ b/test/normal/selection-undo/undo/script
@@ -1,2 +1,2 @@
 ui_out -ignore 4
-ui_in '{ "jsonrpc": "2.0", "method": "keys", "params": [ "j2j<c-h><c-h>ihere<esc>" ] }'
+ui_in '{ "jsonrpc": "2.0", "method": "keys", "params": [ "j2j<a-u><a-u>ihere<esc>" ] }'

--- a/test/normal/selection-undo/windisplay-hook/script
+++ b/test/normal/selection-undo/windisplay-hook/script
@@ -1,2 +1,2 @@
 ui_out -ignore 4
-ui_in '{ "jsonrpc": "2.0", "method": "keys", "params": [ "j:buffer *debug*<ret><c-h>ihere<esc>" ] }'
+ui_in '{ "jsonrpc": "2.0", "method": "keys", "params": [ "j:buffer *debug*<ret><a-u>ihere<esc>" ] }'


### PR DESCRIPTION
Change the initial `<c-h>`/`<c-k>` bindings to the recently freed-up
`<a-u>``</a-U>`.

Pros:
- easier to remember
- the redo binding is logical.
- works on legacy terminals, unlike `<c-h>`

Cons:
- It's less convenient to toggle between selection undo and redo
  keys. I think this is okay since this scenario does not happen that
  often in practice
