### PR TITLE
Add an InlineInformation face distinct from Information

### DIFF
--- a/doc/pages/faces.asciidoc
+++ b/doc/pages/faces.asciidoc
@@ -107,6 +107,9 @@ the user interface:
 *Information*::
     Face for windows and messages displaying other information.
 
+*InlineInformation*::
+    Face for windows and messages displaying inline information.
+
 *Error*::
     Face for errors reported by Kakoune in the status line.
 

--- a/src/client.cc
+++ b/src/client.cc
@@ -278,7 +278,8 @@ void Client::redraw_ifn()
 
     if (m_ui_pending & InfoShow and m_info.ui_anchor)
         m_ui->info_show(m_info.title, m_info.content, *m_info.ui_anchor,
-                        faces["Information"], m_info.style);
+                        faces[(is_inline(m_info.style) || m_info.style == InfoStyle::MenuDoc)
+                        ? "InlineInformation" : "Information"], m_info.style);
     if (m_ui_pending & InfoHide)
         m_ui->info_hide();
 

--- a/src/face_registry.cc
+++ b/src/face_registry.cc
@@ -191,6 +191,7 @@ FaceRegistry::FaceRegistry()
         { "MenuBackground", {Face{ Color::Blue, Color::White }} },
         { "MenuInfo", {Face{ Color::Cyan, Color::Default }} },
         { "Information", {Face{ Color::Black, Color::Yellow }} },
+        { "InlineInformation", {Face{}, "Information"} },
         { "Error", {Face{ Color::Black, Color::Red }} },
         { "DiagnosticError", {Face{ Color::Red, Color::Default }} },
         { "DiagnosticWarning", {Face{ Color::Yellow, Color::Default }} },


### PR DESCRIPTION
Themes might want to distinguish between inline and not-inline boxes. Effectively, boxes such as modals do have borders. So as those borders draw the contours, it allows to set the same background as the global background. But by doing that, inline boxes that render without borders blend into the background.

This change allows to have a different face for inline boxes, so that one can set a different background. For instance:

```
face global Information        default+g
face global InlineInformation  default,black+g
```

See the output:

![box_with_borders](https://github.com/mawww/kakoune/assets/3764103/0f5c8c2e-8d3f-4a04-9fa6-1234c65656b2)

![box_without_borders](https://github.com/mawww/kakoune/assets/3764103/9e99a327-4e95-47f9-9fef-6fd41cfcb24d)

This change has been discussed as comments in this PR: https://github.com/mawww/kakoune/pull/3606