### PR TITLE
rc tools git: remove time from blame annotations

### DIFF
--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -188,7 +188,7 @@ define-command -params 1.. \
                       $count = $4;
                   }
                   if (m/^author /) { $authors{$sha} = substr($_,7) }
-                  if (m/^author-time ([0-9]*)/) { $dates{$sha} = strftime("%F %T", localtime $1) }
+                  if (m/^author-time ([0-9]*)/) { $dates{$sha} = strftime("%F", localtime $1) }
                   END { send_flags(1); }'
         ) > /dev/null 2>&1 < /dev/null &
     }


### PR DESCRIPTION
It doesn't seem very useful information, the date should usually be enough
for this overview. No strong opinion though. We can definitely make it
configurable. Other tools like Tig show minute-precision and the author
timezone.
