### PR TITLE
rc/windowing/wayland.kak: add kgx support

### DIFF
--- a/rc/windowing/wayland.kak
+++ b/rc/windowing/wayland.kak
@@ -18,6 +18,7 @@ A shell command is appended to the one set in this option at runtime} \
                    'termite        -e      ' \
                    'wterm          -e sh -c' \
                    'gnome-terminal -e      ' \
+                   'kgx            -e      ' \
                    'xfce4-terminal -e      ' \
                    'konsole        -e      '; do
         terminal=${termcmd%% *}


### PR DESCRIPTION
...[this](https://gitlab.gnome.org/GNOME/console) thing.
why did they switch consoles like that all of a sudden, and why does it have even *less* features, what the hell????
