### PR TITLE
rc/filetype: add forth.kak

### DIFF
--- a/rc/filetype/forth.kak
+++ b/rc/filetype/forth.kak
@@ -1,0 +1,19 @@
+hook global BufCreate .+\.(fth|4th|fs|forth) %{
+    set-option buffer filetype forth
+}
+
+hook global WinSetOption filetype=forth %{
+    require-module forth
+}
+
+hook -group forth-highlight global WinSetOption filetype=forth %{
+    add-highlighter window/forth ref forth
+    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/forth }
+}
+
+provide-module forth %{
+
+add-highlighter shared/forth regions
+add-highlighter shared/forth/comment region '\(' '\)' fill comment
+
+}


### PR DESCRIPTION
This is an initial simple forth filetype plugin. All it does for now is highlight comments, which is crucial to reading forth source code. More highlighting can be added in future commits.