### PR TITLE
Review some special buffer citations in documentation

### DIFF
--- a/doc/pages/buffers.asciidoc
+++ b/doc/pages/buffers.asciidoc
@@ -11,7 +11,7 @@ Scratch buffers are useful for volatile data and quick prototyping.
 They are not linked to files, so Kakoune does not warn about unsaved
 changes at exit, and the `:write` command requires an explicit filename.
 
-One particular scratch buffer, named *\*scratch*\*, is automatically created
+One particular scratch buffer, named `\*scratch*`, is automatically created
 when there are no other buffers left in the current session, which is also
 the case when Kakoune starts up without any files to open.
 
@@ -29,7 +29,7 @@ restrictions compared to regular buffers:
 - Hooks are not always run (like the `BufCreate`/`BufClose` hooks).
 - Display profiling is disabled.
 
-A specific *\*debug*\* buffer is used by Kakoune to write errors or
+A specific `\*debug*` buffer is used by Kakoune to write errors or
 warnings.  This is also where the ouput of the `:debug` and the `:echo
 -debug` commands will land.
 

--- a/doc/pages/commands.asciidoc
+++ b/doc/pages/commands.asciidoc
@@ -48,7 +48,7 @@ of the file onto the filesystem
     *-scratch*:::
         Creates a new buffer named <filename>, which doesn't correspond to any
         file on disk. If no filename is given, the buffer name will be
-        generated based on format `\*scratch-$ID\*`, where `$ID` is an
+        generated based on format `\*scratch-$ID*`, where `$ID` is an
         integer automatically incremented for new buffers.
         (See <<buffers#scratch-buffers,`:doc buffers scratch-buffers`>>)
 
@@ -254,7 +254,7 @@ of the file onto the filesystem
         <<faces#markup-strings,`:doc faces markup-strings`>>)
 
     *-debug*:::
-        print the given text to the *\*debug** buffer
+        print the given text to the `\*debug*` buffer
 
     *-to-file* <filename>:::
         write the given text to the given file on the host
@@ -415,7 +415,7 @@ but not really useful in that context.
     matches the current buffer timestamp (or is not specified).
 
 *debug* {info,buffers,options,memory,shared-strings,profile-hash-maps,faces,mappings}::
-    print some debug information in the *\*debug** buffer
+    print some debug information in the `\*debug*` buffer
 
 == Module commands
 

--- a/doc/pages/options.asciidoc
+++ b/doc/pages/options.asciidoc
@@ -310,7 +310,7 @@ are exclusively available to built-in options.
     then rename it to the target file.
 
 *debug* `flags(hooks|shell|profile|keys|commands)`::
-    dump various debug information in the '\*debug*' buffer
+    dump various debug information in the `\*debug*` buffer
 
 *idle_timeout* `int`::
     _default_ 50 +
@@ -400,7 +400,7 @@ status line using the `echo` command:
 echo %opt{BOM}
 --------------
 
-The current values for all options can be dumped to the *\*debug*\* buffer using
+The current values for all options can be dumped to the `\*debug*` buffer using
 the following command:
 
 -------------


### PR DESCRIPTION
Now `\*debug*` and `\*scratch*` are used when referring these buffers for prettier presentation.
fixes #5197