### PR TITLE
Add normal commands to extend selections downwards/upwards.

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -5,6 +5,9 @@ released versions.
 
 == Development version
 
+* `<X>` and `<a-X>` to expand line selections downwards and upwards,
+  respectively. 
+
 * History is now stored linearly instead of in a tree
 
 * `<a-u>` and `<a-U>` now undo selection history

--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -168,6 +168,14 @@ the Shift modifier and moving will extend each selection instead.
     trim selections to only contain full lines (not including last
     end-of-line)
 
+*X*::
+    expand selections to contain full lines (including end-of-lines) and extend
+    the selected block one line downwards
+
+*<a-X>*::
+    expand selections to contain full lines (including end-of-lines) and extend
+    the selected block one line upwards
+
 *%*, *<percent>*::
     select whole buffer
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -52,6 +52,8 @@ struct {
         "strings (as double quoted strings)\n"
         "» {+u}show-matching -previous{} switch\n"
         "» {+b}<c-g>{} to cancel current operation\n"
+        "» {+b}<X>{} and {+b}<a-X>{} to expand line selections downwards and "
+        "upwards, respectively\n"
     }, {
         20221031,
         "» {+b}<esc>{} does not end macro recording anymore, use {+b}Q{}\n"

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -2344,6 +2344,9 @@ static constexpr HashMap<Key, NormalCmd, MemoryDomain::Undefined, KeymapBackend>
     { {'x'}, {"extend selections to whole lines", select<SelectMode::Replace, select_lines>} },
     { {alt('x')}, {"crop selections to whole lines", select<SelectMode::Replace, trim_partial_lines>} },
 
+    { {'X'}, {"extend selections to whole lines downwards", repeated<select<SelectMode::Replace, extend_lines_downwards>>} },
+    { {alt('X')}, {"extend selections to whole lines upwards", repeated<select<SelectMode::Replace, extend_lines_upwards>>} },
+
     { {'m'}, {"select to matching character", select<SelectMode::Replace, select_matching<true>>} },
     { {alt('m')}, {"backward select to matching character", select<SelectMode::Replace, select_matching<false>>} },
     { {'M'}, {"extend to matching character", select<SelectMode::Extend, select_matching<true>>} },

--- a/src/selectors.cc
+++ b/src/selectors.cc
@@ -861,6 +861,38 @@ trim_partial_lines(const Context& context, const Selection& selection)
     return Selection{anchor, {cursor, max_column}};
 }
 
+Optional<Selection>
+extend_lines_downwards(const Context& context, const Selection& selection)
+{
+    auto& buffer = context.buffer();
+    BufferCoord anchor = selection.anchor();
+    BufferCoord cursor = selection.cursor();
+    BufferCoord& to_line_start = anchor <= cursor ? anchor : cursor;
+    BufferCoord& to_line_end = anchor <= cursor ? cursor : anchor;
+
+    to_line_start.column = 0;
+    to_line_end.column = buffer[to_line_end.line].length()-1;
+    to_line_end.line = std::min(to_line_end.line + 1, buffer.line_count() - 1);
+
+    return Selection{anchor, {cursor, max_column}};
+}
+
+Optional<Selection>
+extend_lines_upwards(const Context& context, const Selection& selection)
+{
+    auto& buffer = context.buffer();
+    BufferCoord anchor = selection.anchor();
+    BufferCoord cursor = selection.cursor();
+    BufferCoord& to_line_start = anchor <= cursor ? anchor : cursor;
+    BufferCoord& to_line_end = anchor <= cursor ? cursor : anchor;
+
+    to_line_start.column = 0;
+    to_line_start.line = std::max(to_line_start.line - 1, LineCount(0));
+    to_line_end.column = buffer[to_line_end.line].length()-1;
+
+    return Selection{anchor, {cursor, max_column}};
+}
+
 static RegexExecFlags
 match_flags(const Buffer& buf, const BufferIterator& begin, const BufferIterator& end)
 {

--- a/src/selectors.hh
+++ b/src/selectors.hh
@@ -107,6 +107,12 @@ select_lines(const Context& context, const Selection& selection);
 Optional<Selection>
 trim_partial_lines(const Context& context, const Selection& selection);
 
+Optional<Selection>
+extend_lines_downwards(const Context& context, const Selection& selection);
+
+Optional<Selection>
+extend_lines_upwards(const Context& context, const Selection& selection);
+
 enum class RegexMode;
 
 template<RegexMode mode>


### PR DESCRIPTION
Since we changed the `x` keys behaviors, the `X` and `<a-X>` have been free.

I think it makes sense to make them work mostly like `/` and other commands, where shift extends the selection and alt changes the direction.

So, the implemented behavior is:
`<X>`   : select the current and next line (extend downwards)
`<a-X>` : select the current and previous line (extend upwards)

Overall, I think it's a good change that's consistent with the way other keys (and modifiers) behave in Kakoune.

Note: in this implementation, pressing once `<X>` or `<a-X>` will result in two lines being selected (regardless of the current line being completely selected). This makes the keys more predictable, but it might be surprising at the beginning, if someone expects the old `X` behavior.
