### PR TITLE
Update README.asciidoc

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -31,8 +31,6 @@ regularly beating the best Vim solution.
 See the link:doc/design.asciidoc[design document] for more information on
 Kakoune's philosophy and design.
 
-:numbered:
-
 Introduction
 ------------
 


### PR DESCRIPTION
Removed :numbered:

The table of contents links seem to be completely broken using :numbered: sections right now.