### PR TITLE
Fixed latex highlighter escaping math mode

### DIFF
--- a/rc/filetype/latex.kak
+++ b/rc/filetype/latex.kak
@@ -42,6 +42,11 @@ add-highlighter shared/latex/content default-region group
 add-highlighter shared/latex/cs region '(?<!\\)(?:\\\\)*\K\\[@\w]' '/\n|(?<![@:\\{}\[\]*])(?![@:\\{}\[\]*])\b|(?<!\\)(?:\\\\)*\K\}\K' group
 add-highlighter shared/latex/comment region '(?<!\\)(?:\\\\)*\K%' '\n' fill comment
 
+# Math mode between dollar signs/pairs
+add-highlighter shared/latex/dollar-math region -match-capture '(?<!\\)(?:\\\\)*\K(\$\$?)' '(?<!\\)(?:\\\\)*(\$\$?)' fill meta
+add-highlighter shared/latex/paren-math region '(?<!\\)(?:\\\\)*\K\\\(' '(?<!\\)(?:\\\\)*\\\)' fill meta
+add-highlighter shared/latex/bracket-math region '(?<!\\)(?:\\\\)*\K\\\[' '(?<!\\)(?:\\\\)*\\\]' fill meta
+
 # Document and LaTeX2e control sequence
 add-highlighter shared/latex/cs/ regex '(?:\\[a-zA-Z@]+)' 0:keyword
 ## Options passed to LaTeX2e control sequences, between brackets
@@ -72,9 +77,6 @@ add-highlighter shared/latex/cs/ regex '_(bool|box|cctab|clist|coffin|dim|fp|ior
 add-highlighter shared/latex/content/ regex '(?<!\\)(?:\\\\)*\K#+[1-9]' 0:string
 ## group containing words and numbers (list separated by ; , / or spaces)
 add-highlighter shared/latex/content/ regex '(?<!\\)(?:\\\\)*\K\{([\s/;,.\w\d]+)\}' 1:string
-
-# Math mode between dollar signs/pairs
-add-highlighter shared/latex/content/ regex '((?<!\\)(?:\\\\)*\K\$(\\\$|[^$])+\$)|((?<!\\)(?:\\\\)*\K\$\$(\\\$|[^$])+\$\$)|((?<!\\)(?:\\\\)*\K\\\[.*?\\\])|(\\\(.*?\\\))' 0:meta
 
 # Indent
 # ------


### PR DESCRIPTION
Previously, using any macro in math mode causes the whole thing to fail to be recognized as math because the macro would be captured by the "cs" region.
For example, this segment would be highlighted incorrectly with `$x \in A$` not highlighted as math and the word `Finally` after it highlighted as math.

```
First $A$ ...
Then $x \in A$ ...
Finally $B$ ...
```
![screenshot_2025-04-09T03:31:24](https://github.com/user-attachments/assets/f6d3d0ce-5e35-4aef-8ace-6a03f587c8d7)