### PR TITLE
typst: fix comment_line and comment_block* options for typst

### DIFF
--- a/rc/tools/comment.kak
+++ b/rc/tools/comment.kak
@@ -16,7 +16,7 @@ hook global BufSetOption filetype=asciidoc %{
     set-option buffer comment_block_end '////'
 }
 
-hook global BufSetOption filetype=(c|cpp|dart|gluon|go|java|javascript|objc|odin|php|pony|protobuf|rust|sass|scala|scss|swift|typescript|groovy) %{
+hook global BufSetOption filetype=(c|cpp|dart|gluon|go|java|javascript|objc|odin|php|pony|protobuf|rust|sass|scala|scss|swift|typescript|typst|groovy) %{
     set-option buffer comment_line '//'
     set-option buffer comment_block_begin '/*'
     set-option buffer comment_block_end '*/'


### PR DESCRIPTION
Typst uses `//` and `/* */` for comments.