### PR TITLE
Fix command name in protobuf newline hook

### DIFF
--- a/rc/filetype/protobuf.kak
+++ b/rc/filetype/protobuf.kak
@@ -76,7 +76,7 @@ define-command -hidden protobuf-trim-indent %{
     }
 }
 
-define-command -hidden protobuf-insert-on-new-line %{
+define-command -hidden protobuf-insert-on-newline %{
     evaluate-commands -draft -itersel %[
         # copy // comments prefix
         try %{ execute-keys -draft <semicolon><c-s>kx s ^\h*\K/{2,}(\h*(?=\S))? <ret> y<c-o>P<esc> }


### PR DESCRIPTION
I was regularly getting the following error in `*debug*` when editing protobuf files:
```
error running hook InsertChar(
)/protobuf-insert: 1:1: 'protobuf-insert-on-newline': no such command
```

This is because of a typo in the command name, which has a dash in the `new-line`.

This PR just fixes that typo, which restores intended behavior.