### PR TITLE
rc windowing: allow to configure windowing system and window placement in new/terminal commands

### DIFF
--- a/rc/windowing/detection.kak
+++ b/rc/windowing/detection.kak
@@ -25,14 +25,62 @@ both automatic module loading and environment detection, enabling complete
 manual control of the module loading." \
 str-list windowing_modules 'tmux' 'screen' 'zellij' 'kitty' 'iterm' 'sway' 'wayland' 'x11' 'wezterm'
 
-hook -group windowing global KakBegin .* %{
+declare-option -docstring %{
+    windowing module to use in the 'terminal' command
+} str windowing_module
 
+declare-option -docstring %{
+    where to create new windows in the 'terminal' command.
+
+    Possible values:
+    - "window" (default) - new window
+    - "horizontal" - horizontal split (left/right)
+    - "vertical" - vertical split (top/bottom)
+    - "tab" - new tab besides current window
+} str windowing_placement window
+
+define-command terminal -params 1.. -docstring %{
+    terminal <program> [<arguments>]: create a new terminal using the preferred windowing environment and placement
+
+    This executes "%opt{windowing_module}-terminal-%opt{windowing_placement}" with the given arguments.
+    If the windowing module is 'wayland', 'sway' or 'x11', then the 'termcmd' option is used as terminal program.
+
+    Example usage:
+
+        terminal sh
+        with-option windowing_placement horizontal terminal sh
+
+    See also the 'new' command.
+} %{
+    "%opt{windowing_module}-terminal-%opt{windowing_placement}" %arg{@}
+}
+complete-command terminal shell
+
+# TODO Move this?
+define-command with-option -params 3.. -docstring %{
+    with-option <option_name> <new_value> <command> [<arguments>]: evaluate a command with a modified option
+} %{
+    evaluate-commands -save-regs s %{
+        evaluate-commands set-register s %exp{%%opt{%arg{1}}}
+        set-option current %arg{1} %arg{2}
+        evaluate-commands %sh{
+            shift 2
+            for arg
+            do
+                printf "'%s' " "$(printf %s "$arg" | sed "s/'/''/g")"
+            done
+        }
+        set-option current %arg{1} %reg{s}
+    }
+}
+
+hook -group windowing global KakBegin .* %{
     evaluate-commands %sh{
         set -- ${kak_opt_windowing_modules}
         if [ $# -gt 0 ]; then
             echo 'try %{ '
             while [ $# -ge 1 ]; do
-                echo "require-module ${1} } catch %{ "
+                echo "require-module ${1}; set-option global windowing_module ${1} } catch %{ "
                 shift
             done
             echo "echo -debug 'no windowing module detected' }"

--- a/rc/windowing/iterm.kak
+++ b/rc/windowing/iterm.kak
@@ -120,6 +120,5 @@ If no client is passed then the current one is used' \
 complete-command -menu iterm-focus client
 
 alias global focus iterm-focus
-alias global terminal iterm-terminal-vertical
 
 }

--- a/rc/windowing/kitty.kak
+++ b/rc/windowing/kitty.kak
@@ -10,8 +10,8 @@ evaluate-commands %sh{
 
 declare-option -docstring %{window type that kitty creates on new and repl calls (window|os-window)} str kitty_window_type window
 
-define-command kitty-terminal -params 1.. -docstring '
-kitty-terminal <program> [<arguments>]: create a new terminal as a kitty window
+define-command kitty-terminal-window -params 1.. -docstring '
+kitty-terminal-window <program> [<arguments>]: create a new terminal as a kitty window
 The program passed as argument will be executed in the new terminal' \
 %{
     nop %sh{
@@ -28,7 +28,7 @@ The program passed as argument will be executed in the new terminal' \
         kitty @ $listen launch --no-response --type="$kak_opt_kitty_window_type" --cwd="$PWD" $match "$@"
     }
 }
-complete-command kitty-terminal shell
+complete-command kitty-terminal-window shell
 
 define-command kitty-terminal-tab -params 1.. -docstring '
 kitty-terminal-tab <program> [<arguments>]: create a new terminal as kitty tab
@@ -74,8 +74,11 @@ If no client is passed then the current one is used' \
 }
 complete-command -menu kitty-focus client
 
-alias global terminal kitty-terminal
-alias global terminal-tab kitty-terminal-tab
 alias global focus kitty-focus
+
+# deprecated
+define-command -hidden kitty-terminal -params 1.. %{
+    kitty-terminal-window %arg{@}
+}
 
 }

--- a/rc/windowing/new-client.kak
+++ b/rc/windowing/new-client.kak
@@ -1,6 +1,6 @@
 define-command new -params .. -docstring '
 new [<commands>]: create a new Kakoune client
-The ''terminal'' alias is being used to determine the user''s preferred terminal emulator
+The ''terminal'' command is used to determine the user''s preferred terminal emulator
 The optional arguments are passed as commands to the new client' \
 %{
     terminal kak -c %val{session} -e "%arg{@}"

--- a/rc/windowing/repl/x11.kak
+++ b/rc/windowing/repl/x11.kak
@@ -11,7 +11,7 @@ define-command -docstring %{
     All optional parameters are forwarded to the new window
 } \
     -params .. \
-    x11-repl %{ x11-terminal sh -c %{
+    x11-repl %{ x11-terminal-window sh -c %{
         winid="${WINDOWID:-$(xdotool search --pid ${PPID} | tail -1)}"
         printf "evaluate-commands -try-client $1 \
             'set-option current x11_repl_id ${winid}'" | kak -p "$2"

--- a/rc/windowing/screen.kak
+++ b/rc/windowing/screen.kak
@@ -25,7 +25,7 @@ define-command screen-terminal-impl -hidden -params 3.. %{
 }
 
 define-command screen-terminal-vertical -params 1.. -docstring '
-screen-terminal-vertical <program> [<arguments>] [<arguments>]: create a new terminal as a screen pane
+screen-terminal-vertical <program> [<arguments>]: create a new terminal as a screen pane
 The current pane is split into two, left and right
 The program passed as argument will be executed in the new terminal' \
 %{

--- a/rc/windowing/screen.kak
+++ b/rc/windowing/screen.kak
@@ -71,6 +71,5 @@ If no client is passed then the current one is used' \
 complete-command -menu screen-focus client 
 
 alias global focus screen-focus
-alias global terminal screen-terminal-vertical
 
 }

--- a/rc/windowing/sway.kak
+++ b/rc/windowing/sway.kak
@@ -9,6 +9,8 @@ evaluate-commands %sh{
 
 require-module 'wayland'
 
+alias global sway-terminal-window wayland-terminal-window
+
 define-command sway-terminal-vertical -params 1.. -docstring '
     sway-terminal-vertical <program> [<arguments>]: create a new terminal as a Sway window
     The current pane is split into two, top and bottom

--- a/rc/windowing/sway.kak
+++ b/rc/windowing/sway.kak
@@ -9,6 +9,26 @@ evaluate-commands %sh{
 
 require-module 'wayland'
 
+define-command sway-terminal-vertical -params 1.. -docstring '
+    sway-terminal-vertical <program> [<arguments>]: create a new terminal as a Sway window
+    The current pane is split into two, top and bottom
+    The program passed as argument will be executed in the new terminal' \
+%{
+    nop %sh{swaymsg split vertical}
+    wayland-terminal-window %arg{@}
+}
+complete-command sway-terminal-vertical shell
+
+define-command sway-terminal-horizontal -params 1.. -docstring '
+    sway-terminal-horizontal <program> [<arguments>]: create a new terminal as a Sway window
+    The current pane is split into two, left and right
+    The program passed as argument will be executed in the new terminal' \
+%{
+    nop %sh{swaymsg split horizontal}
+    wayland-terminal-window %arg{@}
+}
+complete-command sway-terminal-horizontal shell
+
 define-command sway-focus-pid -hidden %{
     evaluate-commands %sh{
         pid=$kak_client_pid
@@ -45,7 +65,6 @@ If no client is passed, then the current client is used' \
 }
 complete-command -menu sway-focus client
 
-unalias global focus
 alias global focus sway-focus
 
 }

--- a/rc/windowing/sway.kak
+++ b/rc/windowing/sway.kak
@@ -29,6 +29,15 @@ define-command sway-terminal-horizontal -params 1.. -docstring '
 }
 complete-command sway-terminal-horizontal shell
 
+define-command sway-terminal-tab -params 1.. -docstring '
+    sway-terminal-tab <program> [<arguments>]: create a new terminal as a Sway window
+    The program passed as argument will be executed in the new terminal' \
+%{
+    nop %sh{swaymsg 'split horizontal; layout tabbed'}
+    wayland-terminal-window %arg{@}
+}
+complete-command sway-terminal-tab shell
+
 define-command sway-focus-pid -hidden %{
     evaluate-commands %sh{
         pid=$kak_client_pid

--- a/rc/windowing/tmux.kak
+++ b/rc/windowing/tmux.kak
@@ -52,7 +52,7 @@ The program passed as argument will be executed in the new terminal' \
 complete-command tmux-terminal-horizontal shell
 
 define-command tmux-terminal-window -params 1.. -docstring '
-tmux-terminal-window <program> [<arguments>] [<arguments>]: create a new terminal as a tmux window
+tmux-terminal-window <program> [<arguments>]: create a new terminal as a tmux window
 The program passed as argument will be executed in the new terminal' \
 %{
     tmux-terminal-impl 'new-window' %arg{@}

--- a/rc/windowing/tmux.kak
+++ b/rc/windowing/tmux.kak
@@ -78,6 +78,5 @@ complete-command -menu tmux-focus client
 
 ## The default behaviour for the `new` command is to open an horizontal pane in a tmux session
 alias global focus tmux-focus
-alias global terminal tmux-terminal-horizontal
 
 }

--- a/rc/windowing/wayland.kak
+++ b/rc/windowing/wayland.kak
@@ -28,8 +28,8 @@ A shell command is appended to the one set in this option at runtime} \
     done
 }
 
-define-command wayland-terminal -params 1.. -docstring '
-wayland-terminal <program> [<arguments>]: create a new terminal as a Wayland window
+define-command wayland-terminal-window -params 1.. -docstring '
+wayland-terminal-window <program> [<arguments>]: create a new terminal as a Wayland window
 The program passed as argument will be executed in the new terminal' \
 %{
     evaluate-commands -save-regs 'a' %{
@@ -46,7 +46,7 @@ The program passed as argument will be executed in the new terminal' \
         }
     }
 }
-complete-command wayland-terminal shell
+complete-command wayland-terminal-window shell
 
 define-command wayland-focus -params ..1 -docstring '
 wayland-focus [<kakoune_client>]: focus a given client''s window
@@ -57,6 +57,10 @@ If no client is passed, then the current client is used' \
 complete-command -menu wayland-focus client
 
 alias global focus wayland-focus
-alias global terminal wayland-terminal
+
+# deprecated
+define-command -hidden wayland-terminal -params 1.. %{
+    wayland-terminal-window %arg{@}
+}
 
 }

--- a/rc/windowing/wezterm.kak
+++ b/rc/windowing/wezterm.kak
@@ -16,7 +16,7 @@ define-command wezterm-terminal-impl -hidden -params 2.. %{
 }
 
 define-command wezterm-terminal-vertical -params 1.. -docstring '
-wezterm-terminal-vertical <program> [<arguments>] [<arguments>]: create a new terminal as a wezterm pane
+wezterm-terminal-vertical <program> [<arguments>]: create a new terminal as a wezterm pane
 The current pane is split into two, top and bottom
 The program passed as argument will be executed in the new terminal' \
 %{

--- a/rc/windowing/wezterm.kak
+++ b/rc/windowing/wezterm.kak
@@ -66,6 +66,5 @@ If no client is passed then the current one is used' \
 complete-command -menu wezterm-focus client
 
 alias global focus wezterm-focus
-alias global terminal wezterm-terminal-vertical
 
 }

--- a/rc/windowing/x11.kak
+++ b/rc/windowing/x11.kak
@@ -33,8 +33,8 @@ A shell command is appended to the one set in this option at runtime} \
     done
 }
 
-define-command x11-terminal -params 1.. -docstring '
-x11-terminal <program> [<arguments>]: create a new terminal as an X11 window
+define-command x11-terminal-window -params 1.. -docstring '
+x11-terminal-window <program> [<arguments>]: create a new terminal as an X11 window
 The program passed as argument will be executed in the new terminal' \
 %{
     evaluate-commands -save-regs 'a' %{
@@ -51,7 +51,7 @@ The program passed as argument will be executed in the new terminal' \
         }
     }
 }
-complete-command x11-terminal shell 
+complete-command x11-terminal-window shell 
 
 define-command x11-focus -params ..1 -docstring '
 x11-focus [<kakoune_client>]: focus a given client''s window
@@ -69,6 +69,10 @@ If no client is passed, then the current client is used' \
 complete-command -menu x11-focus client 
 
 alias global focus x11-focus
-alias global terminal x11-terminal
+
+# deprecated
+define-command -hidden x11-terminal -params 1.. %{
+    x11-terminal-window %arg{@}
+}
 
 }

--- a/rc/windowing/zellij.kak
+++ b/rc/windowing/zellij.kak
@@ -17,10 +17,10 @@ define-command -hidden -params 2.. zellij-run %{ nop %sh{
     zellij --session "$kak_client_env_ZELLIJ_SESSION_NAME" run $zellij_run_options -- "$@"
 }}
 
-define-command -hidden -params 1.. zellij-terminal-impl %{
+define-command -hidden -params 1.. zellij-terminal-window %{
     zellij-run "--close-on-exit" %arg{@}
 }
-complete-command zellij-terminal-impl shell
+complete-command zellij-terminal-window shell
 
 define-command zellij-terminal-vertical -params 1.. -docstring '
 zellij-terminal-vertical <program> [<arguments>]: create a new terminal as a zellij pane
@@ -62,7 +62,6 @@ complete-command -menu zellij-focus client
 
 ## The default behaviour for the `new` command is to open an horizontal pane in a zellij session
 alias global focus zellij-focus
-alias global terminal zellij-terminal-impl
 
 }
 


### PR DESCRIPTION
Today I can control "terminal" and "new" by changing the terminal
alias but I always need to choose a concrete implementation, like
"tmux-terminal-horizontal", even when there is otherwise no need to
mention tmux in my config.

Allow to configure windowing system and window placement independently
by introducing dedicated options.

This allows to create mappings that work in any windowing system like

	map global user c   %{:with-option windowing_placement window new<ret>}
	map global user '"' %{:with-option windowing_placement vertical new<ret>}
	map global user '%' %{:with-option windowing_placement horizontal new<ret>}

For windowing systems that don't support all placements, you can wrap
the above in try/catch to fall back on the "window" variant which is
defined for all windowing systems.

When using multiple (nested) windowing systems, you might want to
add mappings like

	map global user t %{:with-option windowing_module tmux new<ret>}
	map global user T %{:with-option windowing_module wayland new<ret>}

---

This changes the default "terminal" alias for some modules. In
particular, instead of delegating to

    iterm-terminal-vertical
    screen-terminal-vertical
    tmux-terminal-horizontal
    wezterm-terminal-vertical

it will now by default delegate to the respective "-window" variant.
We could maintain backwards compatiblity here by setting the
"windowing_placement" option accordingly, but the new behavior seems
more logical?

Also, this removes the "terminal-tab" alias which was only defined
by the kitty module.

We could try to keep the alias approach and implement a "with-alias"
command, however that approach can only capture both dimensions
(windowing system and placement) if we add tons of commands
like "terminal-horizontal" (with implied windowing system) and
"tmux-terminal" (with implied placement).

Side thought: we could also get rid of the "focus" alias and instead
define

    define-command focus %{
        "%opt{windowing_module}-focus"
    }

Closes #3943, #4425