### PR TITLE
rc/filetype/wren.kak: fix invalid escape interpretation in raw strings

### DIFF
--- a/rc/filetype/wren.kak
+++ b/rc/filetype/wren.kak
@@ -4,7 +4,7 @@ provide-module -override wren %§
     add-highlighter shared/wren/line_comment region '//' '$' fill comment
     add-highlighter shared/wren/block_comment region -recurse '/\*' '/\*' '\*/' fill comment
 
-    add-highlighter shared/wren/raw_string region '"""' '(?<!\\)(?:\\\\)*"""' fill string
+    add-highlighter shared/wren/raw_string region '"""' '"""' fill string
 
     add-highlighter shared/wren/string region '"' '(?<!\\)(\\\\)*"' group
     add-highlighter shared/wren/string/ fill string


### PR DESCRIPTION
I must've had a brainfart while writing this but raw strings interpret escapes when the website reads against it, it's literally the second sentence in the section about raw strings:

> **Raw strings do not process escapes and do not apply any interpolation.**
> \- https://wren.io/values.html#raw-strings

sorry for the small PR :/


