### PR TITLE
rc tools patch: skip spurious diff header for files with no changes

### DIFF
--- a/rc/tools/patch-range.pl
+++ b/rc/tools/patch-range.pl
@@ -18,6 +18,7 @@ my $reverse = grep /^(--reverse|-R)$/, @ARGV;
 
 my $lineno = 0;
 my $original = "";
+my $diff_header = "";
 my $wheat = "";
 my $chaff = "";
 my $state = undef;
@@ -41,6 +42,10 @@ sub compute_hunk_header {
 sub finish_hunk {
     return unless defined $hunk_header;
     if ($hunk_wheat =~ m{^[-+]}m) {
+        if ($diff_header) {
+            $wheat .= $diff_header;
+            $diff_header = "";
+        }
         $wheat .= (compute_hunk_header $hunk_header, $hunk_wheat). $hunk_wheat;
     }
     $chaff .= (compute_hunk_header $hunk_header, $hunk_chaff) . $hunk_chaff;
@@ -53,6 +58,7 @@ while (<STDIN>) {
     if (m{^diff}) {
         finish_hunk();
         $state = "diff header";
+        $diff_header = "";
     }
     if (m{^@@}) {
         finish_hunk();
@@ -63,7 +69,7 @@ while (<STDIN>) {
         next;
     }
     if ($state eq "diff header") {
-        $wheat .= $_;
+        $diff_header .= $_;
         $chaff .= $_;
         next;
     }

--- a/test/tools/patch/ignore-first-file/cmd
+++ b/test/tools/patch/ignore-first-file/cmd
@@ -1,0 +1,1 @@
+%:patch tee applied.diff<ret><ret>!echo Applied:; cat applied.diff; echo; echo Updated buffer:<ret>

--- a/test/tools/patch/ignore-first-file/in
+++ b/test/tools/patch/ignore-first-file/in
@@ -1,0 +1,11 @@
+diff -ur a/file1 b/file1
+--- a/file1
++++ b/file1
+@@ -1 +1 @@
+ file1 here
+diff -ur a/file2 b/file2
+--- a/file2
++++ b/file2
+@@ -1 +1 @@
+-file2 here
++modified file2 here

--- a/test/tools/patch/ignore-first-file/out
+++ b/test/tools/patch/ignore-first-file/out
@@ -1,0 +1,19 @@
+Applied:
+diff -ur a/file2 b/file2
+--- a/file2
++++ b/file2
+@@ -1 +1 @@
+-file2 here
++modified file2 here
+
+Updated buffer:
+diff -ur a/file1 b/file1
+--- a/file1
++++ b/file1
+@@ -1 +1 @@
+ file1 here
+diff -ur a/file2 b/file2
+--- a/file2
++++ b/file2
+@@ -1 +1 @@
+ modified file2 here

--- a/test/tools/patch/ignore-first-file/rc
+++ b/test/tools/patch/ignore-first-file/rc
@@ -1,0 +1,1 @@
+source "%val{runtime}/rc/tools/patch.kak"


### PR DESCRIPTION
Since :patch transforms its inputs into context-only lines, we can
easily get into a state where a file diff has only context lines.
git apply does not accept a "diff" without any hunk, so let's skip
that.
