### PR TITLE
introduce jump_pattern option

### DIFF
--- a/rc/tools/jump.kak
+++ b/rc/tools/jump.kak
@@ -3,7 +3,7 @@ declare-option -docstring "name of the client in which all source code jumps wil
 declare-option -docstring "name of the client in which utilities display information" \
     str toolsclient
 declare-option -docstring "the pattern for the jump information in the line, such as file:line:col" \
-    str jump_pattern "^([^:\n]+)(?::(\d+))?(?::(\d+))?"
+    str jump_pattern "^([^:\n]+)(?::(\d+))(?::(\d+))?"
 
 provide-module jump %{
 

--- a/rc/tools/jump.kak
+++ b/rc/tools/jump.kak
@@ -11,7 +11,10 @@ define-command -hidden jump %{
     evaluate-commands -save-regs a %{ # use evaluate-commands to ensure jumps are collapsed
         try %{
             evaluate-commands -draft %{
-                execute-keys ',xs^([^:\n]+):(\d+):(\d+)?<ret>'
+                # file
+                # file:line
+                # file:line:col
+                execute-keys ',xs^([^:\n]+)(?::(\d+))?(?::(\d+))?<ret>'
                 set-register a %reg{1} %reg{2} %reg{3}
             }
             set-option buffer jump_current_line %val{cursor_line}


### PR DESCRIPTION
Sometime, we don't have line and column information in context, like fd output, log etc. 
Let's extract an option `jump_pattern` to let other use cases can override it.