### PR TITLE
Add -no-indent-skip switch to show-whitespaces highlighter

### DIFF
--- a/doc/pages/highlighters.asciidoc
+++ b/doc/pages/highlighters.asciidoc
@@ -64,6 +64,9 @@ highlighter is replaced with the new one.
         according to the *indentwidth* option, or an empty string to ignore them.
         This will use the `WhitespaceIndent` face.
 
+    *-no-indent-skip*:::
+        don't omit the indent character for the leftmost column
+
     *-only-trailing*:::
         only highlight whitespaces at the end of the line
 


### PR DESCRIPTION
![Screenshot_20250122_081645](https://github.com/user-attachments/assets/9a271985-41ac-48cc-bbb7-16469cd21929)

A flag you can pass to the show-whitespaces highlighter to disable the default behavior of skipping the first column when rendering indent guides, since this behavior makes sense with some languages/choices of whitespace character but not others. Opted for `no-indent-skip` rather than `indent-skip` to avoid messing with any existing configuration.