### PR TITLE
Missing display_buffer include

### DIFF
--- a/src/display_buffer.hh
+++ b/src/display_buffer.hh
@@ -9,6 +9,8 @@
 #include "vector.hh"
 #include "hash_map.hh"
 
+#include <functional> // for std::mem_fn
+
 namespace Kakoune
 {
 


### PR DESCRIPTION
This PR brings the `functionnal` include required for `std::mem_fn` usage in **display_buffer.hh**