### PR TITLE
rc windowing: with-option to restore option value also after error

### DIFF
--- a/rc/windowing/detection.kak
+++ b/rc/windowing/detection.kak
@@ -63,12 +63,17 @@ define-command with-option -params 3.. -docstring %{
     evaluate-commands -save-regs s %{
         evaluate-commands set-register s %exp{%%opt{%arg{1}}}
         set-option current %arg{1} %arg{2}
-        evaluate-commands %sh{
-            shift 2
-            for arg
-            do
-                printf "'%s' " "$(printf %s "$arg" | sed "s/'/''/g")"
-            done
+        try %{
+            evaluate-commands %sh{
+                shift 2
+                for arg
+                do
+                    printf "'%s' " "$(printf %s "$arg" | sed "s/'/''/g")"
+                done
+            }
+        } catch %{
+            set-option current %arg{1} %reg{s}
+            fail "with-option: %val{error}"
         }
         set-option current %arg{1} %reg{s}
     }


### PR DESCRIPTION
Today "with-option foo bar command-that-fails" fails with

	Error: 1:1: 'evaluate-commands': 1:1: 'with-option': 2:5: 'evaluate-commands': 4:9: 'evaluate-commands': 1:2: 'no-such-command': no such command

but leaks the option value. Fix this by resetting the option and
rethrowing the error.  Unfortunately the original stack trace is lost
(questionable behavior inherited from C++?).
