### PR TITLE
rc windowing wayland/x11: do not pollute terminal environment

### DIFF
--- a/rc/windowing/wayland.kak
+++ b/rc/windowing/wayland.kak
@@ -39,7 +39,10 @@ The program passed as argument will be executed in the new terminal' \
                 echo "fail 'termcmd option is not set'"
                 exit
             fi
-            setsid ${kak_opt_termcmd} "$kak_quoted_reg_a" < /dev/null > /dev/null 2>&1 &
+            termcmd=$kak_opt_termcmd
+            args=$kak_quoted_reg_a
+            unset kak_opt_termcmd kak_quoted_reg_a
+            setsid ${termcmd} "$args" < /dev/null > /dev/null 2>&1 &
         }
     }
 }

--- a/rc/windowing/x11.kak
+++ b/rc/windowing/x11.kak
@@ -44,7 +44,10 @@ The program passed as argument will be executed in the new terminal' \
                 echo "fail 'termcmd option is not set'"
                 exit
             fi
-            setsid ${kak_opt_termcmd} "$kak_quoted_reg_a" < /dev/null > /dev/null 2>&1 &
+            termcmd=$kak_opt_termcmd
+            args=$kak_quoted_reg_a
+            unset kak_opt_termcmd kak_quoted_reg_a
+            setsid ${termcmd} "$args" < /dev/null > /dev/null 2>&1 &
         }
     }
 }


### PR DESCRIPTION
The x11-terminal command spawns a potentially long-lived terminal
process. The terminal can is completely independent of the Kakoune
session that created it.
Due to how it's implemented, the spawned terminals will have
environment variables "kak_opt_termcmd" and  "kak_quoted_reg_a"
set.  This can be surprising, especially since, by convention, the
environment contains no lowercase variables. Let's stop exporting them.
