### PR TITLE
Add filetype for ember js .gjs and .gts files

### DIFF
--- a/rc/filetype/gjs.kak
+++ b/rc/filetype/gjs.kak
@@ -1,0 +1,65 @@
+# https://github.com/ember-template-imports/ember-template-imports
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+# Detection
+# ‾‾‾‾‾‾‾‾‾
+
+hook global BufCreate .*[.](gjs) %{
+    set-option buffer filetype gjs
+}
+
+hook global BufCreate .*[.](gts) %{
+    set-option buffer filetype gts
+}
+
+# Initialization
+# ‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+hook global WinSetOption filetype=(gjs|gts) %{
+    require-module javascript
+
+    hook window ModeChange pop:insert:.* -group "%val{hook_param_capture_1}-trim-indent" javascript-trim-indent
+    hook window InsertChar .* -group "%val{hook_param_capture_1}-indent" javascript-indent-on-char
+    hook window InsertChar \n -group "%val{hook_param_capture_1}-insert" javascript-insert-on-new-line
+    hook window InsertChar \n -group "%val{hook_param_capture_1}-indent" javascript-indent-on-new-line
+
+    hook -once -always window WinSetOption filetype=.* "
+        remove-hooks window %val{hook_param_capture_1}-.+
+    "
+}
+
+hook -group gjs-highlight global WinSetOption filetype=gjs %{
+    require-module gjs
+    add-highlighter window/gjs ref gjs
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/gjs }
+}
+
+hook -group gts-highlight global WinSetOption filetype=gts %{
+    require-module gts
+    add-highlighter window/gts ref gts
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/gts }
+}
+
+# Modules
+
+provide-module gjs %{
+    require-module javascript
+    require-module hbs
+    require-module html
+    maybe-add-hbs-to-html
+
+    add-highlighter "shared/gjs" regions
+    add-highlighter "shared/gjs/" default-region ref javascript
+    add-highlighter "shared/gjs/hbs" region '<template>' '</template>' ref html
+}
+
+provide-module gts %{
+    require-module javascript
+    require-module hbs
+    require-module html
+    maybe-add-hbs-to-html
+
+    add-highlighter "shared/gts" regions
+    add-highlighter "shared/gts/" default-region ref typescript
+    add-highlighter "shared/gts/hbs" region '<template>' '</template>' ref html
+}


### PR DESCRIPTION
Im trying to add highlighting for [`.gjs` and `.gts`](https://github.com/ember-template-imports/ember-template-imports) files. I copied the `.js` and `.hbs` file and started to hack around a bit.
But im now getting errors that my closing expansion characters are not commands. Could someone help me out on this?

This is just an attempt and by no means complete or anything yet. I just thought i would ask if someone could help me out on this since I've been struggling with this for some times.

Example of an `.gjs` file:
```gjs
import { on } from '@ember/modifier';
import FancyButton from './fancy-button';

function greet() {
  alert("AHOY!")
}

<template>
  <p>Hello, {{@name}}!</p>
  <FancyButton @label="Say hello!" {{on "click" greet}} />
</template>
```