### PR TITLE
Use a map instead of a hook to jump to grep result

### DIFF
--- a/rc/tools/grep.kak
+++ b/rc/tools/grep.kak
@@ -45,8 +45,7 @@ hook -group grep-highlight global WinSetOption filetype=grep %{
 }
 
 hook global WinSetOption filetype=grep %{
-    hook buffer -group grep-hooks NormalKey <ret> jump
-    hook -once -always window WinSetOption filetype=.* %{ remove-hooks buffer grep-hooks }
+    map buffer normal <ret> :jump<ret>
 }
 
 define-command -hidden grep-jump %{


### PR DESCRIPTION
This has been discussed a little bit on Discord, but I think we do not need a hook for the `<ret>` mapping in the `grep` module.

I guess this was something that was necessary in the past, but I am not sure that we need it anymore.

Also, it prevents from overriding the `<ret>` key easily at the user level with:

```
map global normal <ret> "..."
```