### PR TITLE
Introduce `history_since_<id>` value expansion

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -305,6 +305,11 @@ The following expansions are supported (with required context _in italics_):
     history), and each _modification_ is presented as in
     `%val{uncommitted_modifications}`.
 
+*%val{history_since_id}*::
+    _in buffer, window scope_ +
+    a partial history of the buffer in the same format as `%val{history}`
+    starting after entry _id_
+
 *%val{history_id}*::
     _in buffer, window scope_ +
     history id of the current buffer, an integer value which refers to a

--- a/src/buffer_utils.cc
+++ b/src/buffer_utils.cc
@@ -392,7 +392,7 @@ static String modification_as_string(const Buffer::Modification& modification)
                   modification.content->strview());
 }
 
-Vector<String> history_as_strings(const Vector<Buffer::HistoryNode>& history)
+Vector<String> history_as_strings(ConstArrayView<Buffer::HistoryNode> history)
 {
     Vector<String> res;
     for (auto& node : history)

--- a/src/buffer_utils.hh
+++ b/src/buffer_utils.hh
@@ -97,7 +97,7 @@ void write_buffer_to_backup_file(Buffer& buffer);
 
 void write_to_debug_buffer(StringView str);
 
-Vector<String> history_as_strings(const Vector<Buffer::HistoryNode>& history);
+Vector<String> history_as_strings(ConstArrayView<Buffer::HistoryNode> history);
 Vector<String> undo_group_as_strings(const Buffer::UndoGroup& undo_group);
 
 String generate_buffer_name(StringView pattern);

--- a/src/main.cc
+++ b/src/main.cc
@@ -413,6 +413,13 @@ static const EnvVarDesc builtin_env_vars[] = { {
         [](StringView name, const Context& context) -> Vector<String>
         { return history_as_strings(context.buffer().history()); }
     }, {
+        "history_since_", true,
+        [](StringView name, const Context& context) -> Vector<String>
+        { return history_as_strings(
+            ArrayView(context.buffer().history())
+                .subrange(str_to_int(name.substr(14_byte)) + 1)
+        ); }
+    }, {
         "uncommitted_modifications", false,
         [](StringView name, const Context& context) -> Vector<String>
         { return undo_group_as_strings(context.buffer().current_undo_group()); }


### PR DESCRIPTION
# Description

The `history_since_<id>` value expansion allows incremental parsing of a buffer's history.

Resolves #5345

# Example

```kak
declare-option int my_last_history_id
define-command my-process-history ...

# process the initial buffer history
my-process-history %val{bufname} 0 %val{history}
set-option buffer my_last_history_id 0

# only process new history changes on idle
hook buffer NormalIdle %{
  evaluate-commands %exp{
    my-process-history \
      %%val{bufname} \
      %%opt{my_last_history_id} \
      %%val{history_since_%opt{my_last_history_id}}
  }
  set-option buffer my_last_history_id %val{history_id}
}
```