### PR TITLE
Highlight ASCII control characters unambiguously

### DIFF
--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -1327,7 +1327,12 @@ void expand_unprintable(HighlightContext context, DisplayBuffer& display_buffer,
                     if (ByteCount pos(next - line_data); pos < atom_it->end().column)
                         atom_it = line.split(atom_it, {begin.line, pos});
 
-                    atom_it->replace("�");
+                    if (cp < ' ')
+                        atom_it->replace(format("^{}", (char)(cp + '@')));
+                    else if (cp == 127)
+                        atom_it->replace("^?");
+                    else
+                        atom_it->replace("�");
                     atom_it->face = error;
                     break;
                 }


### PR DESCRIPTION
Previously, all ASCII control characters would be shown as the replacement character. This leads to a visual loss of information and ambiguities, particularly when opening files that contain lots of control characters (or binary files). Use the common circumflex notation, known from software such as `cat -v` or vim, instead.

Fixes #2936