### PR TITLE
rust: Highlight char and byte literals as values

### DIFF
--- a/rc/filetype/rust.kak
+++ b/rc/filetype/rust.kak
@@ -94,9 +94,9 @@ add-highlighter shared/rust/code/macro                  regex \b\w+! 0:meta
 # the number literals syntax is defined here:
 # https://doc.rust-lang.org/reference/tokens.html#numb  ers
 add-highlighter shared/rust/code/values                 regex \b(?:self|true|false|[0-9][_0-9]*(?:\.[0-9][_0-9]*|(?:\.[0-9][_0-9]*)?E[\+\-][_0-9]+)(?:f(?:32|64))?|(?:0x[_0-9a-fA-F]+|0o[_0-7]+|0b[_01]+|[0-9][_0-9]*)(?:(?:i|u|f)(?:8|16|32|64|128|size))?)\b 0:value
-add-highlighter shared/rust/code/char_character         regex "'([^\\]|\\(.|x[0-9a-fA-F]{2}|u\{[0-9a-fA-F]{1,6}\}))'" 0:green
+add-highlighter shared/rust/code/char_character         regex "'([^\\]|\\(.|x[0-9a-fA-F]{2}|u\{[0-9a-fA-F]{1,6}\}))'" 0:value
 # TODO highlight error for unicode or single escape by  te character
-add-highlighter shared/rust/code/byte_character         regex b'([\x00-\x5B\x5D-\x7F]|\\(.|x[0-9a-fA-F]{2}))' 0:yellow
+add-highlighter shared/rust/code/byte_character         regex b'([\x00-\x5B\x5D-\x7F]|\\(.|x[0-9a-fA-F]{2}))' 0:value
 add-highlighter shared/rust/code/builtin_types          regex \b(?:u8|u16|u32|u64|u128|usize|i8|i16|i32|i64|i128|isize|f32|f64|bool|char|str|Self)\b 0:type
 add-highlighter shared/rust/code/return                 regex \breturn\b 0:meta
 


### PR DESCRIPTION
Char and byte literals are values.
There is no point in using fixed colors for them.