### PR TITLE
rc/make.kak support override the whole error line pattern

### DIFF
--- a/rc/tools/make.kak
+++ b/rc/tools/make.kak
@@ -1,7 +1,7 @@
 declare-option -docstring "shell command run to build the project" \
     str makecmd make
 declare-option -docstring "pattern that describes lines containing information about errors in the output of the `makecmd` command" \
-    str make_error_pattern " (?:fatal )?error:"
+    str make_error_pattern "^(?:\w:)?[^:\n]+:\d+:(?:\d+:)? (?:fatal )?error:"
 
 declare-option -docstring "name of the client in which utilities display information" \
     str toolsclient
@@ -69,7 +69,7 @@ define-command -hidden make-jump %{
 define-command make-next-error -docstring 'Jump to the next make error' %{
     evaluate-commands -try-client %opt{jumpclient} %{
         buffer '*make*'
-        execute-keys "%opt{make_current_error_line}ggl" "/^(?:\w:)?[^:\n]+:\d+:(?:\d+:)?%opt{make_error_pattern}<ret>"
+        execute-keys "%opt{make_current_error_line}ggl" "/%opt{make_error_pattern}<ret>"
         make-jump
     }
     try %{
@@ -83,7 +83,7 @@ define-command make-next-error -docstring 'Jump to the next make error' %{
 define-command make-previous-error -docstring 'Jump to the previous make error' %{
     evaluate-commands -try-client %opt{jumpclient} %{
         buffer '*make*'
-        execute-keys "%opt{make_current_error_line}g" "<a-/>^(?:\w:)?[^:\n]+:\d+:(?:\d+:)?%opt{make_error_pattern}<ret>"
+        execute-keys "%opt{make_current_error_line}g" "<a-/>%opt{make_error_pattern}<ret>"
         make-jump
     }
     try %{

--- a/rc/tools/make.kak
+++ b/rc/tools/make.kak
@@ -67,9 +67,10 @@ define-command -hidden make-jump %{
 }
 
 define-command make-next-error -docstring 'Jump to the next make error' %{
-    evaluate-commands -try-client %opt{jumpclient} %{
+    evaluate-commands -try-client %opt{jumpclient} -save-regs / %{
         buffer '*make*'
-        execute-keys "%opt{make_current_error_line}ggl" "/%opt{make_error_pattern}<ret>"
+        set-register / %opt{make_error_pattern}
+        execute-keys "%opt{make_current_error_line}ggl" "/<ret>"
         make-jump
     }
     try %{
@@ -81,9 +82,10 @@ define-command make-next-error -docstring 'Jump to the next make error' %{
 }
 
 define-command make-previous-error -docstring 'Jump to the previous make error' %{
-    evaluate-commands -try-client %opt{jumpclient} %{
+    evaluate-commands -try-client %opt{jumpclient} -save-regs / %{
         buffer '*make*'
-        execute-keys "%opt{make_current_error_line}g" "<a-/>%opt{make_error_pattern}<ret>"
+        set-register / %opt{make_error_pattern}
+        execute-keys "%opt{make_current_error_line}g" "<a-/><ret>"
         make-jump
     }
     try %{

--- a/rc/tools/make.kak
+++ b/rc/tools/make.kak
@@ -54,7 +54,6 @@ define-command -hidden make-open-error -params 4 %{
 
 define-command -hidden make-jump %{
     evaluate-commands -save-regs / %{
-        set-register / %sh{ if [ -z "$kak_opt_make_error_line_pattern" ] ; then printf %s "^(?:\w:)?[^:\n]+:\d+:(?:\d+:)?$kak_opt_make_error_pattern" ; else printf %s "$kak_opt_make_error_line_pattern"; fi }
         try %{
             execute-keys gl<a-?> "Entering directory" <ret><a-:>
             # Try to parse the error into capture groups, failing on absolute paths
@@ -62,7 +61,8 @@ define-command -hidden make-jump %{
             set-option buffer make_current_error_line %val{cursor_line}
             make-open-error "%reg{1}/%reg{2}" "%reg{3}" "%reg{4}" "%reg{5}"
         } catch %{
-            execute-keys <a-h><a-l> s "%reg{/}([^\n]+)?\z" <ret>l
+            set-register / %sh{ if [ -z "$kak_opt_make_error_line_pattern" ] ; then printf %s "^(?:\w:)?[^:\n]+:\d+:(?:\d+:)?${kak_opt_make_error_pattern}([^\n]+)?\z" ; else printf %s "${kak_opt_make_error_line_pattern}([^\n]+)?\z"; fi }
+            execute-keys <a-h><a-l> s<ret>l
             set-option buffer make_current_error_line %val{cursor_line}
             make-open-error "%reg{1}" "%reg{2}" "%reg{3}" "%reg{4}"
         }

--- a/rc/tools/make.kak
+++ b/rc/tools/make.kak
@@ -1,9 +1,10 @@
 declare-option -docstring "shell command run to build the project" \
     str makecmd make
-declare-option -docstring "pattern that find lines containing information about errors in the output of the `makecmd` command" \
+declare-option -hidden -docstring "pattern that find lines containing information about errors in the output of the `makecmd` command" \
     str make_error_pattern " (?:fatal )?error:"
-declare-option -docstring "pattern that describes lines containing information about errors in the output of the `makecmd` command" \
-    str make_error_line_pattern ""
+declare-option -docstring "pattern that describes lines containing information about errors in the output of the `makecmd` command. Capture groups must be: 1: filename 2: line number 3: optional column 4: optional error description" \
+    regex make_error_line_pattern "^(?:\w:)?([^:\n]+):(\d+):(?:(\d+):)? (?:fatal )?error:([^\n]+)?"
+
 
 declare-option -docstring "name of the client in which utilities display information" \
     str toolsclient
@@ -61,7 +62,7 @@ define-command -hidden make-jump %{
             set-option buffer make_current_error_line %val{cursor_line}
             make-open-error "%reg{1}/%reg{2}" "%reg{3}" "%reg{4}" "%reg{5}"
         } catch %{
-            set-register / %sh{ if [ -z "$kak_opt_make_error_line_pattern" ] ; then printf %s "^(?:\w:)?[^:\n]+:\d+:(?:\d+:)?${kak_opt_make_error_pattern}([^\n]+)?\z" ; else printf %s "${kak_opt_make_error_line_pattern}([^\n]+)?\z"; fi }
+            set-register / %sh{ if [ "$kak_opt_make_error_pattern" != " (?:fatal )?error:" ] ; then printf %s "^(?:\w:)?([^:\n]+):(\d+):(?:(\d+):)?${kak_opt_make_error_pattern}([^\n]+)?\z" ; else printf %s "${kak_opt_make_error_line_pattern}"; fi }
             execute-keys <a-h><a-l> s<ret>l
             set-option buffer make_current_error_line %val{cursor_line}
             make-open-error "%reg{1}" "%reg{2}" "%reg{3}" "%reg{4}"
@@ -72,7 +73,7 @@ define-command -hidden make-jump %{
 define-command make-next-error -docstring 'Jump to the next make error' %{
     evaluate-commands -try-client %opt{jumpclient} -save-regs / %{
         buffer '*make*'
-        set-register / %sh{ if [ -z "$kak_opt_make_error_line_pattern" ] ; then printf %s "^(?:\w:)?[^:\n]+:\d+:(?:\d+:)?$kak_opt_make_error_pattern" ; else printf %s "$kak_opt_make_error_line_pattern"; fi }
+        set-register / %sh{ if [ "$kak_opt_make_error_pattern" != " (?:fatal )?error:" ] ; then printf %s "^(?:\w:)?[^:\n]+:\d+:(?:\d+:)?$kak_opt_make_error_pattern" ; else printf %s "$kak_opt_make_error_line_pattern"; fi }
         execute-keys "%opt{make_current_error_line}ggl" "/<ret>"
         make-jump
     }
@@ -87,7 +88,7 @@ define-command make-next-error -docstring 'Jump to the next make error' %{
 define-command make-previous-error -docstring 'Jump to the previous make error' %{
     evaluate-commands -try-client %opt{jumpclient} -save-regs / %{
         buffer '*make*'
-        set-register / %sh{ if [ -z "$kak_opt_make_error_line_pattern" ] ; then printf %s "^(?:\w:)?[^:\n]+:\d+:(?:\d+:)?$kak_opt_make_error_pattern" ; else printf %s "$kak_opt_make_error_line_pattern"; fi }
+        set-register / %sh{ if [ "$kak_opt_make_error_pattern" != " (?:fatal )?error:" ] ; then printf %s "^(?:\w:)?[^:\n]+:\d+:(?:\d+:)?$kak_opt_make_error_pattern" ; else printf %s "$kak_opt_make_error_line_pattern"; fi }
         execute-keys "%opt{make_current_error_line}g" "<a-/><ret>"
         make-jump
     }

--- a/rc/tools/make.kak
+++ b/rc/tools/make.kak
@@ -1,9 +1,7 @@
 declare-option -docstring "shell command run to build the project" \
     str makecmd make
-declare-option -hidden -docstring "pattern that find lines containing information about errors in the output of the `makecmd` command" \
-    str make_error_pattern " (?:fatal )?error:"
 declare-option -docstring "pattern that describes lines containing information about errors in the output of the `makecmd` command. Capture groups must be: 1: filename 2: line number 3: optional column 4: optional error description" \
-    regex make_error_line_pattern "^(?:\w:)?([^:\n]+):(\d+):(?:(\d+):)? (?:fatal )?error:([^\n]+)?"
+    regex make_error_pattern "^(?:\w:)?([^:\n]+):(\d+):(?:(\d+):)? (?:fatal )?error:([^\n]+)?"
 
 
 declare-option -docstring "name of the client in which utilities display information" \
@@ -62,7 +60,7 @@ define-command -hidden make-jump %{
             set-option buffer make_current_error_line %val{cursor_line}
             make-open-error "%reg{1}/%reg{2}" "%reg{3}" "%reg{4}" "%reg{5}"
         } catch %{
-            set-register / %sh{ if [ "$kak_opt_make_error_pattern" != " (?:fatal )?error:" ] ; then printf %s "^(?:\w:)?([^:\n]+):(\d+):(?:(\d+):)?${kak_opt_make_error_pattern}([^\n]+)?\z" ; else printf %s "${kak_opt_make_error_line_pattern}"; fi }
+            set-register / %opt{make_error_pattern}
             execute-keys <a-h><a-l> s<ret>l
             set-option buffer make_current_error_line %val{cursor_line}
             make-open-error "%reg{1}" "%reg{2}" "%reg{3}" "%reg{4}"
@@ -73,7 +71,7 @@ define-command -hidden make-jump %{
 define-command make-next-error -docstring 'Jump to the next make error' %{
     evaluate-commands -try-client %opt{jumpclient} -save-regs / %{
         buffer '*make*'
-        set-register / %sh{ if [ "$kak_opt_make_error_pattern" != " (?:fatal )?error:" ] ; then printf %s "^(?:\w:)?[^:\n]+:\d+:(?:\d+:)?$kak_opt_make_error_pattern" ; else printf %s "$kak_opt_make_error_line_pattern"; fi }
+        set-register / %opt{make_error_pattern}
         execute-keys "%opt{make_current_error_line}ggl" "/<ret>"
         make-jump
     }
@@ -88,7 +86,7 @@ define-command make-next-error -docstring 'Jump to the next make error' %{
 define-command make-previous-error -docstring 'Jump to the previous make error' %{
     evaluate-commands -try-client %opt{jumpclient} -save-regs / %{
         buffer '*make*'
-        set-register / %sh{ if [ "$kak_opt_make_error_pattern" != " (?:fatal )?error:" ] ; then printf %s "^(?:\w:)?[^:\n]+:\d+:(?:\d+:)?$kak_opt_make_error_pattern" ; else printf %s "$kak_opt_make_error_line_pattern"; fi }
+        set-register / %opt{make_error_pattern}
         execute-keys "%opt{make_current_error_line}g" "<a-/><ret>"
         make-jump
     }


### PR DESCRIPTION
Can't use current make_error_pattern to support gradle errors like below:

```
e: file:///Users/xxx/work/prj/File.kt:32:6 Parameters must have type annotation
```