### PR TITLE
fix a sed error on mac

### DIFF
--- a/rc/tools/spell.kak
+++ b/rc/tools/spell.kak
@@ -149,7 +149,7 @@ define-command \
             fi
             printf %s "$kak_selection" |
                 eval "aspell -a $options" |
-                sed -n -e '/^&/ { s/^[^:]*: //; s/, /\n/g; p }'
+                sed -n -e '/^&/ { s/^[^:]*: //; s/, /\n/g; p;}'
         } \
         "Replace with: " \
         %{


### PR DESCRIPTION
sed: 1: "/^&/ { s/^[^:]*: //; s/ ...": extra characters at the end of p command