### PR TITLE
Fix Fennel syntax highlighting for names with hyphens, negative numbers etc.

### DIFF
--- a/rc/filetype/fennel.kak
+++ b/rc/filetype/fennel.kak
@@ -59,8 +59,8 @@ evaluate-commands %sh{
     "
 }
 
-add-highlighter shared/fennel/code/operator regex (\.|\?\.|\+|\.\.|\^|-|\*|%|/|>|<|>=|<=|=|\.\.\.|:|->|->>|-\?>|-\?>>) 0:operator
-add-highlighter shared/fennel/code/value regex \b(false|nil|true|[0-9]+(:?\.[0-9])?(:?[eE]-?[0-9]+)?|0x[0-9a-fA-F])\b 0:value
+add-highlighter shared/fennel/code/operator regex (\.|\?\.|\+|\^|-|\*|%|/|>|<|>=|<=|=|not=|:|->|->>|-\?>|-\?>>)\s+|\.\.\.? 0:operator
+add-highlighter shared/fennel/code/value regex (\b(false|nil|true)\b|-?\b[0-9][_0-9]*(:?\.[_0-9]+)?(:?[eE]-?[_0-9]+)?|0x[0-9a-fA-F]\b) 0:value
 add-highlighter shared/fennel/code/function_declaration regex \((?:fn|lambda|λ)\s+([\S]+) 1:function
 add-highlighter shared/fennel/code/method_call regex (?:\w+|\$[0-9]{0,1}):(\S+)\b 1:function
 


### PR DESCRIPTION
While Fennel's operator symbols are shared with Lua for the most part, they only function as operators when called as functions. Characters like `-` and `*` and `?` appear in symbol names all the time, so this change to the regex keeps those from registering as operators as well.