### PR TITLE
Add <C-e> and <C-y> to scroll one line at a time

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -452,6 +452,8 @@ See <<Appending>> below for instructions on extending (appending to) the current
  * `pagedown, <c-f>`: scroll one page down
  * `<c-u>`: scroll half a page up
  * `<c-d>`: scroll half a page down
+ * `<c-y>`: scroll one line up
+ * `<c-e>`: scroll one line down
 
  * `)`: rotate selections (the main selection becomes the next one)
  * `(`: rotate selections backwards

--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -193,6 +193,12 @@ the Shift modifier and moving will extend each selection instead.
 *<c-d>*::
     scroll half a page down
 
+*<c-y>*::
+    scroll one line up
+
+*<c-e>*::
+    scroll one line down
+
 *;*, *<semicolon>*::
     reduce selections to their cursor
 

--- a/src/context.hh
+++ b/src/context.hh
@@ -25,6 +25,7 @@ class KeymapManager;
 class HookManager;
 
 enum Direction { Backward = -1, Forward = 1 };
+enum Distance { FullScreen = 0, HalfScreen = 1, Line = 2 };
 
 struct JumpList
 {

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1590,12 +1590,24 @@ void select_object(Context& context, NormalParams params)
     return select_object(context, params, flags, mode);
 }
 
-template<Direction direction, bool half = false>
+template<Direction direction, Distance distance = FullScreen>
 void scroll(Context& context, NormalParams params)
 {
     const Window& window = context.window();
     const int count = params.count ? params.count : 1;
-    const LineCount offset = (window.dimensions().line - 2) / (half ? 2 : 1) * count;
+    LineCount offset = 0;
+
+    switch (distance) {
+        case FullScreen:
+            offset = (window.dimensions().line - 2) * count;
+            break;
+        case HalfScreen:
+            offset = (window.dimensions().line - 2) / 2 * count;
+            break;
+        case Line:
+            offset = count;
+            break;
+    }
 
     scroll_window(context, offset * direction, OnHiddenCursor::MoveCursorAndAnchor);
 }
@@ -2625,10 +2637,12 @@ static constexpr HashMap<Key, NormalCmd, MemoryDomain::Undefined, KeymapBackend>
     { {Key::PageUp}, {  "scroll one page up", scroll<Backward>} },
     { {Key::PageDown}, {"scroll one page down", scroll<Forward>} },
 
-    { {ctrl('b')}, {"scroll one page up", scroll<Backward >} },
+    { {ctrl('b')}, {"scroll one page up", scroll<Backward>} },
     { {ctrl('f')}, {"scroll one page down", scroll<Forward>} },
-    { {ctrl('u')}, {"scroll half a page up", scroll<Backward, true>} },
-    { {ctrl('d')}, {"scroll half a page down", scroll<Forward, true>} },
+    { {ctrl('u')}, {"scroll half a page up", scroll<Backward, HalfScreen>} },
+    { {ctrl('d')}, {"scroll half a page down", scroll<Forward, HalfScreen>} },
+    { {ctrl('y')}, {"scroll one line up", scroll<Backward, Line>} },
+    { {ctrl('e')}, {"scroll one line down", scroll<Forward, Line>} },
 
     { {'z'}, {"restore selections from register", restore_selections<false>} },
     { {alt('z')}, {"combine selections from register", restore_selections<true>} },


### PR DESCRIPTION
Recently I noticed changes with the behavior of my keybinds:

```
map global normal <C-e> vj
map global normal <C-y> vk
```

This is because the cursor movement behavior changed with vj and vk. Scrolling window was previously blocked by the cursor. Now the cursor and selection stays in place.

I think the view keyboard behaviors are consistent, and coherent with the current state. But this isn't exactly what we want from `<C-e>` and `<C-y>`.

Example, when you start to scroll with `<C-e>` (your cursor stay in place), then you press `<C-d>` (your cursor is moved back to your view).

Example, when you start to scroll with `<C-e>` (your cursor stay in place), then you press `j` or `k` (your view is pushed back to initial position).

To solve this, I think we need news and differents default keybinds `<C-e>` and `<C-y>`.
