### PR TITLE
Allow to disable regex prompt autocompletion

### DIFF
--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -236,7 +236,7 @@ are exclusively available to built-in options.
     _default_ command|onkey +
     display automatic information box in the enabled contexts
 
-*autocomplete* `flags(insert|prompt)`::
+*autocomplete* `flags(insert|prompt|no-regex-prompt)`::
     _default_ insert|prompt +
     automatically display possible completions in the enabled modes.
 

--- a/src/input_handler.hh
+++ b/src/input_handler.hh
@@ -81,7 +81,8 @@ public:
     // not change the mode itself
     void prompt(StringView prompt, String initstr, String emptystr,
                 Face prompt_face, PromptFlags flags, char history_register,
-                PromptCompleter completer, PromptCallback callback);
+                PromptCompleter completer, PromptCallback callback,
+                bool for_regex = false);
     void set_prompt_face(Face prompt_face);
 
     // enter menu mode, callback is called on each selection change,
@@ -172,7 +173,8 @@ enum class AutoComplete
 {
     None = 0,
     Insert = 0b01,
-    Prompt = 0b10
+    Prompt = 0b10,
+    NoRegexPrompt = 0b100,
 };
 constexpr bool with_bit_ops(Meta::Type<AutoComplete>) { return true; }
 
@@ -180,7 +182,8 @@ constexpr auto enum_desc(Meta::Type<AutoComplete>)
 {
     return make_array<EnumDesc<AutoComplete>>({
         { AutoComplete::Insert, "insert"},
-        { AutoComplete::Prompt, "prompt" }
+        { AutoComplete::Prompt, "prompt" },
+        { AutoComplete::NoRegexPrompt, "no_regex_prompt" },
     });
 }
 

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -870,7 +870,7 @@ void regex_prompt(Context& context, String prompt, char reg, T func)
                 if (event == PromptEvent::Validate)
                     throw;
             }
-        });
+        }, true);
 }
 
 template<RegexMode mode>


### PR DESCRIPTION
Autocompletion in regex promps can potentially significant delay on
multi-gigabyte buffers. Allow to turn that specific autocompletion
off while keeping other prompt completion.

Use like

	set-option global autocomplete insert|prompt|no_regex_prompt

This commit is experimental because the semantics are twisted, mostly
because it's trying to maintain compatibility for users who already
set the autocomplete option. Maybe there is a better solution..
