### PR TITLE
Fix quoting of arguments to kak -c SESSION

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1229,7 +1229,7 @@ int main(int argc, char* argv[])
             }
             String new_files;
             for (auto name : files) {
-                new_files += format("edit '{}'", escape(real_path(name), "'", '\\'));
+                new_files += format("edit '{}'", escape(real_path(name), "'", '\''));
                 if (init_coord) {
                     new_files += format(" {} {}", init_coord->line + 1, init_coord->column + 1);
                     init_coord.reset();


### PR DESCRIPTION
Filename arguments to `kak -c SESSION` are passed to the remote sessions as commands like

    edit 'FILENAME';

but single-quotes in `FILENAME` are incorrectly escaped as `\'` instead of being doubled-up. Fix this so `kak -c SESSION "foo'bar"` becomes

    edit 'foo''bar';

instead of

    edit 'foo\'bar';

Reported by @FlyingWombat in https://github.com/mawww/kakoune/issues/4980