### PR TITLE
rc tools git: fix off-by-one regression in git blame SHA column

### DIFF
--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -165,7 +165,7 @@ define-command -params 1.. \
                   sub send_flags {
                       my $flush = shift;
                       if (not defined $line) { return; }
-                      my $text = substr($sha,1,8) . " " . $dates{$sha} . " " . $authors{$sha};
+                      my $text = substr($sha,0,7) . " " . $dates{$sha} . " " . $authors{$sha};
                       $text =~ s/~/~~/g;
                       for ( my $i = 0; $i < $count; $i++ ) {
                           $flags .= " %~" . ($line+$i) . "|$text~";


### PR DESCRIPTION
Introduced in f27f6fa2d (rc git: fix "git blame" on macOS with perl
rewrite, 2023-11-12); awk uses 1-based indices but perl uses offsets.
