### PR TITLE
Perl files are not always executable

### DIFF
--- a/rc/tools/patch.kak
+++ b/rc/tools/patch.kak
@@ -54,7 +54,7 @@ define-command patch -params .. -docstring %{
                 # a shell where it expands to nothing.
                 eval set -- $kak_quoted_reg_a
 
-                "${kak_reg_f%/*}/patch-range.pl" $min_line $max_line "$@" ||
+                perl "${kak_reg_f%/*}/patch-range.pl" $min_line $max_line "$@" ||
                     echo >$kak_command_fifo "set-register e fail 'patch: failed to apply selections, see *debug* buffer'"
             }
             execute-keys |<ret>


### PR DESCRIPTION
The way kakoune is packaged on NixOS makes rc files not executable.

So in this example, `rc/tools/patch-range.pl` was not executable and it led to errors when trying to use `:patch`.

Solution here is to avoid relying on the shebang and directly call the script with perl.

Not sure exactly about all the usecases of `:patch` as I did not take long to test them. @krobelus , maybe you can have a quick look and see if it is still ok for you with this change?

Thanks