### PR TITLE
SQL filetype detection: Correctly match against '.sql' file extension, not 'sql' suffix.

### DIFF
--- a/rc/filetype/sql.kak
+++ b/rc/filetype/sql.kak
@@ -4,7 +4,7 @@
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
-hook global BufCreate .*/?(?i)sql %{
+hook global BufCreate .*[.](?i)sql %{
     set-option buffer filetype sql
 }
 


### PR DESCRIPTION
The SQL filetype detection currently matches against a 'sql' suffix on the filename, which incorrectly matches a filename like 'run-psql'. Instead, explicitly match against a '.sql' suffix.