### PR TITLE
Fixup documentation on history navigation commands

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -5,9 +5,8 @@ released versions.
 
 == Development version
 
-* History is now stored linearly instead of in a tree
-
-* `<a-u>` and `<a-U>` now undo selection history
+* `<a-u>` and `<a-U>` now undo/redo selection changes; the previous meaning
+  of moving in history tree has been moved to `<c-j>` and `<c-k>`
 
 * `%exp{...}` expansions provide flexible quoting for expanded strings
   (as double quoted strings)

--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -312,7 +312,7 @@ Yanking (copying) and pasting use the *"* register by default (See <<registers#,
     move forward in changes history
 
 *<c-k>*::
-    move forward in changes history
+    move backward in changes history
 
 *<a-u>*::
     undo last selection change

--- a/src/main.cc
+++ b/src/main.cc
@@ -45,9 +45,9 @@ struct {
     StringView notes;
 } constexpr version_notes[] = { {
         0,
-        "» Selection undo/redo moved to {+b}<a-u>{}/{+b}<a-U>{} "
-        "and moving in history tree to {+b}<c-k>{}/{+b}c-j>{}\n"
-        "» {+b}<a-u>{} and {+b}<a-U>{} now undo selection history\n"
+        "» {+b}<a-u>{} and {+b}<a-U>{} now undo/redo selection changes; "
+        "the previous meaning of moving in history tree has been moved to "
+        "{+b}<c-j>{} and {+b}<c-k>{}\n"
         "» {+u}%exp\\{...}{} expansions provide flexible quoting for expanded "
         "strings (as double quoted strings)\n"
         "» {+u}show-matching -previous{} switch\n"


### PR DESCRIPTION
This fixes documentation to align with 5901d2e06b7c43fd0e6156a49761b81b747ea908