### PR TITLE
changelog: escape `{` as `\\{`  in version notes

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -47,7 +47,7 @@ struct {
 } constexpr version_notes[] = { {
         0,
         "» asynchronous {+u}shell-script-candidates{} completion\n"
-        "» {+b}%val{window_range}{} is now emitted as separate strings\n"
+        "» {+b}%val\\{window_range}{} is now emitted as separate strings\n"
         "» {+b}+{} only duplicates identical selections a single time\n"
         "» {+u}daemonize-session{} command\n"
     }, {


### PR DESCRIPTION
Otherwise `%val{window_range}` appears as (truncated) `%val` in version notes startup splash