### PR TITLE
add default terminal implementation

### DIFF
--- a/rc/windowing/detection.kak
+++ b/rc/windowing/detection.kak
@@ -23,7 +23,7 @@ declare-option -docstring \
 "Ordered list of windowing modules to try and load. An empty list disables
 both automatic module loading and environment detection, enabling complete
 manual control of the module loading." \
-str-list windowing_modules 'tmux' 'screen' 'zellij' 'kitty' 'iterm' 'appleterminal' 'sway' 'wayland' 'x11' 'wezterm'
+str-list windowing_modules 'tmux' 'screen' 'zellij' 'kitty' 'iterm' 'appleterminal' 'sway' 'wayland' 'x11' 'wezterm' 'envterm'
 
 declare-option -docstring %{
     windowing module to use in the 'terminal' command

--- a/rc/windowing/envterm.kak
+++ b/rc/windowing/envterm.kak
@@ -1,0 +1,16 @@
+provide-module envterm %{
+
+# ensure that we're running on iTerm
+evaluate-commands %sh{
+    [ -z "${kak_opt_windowing_modules}" ] || [ -z "$kak_env_TERM" ] || echo 'fail $TERM not found'
+}
+
+define-command envterm-terminal-window -params 1.. -docstring '
+envterm-terminal-window <program> [<arguments>]: create a new terminal as an $TERM window
+The program passed as argument will be executed in the new terminal'\
+%{
+    nop %sh{ "$TERM" -e "$@" > /dev/null 2>&1 & }
+}
+
+}
+

--- a/rc/windowing/envterm.kak
+++ b/rc/windowing/envterm.kak
@@ -2,7 +2,7 @@ provide-module envterm %{
 
 # ensure that we're running on iTerm
 evaluate-commands %sh{
-    [ -z "${kak_opt_windowing_modules}" ] || [ -z "$kak_env_TERM" ] || echo 'fail $TERM not found'
+    [ -z "${kak_opt_windowing_modules}" ] || ! which "$kak_env_TERM" || echo 'fail $TERM binary not found'
 }
 
 define-command envterm-terminal-window -params 1.. -docstring '


### PR DESCRIPTION
it seems that most of terminal support `-e` option, let use it as a fallback implementation so that we can use `terminal` and `new` on other undefined terminal like alacritty, Terminal.app.