### PR TITLE
Quote completions of regex options

### DIFF
--- a/src/regex.cc
+++ b/src/regex.cc
@@ -1,5 +1,6 @@
 #include "regex.hh"
 #include "ranges.hh"
+#include "string_utils.hh"
 
 namespace Kakoune
 {
@@ -17,9 +18,9 @@ int Regex::named_capture_index(StringView name) const
     return it != m_impl->named_captures.end() ? it->index : -1;
 }
 
-String option_to_string(const Regex& re)
+String option_to_string(const Regex& re, Quoting quoting)
 {
-    return re.str();
+    return option_to_string(re.str(), quoting);
 }
 
 Regex option_from_string(Meta::Type<Regex>, StringView str)

--- a/src/regex.hh
+++ b/src/regex.hh
@@ -162,7 +162,8 @@ bool backward_regex_search(It begin, It end, It subject_begin, It subject_end,
     return regex_search<It, RegexMode::Backward>(begin, end, subject_begin, subject_end, res, re, flags, idle_func);
 }
 
-String option_to_string(const Regex& re);
+enum class Quoting;
+String option_to_string(const Regex& re, Quoting quoting);
 Regex option_from_string(Meta::Type<Regex>, StringView str);
 
 template<typename Iterator, RegexMode mode = RegexMode::Forward,


### PR DESCRIPTION
Recent changes to `make_error_pattern` added a space to the default
value. This means that

	set g make_error_pattern <tab>

now produces an invalid command because regexes are not quoted.  We do
quote strings; regexes are not all that different so quote them too.
