### PR TITLE
Update changelog

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -14,7 +14,11 @@ released versions.
   and slow exponential growth in the number of selections.
 
 * `daemonize-session` command makes it possible to convert the current session
-  to a deamon one (which will not exit on last client disconnecting)
+  to a daemon one (which will not exit on last client disconnecting)
+
+* View mode commands and mouse scrolling no longer change selections when those go off-screen.
+
+* New commands `git apply`, `git edit`, `git grep`
 
 == Kakoune 2023.08.08
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -50,6 +50,8 @@ struct {
         "» {+b}%val{window_range}{} is now emitted as separate strings\n"
         "» {+b}+{} only duplicates identical selections a single time\n"
         "» {+u}daemonize-session{} command\n"
+        "» view mode and mouse scrolling no longer change selections\n"
+        "» {+u}git apply/edit/grep{} commands\n"
     }, {
         20230805,
         "» Fix FreeBSD/MacOS clang compilation\n"


### PR DESCRIPTION
* View mode commands and mouse scrolling no longer change selections when those go off-screen.

* New commands `git apply`, `git edit`, `git grep`
