### PR TITLE
rc tools git: command for easy recursive blaming

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -18,7 +18,11 @@ released versions.
 
 * View mode commands and mouse scrolling no longer change selections when those go off-screen.
 
-* New commands `git apply`, `git edit`, `git grep`
+* New commands `git apply`, `git edit`, `git grep` and `git show-blamed`.
+
+* When git blame annotations are shown, press `<ret>` to jump to blamed commit.
+
+* `git blame` now also works in git diff buffers.
 
 == Kakoune 2023.08.08
 

--- a/rc/filetype/diff-parse.pl
+++ b/rc/filetype/diff-parse.pl
@@ -1,0 +1,127 @@
+#!/usr/bin/env perl
+
+use warnings;
+
+sub quote {
+    my $token = shift;
+    $token =~ s/'/''/g;
+    return "'$token'";
+}
+sub fail {
+    my $reason = shift;
+    print "set-register e fail " . quote("diff-parse.pl: $reason");
+    exit;
+}
+
+my $begin;
+my $end;
+
+while (defined $ARGV[0]) {
+    if ($ARGV[0] eq "--") {
+        shift;
+        last;
+    }
+    if ($ARGV[0] =~ m{^(BEGIN|END)$}) {
+        if (not defined $ARGV[1]) {
+            fail "missing argument to $ARGV[0]";
+        }
+        if ($ARGV[0] eq "BEGIN") {
+            $begin = $ARGV[1];
+        } else {
+            $end = $ARGV[1];
+        }
+        shift, shift;
+        next;
+    }
+    fail "unknown argument: $ARGV[0]";
+}
+
+# Inputs
+our $directory = $ENV{PWD};
+our $strip;
+our $version = "+";
+
+eval $begin if defined $begin;
+
+# Outputs
+our $file;
+our $file_line;
+our $diff_line_text;
+
+my $other_version;
+if ($version eq "+") {
+    $other_version = "-";
+} else {
+    $other_version = "+";
+}
+my $is_recursive_diff = 0;
+my $state = "header";
+my $fallback_file;
+my $other_file;
+my $other_file_line;
+
+sub strip {
+    my $is_recursive_diff = shift;
+    my $f = shift;
+
+    my $effective_strip;
+    if (defined $strip) {
+        $effective_strip = $strip;
+    } else {
+        # A "diff -r" or "git diff" adds "diff" lines to
+        # the output.  If no such line is present, we have
+        # a plain diff between files (not directories), so
+        # there should be no need to strip the directory.
+        $effective_strip = $is_recursive_diff ? 1 : 0;
+    }
+
+    if ($f !~ m{^/}) {
+        $f =~ s,^([^/]+/+){$effective_strip},, or fail "directory prefix underflow";
+        $f = "$directory/$f";
+    }
+    return $f;
+}
+
+while (<STDIN>) {
+    s/^(> )*//g;
+    $diff_line_text = $_;
+    if (m{^diff\b}) {
+        $state = "header";
+        $is_recursive_diff = 1;
+        if (m{^diff -\S* (\S+) (\S+)$}) {
+            $fallback_file = strip $is_recursive_diff, ($version eq "+" ? $2 : $1);
+        }
+        next;
+    }
+    if ($state eq "header") {
+        if (m{^[$version]{3} ([^\t\n]+)}) {
+            $file = strip $is_recursive_diff, $1;
+            next;
+        }
+        if (m{^[$other_version]{3} ([^\t\n]+)}) {
+            $other_file = strip $is_recursive_diff, $1;
+            next;
+        }
+    }
+    if (m{^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@}) {
+        $state = "contents";
+        $file_line = ($version eq "+" ? $2 : $1) - 1;
+        $other_file_line = ($version eq "+" ? $1 : $2) - 1;
+    } else {
+        my $iscontext = m{^[ ]};
+        if (m{^[ $version]}) {
+           $file_line++ if defined $file_line;
+        }
+        if (m{^[ $other_version]}) {
+           $other_file_line++ if defined $other_file_line;
+        }
+    }
+}
+if (not defined $file) {
+    $file = ($fallback_file or $other_file);
+}
+if (not defined $file) {
+    fail "missing diff header";
+}
+
+eval $end if defined $end;

--- a/rc/filetype/diff-parse.pl
+++ b/rc/filetype/diff-parse.pl
@@ -39,11 +39,17 @@ while (defined $ARGV[0]) {
 # Inputs
 our $directory = $ENV{PWD};
 our $strip;
+our $in_file;
+our $in_file_line;
 our $version = "+";
 
 eval $begin if defined $begin;
 
+$in_file = "$directory/$in_file" if defined $in_file;
+
 # Outputs
+our $diff_line = 0;
+our $commit;
 our $file;
 our $file_line;
 our $diff_line_text;
@@ -83,8 +89,13 @@ sub strip {
 }
 
 while (<STDIN>) {
+    $diff_line++;
     s/^(> )*//g;
     $diff_line_text = $_;
+    if (m{^commit (\w+)}) {
+        $commit = $1;
+        next;
+    }
     if (m{^diff\b}) {
         $state = "header";
         $is_recursive_diff = 1;
@@ -114,6 +125,11 @@ while (<STDIN>) {
         }
         if (m{^[ $other_version]}) {
            $other_file_line++ if defined $other_file_line;
+        }
+    }
+    if (defined $in_file and defined $file and $file eq $in_file) {
+        if (defined $in_file_line and defined $file_line and $file_line >= $in_file_line) {
+            last;
         }
     }
 }

--- a/rc/filetype/diff.kak
+++ b/rc/filetype/diff.kak
@@ -43,7 +43,7 @@ define-command diff-jump -params .. -docstring %{
         }
         set-register a %arg{@}
         set-register | %{
-            [ -n "$kak_reg_a" ] && eval set -- $kak_quoted_reg_a
+            [ -n "$kak_reg_a" ] && eval set -- "$kak_quoted_reg_a"
             cmd=$(column=$kak_reg_c perl -we '
                 sub quote {
                     $SQ = "'\''";

--- a/rc/filetype/diff.kak
+++ b/rc/filetype/diff.kak
@@ -29,7 +29,7 @@ define-command diff-jump -params .. -docstring %{
             -       jump to the old file instead of the new file
             -<num> strip <num> leading directory components, like -p<num> in patch(1). Defaults to 1 if there is a 'diff' line (as printed by 'diff -r'), or 0 otherwise.
     } %{
-    evaluate-commands -draft -save-regs ac| %{
+    evaluate-commands -draft -save-regs c| %{
         # Save the column because we will move the cursor.
         set-register c %val{cursor_column}
         # If there is a "diff" line, we don't need to look further back.
@@ -41,114 +41,51 @@ define-command diff-jump -params .. -docstring %{
             # or content.
             execute-keys Gk
         }
-        set-register a %arg{@}
-        set-register | %{
-            [ -n "$kak_reg_a" ] && eval set -- "$kak_quoted_reg_a"
-            cmd=$(column=$kak_reg_c perl -we '
-                sub quote {
-                    $SQ = "'\''";
-                    $token = shift;
-                    $token =~ s/$SQ/$SQ$SQ/g;
-                    return "$SQ$token$SQ";
+        diff-parse BEGIN %{
+            my $seen_ddash = 0;
+            foreach (@ARGV) {
+                if ($seen_ddash or !m{^-}) {
+                    $directory = $_;
+                } elsif ($_ eq "-") {
+                    $version = "-", $other_version = "+";
+                } elsif (m{^-(\d+)$}) {
+                    $strip = $1;
+                } elsif ($_ eq "--") {
+                    $seen_ddash = 1;
+                } else {
+                    fail "unknown option: $_";
                 }
-                sub fail {
-                    $reason = shift;
-                    print "fail " . quote("diff-jump: $reason");
-                    exit;
-                }
-                $version = "+", $other_version = "-";
-                $strip = undef;
-                $directory = $ENV{PWD};
-                $seen_ddash = 0;
-                foreach (@ARGV) {
-                    if ($seen_ddash or !m{^-}) {
-                        $directory = $_;
-                    } elsif ($_ eq "-") {
-                        $version = "-", $other_version = "+";
-                    } elsif (m{^-(\d+)$}) {
-                        $strip = $1;
-                    } elsif ($_ eq "--") {
-                        $seen_ddash = 1;
-                    } else {
-                        fail "unknown option: $_";
-                    }
-                }
-                $have_diff_line = 0;
-                $state = "header";
-                while (<STDIN>) {
-                    s/^(> )*//g;
-                    $last_line = $_;
-                    if (m{^diff\b}) {
-                        $state = "header";
-                        $have_diff_line = 1;
-                        if (m{^diff -\S* (\S+) (\S+)$}) {
-                            $fallback_file = $version eq "+" ? $2 : $1;
-                        }
-                        next;
-                    }
-                    if ($state eq "header") {
-                        if (m{^[$version]{3} ([^\t\n]+)}) {
-                            $file = $1;
+            }
+        } END %exp{
+            my $file_column;
+            if (not defined $file_line) {
+                $file_line = "";
+                $file_column = "";
+            } else {
+                my $diff_column = %reg{c};
+                $file_column = $diff_column - 1; # Account for [ +-] diff prefix.
+                # If the cursor was on a hunk header, go to the section header if possible.
+                if ($diff_line_text =~ m{^(@@ -\d+(?:,\d+)? \+\d+(?:,\d+) @@ )([^\n]*)}) {
+                    my $hunk_header_prefix = $1;
+                    my $hunk_header_from_userdiff = $2;
+                    open FILE, "<", $file or fail "failed to open file: $!: $file";
+                    my @lines = <FILE>;
+                    for (my $i = $file_line - 1; $i >= 0 and $i < scalar @lines; $i--) {
+                        if ($lines[$i] !~ m{\Q$hunk_header_from_userdiff}) {
                             next;
                         }
-                        if (m{^[$other_version]{3} ([^\t\n]+)}) {
-                            $fallback_file = $1;
-                            next;
-                        }
-                    }
-                    if (m{^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@}) {
-                        $state = "contents";
-                        $line = ($version eq "+" ? $2 : $1) - 1;
-                    } elsif (m{^[ $version]}) {
-                        $line++ if defined $line;
+                        $file_line = $i + 1;
+                        # Re-add 1 because the @@ line does not have a [ +-] diff prefix.
+                        $file_column = $diff_column + 1 - length $hunk_header_prefix;
+                        last;
                     }
                 }
-                if (not defined $file) {
-                    $file = $fallback_file;
-                }
-                if (not defined $file) {
-                    fail "missing diff header";
-                }
-                if (not defined $strip) {
-                    # A "diff -r" or "git diff" adds "diff" lines to
-                    # the output.  If no such line is present, we have
-                    # a plain diff between files (not directories), so
-                    # there should be no need to strip the directory.
-                    $strip = $have_diff_line ? 1 : 0;
-                }
-                if ($file !~ m{^/}) {
-                    $file =~ s,^([^/]+/+){$strip},, or fail "directory prefix underflow";
-                    $file = "$directory/$file";
-                }
-
-                if (defined $line) {
-                    $column = $ENV{column} - 1; # Account for [ +-] diff prefix.
-                    # If the cursor was on a hunk header, go to the section header if possible.
-                    if ($last_line =~ m{^(@@ -\d+(?:,\d+)? \+\d+(?:,\d+) @@ )([^\n]*)}) {
-                        $hunk_header_prefix = $1;
-                        $hunk_header_from_userdiff = $2;
-                        open FILE, "<", $file or fail "failed to open file: $!: $file";
-                        @lines = <FILE>;
-                        for (my $i = $line - 1; $i >= 0 && $i < scalar @lines; $i--) {
-                            if ($lines[$i] !~ m{\Q$hunk_header_from_userdiff}) {
-                                next;
-                            }
-                            $line = $i + 1;
-                            # Re-add 1 because the @@ line does not have a [ +-] diff prefix.
-                            $column = $column + 1 - length $hunk_header_prefix;
-                            last;
-                        }
-                    }
-                }
-
-                printf "edit -existing -- %s $line $column", quote($file);
-            ' -- "$@")
-            echo "set-register c $cmd" >"$kak_command_fifo"
-        }
-        execute-keys <a-|><ret>
+            }
+            printf "set-register c %%s $file_line $file_column\n", quote($file);
+        } -- %arg{@}
         evaluate-commands -client %val{client} %{
             evaluate-commands -try-client %opt{jumpclient} %{
-                %reg{c}
+                edit -existing -- %reg{c}
             }
         }
     }
@@ -156,6 +93,22 @@ define-command diff-jump -params .. -docstring %{
 complete-command diff-jump file
 
 §
+
+define-command -hidden diff-parse -params 2.. %exp{
+    evaluate-commands -save-regs aef %%{
+        set-register f %val{source}
+        %{
+            set-register a %arg{@}
+            set-register e nop
+            set-register | %{
+                eval set -- "$kak_quoted_reg_a"
+                perl "${kak_reg_f%/*}/diff-parse.pl" "$@" >"$kak_command_fifo"
+            }
+            execute-keys <a-|><ret>
+            %reg{e}
+        }
+    }
+}
 
 define-command \
     -docstring %{diff-select-file: Select surrounding patch file} \

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -365,10 +365,10 @@ define-command -params 1.. \
             run_git_blame "$@"
             ;;
         hide-blame)
-            printf %s "try %{
+            printf %s "
                 set-option buffer=$kak_bufname git_blame_flags $kak_timestamp
                 remove-highlighter window/git-blame
-            }"
+            "
             ;;
         show-diff)
             echo 'try %{ add-highlighter window/git-diff flag-lines Default git_diff_flags }'

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -62,13 +62,12 @@ define-command -params 1.. \
         Available commands:
             add
             apply (alias for "patch git apply")
-            blame
+            blame (toggle blame annotations)
             checkout
             commit
             diff
             edit
             grep
-            hide-blame
             hide-diff
             init
             log
@@ -91,7 +90,6 @@ define-command -params 1.. \
             diff \
             edit \
             grep \
-            hide-blame \
             hide-diff \
             init \
             log \
@@ -153,7 +151,18 @@ define-command -params 1.. \
               }"
     }
 
+    hide_blame() {
+        printf %s "
+            set-option buffer=$kak_bufname git_blame_flags $kak_timestamp
+            remove-highlighter window/git-blame
+        "
+    }
+
     run_git_blame() {
+        if [ "${kak_opt_git_blame_flags#* *}" != "${kak_opt_git_blame_flags}" ]; then
+            hide_blame
+            exit
+        fi
         (
             cd_bufdir
             printf %s "evaluate-commands -client '$kak_client' %{
@@ -365,10 +374,7 @@ define-command -params 1.. \
             run_git_blame "$@"
             ;;
         hide-blame)
-            printf %s "
-                set-option buffer=$kak_bufname git_blame_flags $kak_timestamp
-                remove-highlighter window/git-blame
-            "
+            hide_blame
             ;;
         show-diff)
             echo 'try %{ add-highlighter window/git-diff flag-lines Default git_diff_flags }'

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -188,7 +188,7 @@ define-command -params 1.. \
                       $count = $4;
                   }
                   if (m/^author /) { $authors{$sha} = substr($_,7) }
-                  if (m/^author-time ([0-9]*)/) { $dates{$sha} = strftime("%F %T", localtime $1) }
+                  if (m/^author-time ([0-9]*)/) { $dates{$sha} = strftime("%F", localtime $1) }
                   END { send_flags(1); }'
         ) > /dev/null 2>&1 < /dev/null &
     }

--- a/rc/tools/patch.kak
+++ b/rc/tools/patch.kak
@@ -52,7 +52,7 @@ define-command patch -params .. -docstring %{
                 # Since registers are never empty, we get an empty arg even if
                 # there were no args. This does no harm because we pass it to
                 # a shell where it expands to nothing.
-                eval set -- $kak_quoted_reg_a
+                eval set -- "$kak_quoted_reg_a"
 
                 perl "${kak_reg_f%/*}/patch-range.pl" $min_line $max_line "$@" ||
                     echo >$kak_command_fifo "set-register e fail 'patch: failed to apply selections, see *debug* buffer'"

--- a/src/main.cc
+++ b/src/main.cc
@@ -51,7 +51,9 @@ struct {
         "» {+b}+{} only duplicates identical selections a single time\n"
         "» {+u}daemonize-session{} command\n"
         "» view mode and mouse scrolling no longer change selections\n"
-        "» {+u}git apply/edit/grep{} commands\n"
+        "» {+u}git apply/edit/grep/show-blamed{} commands\n"
+        "» after {+u}git blame{}, jump to blamed commit with {+b}<ret>{}\n"
+        "» {+u}git blame{} works in git diff buffers\n"
     }, {
         20230805,
         "» Fix FreeBSD/MacOS clang compilation\n"


### PR DESCRIPTION
(EDIT This description is mildly outdated, refer to the commit messages)

I frequently want to find out why a piece of code was introduced.
We have ":git blame" to annotate each line with the most recent commit.
However often a line has been modified by several commits.

Introduce ":git show-blamed" which shows the commit that added the
line at cursor. Crucially, it works also in Git diff buffers, so it can
be used recursively to find the full history of a line.

Previously I used Tig's "b" shortcut. In diff views, I would navigate
to the old ("-"-prefixed) version of the line, press "b" and repeat.
In most cases, it's a boring task to navigate to the old version
because that one is usually located very close to the new version.
In Tig I use "/" to search for it.

Automate this common case by making ":git show-blamed" jump to
the blamed line directly. This means the initial diff view might
not include the commit message etc. Compensate this by showing the
commit's date+author+subject in the status line.

Future work:

- The existing ":git blame" should also learn to work inside
  ":git show" buffers, much like Tig/Magit/Fugitive etc..
- To go back to the previously-blamed commit we need to have had the
  foresight to use "rename-buffer". Perhaps we want to add some kind
  of buffer stack (like Magit does for example).
