### PR TITLE
Fixed eruby highlighter marking everything as string in ERB files

### DIFF
--- a/rc/filetype/eruby.kak
+++ b/rc/filetype/eruby.kak
@@ -20,7 +20,6 @@ provide-module eruby %{
   require-module html
   add-highlighter shared/eruby regions
   add-highlighter shared/eruby/html default-region ref html
-  add-highlighter shared/eruby/simple-expression-tag region '<%=' '%>' ref ruby
-  add-highlighter shared/eruby/simple-execution-tag region '<%' '%>' ref ruby
   add-highlighter shared/eruby/simple-comment-tag region '<%#' '%>' fill comment
+  add-highlighter shared/eruby/simple-execution-tag region (?<=<%) '%>' ref ruby
 }


### PR DESCRIPTION
It seems the `ref` highlighter sees the opening and closing delimiters as well. This causes problems with the `<%= ... %>` syntax in ERB files because ruby strings can be delimited with [`%` then *any character*](https://docs.ruby-lang.org/en/3.2/syntax/literals_rdoc.html#label-Percent+Literals), so it sees `%=` as starting a string.

Making `<%` a look-behind match seems to fix this.