### PR TITLE
Cancel regex search on Control-C

### DIFF
--- a/src/buffer.hh
+++ b/src/buffer.hh
@@ -217,6 +217,9 @@ public:
     };
     ConstArrayView<Change> changes_since(size_t timestamp) const;
 
+    void set_highlighting_interrupted() { m_highlighting_interrupted = true; }
+    bool highlighting_interrupted() const { return m_highlighting_interrupted; }
+
     String debug_description() const;
 
     // Methods called by the buffer manager
@@ -294,6 +297,8 @@ private:
     Vector<Change, MemoryDomain::BufferMeta> m_changes;
 
     FsStatus m_fs_status;
+
+    bool m_highlighting_interrupted = false;
 
     // Values are just data holding by the buffer, they are not part of its
     // observable state

--- a/src/client.cc
+++ b/src/client.cc
@@ -53,7 +53,7 @@ Client::Client(std::unique_ptr<UserInterface>&& ui,
             killpg(getpgrp(), SIGINT);
             set_signal_handler(SIGINT, prev_handler);
         }
-        else if (key == ctrl('g'))
+        if (key == ctrl('g') or key == ctrl('c'))
         {
             m_pending_keys.clear();
             print_status({"operation cancelled", context().faces()["Error"]});

--- a/src/display_buffer.hh
+++ b/src/display_buffer.hh
@@ -185,10 +185,13 @@ public:
     void set_timestamp(size_t timestamp) { m_timestamp = timestamp; }
     size_t timestamp() const { return m_timestamp; }
 
+    void set_highlighting_interrupted(bool interrupted) { m_highlighting_interrupted = interrupted; }
+    bool highlighting_interrupted() const { return m_highlighting_interrupted; }
 private:
     DisplayLineList m_lines;
     BufferRange m_range;
     size_t m_timestamp = -1;
+    bool m_highlighting_interrupted = false;
 };
 
 }

--- a/src/highlighter.cc
+++ b/src/highlighter.cc
@@ -11,6 +11,10 @@ void Highlighter::highlight(HighlightContext context, DisplayBuffer& display_buf
     {
         do_highlight(context, display_buffer, range);
     }
+    catch (cancel&)
+    {
+        throw;
+    }
     catch (runtime_error& error)
     {
         write_to_debug_buffer(format("Error while highlighting: {}", error.what()));

--- a/src/input_handler.hh
+++ b/src/input_handler.hh
@@ -81,7 +81,8 @@ public:
     // not change the mode itself
     void prompt(StringView prompt, String initstr, String emptystr,
                 Face prompt_face, PromptFlags flags, char history_register,
-                PromptCompleter completer, PromptCallback callback);
+                PromptCompleter completer, PromptCallback callback,
+                bool for_regex = false);
     void set_prompt_face(Face prompt_face);
 
     // enter menu mode, callback is called on each selection change,
@@ -172,7 +173,8 @@ enum class AutoComplete
 {
     None = 0,
     Insert = 0b01,
-    Prompt = 0b10
+    Prompt = 0b10,
+    NoRegexPrompt = 0b100,
 };
 constexpr bool with_bit_ops(Meta::Type<AutoComplete>) { return true; }
 
@@ -180,7 +182,8 @@ constexpr auto enum_desc(Meta::Type<AutoComplete>)
 {
     return make_array<EnumDesc<AutoComplete>>({
         { AutoComplete::Insert, "insert"},
-        { AutoComplete::Prompt, "prompt" }
+        { AutoComplete::Prompt, "prompt" },
+        { AutoComplete::NoRegexPrompt, "no_regex_prompt" },
     });
 }
 

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -870,7 +870,7 @@ void regex_prompt(Context& context, String prompt, char reg, T func)
                 if (event == PromptEvent::Validate)
                     throw;
             }
-        });
+        }, true);
 }
 
 template<RegexMode mode>

--- a/src/regex_impl.hh
+++ b/src/regex_impl.hh
@@ -478,9 +478,10 @@ private:
         m_found_match = false;
         while (true) // Iterate on all codepoints and once at the end
         {
+            idle_func();
+
             if (++current_step == 0)
             {
-                idle_func();
 
                 // We wrapped, avoid potential collision on inst.last_step by resetting them
                 ConstArrayView<CompiledRegex::Instruction> instructions{m_program.instructions};

--- a/src/regex_impl.hh
+++ b/src/regex_impl.hh
@@ -269,7 +269,7 @@ public:
         {
             if (search)
             {
-                to_next_start(start, config, *start_desc);
+                to_next_start(start, config, *start_desc, idle_func);
                 if (start == config.end) // If start_desc is not null, it means we consume at least one char
                     return false;
             }
@@ -512,17 +512,18 @@ private:
             if (search and not m_found_match)
             {
                 if (start_desc and m_threads.next_is_empty())
-                    to_next_start(pos, config, *start_desc);
+                    to_next_start(pos, config, *start_desc, idle_func);
                 m_threads.push_next({first_inst, -1});
             }
             m_threads.swap_next();
         }
     }
 
-    static void to_next_start(Iterator& start, const ExecConfig& config, const StartDesc& start_desc)
+    static void to_next_start(Iterator& start, const ExecConfig& config, const StartDesc& start_desc, auto&& idle_func)
     {
         while (start != config.end)
         {
+            idle_func();
             static_assert(StartDesc::count <= 128, "start desc should be ascii only");
             if constexpr (forward)
             {

--- a/src/window.cc
+++ b/src/window.cc
@@ -22,13 +22,13 @@ void setup_builtin_highlighters(HighlighterGroup& group);
 Window::Window(Buffer& buffer)
     : Scope(buffer),
       m_buffer(&buffer),
-      m_builtin_highlighters{highlighters()}
+      m_highlighters{highlighters()}
 {
     run_hook_in_own_context(Hook::WinCreate, buffer.name());
 
     options().register_watcher(*this);
 
-    setup_builtin_highlighters(m_builtin_highlighters.group());
+    setup_builtin_highlighters(m_highlighters.group());
 
     // gather as on_option_changed can mutate the option managers
     for (auto& option : options().flatten_options()
@@ -156,7 +156,7 @@ const DisplayBuffer& Window::update_display_buffer(const Context& context)
     m_display_buffer.compute_range();
     const BufferRange range{{0,0}, buffer().end_coord()};
     for (auto pass : { HighlightPass::Wrap, HighlightPass::Move, HighlightPass::Colorize })
-        m_builtin_highlighters.highlight({context, setup, pass, {}}, m_display_buffer, range);
+        m_highlighters.highlight({context, setup, pass, {}}, m_display_buffer, range);
 
     for (auto& line : m_display_buffer.lines())
         line.trim_from(setup.widget_columns, setup.first_column, m_dimensions.column);
@@ -236,7 +236,7 @@ DisplaySetup Window::compute_display_setup(const Context& context) const
         offset
     };
     for (auto pass : { HighlightPass::Move, HighlightPass::Wrap })
-        m_builtin_highlighters.compute_display_setup({context, setup, pass, {}}, setup);
+        m_highlighters.compute_display_setup({context, setup, pass, {}}, setup);
     check_display_setup(setup, *this);
 
     // now ensure the cursor column is visible

--- a/src/window.hh
+++ b/src/window.hh
@@ -67,7 +67,7 @@ private:
     DisplayCoord m_dimensions;
     DisplayBuffer m_display_buffer;
 
-    Highlighters m_builtin_highlighters;
+    Highlighters m_highlighters;
     bool m_resize_hook_pending = false;
 
     struct Setup


### PR DESCRIPTION
On large files (for example "seq 10000000"), regex search is slow.
I often only realize that _after_ starting an (incremental) search,
which cannot be canceled.
Let's allow canceling regex searches with Control-C, similar to Vim
and less.

Apply this to all regex searches except for things like highlighting
(following commit). Also exclude things like hook filtering (users
of regex_match()) to ensure the behavior is predictable.

There are probably other places where we should check for Control-C
to prevent hangs on huge buffers.

Closes #3950

Also includes experimental commits to disable
- word completion in regex prompts
- regex highlighting in a buffer after interrupted by Control-C
