### PR TITLE
Smart-case regex matching

### DIFF
--- a/doc/pages/regex.asciidoc
+++ b/doc/pages/regex.asciidoc
@@ -165,6 +165,8 @@ them:
 
 * `(?i)` starts case-insensitive matching.
 * `(?I)` starts case-sensitive matching (default).
+* `(?c)` starts smart-case matching - same as case-insensitive matching
+         unless the pattern contains an uppercase character.
 * `(?s)` allows `.` to match newlines (default).
 * `(?S)` prevents `.` from matching newlines.
 


### PR DESCRIPTION
Adds new regex modifier `(?c)` to enable smart-case matching.

In this mode, case-insensitive matching is used unless there is an uppercase character present in the pattern; otherwise case-insensitive matching applies (e.g.  `A`, `[A-Z]`, `\QA\E`, `\x41` count as an uppercase).

Fixes #4856 and #5320.

```
#  Use incremental smart-case search by default.
:map global normal '/' '/(?c)'
```
