### PR TITLE
rc tools git: blame to hide blame if already shown

### DIFF
--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -365,10 +365,10 @@ define-command -params 1.. \
             run_git_blame "$@"
             ;;
         hide-blame)
-            printf %s "try %{
+            printf %s "
                 set-option buffer=$kak_bufname git_blame_flags $kak_timestamp
                 remove-highlighter window/git-blame
-            }"
+            "
             ;;
         show-diff)
             echo 'try %{ add-highlighter window/git-diff flag-lines Default git_diff_flags }'

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -62,13 +62,12 @@ define-command -params 1.. \
         Available commands:
             add
             apply (alias for "patch git apply")
-            blame
+            blame (toggle blame annotations)
             checkout
             commit
             diff
             edit
             grep
-            hide-blame
             hide-diff
             init
             log
@@ -91,7 +90,6 @@ define-command -params 1.. \
             diff \
             edit \
             grep \
-            hide-blame \
             hide-diff \
             init \
             log \
@@ -153,7 +151,18 @@ define-command -params 1.. \
               }"
     }
 
+    hide_blame() {
+        printf %s "
+            set-option buffer=$kak_bufname git_blame_flags $kak_timestamp
+            remove-highlighter window/git-blame
+        "
+    }
+
     run_git_blame() {
+        if [ "${kak_opt_git_blame_flags#* *}" != "${kak_opt_git_blame_flags}" ]; then
+            hide_blame
+            exit
+        fi
         (
             cd_bufdir
             printf %s "evaluate-commands -client '$kak_client' %{
@@ -365,10 +374,7 @@ define-command -params 1.. \
             run_git_blame "$@"
             ;;
         hide-blame)
-            printf %s "
-                set-option buffer=$kak_bufname git_blame_flags $kak_timestamp
-                remove-highlighter window/git-blame
-            "
+            hide_blame
             ;;
         show-diff)
             echo 'try %{ add-highlighter window/git-diff flag-lines Default git_diff_flags }'


### PR DESCRIPTION
This simplifies the UI (no need to add multiple mappings) and might
obsolete hide-blame.
