### PR TITLE
For OpenLineBelow, add newline to the end of the line of the current …

### DIFF
--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -408,7 +408,7 @@ void Buffer::check_invariant() const
 #endif
 }
 
-BufferRange Buffer::do_insert(BufferCoord pos, StringView content)
+BufferRange Buffer::do_insert(BufferCoord pos, StringView content, bool draft)
 {
     kak_assert(is_valid(pos));
 
@@ -452,7 +452,7 @@ BufferRange Buffer::do_insert(BufferCoord pos, StringView content)
     const auto end = at_end ? line_count()
                             : BufferCoord{ last_line, m_lines[last_line].length() - suffix.length() };
 
-    m_changes.push_back({ Change::Insert, pos, end });
+    m_changes.push_back({ draft ? Change::Draft : Change::Insert, pos, end });
     return {pos, end};
 }
 
@@ -499,7 +499,7 @@ void Buffer::apply_modification(const Modification& modification)
     }
 }
 
-BufferRange Buffer::insert(BufferCoord pos, StringView content)
+BufferRange Buffer::insert(BufferCoord pos, StringView content, bool draft)
 {
     throw_if_read_only();
 
@@ -515,7 +515,7 @@ BufferRange Buffer::insert(BufferCoord pos, StringView content)
 
     if (not (m_flags & Flags::NoUndo))
         m_current_undo_group.push_back({Modification::Insert, pos, real_content});
-    return do_insert(pos, real_content->strview());
+    return do_insert(pos, real_content->strview(), draft);
 }
 
 BufferCoord Buffer::erase(BufferCoord begin, BufferCoord end)

--- a/src/buffer.hh
+++ b/src/buffer.hh
@@ -142,7 +142,7 @@ public:
     bool set_name(String name);
     void update_display_name();
 
-    BufferRange insert(BufferCoord pos, StringView content);
+    BufferRange insert(BufferCoord pos, StringView content, bool draft = false);
     BufferCoord erase(BufferCoord begin, BufferCoord end);
     BufferRange replace(BufferCoord begin, BufferCoord end, StringView content);
 
@@ -220,7 +220,7 @@ public:
 
     struct Change
     {
-        enum Type : char { Insert, Erase };
+        enum Type : char { Insert, Erase, Draft };
         Type type;
         BufferCoord begin;
         BufferCoord end;
@@ -265,7 +265,7 @@ public:
 private:
     void on_option_changed(const Option& option) override;
 
-    BufferRange do_insert(BufferCoord pos, StringView content);
+    BufferRange do_insert(BufferCoord pos, StringView content, bool draft = false);
     BufferCoord do_erase(BufferCoord begin, BufferCoord end);
 
     void apply_modification(const Modification& modification);

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -1482,13 +1482,16 @@ private:
             break;
         case InsertMode::OpenLineBelow:
         {
+            const bool draft = ( context().flags() == Context::Flags::Draft );
             Vector<Selection> new_sels;
             count = count > 0 ? count : 1;
             LineCount inserted_count = 0;
             for (auto sel : selections)
             {
-                buffer.insert({sel.max().line + inserted_count, buffer[sel.max().line].length() - 1},
-                              String{'\n', CharCount{count}});
+                buffer.insert({sel.max().line + inserted_count,
+                              buffer[sel.max().line].length() - 1},
+                              String{'\n', CharCount{count}},
+                              draft);
                 for (int i = 0; i < count; ++i)
                     new_sels.push_back({sel.max().line + inserted_count + i + 1});
                 inserted_count += count;

--- a/src/selection.cc
+++ b/src/selection.cc
@@ -240,12 +240,14 @@ void update_selections(Vector<Selection>& selections, size_t& main, const Buffer
 
         if (forward_end >= backward_end)
         {
-            update_forward({ change_it, forward_end }, selections);
+            if (change_it->type != Buffer::Change::Draft)
+                update_forward({ change_it, forward_end }, selections);
             change_it = forward_end;
         }
         else
         {
-            update_backward({ change_it, backward_end }, selections);
+            if (change_it->type != Buffer::Change::Draft)
+                update_backward({ change_it, backward_end }, selections);
             change_it = backward_end;
         }
         kak_assert(std::is_sorted(selections.begin(), selections.end(),


### PR DESCRIPTION
For OpenLineBelow, add newline to the end of the line of the current selection, instead of the line below the selection, for a more consistent history

Given the following buffer:

> Line Zero\n$
> $

Pressing the ```o``` key on (zero indexed) line one, results in the following ```history```:

- 1561858 1 0 1561866 2 +0.0|L +0.1|i +0.2|n +0.3|e +0.4|  +0.5|Z +0.6|e +0.7|r +0.8|o +0.9|\n
1 1561872 - +2.0|\n
+2.0|Line Two

After the patch, pressing the ```o``` key, the history would look like the following, which would match if ```i``` and ```<ret>``` had been pressed on line one.

- 1561858 1 0 1561866 2 +0.0|L +0.1|i +0.2|n +0.3|e +0.4|  +0.5|Z +0.6|e +0.7|r +0.8|o +0.9|\n
1 1561872 - +1.0|\n
+2.0|Line Two