### PR TITLE
rc git: Use wider characters for added/modified lines

### DIFF
--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -2,10 +2,10 @@ declare-option -docstring "name of the client in which documentation is to be di
     str docsclient
 
 declare-option -docstring "git diff added character" \
-    str git_diff_add_char "▏"
+    str git_diff_add_char "▊"
 
 declare-option -docstring "git diff modified character" \
-    str git_diff_mod_char "▏"
+    str git_diff_mod_char "▊"
 
 declare-option -docstring "git diff deleted character" \
     str git_diff_del_char "_"


### PR DESCRIPTION
I find the current default characters very difficult to see, to the point where I didn't know if `git show-diff` was actually working.