### PR TITLE
Disable keymaps when playing macro

### DIFF
--- a/src/normal.cc
+++ b/src/normal.cc
@@ -1610,6 +1610,7 @@ void replay_macro(Context& context, NormalParams params)
     auto keys = parse_keys(reg_val[0]);
     ScopedEdition edition(context);
     ScopedSelectionEdition selection_edition{context};
+    ScopedSetBool disable_keymaps(context.keymaps_disabled());
     do
     {
         for (auto& key : keys)


### PR DESCRIPTION
Macros are already recorded with keymaps resolved, so there's no need to resolve them again.

Fixes #5309.