### PR TITLE
Makefile: allow PREFIX to be overridden. Example: `PREFIX=~/.local make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ LDFLAGS-static-yes = -static -pthread
 
 version != cat .version 2>/dev/null || git describe --tags HEAD 2>/dev/null || echo unknown
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR = # root dir
 
 bindir = $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
Makefile: allow PREFIX to be overridden. Example: `PREFIX=~/.local make install`

It was always possible to install kakoune with custom prefix. This seems to be a regression due to recent changes to the Makefile. This commit should hopefully restore old behavior.