### PR TITLE
Hide line number on wrapped lines

### DIFF
--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -1118,6 +1118,8 @@ private:
 
         char format[16];
         format_to(format, "%{}d", digit_count);
+        char empty[16];
+        format_to(empty, "%{}s", digit_count);
         const int main_line = (int)context.context.selections().main().cursor().line + 1;
         int last_line = -1;
         for (auto& line : display_buffer.lines())
@@ -1127,7 +1129,10 @@ private:
             const int line_to_format = (m_relative and not is_cursor_line) ?
                                        current_line - main_line : current_line;
             char buffer[16];
-            snprintf(buffer, 16, format, std::abs(line_to_format));
+            if (last_line == current_line)
+                snprintf(buffer, 16, empty, " ");
+            else
+                snprintf(buffer, 16, format, std::abs(line_to_format));
             const auto atom_face = last_line == current_line ? face_wrapped :
                 ((m_hl_cursor_line and is_cursor_line) ? face_absolute : face);
 


### PR DESCRIPTION
I started discussing this topic on that issue: https://github.com/mawww/kakoune/issues/4982#issuecomment-1723428016

This is a draft, so it does not implement the whole behavior, and it is really rough. This is more to discuss the idea, and the implementation can be reviewed then.

This is about trying to hide line numbers on lines that are wrapped. As of today, line numbers are duplicated when lines are wrapped. This duplication can be desired for some users. But for some others, they prefer having them hidden, to clearly distinguish a regular line from a wrapped one.

So the idea of this PR is to draw empty spaces in replacement of the line number for wrapped lines. And this could be activated using an option on the `number-lines` highlighter.

What do you think?

See the result:

![wrap_lines_double](https://github.com/mawww/kakoune/assets/3764103/507ab3a3-6b1e-46cd-926a-d4031993d5ca)

![wrap_lines_hidden](https://github.com/mawww/kakoune/assets/3764103/aac0a195-6b30-42f7-9a00-cbd091240789)
