### PR TITLE
Fix escaping in the scheme.kak highlighter awk script

### DIFF
--- a/rc/filetype/scheme.kak
+++ b/rc/filetype/scheme.kak
@@ -162,7 +162,7 @@ evaluate-commands %sh{ exec awk -f - <<'EOF'
         # unprefixed decimals
         add_highlighter("(?<![" normal_identifiers "])(\\d+(\\.\\d*)?|\\.\\d+)(?:[esfdlESFDL][-+]?\\d+)?(?![" normal_identifiers "])", "0:value");
         # inf and nan
-        add_highlighter("(?<![" normal_identifiers "])[+-](?:inf|nan)\.0(?![" normal_identifiers "])", "0:value");
+        add_highlighter("(?<![" normal_identifiers "])[+-](?:inf|nan)\\.0(?![" normal_identifiers "])", "0:value");
     }
 EOF
 }


### PR DESCRIPTION
The awk-generated highlighters in scheme.kak need `\\.` to obtain `\.` in the generated kakscript output. Fix the inf/nan rule (which should generate `(?:inf|nan)\.0`) to read `(?:inf|nan)\\.0` in the awk.