### PR TITLE
Fix #5363

### DIFF
--- a/src/utils.hh
+++ b/src/utils.hh
@@ -1,6 +1,8 @@
 #ifndef utils_hh_INCLUDED
 #define utils_hh_INCLUDED
 
+#include <utility>
+
 #include "assert.hh"
 
 namespace Kakoune


### PR DESCRIPTION
Does not build without this header for me, with GCC 11.4.0.

I don't know the codebase at all, so don't know whether this is the intended solution.

Building works and all tests are passed.