### PR TITLE
Hide empty and undocumented mappings from autoinfo

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -193,6 +193,8 @@ String build_autoinfo_for_mapping(const Context& context, KeymapMode mode,
     for (auto& key : keymaps.get_mapped_keys(mode))
     {
         const String& docstring = keymaps.get_mapping_docstring(key, mode);
+        if (keymaps.get_mapping_keys(key, mode).empty() and docstring.empty())
+            continue;
         if (auto it = find_if(descs, [&](auto& elem) { return elem.second == docstring; });
             it != descs.end())
             it->first += ',' + to_string(key);


### PR DESCRIPTION
Users who rebind default keys and unmap the originals by binding them to empty strings with empty docstrings end up with empty lines in the autoinfo. For example, https://github.com/mawww/kakoune/issues/4918.

Hide completely null bindings which have both an empty mapping and an empty docstring in the autoinfo, as an easy mechanism for these users to eliminate the UI noise.

Fixes: https://github.com/mawww/kakoune/issues/4918