### PR TITLE
Fix use after move in HashMap::insert

### DIFF
--- a/src/hash_map.hh
+++ b/src/hash_map.hh
@@ -214,7 +214,8 @@ struct HashMap
 
     constexpr EffectiveValue& insert(Item item)
     {
-        return insert(std::move(item), hash_value(item_key(item)));
+        const auto hash = hash_value(item_key(item));
+        return insert(std::move(item), hash);
     }
 
     template<typename KeyType> requires IsHashCompatible<Key, KeyType>


### PR DESCRIPTION
Apparently GCC builds worked fine but Clang builds started failing the
"(hash == hash_value(item_key(item)))" assertion.
