### PR TITLE
Document the new <c-g> key, and <c-c> too while we're at it.

### DIFF
--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -825,3 +825,23 @@ The following keys are recognized by this mode to help with editing
 *<space>*::
     enter default `user mode` to access custom commands
     (See <<modes#user-mode,`:doc modes user-mode`>>)
+
+== Cancelling operations
+
+These keys are used to cancel long-running operations, either inside
+Kakoune or outside it. Because they are intended as a safety mechanism
+when something goes wrong, these keys are handled very early on in
+Kakoune's input processing, and therefore cannot be remapped in any mode.
+
+*<c-c>*::
+    Stop any external processes. If you ever see Kakoune display a message
+    like "waiting for shell command to finish", this key will stop
+    that command so you can regain control of Kakoune.
+    Technically, this key causes Kakoune to send the SIGINT signal
+    to its entire process group.
+
+*<c-g>*::
+    Cancel a long-running Kakoune operation, such as a regex search on a
+    very large file. This also clears Kakoune's input buffer, so any
+    commands that were waiting for the long-running operation to complete
+    will also be cancelled.

--- a/doc/pages/mapping.asciidoc
+++ b/doc/pages/mapping.asciidoc
@@ -144,6 +144,9 @@ possible combination can be triggered. For example, due to limitations in
 the way terminals handle control characters, mappings like *<c-s-a>* are
 unlikely to work in Kakoune's terminal UI.
 
+Some keys, like `<c-c>` and `<c-g>`, cannot be remapped because they are
+used to cancel operations. See <<keys#cancelling-operations,`:doc keys cancelling-operations`>>.
+
 == Default mappings
 
 Some mappings exist by default in the global scope:


### PR DESCRIPTION
Sometimes we get people asking why <c-c> can't be mapped. It should be mentioned in the `:help mapping` documentation, along with any other unmappable keys.