### PR TITLE
filetype/hg-commit: Fix broken filetype detection and improve highlighting

### DIFF
--- a/rc/filetype/mercurial.kak
+++ b/rc/filetype/mercurial.kak
@@ -4,7 +4,7 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*hg-editor-\w+\.txt$ %{
+hook global BufCreate .*hg-editor-.*\.txt$ %{
     set-option buffer filetype hg-commit
 }
 

--- a/rc/filetype/mercurial.kak
+++ b/rc/filetype/mercurial.kak
@@ -27,7 +27,11 @@ set-face global MercurialCommitComment cyan
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
-add-highlighter shared/hg-commit group
-add-highlighter shared/hg-commit/ regex '^HG:[^\n]*' 0:comment
+add-highlighter shared/hg-commit regions
+add-highlighter shared/hg-commit/comments region ^HG:\  $ group
+add-highlighter shared/hg-commit/comments/ fill comment
+add-highlighter shared/hg-commit/comments/ regex \
+	"\b(?:(changed)|(removed)|(added)|(bookmark)|(branch)|(user:)) ([^\n]*)$" \
+	      1:yellow  2:red     3:green 4:blue     5:magenta 6:white
 
 }


### PR DESCRIPTION
I typically use Mercurial with hg-git for my work. A few months ago I added my own hg-commit file type into my kakoune config not realising that there is one included in kakoune ootb. However, it is broken in that it doesn't properly detect mercurial VCS files, which is why I didn't discover it.

This patch fixes the file type detection and also adds a few nice highlighters that I had added to my own mecurial file type.

Also see the commit messages for details on my changes.

Please let me know if there's anything I should change.
