### PR TITLE
fallback to terminal-window if given placement is not supported

### DIFF
--- a/rc/windowing/detection.kak
+++ b/rc/windowing/detection.kak
@@ -52,7 +52,13 @@ define-command terminal -params 1.. -docstring %{
 
     See also the 'new' command.
 } %{
-    "%opt{windowing_module}-terminal-%opt{windowing_placement}" %arg{@}
+    try %{
+        "%opt{windowing_module}-terminal-%opt{windowing_placement}" %arg{@}
+    } catch %{
+        # falback to window if other placements not supported
+        # maybe we shall let each windowing_module handle windowing_placement instead?
+        "%opt{windowing_module}-terminal-window" %arg{@}
+    }
 }
 complete-command terminal shell
 


### PR DESCRIPTION
While defining commands, I think it's better to take `windowing_placement` as a reasonable suggestion if current environment doesn't support it (like x11), instead of adding a test logic before using it or failing the command. 