### PR TITLE
Two fixes for :write -method replace

### DIFF
--- a/src/file.cc
+++ b/src/file.cc
@@ -376,6 +376,8 @@ void write_buffer_to_file(Buffer& buffer, StringView filename,
         throw runtime_error("replacing file failed");
     }
 
+    if (replace and geteuid() == 0 and ::chown(zfilename, st.st_uid, st.st_gid) < 0)
+        throw runtime_error(format("unable to restore file ownership: {}", strerror(errno)));
     if ((force or replace) and ::chmod(zfilename, st.st_mode) < 0)
         throw runtime_error(format("unable to restore file permissions: {}", strerror(errno)));
 


### PR DESCRIPTION
These are two fixes to the `replace` mode of `:write`.

The first fixes a crash when a user attempts to save a file without write permission for the containing directory, and with `writemethod` set as `replace` or an explicit `:write -method replace` command. (An easy example is to attempt to edit and save `/etc/passwd` as non-root with `:write -method replace`.) While a runtime error is being raised from failing to create a temporary file, a second unhandled exception is raised from an attempt to restore (unmodified) file permissions.

The second fixes a bug where file ownerships are reset to `root:root` when editing a file as root with `writemethod` set to `replace`. This turns a `user:user` file into `root:root` when root fixes something on behalf of the user and then saves the file. Permissions are still restored, so without this fix, kak can even turn u+s user:user into u+s root:root, although in practice few platforms support setuid scripts and binaries wouldn't be edited with a text editor.