### PR TITLE
Add -indent option to show-whitespace highlighter

### DIFF
--- a/doc/pages/highlighters.asciidoc
+++ b/doc/pages/highlighters.asciidoc
@@ -55,6 +55,10 @@ highlighter is replaced with the new one.
     *-tabpad* <separator>:::
         a one character long separator that will be appended to tabulations to honor the *tabstop* option
 
+    *-indent* <separator>:::
+        a one character long separator that will replace the first space in indentation according to the *indentwidth* option
+        This will use the `WhitespaceIndent` face.
+
     *-only-trailing*:::
         only highlight whitespaces at the end of the line
 

--- a/src/face_registry.cc
+++ b/src/face_registry.cc
@@ -204,6 +204,7 @@ FaceRegistry::FaceRegistry()
         { "MatchingChar", {Face{ Color::Default, Color::Default, Attribute::Bold }} },
         { "BufferPadding", {Face{ Color::Blue, Color::Default }} },
         { "Whitespace", {Face{ Color::Default, Color::Default, Attribute::FinalFg }} },
+        { "WhitespaceIndent", {Face{}, "Whitespace"} },
       }
 {}
 


### PR DESCRIPTION
![image](https://github.com/mawww/kakoune/assets/3133596/2c60aea8-03a7-4c78-9525-423b6107eff6)

A couple of semi-opinionated choices were made in this implementation:

 1. The guide is hidden in the first column.
 2. The indent guides are highlighted using a new `WhitespaceIndent` face.
 3. Nothing is done to continue the guide through empty lines. I believe this to be the correct approach, at least as long as it is kept as a part of the show-whitespaces highlighter. However some people's oppinion may differ, and if so, that could be implemented.
 4. The guides default to on, like the other show-whitespace options. Default character is "│".
 5. Spaces between the indent guides are currently highlighted as other spaces. Other reasonable options would be no replacement, -tabpad, or a similar -indentpad.
 6. Guides are disabled by passing `-indent ""`.
 7. Indent guides are separate from tab highlighting.

Additionally, we could consider adding a separate face for the "current" indent level as many editors do, but this is a bit harder in kakoune because of multiple selections.

Closes #2323