### PR TITLE
Update tutorial regarding macros

### DIFF
--- a/contrib/TRAMPOLINE
+++ b/contrib/TRAMPOLINE
@@ -455,8 +455,8 @@ using the built-in `:doc` command.
         | Q |       chunk interactively, and replay the sequence of keys
         `---'       at will. The sequence in question is a macro: the `Q`
                     primitive will create a new one (i.e., record all the keys
-.---, .---,         hit henceforth until the escape key `<esc>` is hit), and
-|ctl|+| r |_.       the `q` primitive will replay the keys saved in the macro.
+.---, .---,         hit henceforth until `Q` is hit again), and the `q`
+|ctl|+| r |_.       primitive will replay the keys saved in the macro.
 `---' `---'  `.---,
               | @ | Notes: macros can easily be translated into a proper
               `---' script, as they are saved in the `@` register, which you


### PR DESCRIPTION
The tutorial states that a macro recording can be stopped by hitting the `<esc>` key. This behavior was changed in commit f3cb2e43. This pull request updates the tutorial (`contrib/TRAMPOLINE`) accordingly.