### PR TITLE
Update changelog

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -20,6 +20,10 @@ released versions.
 
 * New commands `git apply`, `git edit`, `git grep`
 
+* Completions provided via `shell-script-candidates` or `completers` are no longer sorted if the typed text is empty.
+
+* The `terminal` alias has been replaced with a command that selects terminal program and placement based on windowing options.
+
 == Kakoune 2023.08.08
 
 * Fix compilation errors on FreeBSD and MacOS using clang

--- a/src/main.cc
+++ b/src/main.cc
@@ -52,6 +52,8 @@ struct {
         "» {+u}daemonize-session{} command\n"
         "» view mode and mouse scrolling no longer change selections\n"
         "» {+u}git apply/edit/grep{} commands\n"
+        "» custom completions are no longer sorted if the typed text is empty\n"
+        "» {+u}terminal{} now selects implementation based on windowing options\n"
     }, {
         20230805,
         "» Fix FreeBSD/MacOS clang compilation\n"


### PR DESCRIPTION
* Completions provided via `shell-script-candidates` or `completers` are no longer sorted if the typed text is empty.

* The `terminal` alias has been replaced with a command that selects terminal program and placement based on windowing options.
