### PR TITLE
Quote doc file path in doc-render command

### DIFF
--- a/rc/tools/doc.kak
+++ b/rc/tools/doc.kak
@@ -99,7 +99,7 @@ define-command -hidden doc-follow-link %{
 
 define-command -params 1 -hidden doc-render %{
     edit! -scratch "*doc-%sh{basename $1 .asciidoc}*"
-    execute-keys "!cat %arg{1}<ret>gg"
+    execute-keys "!cat '%arg{1}'<ret>gg"
 
     doc-parse-anchors
 


### PR DESCRIPTION
Without quoting the file path,
the `doc` command fails to display any docs with spaces or backslashs (on Cygwin) in their paths.