### PR TITLE
Fix completion pager not rendering after <a-semicolon> in prompt

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1126,7 +1126,7 @@ private:
                 items.push_back({ candidate, {} });
 
             const auto menu_style = (m_flags & PromptFlags::Search) ? MenuStyle::Search : MenuStyle::Prompt;
-            context().client().menu_show(items, {}, menu_style);
+            context().client().menu_show(std::move(items), {}, menu_style);
 
             const bool menu = (bool)(m_completions.flags & Completions::Flags::Menu);
             if (menu)


### PR DESCRIPTION
Usually, the prompt resets "m_line_changed" after invoking the
change handler:

	if (m_line_changed)
	{
	    m_callback(m_line_editor.line(), PromptEvent::Change, context());
	    m_line_changed = false;
	}

but with

	prompt '' '' -on-change %{ execute-keys <a-semicolon>vl } -shell-script-candidates %{ seq 100 }

the change handler pushes a normal mode with "<a-semicolon>" and then
hands back control to the event loop. Later when the normal mode is
popped we run "Prompt::on_enabled()" but don't actually redraw the
completion pager.
Since the <a-semicolon> excursion by definition did not change our
prompt state, we don't need to recompute completions, only render them.
Do that.

This helps commands that use preview the selected completion via a
"prompt -on-change" handler.
