### PR TITLE
Enable remapping of Ctrl-C and Ctrl-G

### DIFF
--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -837,7 +837,9 @@ The following keys are recognized by this mode to help with editing
 These keys are used to cancel long-running operations, either inside
 Kakoune or outside it. Because they are intended as a safety mechanism
 when something goes wrong, these keys are handled very early on in
-Kakoune's input processing, and therefore cannot be remapped in any mode.
+Kakoune's input processing, so they can only be remapped by changing
+the `interrupt_key` and `cancel_key` options (see
+<<options#builtin-options,`:doc options builtin-options`>>).
 
 *<c-c>*::
     Stop any external processes. If you ever see Kakoune display a message

--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -317,6 +317,15 @@ are exclusively available to built-in options.
 *debug* `flags(hooks|shell|profile|keys|commands)`::
     dump various debug information in the '\*debug*' buffer
 
+*interrupt_key* `key`::
+    _default_ <c-c> +
+    key used to interrupt any running external processes
+
+*cancel_key* `key`::
+    _default_ <c-g> +
+    key used to cancel long-running Kakoune operations and clear the input
+    buffer
+
 *idle_timeout* `int`::
     _default_ 50 +
     timeout, in milliseconds, with no user input that will trigger the

--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -79,6 +79,11 @@ are exclusively available to built-in options.
     as a string but the set commands will complain if the entered text
     is not a valid regex
 
+*key*::
+    a single keypress using the same syntax as `map` (see
+    <<mapping#mappable-keys,`:doc mapping mappable-keys`>>).  If
+    multiple keys are entered, only the first will be used.
+
 *coord*::
     a line, column pair (separated by a comma)
     Cannot be used with `declare-option`

--- a/src/client.cc
+++ b/src/client.cc
@@ -47,13 +47,14 @@ Client::Client(std::unique_ptr<UserInterface>&& ui,
     m_ui->set_ui_options(m_window->options()["ui_options"].get<UserInterface::Options>());
     m_ui->set_on_key([this](Key key) {
         kak_assert(key != Key::Invalid);
-        if (key == ctrl('c'))
+        auto opts = context().options();
+        if (key == opts["interrupt_key"].get<Key>())
         {
             auto prev_handler = set_signal_handler(SIGINT, SIG_IGN);
             killpg(getpgrp(), SIGINT);
             set_signal_handler(SIGINT, prev_handler);
         }
-        else if (key == ctrl('g'))
+        else if (key == opts["cancel_key"].get<Key>())
         {
             m_pending_keys.clear();
             print_status({"operation cancelled", context().faces()["Error"]});

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1827,6 +1827,7 @@ const CommandDesc declare_option_cmd = {
     "    bool: boolean (true/false or yes/no)\n"
     "    str: character string\n"
     "    regex: regular expression\n"
+    "    key: keystroke specifier\n"
     "    int-list: list of integers\n"
     "    str-list: list of character strings\n"
     "    completions: list of completion candidates\n"
@@ -1843,7 +1844,7 @@ const CommandDesc declare_option_cmd = {
     make_completer(
         [](const Context& context, CompletionFlags flags,
            StringView prefix, ByteCount cursor_pos) -> Completions {
-               auto c = {"int", "bool", "str", "regex", "int-list", "str-list", "completions", "line-specs", "range-specs", "str-to-str-map"};
+               auto c = {"int", "bool", "str", "regex", "key", "int-list", "str-list", "completions", "line-specs", "range-specs", "str-to-str-map"};
                return { 0_byte, cursor_pos, complete(prefix, cursor_pos, c), Completions::Flags::Menu };
     }),
     [](const ParametersParser& parser, Context& context, const ShellContext&)
@@ -1866,6 +1867,8 @@ const CommandDesc declare_option_cmd = {
             opt = &reg.declare_option<String>(parser[1], docstring, "", flags);
         else if (parser[0] == "regex")
             opt = &reg.declare_option<Regex>(parser[1], docstring, Regex{}, flags);
+        else if (parser[0] == "key")
+            opt = &reg.declare_option<Key>(parser[1], docstring, Key(Key::Invalid), flags);
         else if (parser[0] == "int-list")
             opt = &reg.declare_option<Vector<int, MemoryDomain::Options>>(parser[1], docstring, {}, flags);
         else if (parser[0] == "str-list")

--- a/src/keys.cc
+++ b/src/keys.cc
@@ -221,6 +221,20 @@ String to_string(Key key)
     return res;
 }
 
+String option_to_string(const Key& key)
+{
+    return to_string(key);
+}
+
+Key option_from_string(Meta::Type<Key>, StringView str)
+{
+    auto keys = parse_keys(str);
+    if (keys.empty())
+        return Key(Key::Invalid);
+
+    return keys.front();
+}
+
 UnitTest test_keys{[]()
 {
     KeyList keys{

--- a/src/keys.hh
+++ b/src/keys.hh
@@ -94,6 +94,8 @@ struct Key
     static Modifiers to_modifier(MouseButton button) { return Key::Modifiers{((int)button << 6) & (int)Modifiers::MouseButtonMask}; }
 
     Optional<Codepoint> codepoint() const;
+
+    static constexpr const char* option_type_name = "key";
 };
 
 constexpr bool with_bit_ops(Meta::Type<Key::Modifiers>) { return true; }
@@ -107,6 +109,8 @@ KeyList parse_keys(StringView str);
 String  to_string(Key key);
 StringView to_string(Key::MouseButton button);
 Key::MouseButton str_to_button(StringView str);
+String option_to_string(const Key& key);
+Key option_from_string(Meta::Type<Key>, StringView str);
 
 constexpr Key shift(Key key)
 {

--- a/src/main.cc
+++ b/src/main.cc
@@ -609,6 +609,8 @@ void register_options()
         "set of pair of characters to be considered as matching pairs",
         { '(', ')', '{', '}', '[', ']', '<', '>' });
     reg.declare_option<int>("startup_info_version", "version up to which startup info changes should be hidden", 0);
+    reg.declare_option("cancel_key", "key used to cancel long-running operations", ctrl('g'));
+    reg.declare_option("interrupt_key", "key used to stop external processes", ctrl('c'));
 }
 
 static Client* local_client = nullptr;


### PR DESCRIPTION
The interrupt <c-c> and cancel <c-g> keys [cannot be remapped](https://github.com/mawww/kakoune/issues/2742) because they are processed by the Kakoune client before reaching the input manager. (As noted [in a comment](https://github.com/mawww/kakoune/pull/4909#issuecomment-1571133026), processing them early is intentional.)

This PR adds two options, `interrupt_key` and `cancel_key`, which can be used to customize which keys are used for these purposes, freeing the defaults up to be mapped to another action using the `map` command.  This approach ends up requiring fewer changes (+27/-3) than the earlier work in #4909, and it keeps the processing of these keys early and uncomplicated.

(Note: I'm experienced with C but not C++, so feel free to educate me if I've written anything unidiomatic.)