### PR TITLE
Remove whitespace in hooks documentation

### DIFF
--- a/doc/pages/hooks.asciidoc
+++ b/doc/pages/hooks.asciidoc
@@ -140,7 +140,7 @@ name. Hooks with no description will always use an empty string.
 *ClientClose* `client name`::
     executed when a client is closed, after it was removed from the client
     list.
-    
+
 *ClientRenamed* `<old name>:<new name>`::
     executed when a client is renamed using the `rename-client` command
 


### PR DESCRIPTION
There are some whitespace in the hooks documentation and it makes `ClientClose` and `ClientRenamed` collapse when rendered from `:doc hooks`.

```
ClientCreate client name
    executed when a new client is created.

ClientClose client name
    executed when a client is closed, after it was removed from the client list. 
ClientRenamed <old name>:<new name>
    executed when a client is renamed using the rename-client command

SessionRenamed <old name>:<new name>
    executed when a session is renamed using the rename-session command
```