### PR TITLE
Echo json

### DIFF
--- a/doc/pages/commands.asciidoc
+++ b/doc/pages/commands.asciidoc
@@ -275,8 +275,11 @@ of the file onto the filesystem
             embedded quotes.
 
         - *shell*::::
-            also wrap each arguments in single quotes and escape
+            also wrap each argument in single quotes and escape
             embedded quotes in a shell compatible way.
+
+        - *json*::::
+            convert each argument to a json string and join on newline.
 
 *set-face* <scope> <name> <facespec>::
     *alias* face +

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -28,6 +28,7 @@
 #include "remote.hh"
 #include "shell_manager.hh"
 #include "string.hh"
+#include "string_utils.hh"
 #include "user_interface.hh"
 #include "window.hh"
 
@@ -1523,7 +1524,7 @@ const CommandDesc echo_cmd = {
     "echo <params>...: display given parameters in the status line",
     ParameterDesc{
         { { "markup", { {}, "parse markup" } },
-          { "quoting", { {arg_completer(Array{"raw", "kakoune", "shell"})}, "quote each argument separately using the given style (raw|kakoune|shell)" } },
+          { "quoting", { {arg_completer(Array{"raw", "kakoune", "shell", "json"})}, "quote each argument separately using the given style (raw|kakoune|shell|json)" } },
           { "end-of-line", { {}, "add trailing end-of-line" } },
           { "to-file", { {filename_arg_completer<false>}, "echo contents to given filename" } },
           { "to-shell-script", { ArgCompleter{}, "pipe contents to given shell script" } },
@@ -1537,8 +1538,11 @@ const CommandDesc echo_cmd = {
     {
         String message;
         if (auto quoting = parser.get_switch("quoting"))
-            message = join(parser | transform(quoter(option_from_string(Meta::Type<Quoting>{}, *quoting))),
-                           ' ', false);
+        {
+            auto quote_type = option_from_string(Meta::Type<Quoting>{}, *quoting);
+            message = join(parser | transform(quoter(quote_type)),
+                           (quote_type == Quoting::Json ? '\n' : ' '), false);
+        }
         else
             message = join(parser, ' ', false);
 

--- a/src/string_utils.hh
+++ b/src/string_utils.hh
@@ -7,6 +7,7 @@
 #include "ranges.hh"
 #include "optional.hh"
 #include "utils.hh"
+#include "json.hh"
 
 namespace Kakoune
 {
@@ -188,11 +189,17 @@ inline String shell_quote(StringView s)
     return format("'{}'", replace(s, "'", R"('\'')"));
 }
 
+inline String json_quote(StringView s)
+{
+    return format("{}", to_json(s));
+}
+
 enum class Quoting
 {
     Raw,
     Kakoune,
-    Shell
+    Shell,
+    Json
 };
 
 constexpr auto enum_desc(Meta::Type<Quoting>)
@@ -200,7 +207,8 @@ constexpr auto enum_desc(Meta::Type<Quoting>)
     return make_array<EnumDesc<Quoting>>({
         { Quoting::Raw, "raw" },
         { Quoting::Kakoune, "kakoune" },
-        { Quoting::Shell, "shell" }
+        { Quoting::Shell, "shell" },
+        { Quoting::Json, "json" }
     });
 }
 
@@ -210,6 +218,7 @@ inline auto quoter(Quoting quoting)
     {
         case Quoting::Kakoune: return &quote;
         case Quoting::Shell: return &shell_quote;
+        case Quoting::Json: return &json_quote;
         case Quoting::Raw:
         default:
             return +[](StringView s) { return s.str(); };


### PR DESCRIPTION
Add -quoting json option to echo. This converts each argument to a json string and joins on newline. It supports this, for example:
```
echo -quoting json -to-shell-script 'jq -n "[inputs] ..."' %val{selections}
```
A script can obtain potentially large sets of strings, like selections, as input rather than environment.

