### PR TITLE
fix install of kakrc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ install: src/kak installdirs install-debug-$(debug) install-gzip-man-$(gzip_man)
 
 	ln -sf ../../bin/kak $(libexecdir)/kak
 
-	cp src/kak/kakrc $(sharedir)
+	cp share/kak/kakrc $(sharedir)
 	chmod 0644 $(sharedir)/kakrc
 
 	cp -r rc/* $(sharedir)/rc

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -22,9 +22,9 @@ TL;DR
 
 ---------------------------------------------
 git clone https://github.com/mawww/kakoune.git
-cd kakoune/src
+cd kakoune
 make
-./kak
+./src/kak
 ---------------------------------------------
 
 See https://github.com/mawww/golf for Kakoune solutions to vimgolf challenges,


### PR DESCRIPTION
There's a typo in the new Makefile that prevents kakrc from being installed.
Also, update README with new installation instructions.