### PR TITLE
Skip output synchronization query when explicitly disabled

### DIFF
--- a/src/terminal_ui.cc
+++ b/src/terminal_ui.cc
@@ -1472,7 +1472,6 @@ void TerminalUI::setup_terminal()
         "\033[22t"    // save the current window title
         "\033[?25l"   // hide cursor
         "\033="       // set application keypad mode, so the keypad keys send unique codes
-        "\033[?2026$p" // query support for synchronize output
         "\033[?2004h" // force enable bracketed-paste events
     );
 }
@@ -1542,6 +1541,10 @@ void TerminalUI::set_ui_options(const Options& options)
     auto synchronized = find("terminal_synchronized").map(to_bool);
     m_synchronized.set = (bool)synchronized;
     m_synchronized.requested = synchronized.value_or(false);
+    if (not m_synchronized.queried and not m_synchronized.set) {
+        write(STDOUT_FILENO, "\033[?2026$p");
+        m_synchronized.queried = true;
+    }
 
     m_shift_function_key = find("terminal_shift_function_key").map(str_to_int_ifp).value_or(default_shift_function_key);
 

--- a/src/terminal_ui.hh
+++ b/src/terminal_ui.hh
@@ -157,6 +157,7 @@ private:
 
     struct Synchronized
     {
+        bool queried : 1;
         bool supported : 1;
         bool set : 1;
         bool requested : 1;


### PR DESCRIPTION
Some terminals misbehave when queried for output synchronization support, such as Windows Terminal as reported in https://github.com/mawww/kakoune/issues/5032. The relatively long response from a terminal which does support output-sync is also prone to getting torn over a slow link such as a serial console, causing stray input to the editor.

In `ui_options`, the `terminal_synchronized` option controls the use of this feature, but unfortunately the query is unconditionally sent at startup even when this is set false.

Skip the query at startup when `terminal_synchronized` is explicitly false. We query at most once per terminal in `set_ui_options()` so the behaviour is correct both when kakoune is started with `terminal_synchronized` unset and when it is started with `terminal_synchronized` set false but this is later unset.

I've had this as a local patch for some time and assumed I was alone in seeing this problem, as using kakoune on a serial console when recovering machines is probably quite niche. However, https://github.com/mawww/kakoune/issues/5032 suggests that these queries may cause problems for others too, and it would be nice to be able to give them simple advice to
```
set-option -add global ui_options terminal_synchronized=false
```
when they get bitten.