### PR TITLE
Add terminal_info_inline_borders option

### DIFF
--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -392,6 +392,10 @@ are exclusively available to built-in options.
             if *yes* or *true*, use native terminal cursor visibility control
             instead of Kakoune's cursor management (defaults to *false*)
 
+        *terminal_info_inline_borders*:::
+            if *yes* or *true*, borders will be drawn around info boxes with the
+            *inline* style.
+
 [[startup-info]]
 *startup_info_version* `int`::
     _default_ 0 +

--- a/src/main.cc
+++ b/src/main.cc
@@ -533,7 +533,8 @@ void register_options()
                        "    terminal_padding_char          codepoint\n"
                        "    terminal_padding_fill          bool\n"
                        "    terminal_cursor_native         bool\n"
-                       "    terminal_info_max_width        int\n",
+                       "    terminal_info_max_width        int\n"
+                       "    terminal_info_inline_borders   bool\n",
                        UserInterface::Options{});
     reg.declare_option("modelinefmt", "format string used to generate the modeline",
                        "%val{bufname} %val{cursor_line}:%val{cursor_char_column} {{context_info}} {{mode_info}} - %val{client}@[%val{session}]"_str);

--- a/src/terminal_ui.cc
+++ b/src/terminal_ui.cc
@@ -1339,7 +1339,7 @@ void TerminalUI::info_show(const DisplayLine& title, const DisplayLineList& cont
     m_info.face = face;
     m_info.style = style;
 
-    const bool framed = style == InfoStyle::Prompt or style == InfoStyle::Modal;
+    const bool framed = style == InfoStyle::Prompt or style == InfoStyle::Modal or m_info_inline_borders;
     const bool assisted = style == InfoStyle::Prompt and m_assistant.size() != 0;
 
     DisplayCoord max_size = m_dimensions;
@@ -1602,6 +1602,7 @@ void TerminalUI::set_ui_options(const Options& options)
     }
 
     m_info_max_width = find("terminal_info_max_width").map(str_to_int_ifp).value_or(0);
+    m_info_inline_borders = find("terminal_info_inline_borders").map(to_bool).value_or(false);
 }
 
 }

--- a/src/terminal_ui.hh
+++ b/src/terminal_ui.hh
@@ -176,6 +176,7 @@ private:
     ColumnCount m_status_pos = 0;
     ColumnCount m_status_cursor_pos = 0;
     ColumnCount m_info_max_width = 0;
+    bool m_info_inline_borders = false;
 };
 
 }


### PR DESCRIPTION
**Before:**
![image](https://github.com/mawww/kakoune/assets/3515394/ae7e62b3-6462-434f-93b4-2c89ea016e6d)

**After:**
![image](https://github.com/mawww/kakoune/assets/3515394/bde5886f-928f-4266-9f2c-b183a2883483)
