### PR TITLE
Allow canceling buffer highlighting

### DIFF
--- a/src/buffer.hh
+++ b/src/buffer.hh
@@ -217,6 +217,9 @@ public:
     };
     ConstArrayView<Change> changes_since(size_t timestamp) const;
 
+    void set_highlighting_interrupted() { m_highlighting_interrupted = true; }
+    bool highlighting_interrupted() const { return m_highlighting_interrupted; }
+
     String debug_description() const;
 
     // Methods called by the buffer manager
@@ -294,6 +297,8 @@ private:
     Vector<Change, MemoryDomain::BufferMeta> m_changes;
 
     FsStatus m_fs_status;
+
+    bool m_highlighting_interrupted = false;
 
     // Values are just data holding by the buffer, they are not part of its
     // observable state

--- a/src/display_buffer.hh
+++ b/src/display_buffer.hh
@@ -185,10 +185,13 @@ public:
     void set_timestamp(size_t timestamp) { m_timestamp = timestamp; }
     size_t timestamp() const { return m_timestamp; }
 
+    void set_highlighting_interrupted(bool interrupted) { m_highlighting_interrupted = interrupted; }
+    bool highlighting_interrupted() const { return m_highlighting_interrupted; }
 private:
     DisplayLineList m_lines;
     BufferRange m_range;
     size_t m_timestamp = -1;
+    bool m_highlighting_interrupted = false;
 };
 
 }

--- a/src/highlighter.cc
+++ b/src/highlighter.cc
@@ -11,6 +11,10 @@ void Highlighter::highlight(HighlightContext context, DisplayBuffer& display_buf
     {
         do_highlight(context, display_buffer, range);
     }
+    catch (cancel&)
+    {
+        throw;
+    }
     catch (runtime_error& error)
     {
         write_to_debug_buffer(format("Error while highlighting: {}", error.what()));

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -7,6 +7,7 @@
 #include "context.hh"
 #include "clock.hh"
 #include "display_buffer.hh"
+#include "event_manager.hh"
 #include "face_registry.hh"
 #include "highlighter_group.hh"
 #include "line_modification.hh"
@@ -276,6 +277,8 @@ public:
 
     void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range) override
     {
+        if (display_buffer.highlighting_interrupted())
+            return;
         auto overlaps = [](const BufferRange& lhs, const BufferRange& rhs) {
             return lhs.begin < rhs.begin ? lhs.end > rhs.begin
                                          : rhs.end > lhs.begin;
@@ -376,7 +379,8 @@ private:
                                           match_flags(is_bol(range.begin),
                                                       is_eol(buffer, range.end),
                                                       is_bow(buffer, range.begin),
-                                                      is_eow(buffer, range.end))})
+                                                      is_eow(buffer, range.end)),
+                                          EventManager::handle_urgent_events})
         {
             for (auto& face : m_faces)
             {
@@ -466,6 +470,8 @@ public:
 
     void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range) override
     {
+        if (display_buffer.highlighting_interrupted())
+            return;
         Regex regex = m_regex_getter(context.context);
         FacesSpec face = regex.empty() ? FacesSpec{} : m_face_getter(context.context, regex);
         if (regex != m_last_regex or face != m_last_face)
@@ -1906,6 +1912,8 @@ public:
 
     void do_highlight(HighlightContext context, DisplayBuffer& display_buffer, BufferRange range) override
     {
+        if (display_buffer.highlighting_interrupted())
+            return;
         if (m_regions.empty())
             return;
 
@@ -2268,7 +2276,7 @@ private:
                 {
                     auto extra_flags = RegexExecFlags::None;
                     auto pos = l.begin();
-                    while (vm.exec(pos, l.end(), l.begin(), l.end(), flags | extra_flags))
+                    while (vm.exec(pos, l.end(), l.begin(), l.end(), flags | extra_flags, EventManager::handle_urgent_events))
                     {
                         ConstArrayView<const char*> captures = vm.captures();
                         const bool with_capture = regex.mark_count() > 0 and captures[2] != nullptr and

--- a/src/window.cc
+++ b/src/window.cc
@@ -22,13 +22,13 @@ void setup_builtin_highlighters(HighlighterGroup& group);
 Window::Window(Buffer& buffer)
     : Scope(buffer),
       m_buffer(&buffer),
-      m_builtin_highlighters{highlighters()}
+      m_highlighters{highlighters()}
 {
     run_hook_in_own_context(Hook::WinCreate, buffer.name());
 
     options().register_watcher(*this);
 
-    setup_builtin_highlighters(m_builtin_highlighters.group());
+    setup_builtin_highlighters(m_highlighters.group());
 
     // gather as on_option_changed can mutate the option managers
     for (auto& option : options().flatten_options()
@@ -156,7 +156,7 @@ const DisplayBuffer& Window::update_display_buffer(const Context& context)
     m_display_buffer.compute_range();
     const BufferRange range{{0,0}, buffer().end_coord()};
     for (auto pass : { HighlightPass::Wrap, HighlightPass::Move, HighlightPass::Colorize })
-        m_builtin_highlighters.highlight({context, setup, pass, {}}, m_display_buffer, range);
+        m_highlighters.highlight({context, setup, pass, {}}, m_display_buffer, range);
 
     for (auto& line : m_display_buffer.lines())
         line.trim_from(setup.widget_columns, setup.first_column, m_dimensions.column);
@@ -236,7 +236,7 @@ DisplaySetup Window::compute_display_setup(const Context& context) const
         offset
     };
     for (auto pass : { HighlightPass::Move, HighlightPass::Wrap })
-        m_builtin_highlighters.compute_display_setup({context, setup, pass, {}}, setup);
+        m_highlighters.compute_display_setup({context, setup, pass, {}}, setup);
     check_display_setup(setup, *this);
 
     // now ensure the cursor column is visible

--- a/src/window.cc
+++ b/src/window.cc
@@ -155,8 +155,19 @@ const DisplayBuffer& Window::update_display_buffer(const Context& context)
 
     m_display_buffer.compute_range();
     const BufferRange range{{0,0}, buffer().end_coord()};
-    for (auto pass : { HighlightPass::Wrap, HighlightPass::Move, HighlightPass::Colorize })
+    for (auto pass : { HighlightPass::Wrap, HighlightPass::Move })
         m_highlighters.highlight({context, setup, pass, {}}, m_display_buffer, range);
+    m_display_buffer.set_highlighting_interrupted(buffer().highlighting_interrupted());
+    try
+    {
+        m_highlighters.highlight({context, setup, HighlightPass::Colorize, {}}, m_display_buffer, range);
+    }
+    catch (cancel&)
+    {
+        write_to_debug_buffer("buffer highlighting cancelled");
+        context.print_status({"buffer highlighting cancelled", context.faces()["StatusLine"]});
+        buffer().set_highlighting_interrupted();
+    }
 
     for (auto& line : m_display_buffer.lines())
         line.trim_from(setup.widget_columns, setup.first_column, m_dimensions.column);

--- a/src/window.hh
+++ b/src/window.hh
@@ -67,7 +67,7 @@ private:
     DisplayCoord m_dimensions;
     DisplayBuffer m_display_buffer;
 
-    Highlighters m_builtin_highlighters;
+    Highlighters m_highlighters;
     bool m_resize_hook_pending = false;
 
     struct Setup


### PR DESCRIPTION
(I won't need this myself but maybe it's useful to others)

On huge files [1], initial highlighting can take a while.
The canonical solution is to disable highlighting for such files.
However we can improve the experience if the user forgot to do so

Allow regex highlighters to be interrupted with the interrupt key.
When that happens, mark the affected buffer and never again try to
highlight it with regex highlighters.

This commit is experimental because the behavior is difficult to
predict (it only affects some highlighters) but it could be quite
helpful for users who forgot to disable highlighting.

[1]: https://github.com/mawww/kakoune/issues/4685#issuecomment-1208129806
