### PR TITLE
Fix segfault when adding an invalid default-region highlighter

### DIFF
--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -2044,7 +2044,13 @@ public:
         static const ParameterDesc param_desc{ {}, ParameterDesc::Flags::SwitchesOnlyAtStart, 1 };
         ParametersParser parser{params, param_desc};
 
-        auto delegate = HighlighterRegistry::instance()[parser[0]].factory(parser.positionals_from(1), nullptr);
+        const auto& type = parser[0];
+        auto& registry = HighlighterRegistry::instance();
+        auto it = registry.find(type);
+        if (it == registry.end())
+            throw runtime_error(format("no such highlighter type: '{}'", type));
+
+        auto delegate = it->value.factory(parser.positionals_from(1), nullptr);
         return std::make_unique<RegionHighlighter>(std::move(delegate));
     }
 


### PR DESCRIPTION
`RegionsHighlighter::create_region()` validates the highlighter type argument but `RegionsHighlighter::create_default_region()` assumes it is correct, segfaulting from dereferencing a null pointer if the given type isn't in the highlighter registry HashMap.

@PJungkamp reported this in https://github.com/mawww/kakoune/issues/4959 with a simple recipe to reproduce:

    :add-highlighter shared/test regions
    :add-highlighter shared/test/ default-region invalid highlighter
    :add-highlighter window/test ref test

Validate the type argument in `RegionsHighlighter::create_default_region()` in the same way as `RegionsHighlighter::create_region()`.