### PR TITLE
rc tools git: if $PWD is not inside a Git worktree, fall back to the buffer's worktree

### DIFF
--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -197,7 +197,8 @@ define-command -params 1.. \
         if git "${@}" > /dev/null 2>&1; then
           printf %s "echo -markup '{Information}git $1 succeeded'"
         else
-          printf 'fail git %s failed\n' "$1"
+          printf "fail '%s'\n" \
+            "$(printf 'failed to run git %s' "$(printf ' %s' "$@")" | sed "s/'/''/g")"
         fi
     }
 

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -391,7 +391,7 @@ define-command -params 1.. \
         add|rm)
             cmd="$1"
             shift
-            run_git_cmd $cmd "${@:-${kak_buffile}}"
+            run_git_cmd $cmd "${@:-"${kak_buffile}"}"
             ;;
         reset|checkout)
             run_git_cmd "$@"


### PR DESCRIPTION
When editing $PWD/some-project/foo and neither $PWD nor any of its
parents is a Git worktree (only $PWD/some-project/ is), then git
commands will fail. Let's use the buffer's worktree in this case.

When when running a command from a *git* buffer we face the same problem.
Fix this by using the worktree that was used to create the *git* buffer.

Closes #5003
