### PR TITLE
add header file to src/backtrace.cc

### DIFF
--- a/src/backtrace.cc
+++ b/src/backtrace.cc
@@ -1,6 +1,7 @@
 #include "backtrace.hh"
 
 #include "string.hh"
+#include "format.hh"
 
 #if defined(__GLIBC__) || defined(__APPLE__)
 # include <execinfo.h>


### PR DESCRIPTION
fix building error about missing hex(...) function

`#include "format.hh"` was removed by this commit https://github.com/mawww/kakoune/pull/5219