### PR TITLE
add scroll coordinates in scroll key

### DIFF
--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -127,7 +127,10 @@ struct MouseHandler
 
         Buffer& buffer = context.buffer();
         BufferCoord cursor;
-        constexpr auto modifiers = Key::Modifiers::Control | Key::Modifiers::Alt | Key::Modifiers::Shift | Key::Modifiers::MouseButtonMask;
+        // bits above these potentially store additional information
+        constexpr auto mask = (Key::Modifiers) 0x7FF;
+        constexpr auto modifiers = Key::Modifiers::Control | Key::Modifiers::Alt | Key::Modifiers::Shift | Key::Modifiers::MouseButtonMask | ~mask;
+
         switch ((key.modifiers & ~modifiers).value)
         {
         case Key::Modifiers::MousePress:
@@ -193,7 +196,7 @@ struct MouseHandler
         }
 
         case Key::Modifiers::Scroll:
-            scroll_window(context, static_cast<int32_t>(key.key), m_dragging ? OnHiddenCursor::MoveCursor : OnHiddenCursor::PreserveSelections);
+            scroll_window(context, key.scroll_amount(), m_dragging ? OnHiddenCursor::MoveCursor : OnHiddenCursor::PreserveSelections);
             return true;
 
         default: return false;

--- a/src/keys.cc
+++ b/src/keys.cc
@@ -7,6 +7,7 @@
 #include "utf8_iterator.hh"
 #include "utils.hh"
 #include "string_utils.hh"
+#include "terminal_ui.hh"
 
 namespace Kakoune
 {
@@ -196,7 +197,7 @@ String to_string(Key key)
     else if (key.modifiers & Key::Modifiers::MouseRelease)
         res = format("mouse:release:{}:{}.{}", key.mouse_button(), coord.line, coord.column);
     else if (key.modifiers & Key::Modifiers::Scroll)
-        res = format("scroll:{}", static_cast<int>(key.key));
+        res = format("scroll:{}:{}.{}", key.scroll_amount(), coord.line, coord.column);
     else if (key.modifiers & Key::Modifiers::Resize)
         res = format("resize:{}.{}", coord.line, coord.column);
     else

--- a/src/keys.cc
+++ b/src/keys.cc
@@ -7,7 +7,6 @@
 #include "utf8_iterator.hh"
 #include "utils.hh"
 #include "string_utils.hh"
-#include "terminal_ui.hh"
 
 namespace Kakoune
 {

--- a/src/keys.hh
+++ b/src/keys.hh
@@ -91,6 +91,7 @@ struct Key
 
     constexpr DisplayCoord coord() const { return {(int)((key & 0xFFFF0000) >> 16), (int)(key & 0x0000FFFF)}; }
     constexpr MouseButton mouse_button() { return MouseButton{((int)modifiers & (int)Modifiers::MouseButtonMask) >> 6}; }
+    constexpr int scroll_amount() { return (int)modifiers >> 16; }
     static Modifiers to_modifier(MouseButton button) { return Key::Modifiers{((int)button << 6) & (int)Modifiers::MouseButtonMask}; }
 
     Optional<Codepoint> codepoint() const;

--- a/src/keys.hh
+++ b/src/keys.hh
@@ -89,9 +89,9 @@ struct Key
     constexpr bool operator==(Key other) const { return val() == other.val(); }
     constexpr auto operator<=>(Key other) const { return val() <=> other.val(); }
 
-    constexpr DisplayCoord coord() const { return {(int)((key & 0xFFFF0000) >> 16), (int)(key & 0x0000FFFF)}; }
+    constexpr DisplayCoord coord() const { return {(int)((int32_t) (key & 0xFFFF0000) >> 16), (int)(key & 0x0000FFFF)}; }
     constexpr MouseButton mouse_button() { return MouseButton{((int)modifiers & (int)Modifiers::MouseButtonMask) >> 6}; }
-    constexpr int scroll_amount() { return (int)modifiers >> 16; }
+    constexpr int scroll_amount() { return (int32_t)modifiers >> 16; }
     static Modifiers to_modifier(MouseButton button) { return Key::Modifiers{((int)button << 6) & (int)Modifiers::MouseButtonMask}; }
 
     Optional<Codepoint> codepoint() const;

--- a/src/terminal_ui.cc
+++ b/src/terminal_ui.cc
@@ -798,9 +798,8 @@ Optional<Key> TerminalUI::get_next_key()
             return Key{mod | Key::to_modifier(button), coord};
         };
 
-        auto mouse_scroll = [this](Key::Modifiers mod, bool down) -> Key {
-            return {mod | Key::Modifiers::Scroll,
-                    (Codepoint)((down ? 1 : -1) * m_wheel_scroll_amount)};
+        auto mouse_scroll = [this](Key::Modifiers mod, Codepoint coord, bool down) -> Key {
+            return {mod | Key::Modifiers::Scroll | (Key::Modifiers)((down ? m_wheel_scroll_amount : -1 * m_wheel_scroll_amount) << 16), coord};
         };
 
         auto masked_key = [&](Codepoint key, Codepoint shifted_key = 0) {
@@ -921,8 +920,8 @@ Optional<Key> TerminalUI::get_next_key()
                 else if (int guess = ffs(m_mouse_state) - 1; 0 <= guess and guess < 3)
                     return mouse_button(mod, Key::MouseButton{guess}, coord, true);
                 break;
-            case 64: return mouse_scroll(mod, false);
-            case 65: return mouse_scroll(mod, true);
+            case 64: return mouse_scroll(mod, coord, false);
+            case 65: return mouse_scroll(mod, coord, true);
             }
             return Key{Key::Modifiers::MousePos, coord};
         }


### PR DESCRIPTION
`on-key` + a scoll event now emits `<scroll:amount:line.column>`, instead of `<scroll:amount>`. That is, the position of the mouse is included in the scroll key. This matches up with mouse press and release events `<mouse:button:action:line.column>`.

- adds scroll amount in the upper 16-bits of `Key.modifiers`, allowing `key` to store the coordinates.

- additionally, this PR fixes an issue where `ui_options terminal_status_on_top=yes` is set, we run `on-key %{ echo %val{key} }` and clicking on the status line, we get `<mouse:press:left:65536.1>` (which is not the correct line location). This PR now returns `<mouse:press:left:0.1>`, which I think is at least a bit more correct.