### PR TITLE
add -ruler switch to column highlighter

### DIFF
--- a/doc/pages/highlighters.asciidoc
+++ b/doc/pages/highlighters.asciidoc
@@ -111,8 +111,13 @@ highlighter is replaced with the new one.
 *fill* <face>::
     fill using the given *face*, mostly useful with regions highlighters
 
-*column* <number> <face>::
-    highlight column *number* with face *face*
+*column* <number> <face> [options]::
+    highlight column *number* with face *face*, with the following *options*:
+
+    *-ruler* <character>:::
+        a single character to display instead of empty or whitespace cells at
+        column *number*. If this option is provided, *face* will also not
+        apply to non-empty cells, and will only apply to *character*.
 
 *line* <number> <face>::
     highlight line *number* with face *face*

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -534,7 +534,7 @@ UniquePtr<Highlighter> create_column_highlighter(HighlighterParameters params, H
     auto positionals = parser.positionals_from(0);
 
     auto ruler = parser.get_switch("ruler");
-    bool highlight_non_blank = static_cast<bool>(ruler);
+    bool highlight_non_blank = (bool)ruler;
     auto col_char = ruler.value_or(" ").str();
     if (col_char.char_length() > 1)
         throw runtime_error("-ruler expects a single character");

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -534,7 +534,7 @@ UniquePtr<Highlighter> create_column_highlighter(HighlighterParameters params, H
     auto positionals = parser.positionals_from(0);
 
     auto ruler = parser.get_switch("ruler");
-    bool highlight_non_blank = (bool)ruler;
+    bool highlight_non_blank = not (bool)ruler;
     auto col_char = ruler.value_or(" ").str();
     if (col_char.char_length() > 1)
         throw runtime_error("-ruler expects a single character");
@@ -574,7 +574,7 @@ UniquePtr<Highlighter> create_column_highlighter(HighlighterParameters params, H
                         atom_it = ++line.split(atom_it, remaining_col);
                     if (atom_it->length() > 1)
                         atom_it = line.split(atom_it, 1_col);
-                    if (!highlight_non_blank)
+                    if (highlight_non_blank)
                         atom_it->face = merge_faces(atom_it->face, face);
                     else if (is_blank(atom_it->content()[0]))
                     {

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -524,7 +524,7 @@ const HighlighterDesc column_desc = {
     "Highlight the column <column> with <face>",
     {
         { { "ruler", { ArgCompleter{}, "replace empty or whitespace cells with the given character. When provided, <face> is not applied to non-empty cells" } } },
-        ParameterDesc::Flags::SwitchesOnlyAtStart, 2, 2
+        ParameterDesc::Flags::None, 2, 2
     },
 };
 UniquePtr<Highlighter> create_column_highlighter(HighlighterParameters params, Highlighter*)
@@ -532,14 +532,14 @@ UniquePtr<Highlighter> create_column_highlighter(HighlighterParameters params, H
     ParametersParser parser{params, column_desc.params};
 
     auto positionals = parser.positionals_from(0);
+
     auto ruler = parser.get_switch("ruler");
-    if (ruler.value_or(" ").char_length() > 1)
+    bool highlight_non_blank = static_cast<bool>(ruler);
+    auto col_char = ruler.value_or(" ").str();
+    if (col_char.char_length() > 1)
         throw runtime_error("-ruler expects a single character");
 
-    auto ruler_provided = static_cast<bool>(ruler);
-    auto col_char = ruler.value_or(" ").str();
-
-    auto func = [col_expr=positionals[0], facespec=parse_face(positionals[1]), ruler_provided, col_char]
+    auto func = [col_expr=positionals[0], facespec=parse_face(positionals[1]), highlight_non_blank, col_char]
                 (HighlightContext context, DisplayBuffer& display_buffer, BufferRange)
     {
         ColumnCount column = -1;
@@ -574,9 +574,10 @@ UniquePtr<Highlighter> create_column_highlighter(HighlighterParameters params, H
                         atom_it = ++line.split(atom_it, remaining_col);
                     if (atom_it->length() > 1)
                         atom_it = line.split(atom_it, 1_col);
-                    if (!ruler_provided)
+                    if (!highlight_non_blank)
                         atom_it->face = merge_faces(atom_it->face, face);
-                    if (ruler_provided && is_blank(atom_it->content()[0])) {
+                    else if (is_blank(atom_it->content()[0]))
+                    {
                         atom_it->replace(col_char);
                         atom_it->face = merge_faces(atom_it->face, face);
                     }


### PR DESCRIPTION
the `-ruler <character>` switch on the column highlighter replaces the column (for empty and whitespace cells) with `<character>`. this is useful for drawing rulers. because rulers typically appear over whitespace regions in other editors, we also do that here.

additionally, the color of the ruler should only be applied to the ruler, so when -ruler `<character>` is provided, we do not apply the `<face>` parameter to cells which are non-empty, aka where the ruler isn't inserted.

However, in order to ensure the ruler has the same color even in regions that are already highlighted, we must use a `+f` attribute on the face provided to the highlighter. Perhaps that attribute should be automatically added when passing the `-ruler` switch, I'm not sure.

For example, after
```
add-highlighter buffer/ column -ruler ┊ 80 rgb:444444+f
```

<img width="542" height="432" alt="image" src="https://github.com/user-attachments/assets/093eadb5-ba62-4e57-859e-fc03c3e686c1" />

I'm also open to making this a separate `ruler` highlighter instead of hijacking the column highligher. Please let me know if there's any interest in this change, thank you in advance.
