### PR TITLE
Fix compiler warnings when char is unsigned

### DIFF
--- a/src/json.cc
+++ b/src/json.cc
@@ -20,7 +20,7 @@ String to_json(StringView str)
     for (auto it = str.begin(), end = str.end(); it != end; )
     {
         auto next = std::find_if(it, end, [](char c) {
-            return c == '\\' or c == '"' or (c >= 0 and c <= 0x1F);
+            return c == '\\' or c == '"' or (unsigned char) c <= 0x1F;
         });
 
         res += StringView{it, next};
@@ -28,7 +28,7 @@ String to_json(StringView str)
             break;
 
         char buf[7] = {'\\', *next, 0};
-        if (*next >= 0 and *next <= 0x1F)
+        if ((unsigned char) *next <= 0x1F)
             format_to(buf, "\\u{:04}", hex(*next));
 
         res += buf;

--- a/src/terminal_ui.cc
+++ b/src/terminal_ui.cc
@@ -30,8 +30,8 @@ static String fix_atom_text(StringView str)
     auto pos = str.begin();
     for (auto it = str.begin(), end = str.end(); it != end; ++it)
     {
-        char c = *it;
-        if (c >= 0 and c <= 0x1F)
+        unsigned char c = *it;
+        if (c <= 0x1F)
         {
             res += StringView{pos, it};
             res += String{Codepoint{(uint32_t)(0x2400 + c)}};


### PR DESCRIPTION
In several places, we check for a control character with something like
```c
  char c;
  [...]
  if (c >= 0 and c <= 0x1F)
    [...]
```
When `char` is signed (e.g. amd64) this is fine, but when char is unsigned by default (e.g. arm32 and arm64) this generates warnings about the tautologous check that an unsigned value is non-negative.

Write as
```c
  if ((unsigned char) c <= 0x1F)
    [...]
```
which is both correct and not suspicious under both conventions.