### PR TITLE
 Take into account scrolloff when moving viewport

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -383,6 +383,9 @@ void view_commands(Context& context, NormalParams params)
 
         const BufferCoord cursor = context.selections().main().cursor();
         Window& window = context.window();
+        const DisplayCoord max_offset{(window.dimensions().line - 1)/2, (window.dimensions().column - 1)/2};
+        const DisplayCoord scrolloff =
+            std::min(context.options()["scrolloff"].get<DisplayCoord>(), max_offset);
         switch (*cp)
         {
         case 'v':
@@ -394,10 +397,10 @@ void view_commands(Context& context, NormalParams params)
                 context.buffer()[cursor.line].column_count_to(cursor.column));
             break;
         case 't':
-            window.display_line_at(cursor.line, 0);
+            window.display_line_at(cursor.line, scrolloff.line);
             break;
         case 'b':
-            window.display_line_at(cursor.line, window.dimensions().line-1);
+            window.display_line_at(cursor.line, window.dimensions().line-1-scrolloff.line);
             break;
         case '<':
             window.display_column_at(context.buffer()[cursor.line].column_count_to(cursor.column), 0);

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -383,9 +383,10 @@ void view_commands(Context& context, NormalParams params)
 
         const BufferCoord cursor = context.selections().main().cursor();
         Window& window = context.window();
-        const DisplayCoord max_offset{(window.dimensions().line - 1)/2, (window.dimensions().column - 1)/2};
-        const DisplayCoord scrolloff =
-            std::min(context.options()["scrolloff"].get<DisplayCoord>(), max_offset);
+
+        const DisplayCoord scrolloff = context.options()["scrolloff"].get<DisplayCoord>();
+        const LineCount line_offset{std::min((window.dimensions().line - 1) / 2, scrolloff.line)};
+        const ColumnCount column_offset{std::min((window.dimensions().column - 1) / 2, scrolloff.column)};
         switch (*cp)
         {
         case 'v':
@@ -397,17 +398,18 @@ void view_commands(Context& context, NormalParams params)
                 context.buffer()[cursor.line].column_count_to(cursor.column));
             break;
         case 't':
-            window.display_line_at(cursor.line, scrolloff.line);
+            window.display_line_at(cursor.line, line_offset);
             break;
         case 'b':
-            window.display_line_at(cursor.line, window.dimensions().line-1-scrolloff.line);
+            window.display_line_at(cursor.line, window.dimensions().line-1-line_offset);
             break;
         case '<':
-            window.display_column_at(context.buffer()[cursor.line].column_count_to(cursor.column), 0);
+            window.display_column_at(context.buffer()[cursor.line].column_count_to(cursor.column),
+                                    column_offset);
             break;
         case '>':
             window.display_column_at(context.buffer()[cursor.line].column_count_to(cursor.column),
-                                     window.dimensions().column-1);
+                                     window.dimensions().column-1-column_offset);
             break;
         case 'h':
             window.scroll(-std::max<ColumnCount>(1, count));


### PR DESCRIPTION
`vt` and `vb` respect custom scroll offset.
fixes #5178