### PR TITLE
Expose %val{register} and %val{count} to the modeline

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -244,7 +244,8 @@ The following expansions are supported (with required context _in italics_):
     directory containing the user configuration
 
 *%val{count}*::
-    _in `map` command <keys> parameter and `<a-;>` from object menu_ +
+    _in `map` command <keys> parameter, `<a-;>` from object menu and
+    `modelinefmt` expansion._ +
     current count when the mapping was triggered, defaults to 0 if no
     count given
 
@@ -320,7 +321,8 @@ The following expansions are supported (with required context _in italics_):
     beginning, and `to_end` if the user wants to select to the end
 
 *%val{register}*::
-    _in `map` command <keys> parameter and `<a-;>` from the object menu_ +
+    _in `map` command <keys> parameter, `<a-;>` from object menu and
+    `modelinefmt` expansion_ +
     current register when the mapping was triggered
 
 *%val{runtime}*::

--- a/src/client.cc
+++ b/src/client.cc
@@ -5,6 +5,7 @@
 #include "buffer_manager.hh"
 #include "buffer_utils.hh"
 #include "file.hh"
+#include "normal.hh"
 #include "remote.hh"
 #include "option.hh"
 #include "option_types.hh"
@@ -169,7 +170,12 @@ DisplayLine Client::generate_mode_line() const
         HashMap<String, DisplayLine> atoms{{ "mode_info", context().client().input_handler().mode_line() },
                                            { "context_info", {generate_context_info(context()),
                                                               context().faces()["Information"]}}};
-        auto expanded = expand(modelinefmt, context(), ShellContext{},
+        const NormalParams* normal_params = context().client().input_handler().get_normal_params();
+        ShellContext shell_context = { {}, {
+        {"register", normal_params ? String(normal_params->reg) : String("") }, 
+        {"count", normal_params ? String(to_string(normal_params->count)) : ""}}};
+        
+        auto expanded = expand(modelinefmt, context(), shell_context,
                                [](String s) { return escape(s, '{', '\\'); });
         modeline = parse_display_line(expanded, context().faces(), atoms);
     }

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -54,6 +54,8 @@ public:
         auto coord = context().window().display_position(cursor).value_or(DisplayCoord{});
         return {CursorMode::Buffer, coord};
     }
+    
+    virtual const NormalParams* get_normal_params() const { return nullptr; }
 
     using Insertion = InputHandler::Insertion;
 
@@ -385,6 +387,10 @@ public:
             atoms.emplace_back(StringView(m_params.reg).str(), context().faces()["StatusLineValue"]);
         }
         return atoms;
+    }
+    
+    const NormalParams* get_normal_params() const override {
+        return &m_params;
     }
 
     KeymapMode keymap_mode() const override { return KeymapMode::Normal; }
@@ -1709,6 +1715,11 @@ DisplayLine InputHandler::mode_line() const
 std::pair<CursorMode, DisplayCoord> InputHandler::get_cursor_info() const
 {
     return current_mode().get_cursor_info();
+}
+
+
+const NormalParams* InputHandler::get_normal_params() const {
+    return current_mode().get_normal_params();
 }
 
 bool should_show_info(AutoInfo mask, const Context& context)

--- a/src/input_handler.hh
+++ b/src/input_handler.hh
@@ -100,6 +100,7 @@ public:
     DisplayLine mode_line() const;
 
     std::pair<CursorMode, DisplayCoord> get_cursor_info() const;
+    const NormalParams* get_normal_params() const;
 
     // Force an input handler into normal mode temporarily
     struct ScopedForceNormal


### PR DESCRIPTION
this opens up for a lot more customization of the modeline, as all information in {{mode_info}} can now be obtained individually.

See for instance https://github.com/Hjagu09/yummy.kak for a usecase.