### PR TITLE
Update README to match new `make install` command

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -215,7 +215,7 @@ If you want to compile from source on 20.04 or earlier, you must force the build
 ----------------------------------------------------------------
 git clone https://github.com/mawww/kakoune.git && cd kakoune/src
 CXX=g++-10 make
-PREFIX=$HOME/.local make install
+make PREFIX=$HOME/.local install
 ----------------------------------------------------------------
 ====
 


### PR DESCRIPTION
It appears that the command to specify the `PREFIX` variable to the makefile has changed.

I had to run `make PREFIX=$HOME/.local install` in order to override the hardcoded `PREFIX` value in the makefile. I infer that the instructions need to be changed for those who don't know. (TIL. ;) )