### PR TITLE
Fix build using GCC 13.1

### DIFF
--- a/src/display_buffer.hh
+++ b/src/display_buffer.hh
@@ -2,12 +2,12 @@
 #define display_buffer_hh_INCLUDED
 
 #include "face.hh"
-#include "hash.hh"
 #include "coord.hh"
 #include "range.hh"
 #include "string.hh"
 #include "vector.hh"
 #include "hash_map.hh"
+#include <functional>
 
 namespace Kakoune
 {


### PR DESCRIPTION
The `<functional>` header was missing and the "hash.hh" was not used.