### PR TITLE
Highlight inline patches and signatures in mail.kak

### DIFF
--- a/rc/filetype/mail.kak
+++ b/rc/filetype/mail.kak
@@ -21,8 +21,10 @@ provide-module mail %{
 require-module diff
 
 add-highlighter shared/mail group
+add-highlighter shared/mail/ ref diff
 add-highlighter shared/mail/ regex ^(From|To|Cc|Bcc|Subject|Reply-To|In-Reply-To|References|Date|Message-Id|User-Agent):([^\n]*(?:\n\h+[^\n]+)*)$ 1:keyword 2:attribute
 add-highlighter shared/mail/ regex <[^@>]+@.*?> 0:string
 add-highlighter shared/mail/ regex ^>.*?$ 0:comment
+add-highlighter shared/mail/ regex ^--\ \n.* 0:comment
 
 }


### PR DESCRIPTION
We already pull in the `diff` module in `mail.kak` to enable the nice `:diff-jump` behaviour on inline patches. Also enable the `shared/diff/` highlighter underneath our `shared/mail/` highlighter for inline diffs, listing it first so mail patterns take precedence over diff patterns.

De-emphasise signatures including the standard `^-- \n` separator in the same way as quoted text in a reply.

Fixes: https://github.com/mawww/kakoune/issues/4998