### PR TITLE
Added autorecognition and html syntax support to  jinja configuration

### DIFF
--- a/rc/filetype/jinja.kak
+++ b/rc/filetype/jinja.kak
@@ -1,14 +1,28 @@
 # https://palletsprojects.com/p/jinja/
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
+hook global BufCreate .*\.jinja %{
+    set-option buffer filetype jinja
+}
+
+hook global WinSetOption filetype=jinja %{
+    require-module jinja
+    add-highlighter window/jinja ref jinja
+    hook -once -always window WinSetOption filetype=.* %{
+        remove-highlighter window/jinja
+    }
+}
+
 provide-module jinja %[
 
 require-module python
+require-module html
 
 # Highlighters
 # ‾‾‾‾‾‾‾‾‾‾‾‾
 
 add-highlighter shared/jinja regions
+add-highlighter shared/jinja/html default-region ref html
 add-highlighter shared/jinja/comment region '\{#' '#\}' fill comment
 
 # TODO: line statements # …


### PR DESCRIPTION
The configuration file shipped with kakoune does not help the recognition of template files and it does not provide any kind of highlighting for html, css or js sections. Simply requiring the html module in the jinja module fixes the issue. 