### PR TITLE
erlang: Fix the comment_line configuration

### DIFF
--- a/rc/tools/comment.kak
+++ b/rc/tools/comment.kak
@@ -75,7 +75,7 @@ hook global BufSetOption filetype=(html|xml) %{
     set-option buffer comment_block_end '-->'
 }
 
-hook global BufSetOption filetype=(latex|mercury) %{
+hook global BufSetOption filetype=(erlang|latex|mercury) %{
     set-option buffer comment_line '%'
 }
 


### PR DESCRIPTION
Erlang comments start with `%`. This is correctly highlighted but the comment-line/comment-block commands don't work correctly.