### PR TITLE
Add kak-connect to connect external programs as file browsers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,8 @@ installdirs-debug-yes: installdirs-debug-no
 install: src/kak installdirs install-debug-$(debug) install-gzip-man-$(gzip_man)
 	cp src/kak$(suffix) $(bindir)
 	chmod 0755 $(bindir)/kak
+	cp src/kak-connect$(suffix) $(bindir)
+	chmod 0755 $(bindir)/kak-connect
 
 	ln -sf ../../bin/kak $(libexecdir)/kak
 

--- a/rc/windowing/connect.kak
+++ b/rc/windowing/connect.kak
@@ -1,0 +1,19 @@
+define-command -override connect -params 1.. -command-completion -docstring 'Run a command as <command> sh -c {connect} -- [arguments].  Example: connect terminal sh' %{
+  %arg{1} sh -c %{
+    export KAKOUNE_SESSION=$1
+    export KAKOUNE_CLIENT=$2
+    shift 3
+
+    export EDITOR='kak-connect'
+
+    [ $# = 0 ] && set -- "$SHELL"
+
+    "$@"
+  } -- %val{session} %val{client} %arg{@}
+}
+
+define-command -override run -params 1.. -shell-completion -docstring 'Run a program in a new session' %{
+  nop %sh{
+    nohup "$@" < /dev/null > /dev/null 2>&1 &
+  }
+}

--- a/rc/windowing/connect.kak
+++ b/rc/windowing/connect.kak
@@ -1,3 +1,5 @@
+provide-module connect %{
+
 define-command -override connect -params 1.. -command-completion -docstring 'Run a command as <command> sh -c {connect} -- [arguments].  Example: connect terminal sh' %{
   %arg{1} sh -c %{
     export KAKOUNE_SESSION=$1
@@ -16,4 +18,6 @@ define-command -override run -params 1.. -shell-completion -docstring 'Run a pro
   nop %sh{
     nohup "$@" < /dev/null > /dev/null 2>&1 &
   }
+}
+
 }

--- a/rc/windowing/explore-files.kak
+++ b/rc/windowing/explore-files.kak
@@ -1,0 +1,67 @@
+
+provide-module explore-files %{
+
+require-module connect
+
+# explorefilescmd should be set such as the next argument is file or
+# directory to open
+declare-option -docstring %{command run to spawn a file browser} \
+    str explorefilescmd %sh{
+    for explorefilescmd in 'terminal nnn' \
+                   'terminal ranger'; do
+        cmd=${explorefilescmd##* }
+        if command -v $cmd >/dev/null 2>&1; then
+            printf %s\\n "$explorefilescmd"
+            exit
+        fi
+    done
+}
+
+define-command -override -params ..1 explore-files %{
+    evaluate-commands %sh{
+        if [ -z "$kak_opt_explorefilescmd" ]; then
+            echo "fail 'explorefilescmd option is not set'"
+            exit
+        fi
+        printf 'connect %s "%s"\n' "$kak_opt_explorefilescmd" "$1"
+    }
+}
+complete-command explore-files file
+
+hook global RuntimeError "\d+:\d+: '(edit|e)':? wrong argument count" %{
+  evaluate-commands -save-regs 'd' %{
+    set-register d %sh(dirname "$kak_buffile")
+    explore-files %reg{d}
+    echo "Openned file browser !"
+  }
+}
+
+hook global RuntimeError "\d+:\d+: '(?:edit|e)':? (.+): is a directory" %{
+  explore-files %val{hook_param_capture_1}
+  echo "Openned file browser !"
+}
+
+hook global RuntimeError "unable to find file '(.+)'" %{
+  explore-files %val{hook_param_capture_1}
+  echo "Openned file browser !"
+}
+
+hook global KakBegin .* %{
+  hook -once global ClientCreate .* %{
+    try %{
+      evaluate-commands -buffer '*debug*' -save-regs '/' %{
+        set-register / "^error while opening file '(.+?)':?\n[^\n]+: is a directory$"
+        execute-keys '%1s<ret>'
+        evaluate-commands -draft -itersel -save-regs 'd' %{
+          set-register d %reg{.}
+          evaluate-commands -client %val{hook_param} %{
+            explore-files %reg{d}
+            echo "Openned file browser !"
+          }
+        }
+      }
+    }
+  }
+}
+
+}

--- a/src/kak-connect
+++ b/src/kak-connect
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+if [ -z "$*" ] ; then
+	cat <<EOF >&2
+Usage: $(basename "$0") <file> ...
+
+Edit the files in a connected Kakoune session.
+EOF
+	exit 1
+fi
+
+if [ -z "$KAKOUNE_CLIENT" ] || [ -z "$KAKOUNE_SESSION" ]; then
+	cat <<EOF >&2
+No connected Kakoune session.
+EOF
+	exit 1
+fi
+
+while [ -n "$1" ]; do
+	realpath "$1" | \
+		tr '\n' '\0' | \
+		sed 's| |\\ |g' | \
+		xargs -0 printf 'evaluate-commands -try-client %s edit "%s"\n' "$KAKOUNE_CLIENT" | \
+		kak -p "$KAKOUNE_SESSION"
+	shift
+done
+


### PR DESCRIPTION
Kakoune doesn't embark a file browser. It has been designed as client-server, and this make it easy to connect to external programs.

The problem is that there is no easy way to do so out of the box. The users are expected to glue this themselves.

This try to help users to connect external softwares to Kakoune.

:connect is a new command to be used with :terminal or :run to start a new connected terminal, or graphical application.

Those connected software have the corresponding KAKOUNE_SESSION and KAKOUNE_CLIENT environment variables. It also set kak-connect as EDITOR.

kak-connect is a simple POSIX shell script that send commands to the connected Kakoune session, to open the files.

The basic usage of all could be:

:connect terminal nnn
:connect terminal ranger

Which open nnn or ranger in another terminal (external, or in a tmux pane), and to open the files in the Kakoune client.

We can itterate over this:

- Add hooks to open a file browser when the user open a directory, or no file with :edit.
- Make nnn, or other programs detected and configured by default, as we do in windowing terminals. And wrap it with a :file-browser command.