### PR TITLE
lisp highlighter is marking everything as variable

### DIFF
--- a/rc/filetype/lisp.kak
+++ b/rc/filetype/lisp.kak
@@ -36,10 +36,10 @@ add-highlighter shared/lisp/code default-region group
 add-highlighter shared/lisp/string  region '"' (?<!\\)(\\\\)*" fill string
 add-highlighter shared/lisp/comment region ';' '$'             fill comment
 
+add-highlighter shared/lisp/code/ regex (#?(['`:]|,@?))?\b[a-zA-Z][\w!$%&*+./:<=>?@^_~-]* 0:variable
 add-highlighter shared/lisp/code/ regex \b(nil|true|false)\b 0:value
 add-highlighter shared/lisp/code/ regex (((\Q***\E)|(///)|(\Q+++\E)){1,3})|(1[+-])|(<|>|<=|=|>=) 0:operator
 add-highlighter shared/lisp/code/ regex \b(def[a-z]+|if|do|let|lambda|catch|and|assert|while|def|do|fn|finally|let|loop|new|quote|recur|set!|throw|try|var|case|if-let|if-not|when|when-first|when-let|when-not|(cond(->|->>)?))\b 0:keyword
-add-highlighter shared/lisp/code/ regex (#?(['`:]|,@?))?\b[a-zA-Z][\w!$%&*+./:<=>?@^_~-]* 0:variable
 add-highlighter shared/lisp/code/ regex \*[a-zA-Z][\w!$%&*+./:<=>?@^_~-]*\* 0:variable
 add-highlighter shared/lisp/code/ regex (\b\d+)?\.\d+([eEsSfFdDlL]\d+)?\b 0:value
 


### PR DESCRIPTION
The following line in `lisp.kak`
```
add-highlighter shared/lisp/code/ regex (#?(['`:]|,@?))?\b[a-zA-Z][\w!$%&*+./:<=>?@^_~-]* 0:variable
```
is marking keywords like `nil`, `true`, `false`, `def`s as variables.

Moving the highlighter to before the others seems to fix the issue, though I'm not familiar with kak config enough to know if that's a proper fix.