### PR TITLE
doc: declare C++20 as the language version

### DIFF
--- a/doc/coding-style.asciidoc
+++ b/doc/coding-style.asciidoc
@@ -1,7 +1,7 @@
 C++ Coding Style
 ================
 
-Kakoune is written in C++14, here are the main coding style points:
+Kakoune is written in C++20, here are the main coding style points:
 
  * Avoid external dependencies besides posix/stdc++
 


### PR DESCRIPTION
Technically we seem to be compiling with `-std=c++2a` which (if I understand correctly) is 
"all the features we have from 23 and up".

But 20 is the earliest version that compiles for me (with clang). 14 and 17 didn't work.