### PR TITLE
feat(client): allow 'on'/'off' for autoreload option

### DIFF
--- a/src/client.hh
+++ b/src/client.hh
@@ -162,7 +162,9 @@ constexpr auto enum_desc(Meta::Type<Autoreload>)
         { Autoreload::No, "no" },
         { Autoreload::Ask, "ask" },
         { Autoreload::Yes, "true" },
-        { Autoreload::No, "false" }
+        { Autoreload::No, "false" },
+        { Autoreload::Yes, "on" },
+        { Autoreload::No, "off" }
     });
 }
 


### PR DESCRIPTION
I found myself typing on and off several times and getting errors. I think on/off are natural values for something that can be `set`.