### PR TITLE
Fix some compiler warnings with g++ and clang

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -87,7 +87,7 @@ compiler := $(shell $(CXX) --version)
 ifneq (,$(findstring clang,$(compiler)))
     CXXFLAGS += -frelaxed-template-template-args -Wno-ambiguous-reversed-operator
 else ifneq (,$(findstring g++,$(compiler)))
-    CXXFLAGS += -Wno-init-list-lifetime
+    CXXFLAGS += -Wno-init-list-lifetime -Wno-stringop-overflow
 endif
 
 all : kak

--- a/src/display_buffer.hh
+++ b/src/display_buffer.hh
@@ -141,7 +141,7 @@ public:
         if (auto first = std::find_if(beg, end, has_buffer_range); first != end)
         {
             auto& last = *std::find_if(std::reverse_iterator(end), std::reverse_iterator(first), has_buffer_range);
-            m_range.begin = std::min(m_range.begin, first->begin());
+            m_range.begin = std::min(m_range.begin, (*first).begin());
             m_range.end = std::max(m_range.end, last.end());
         }
         return m_atoms.insert(pos, beg, end);

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -913,7 +913,7 @@ public:
             m_idle_timer.set_next_date(Clock::now() + get_idle_timeout(context()));
     }
 
-    void refresh_ifn()
+    void refresh_ifn() override
     {
         bool explicit_completion_selected = m_current_completion != -1 and
             (not m_prefix_in_completions or m_current_completion != m_completions.candidates.size() - 1);


### PR DESCRIPTION
Mark the `refresh_ifn()` implementation as an override in `input_handler.cc`. This was spotted by clang's `-Winconsistent-missing-override` in `-Wall`.

g++ 13.x is confused by the `reinterpret_cast` in Kakoune's `memory.hh` allocator, so use `-Wno-stringop-overflow` to silence a large number of false alarms.

Modern clang with libc++ now complains about the use of the `->` operator on an iterator, which (somewhat surprisingly to me!) was deprecated from C++20 in §2 of [P1252](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1252r2.pdf) (adopted 2019-03) because of x-value vs l-value ambiguity. Luckily we only have one such instance anyway.