### PR TITLE
Support setting diff characters in git diffs.

### DIFF
--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -388,22 +388,6 @@ are exclusively available to built-in options.
     relating to a Kakoune version greater than this value will be displayed. Versions
     are written as a single number: Like `20180413` for version `2018.04.13`
 
-*diff_add_char* `str`::
-	  _default_ ▏ +
-	  Character used to denote added lines in diffs (e.g. git gutter).
-
-*diff_mod_char* `str`::
-	  _default_ ▏ +
-	  Character used to denote modified lines in diffs (e.g. git gutter).
-
-*diff_del_char* `str`::
-	  _default_ _ +
-	  Character used to denote deleted lines in diffs (e.g. git gutter).
-
-*diff_top_char* `str`::
-	  _default_ ‾ +
-	  Character used to denote the first line deleted in diffs (e.g. git gutter).
-
 == Current values
 
 The current value for an option can be viewed using

--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -388,6 +388,22 @@ are exclusively available to built-in options.
     relating to a Kakoune version greater than this value will be displayed. Versions
     are written as a single number: Like `20180413` for version `2018.04.13`
 
+*diff_add_char* `str`::
+	  _default_ ▏ +
+	  Character used to denote added lines in diffs (e.g. git gutter).
+
+*diff_mod_char* `str`::
+	  _default_ ▏ +
+	  Character used to denote modified lines in diffs (e.g. git gutter).
+
+*diff_del_char* `str`::
+	  _default_ _ +
+	  Character used to denote deleted lines in diffs (e.g. git gutter).
+
+*diff_top_char* `str`::
+	  _default_ ‾ +
+	  Character used to denote the first line deleted in diffs (e.g. git gutter).
+
 == Current values
 
 The current value for an option can be viewed using

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -1,17 +1,17 @@
 declare-option -docstring "name of the client in which documentation is to be displayed" \
     str docsclient
 
-declare-option -docstring "diff added character" \
-    str diff_add_char "▏"
+declare-option -docstring "git diff added character" \
+    str git_diff_add_char "▏"
 
-declare-option -docstring "diff modified character" \
-    str diff_mod_char "▏"
+declare-option -docstring "git diff modified character" \
+    str git_diff_mod_char "▏"
 
-declare-option -docstring "diff deleted character" \
-    str diff_del_char "_"
+declare-option -docstring "git diff deleted character" \
+    str git_diff_del_char "_"
 
-declare-option -docstring "diff top deleted character" \
-    str diff_top_char "‾"
+declare-option -docstring "git diff top deleted character" \
+    str git_diff_top_char "‾"
 
 hook -group git-log-highlight global WinSetOption filetype=git-log %{
     require-module diff
@@ -182,10 +182,10 @@ define-command -params 1.. \
             git --no-pager diff --no-ext-diff -U0 "$kak_buffile" | perl -e '
             use utf8;
             $flags = $ENV{"kak_timestamp"};
-            $add_char = $ENV{"kak_opt_diff_add_char"};
-            $del_char = $ENV{"kak_opt_diff_del_char"};
-            $top_char = $ENV{"kak_opt_diff_top_char"};
-            $mod_char = $ENV{"kak_opt_diff_mod_char"};
+            $add_char = $ENV{"kak_opt_git_diff_add_char"};
+            $del_char = $ENV{"kak_opt_git_diff_del_char"};
+            $top_char = $ENV{"kak_opt_git_diff_top_char"};
+            $mod_char = $ENV{"kak_opt_git_diff_mod_char"};
             foreach $line (<STDIN>) {
                 if ($line =~ /@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))?/) {
                     $from_line = $1;

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -1,6 +1,18 @@
 declare-option -docstring "name of the client in which documentation is to be displayed" \
     str docsclient
 
+declare-option -docstring "diff added character" \
+    str diff_add_char "▏"
+
+declare-option -docstring "diff modified character" \
+    str diff_mod_char "▏"
+
+declare-option -docstring "diff deleted character" \
+    str diff_del_char "_"
+
+declare-option -docstring "diff top deleted character" \
+    str diff_top_char "‾"
+
 hook -group git-log-highlight global WinSetOption filetype=git-log %{
     require-module diff
     add-highlighter window/git-log group
@@ -168,7 +180,12 @@ define-command -params 1.. \
         (
             cd_bufdir
             git --no-pager diff --no-ext-diff -U0 "$kak_buffile" | perl -e '
+            use utf8;
             $flags = $ENV{"kak_timestamp"};
+            $add_char = $ENV{"kak_opt_diff_add_char"};
+            $del_char = $ENV{"kak_opt_diff_del_char"};
+            $top_char = $ENV{"kak_opt_diff_top_char"};
+            $mod_char = $ENV{"kak_opt_diff_mod_char"};
             foreach $line (<STDIN>) {
                 if ($line =~ /@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))?/) {
                     $from_line = $1;
@@ -179,39 +196,39 @@ define-command -params 1.. \
                     if ($from_count == 0 and $to_count > 0) {
                         for $i (0..$to_count - 1) {
                             $line = $to_line + $i;
-                            $flags .= " $line|\{green\}+";
+                            $flags .= " $line|\{green\}$add_char";
                         }
                     }
                     elsif ($from_count > 0 and $to_count == 0) {
                         if ($to_line == 0) {
-                            $flags .= " 1|\{red\}‾";
+                            $flags .= " 1|\{red\}$top_char";
                         } else {
-                            $flags .= " $to_line|\{red\}_";
+                            $flags .= " $to_line|\{red\}$del_char";
                         }
                     }
                     elsif ($from_count > 0 and $from_count == $to_count) {
                         for $i (0..$to_count - 1) {
                             $line = $to_line + $i;
-                            $flags .= " $line|\{blue\}~";
+                            $flags .= " $line|\{blue\}$mod_char";
                         }
                     }
                     elsif ($from_count > 0 and $from_count < $to_count) {
                         for $i (0..$from_count - 1) {
                             $line = $to_line + $i;
-                            $flags .= " $line|\{blue\}~";
+                            $flags .= " $line|\{blue\}$mod_char";
                         }
                         for $i ($from_count..$to_count - 1) {
                             $line = $to_line + $i;
-                            $flags .= " $line|\{green\}+";
+                            $flags .= " $line|\{green\}$add_char";
                         }
                     }
                     elsif ($to_count > 0 and $from_count > $to_count) {
                         for $i (0..$to_count - 2) {
                             $line = $to_line + $i;
-                            $flags .= " $line|\{blue\}~";
+                            $flags .= " $line|\{blue\}$mod_char";
                         }
                         $last = $to_line + $to_count - 1;
-                        $flags .= " $last|\{blue+u\}~";
+                        $flags .= " $last|\{blue+u\}$mod_char";
                     }
                 }
             }


### PR DESCRIPTION
This commit adds `diff_add_char`, `diff_mod_char`, `diff_del_char` and `diff_top_char` as `str` options, with typical defaults.

This commit also replaces the hard coded +, _, ≃, etc. hardcoded characters in `git update-diff` to use the options from above.