### PR TITLE
Suppress false positive error when <c-g> is pressed during shell execution

### DIFF
--- a/src/shell_manager.cc
+++ b/src/shell_manager.cc
@@ -363,6 +363,9 @@ std::pair<String, int> ShellManager::eval(
         {
             EventManager::instance().handle_next_events(EventMode::Urgent, &orig_mask);
         }
+        catch (cancel&)
+        {
+        }
         catch (runtime_error& error)
         {
             write_to_debug_buffer(format("error while waiting for shell: {}", error.what()));


### PR DESCRIPTION
During shell command execution <c-g> does nothing but the error
message in the *debug* buffer suggests otherwise.  Fix this.
