### PR TITLE
rc: filetype: sh.kak: add some more zsh files for auto coloring on open

### DIFF
--- a/rc/filetype/sh.kak
+++ b/rc/filetype/sh.kak
@@ -1,4 +1,4 @@
-hook global BufCreate .*\.((z|ba|c|k|mk)?sh(rc|_profile)?|profile) %{
+hook global BufCreate .*\.((z|ba|c|k|mk)?(sh(rc|_profile|env)?|profile)) %{
     set-option buffer filetype sh
 }
 


### PR DESCRIPTION
`.zprofile` and `.zshenv` are not matched by default before this commit.

Though using
```
hook global BufOpenFile .*/(\.)+.+ %{
	set buffer filetype sh
}
```
for more dotfiles.
