### PR TITLE
rc/tools/git: edit a git indexed file with git edit

### DIFF
--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -69,12 +69,13 @@ define-command -params 1.. \
             grep
     } -shell-script-candidates %{
     if [ $kak_token_to_complete -eq 0 ]; then
-        printf "add\nrm\nreset\nblame\ncommit\ncheckout\ndiff\nhide-blame\nhide-diff\nlog\nnext-hunk\nprev-hunk\nshow\nshow-branch\nshow-diff\ninit\nstatus\nupdate-diff\ngrep\n"
+        printf "add\nrm\nreset\nblame\ncommit\ncheckout\ndiff\nhide-blame\nhide-diff\nlog\nnext-hunk\nprev-hunk\nshow\nshow-branch\nshow-diff\ninit\nstatus\nupdate-diff\ngrep\nedit\n"
     else
         case "$1" in
             commit) printf -- "--amend\n--no-edit\n--all\n--reset-author\n--fixup\n--squash\n"; git ls-files -m ;;
             add) git ls-files -dmo --exclude-standard ;;
-            rm|grep) git ls-files -c ;;
+            rm) git ls-files -c ;;
+            grep|edit) git ls-files -c --recurse-submodules ;;
         esac
     fi
   } \
@@ -356,6 +357,11 @@ define-command -params 1.. \
                 grep $enquoted
                 set-option current grepcmd '$kak_opt_grepcmd'
             }"
+            ;;
+        edit)
+            shift
+            enquoted="$(printf '"%s" ' "$@")"
+            printf %s "edit -existing -- $enquoted"
             ;;
         *)
             printf "fail unknown git command '%s'\n" "$1"


### PR DESCRIPTION
A quick addition to allow the user to rapidly open a file known in the git index. This can be handy instead of having to rely on a simple "edit", especially for huge projects with a lot of "compiled artefacts" such as files in `node_modules/`.

Also, I chose to include `--recurse-submodules` as default for completion for `grep` and `edit` because `ls-files` is part of commands that don't respect the global configuration `submodule.recurse` (see https://git-scm.com/docs/git-config#Documentation/git-config.txt-submodulerecurse). And I think it makes sense to let the user grep or open a file in a submodule as well.