### PR TITLE
latex: highlight $ $$ \[ and \( math modes properly.

### DIFF
--- a/rc/filetype/latex.kak
+++ b/rc/filetype/latex.kak
@@ -34,18 +34,22 @@ provide-module latex %~
 
 add-highlighter shared/latex regions
 add-highlighter shared/latex/content default-region group
+
+# Math modes
+# $math$ must have at least one non-$ character inside.
+# This is so that $$math$$ get matched properly.
+add-highlighter shared/latex/dollar-math region '(?<!\\)(?:\\\\)*\K\$[^$]' '(?<!\\)(\\\\)*\$' fill meta
+add-highlighter shared/latex/ddollar-math region '(?<!\\)(?:\\\\)*\K\$\$' '(?<!\\)(\\\\)*\$\$' fill meta
+add-highlighter shared/latex/bracket-math region '(?<!\\)(?:\\\\)*\K\\\[' '\\\]' fill meta
+add-highlighter shared/latex/paren-math region '(?<!\\)(?:\\\\)*\K\\\(' '\\\)' fill meta
+
 # Region for control sequence (includes latex2e arguments and options)
 # starting with unescaped \ and ending :
 # - at eol, or
 # - at word boundaries not preceded nor followed by @ : \ { } [ ] *, or
 # - after an unescaped }
-add-highlighter shared/latex/cs region '(?<!\\)(?:\\\\)*\K\\[@\w]' '/\n|(?<![@:\\{}\[\]*])(?![@:\\{}\[\]*])\b|(?<!\\)(?:\\\\)*\K\}\K' group
+add-highlighter shared/latex/cs region '(?<!\\)(?:\\\\)*\K\\[@\w]' '\n|(?<![@:\\{}\[\]*])(?![@:\\{}\[\]*])\b|(?<!\\)(?:\\\\)*\K\}\K' group
 add-highlighter shared/latex/comment region '(?<!\\)(?:\\\\)*\K%' '\n' fill comment
-
-# Math mode between dollar signs/pairs
-add-highlighter shared/latex/dollar-math region -match-capture '(?<!\\)(?:\\\\)*\K(\$\$?)' '(?<!\\)(?:\\\\)*(\$\$?)' fill meta
-add-highlighter shared/latex/paren-math region '(?<!\\)(?:\\\\)*\K\\\(' '(?<!\\)(?:\\\\)*\\\)' fill meta
-add-highlighter shared/latex/bracket-math region '(?<!\\)(?:\\\\)*\K\\\[' '(?<!\\)(?:\\\\)*\\\]' fill meta
 
 # Document and LaTeX2e control sequence
 add-highlighter shared/latex/cs/ regex '(?:\\[a-zA-Z@]+)' 0:keyword


### PR DESCRIPTION
These math modes were being split apart by control sequence regions. To avoid this, they must be their own regions.
Fixes https://github.com/mawww/kakoune/issues/5249 .

Also, I got rid of an errant / in the control sequence ending regex that couldn't be right.