### PR TITLE
add Highlight for complete-command shell-script

### DIFF
--- a/rc/filetype/kakrc.kak
+++ b/rc/filetype/kakrc.kak
@@ -48,10 +48,10 @@ add-highlighter shared/kakrc/shell1 region -recurse '\{' '(^|\h)\K%?%sh\{' '\}' 
 add-highlighter shared/kakrc/shell2 region -recurse '\(' '(^|\h)\K%?%sh\(' '\)' ref sh
 add-highlighter shared/kakrc/shell3 region -recurse '\[' '(^|\h)\K%?%sh\[' '\]' ref sh
 add-highlighter shared/kakrc/shell4 region -recurse '<'  '(^|\h)\K%?%sh<'  '>'  ref sh
-add-highlighter shared/kakrc/shell5 region -recurse '\{' '(^|\h)\K-?shell-script-(completion|candidates)\h+%\{' '\}' ref sh
-add-highlighter shared/kakrc/shell6 region -recurse '\(' '(^|\h)\K-?shell-script-(completion|candidates)\h+%\(' '\)' ref sh
-add-highlighter shared/kakrc/shell7 region -recurse '\[' '(^|\h)\K-?shell-script-(completion|candidates)\h+%\[' '\]' ref sh
-add-highlighter shared/kakrc/shell8 region -recurse '<'  '(^|\h)\K-?shell-script-(completion|candidates)\h+%<'  '>'  ref sh
+add-highlighter shared/kakrc/shell5 region -recurse '\{' '(^|\h)\K-?shell-script(-completion|-candidates)?\h+%\{' '\}' ref sh
+add-highlighter shared/kakrc/shell6 region -recurse '\(' '(^|\h)\K-?shell-script(-completion|-candidates)?\h+%\(' '\)' ref sh
+add-highlighter shared/kakrc/shell7 region -recurse '\[' '(^|\h)\K-?shell-script(-completion|-candidates)?\h+%\[' '\]' ref sh
+add-highlighter shared/kakrc/shell8 region -recurse '<'  '(^|\h)\K-?shell-script(-completion|-candidates)?\h+%<'  '>'  ref sh
 
 evaluate-commands %sh{
     # Grammar


### PR DESCRIPTION
add add-highlighter for shell-script as we use it in complete-command
```kakrc
complete-command find shell-script %{
    pattern="${@:$kak_token_to_complete+1:1}"
    if [[ -z "$pattern" ]]; then pattern="."; fi
    fd -tf --max-results=20 -p -- "$pattern" .
}
```
