### PR TITLE
rc tools ctags/man: rationalize sorting of completion candidates

### DIFF
--- a/rc/tools/ctags.kak
+++ b/rc/tools/ctags.kak
@@ -16,16 +16,22 @@ define-command -params ..1 \
     -shell-script-candidates %{
         realpath() { ( cd "$(dirname "$1")"; printf "%s/%s\n" "$(pwd -P)" "$(basename "$1")" ) }
         eval "set -- $kak_quoted_opt_ctagsfiles"
-        for candidate in "$@"; do
-            [ -f "$candidate" ] && realpath "$candidate"
-        done | awk '!x[$0]++' | # remove duplicates
+        files=$(
+            for candidate in "$@"; do
+                [ -f "$candidate" ] && realpath "$candidate"
+            done |
+                awk '!x[$0]++; # remove duplicates
+                     END { if (length(x) == 1) { exit 1; } }'
+        )
+        [ $? -eq 1 ] && sort=cat || sort=sort
+        printf %s\\n "$files" |
         while read -r tags; do
             namecache="${tags%/*}/.kak.${tags##*/}.namecache"
             if [ -z "$(find "$namecache" -prune -newer "$tags")" ]; then
                 cut -f 1 "$tags" | grep -v '^!' | uniq > "$namecache"
             fi
             cat "$namecache"
-        done | sort } \
+        done | "$sort" } \
     -docstring %{
         ctags-search [<symbol>]: jump to a symbol's definition
         If no symbol is passed then the current selection is used as symbol name

--- a/rc/tools/man.kak
+++ b/rc/tools/man.kak
@@ -65,8 +65,7 @@ define-command -params ..1 \
     -shell-script-candidates %{
         find /usr/share/man/ $(printf %s "${MANPATH}" |
             sed 's/:/ /') -name '*.[1-8]*' |
-            sed 's,^.*/\(.*\)\.\([1-8][a-zA-Z]*\).*$,\1(\2),' |
-            sort
+            sed 's,^.*/\(.*\)\.\([1-8][a-zA-Z]*\).*$,\1(\2),'
     } \
     -docstring %{
         man [<page>]: manpage viewer wrapper


### PR DESCRIPTION
As of recently, shell script candidate completions are computed in
the background, and displayed incrementally.
Sorting completions means we can't show partial results.

We do this for "ctags-search"; but if there is only one ctags file
there is already a sensible order (which is slightly different than
what GNU sort does). So let's preserve the order in that case.
The number of completions is probably too high for an order to be useful.

Similarly, for "man", sorting is probably not very helpful because
there are so many results.

See https://github.com/mawww/kakoune/pull/5035#discussion_r1413015934
