### PR TITLE
Add double underline in main version notes

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -48,6 +48,7 @@ struct {
 } constexpr version_notes[] = { {
         0,
         "» kak_* appearing in shell arguments will be added to the environment\n"
+        "» {+U}double underline{} support\n"
     }, {
         20240518,
         "» Fix tests failing on some platforms\n"


### PR DESCRIPTION
This should've been in #5210 