### PR TITLE
hare.kak: change back the command to auto-insert the comment

### DIFF
--- a/rc/filetype/hare.kak
+++ b/rc/filetype/hare.kak
@@ -118,7 +118,7 @@ provide-module hare %§
             execute-keys -save-regs '' k x s ^\h*\K//\h* <ret> y
             try %{
                 # paste the comment prefix
-                execute-keys x j x s ^\h* <ret>p
+                execute-keys x j x s ^\h* <ret>P
             }
         } }
         try %{


### PR DESCRIPTION
Previously was changed in

https://github.com/mawww/kakoune/pull/4785

Probably some race condition that right now works with a capital letter P?

Current situation:

![image](https://github.com/mawww/kakoune/assets/20167110/e7f305a7-d8bd-4675-978d-085220bd4b5d)

after pressing "o"

![image](https://github.com/mawww/kakoune/assets/20167110/be5f2474-58b1-46b5-8f00-807233fd0632)

Also works fine with indented comments.