### PR TITLE
Change the no-op assert macros to silence a clang-tidy warning

### DIFF
--- a/src/assert.hh
+++ b/src/assert.hh
@@ -30,7 +30,7 @@ void on_assert_failed(const char* message);
                          "\" at " __FILE__ ":" TOSTRING(__LINE__)); \
     } catch (exception_type &err) {}
 #else
-    #define kak_assert(...) do { (void)sizeof(__VA_ARGS__); } while(false)
+    #define kak_assert(...) do { (void)alignof(decltype(__VA_ARGS__)); } while(false)
     #define kak_expect_throw(_, ...) do { (void)sizeof(__VA_ARGS__); } while(false)
 #endif
 

--- a/src/assert.hh
+++ b/src/assert.hh
@@ -31,7 +31,7 @@ void on_assert_failed(const char* message);
     } catch (exception_type &err) {}
 #else
     #define kak_assert(...) do { (void)alignof(decltype(__VA_ARGS__)); } while(false)
-    #define kak_expect_throw(_, ...) do { (void)sizeof(__VA_ARGS__); } while(false)
+    #define kak_expect_throw(_, ...) do { (void)alignof(decltype(__VA_ARGS__)); } while(false)
 #endif
 
 


### PR DESCRIPTION
When KAK_DEBUG is false (release mode), clang tidy emits a 
warning when we pass a pointer to kak_assert. It's mad about 
passing a pointer to `sizeof`.

We can avoid this warning by using `alignof(decltype(...))`. 
It will still type-check the expression.