### PR TITLE
Allow setting $kak_bin to test kak binaries in alternate locations

### DIFF
--- a/test/run
+++ b/test/run
@@ -24,6 +24,9 @@ main() {
       '
 
   root=$PWD
+  if [ -z $kak_bin ]; then
+    kak_bin=$root/../src/kak
+  fi
   tmpdir="${TMPDIR:-/tmp}"
   work=$(mktemp -d $tmpdir/kak-tests.XXXXXXXX)
   trap "rm -R $work" EXIT
@@ -52,9 +55,13 @@ main() {
     mkfifo ui-in ui-out
     number_tests=$(($number_tests + 1))
     touch in; cp in out
-    session="kak-tests"
-    rm -f "$(session_path $session)"
-    $DEBUGGER $root/../src/kak out -n -s "$session" -ui json -e "$kak_commands" >ui-out <ui-in &
+    rm -f "$session_path"
+    (
+      if [ -f env ]; then
+        . ./env
+      fi
+      exec $DEBUGGER $kak_bin out -n -s "$session" -ui json -e "$kak_commands" >ui-out <ui-in
+    ) &
     kakpid=$!
 
     failed=0
@@ -67,7 +74,7 @@ main() {
       ui_out '{ "jsonrpc": "2.0", "method": "set_ui_options", "params": [{}] }'
     fi
 
-    finished_commands |$root/../src/kak -p "$session" 2>/dev/null
+    finished_commands |$kak_bin -p "$session" 2>/dev/null
     cat <&4 >/dev/null
 
     wait $kakpid


### PR DESCRIPTION
The test/run script will check for a $kak_bin environment variable and, if it's set, treat it as an absolute path to a kak binary. Otherwise the default path src/kak is used.