### PR TITLE
Fix workflow that uploads a static Linux build on releases

### DIFF
--- a/.github/workflows/build-releases-linux.yaml
+++ b/.github/workflows/build-releases-linux.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Build
         run: |
           mkdir -p kakoune-${{ github.event.release.tag_name }}-linux/
-          make -j$(nproc) PREFIX=$(pwd)/kakoune-${{ github.event.release.tag_name }}-linux static=yes install strip
+          make -j$(nproc) PREFIX=$(pwd)/kakoune-${{ github.event.release.tag_name }}-linux static=yes install-strip
           tar cvjf kakoune-${{ github.event.release.tag_name }}-linux.tar.bz2 kakoune-${{ github.event.release.tag_name }}-linux/
       - name: Upload
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-releases-linux.yaml
+++ b/.github/workflows/build-releases-linux.yaml
@@ -22,6 +22,6 @@ jobs:
           make -j$(nproc) PREFIX=$(pwd)/kakoune-${{ github.event.release.tag_name }}-linux static=yes install strip
           tar cvjf kakoune-${{ github.event.release.tag_name }}-linux.tar.bz2 kakoune-${{ github.event.release.tag_name }}-linux/
       - name: Upload
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: kakoune-${{ github.event.release.tag_name }}-linux.tar.bz2


### PR DESCRIPTION
Seems the workflow introduced by https://github.com/mawww/kakoune/pull/4634 has been broken for a bit. This should fix it