### PR TITLE
Improve c-family highlighting of preprocessor directives

### DIFF
--- a/rc/filetype/c-family.kak
+++ b/rc/filetype/c-family.kak
@@ -213,10 +213,10 @@ evaluate-commands %sh{
             add-highlighter shared/$ft/comment region /\\* \\*/ fill comment
             add-highlighter shared/$ft/line_comment region // (?<!\\\\)(?=\\n) fill comment
             add-highlighter shared/$ft/disabled region -recurse "#\\h*if(?:def)?" ^\\h*?#\\h*if\\h+(?:0|FALSE)\\b "#\\h*(?:else|elif|endif)" fill comment
-            add-highlighter shared/$ft/macro region %{^\\h*?\\K#} %{(?<!\\\\)(?=\\n)|(?=//)} group
-
-            add-highlighter shared/$ft/macro/ fill meta
-            add-highlighter shared/$ft/macro/ regex ^\\h*#\\h*include\\h+(\\S*) 1:module
+            add-highlighter shared/$ft/ifdef region %{^\\h*\\K#\\h*(?:define|elif|if)(?=\\h)} %{(?<!\\\\)(?=\\s)|(?=//)} fill meta
+            add-highlighter shared/$ft/macro region %{^\\h*#} %{(?<!\\\\)(?=\\n)|(?=//)} group
+            add-highlighter shared/$ft/macro/ regex ^\\h*(#\\h*\\S*) 1:meta
+            add-highlighter shared/$ft/macro/ regex ^\\h*#\\h*include\\h+(<[^>]*>|"(?:[^"\\\\]|\\\\.)*") 1:module
             add-highlighter shared/$ft/macro/ regex /\\*.*?\\*/ 0:comment
 	EOF
     done


### PR DESCRIPTION
The current handling of preprocessor directives in `filetype/c-family.kak` leads to a wall of solid colour for more complicated `#if` or `#define` directives, although `#include` is already nicely highlighted in a more granular way.

Instead of highlighting an entire directive with the `meta` face, highlight just the `#define`, `#if`, `#elif` keyword as `meta`, treating the rest of the directive as normal c-family expressions. This significantly improves the readability of complex macro definitions.

For example, before this patch:

<img width="633" alt="Screenshot 2023-12-10 at 13 12 05" src="https://github.com/mawww/kakoune/assets/299056/37ecb0ed-cdc8-436a-80dd-f9d15a8f9c93">

and after this change:

<img width="639" alt="Screenshot 2023-12-10 at 13 14 12" src="https://github.com/mawww/kakoune/assets/299056/f2cb9925-9bce-4400-b2f4-39922b9899a4">

As shown in the screenshots, for directives other than `#define`, `#if` and `#elif`, we treat the rest of the directive as an opaque string in normal face rather than trying to highlight it - covering cases like `#error`, `#pragma`, etc. where the rest of the line is an error message string or other non-expression content. This does the right thing for `#ifdef` and `#ifndef` too, as we don't highlight identifiers in c-family text so their arguments should be normal face anyway.