### PR TITLE
rc/repl/tmux: bracketed paste

### DIFF
--- a/rc/windowing/repl/tmux.kak
+++ b/rc/windowing/repl/tmux.kak
@@ -77,7 +77,7 @@ define-command -hidden tmux-send-text -params 0..1 -docstring %{
     } %{
     evaluate-commands %sh{
         if [ $# -eq 0 ]; then
-            tmux set-buffer -b kak_selection -- "${kak_selection}"
+            tmux set-buffer -b kak_selection -- "${kak_selections}"
         else
             tmux set-buffer -b kak_selection -- "$1"
         fi


### PR DESCRIPTION
Hi!

I have made some tweaks to the rc/repl/tmux file which might be useful for others so I thought I'd contribute back :)

Summary
- Use bracketed paste by default, add option to disable (as it might not be supported by all interpreters)
- `tmux-send-repl` sends all selections -- this is to support stripping indent, very useful for Python. No option as the old behaviour can be achieved by `,: tmux-send-repl<ret><a-u>`.

The latter comes with a question which I should probably remove from the commit message and ask somewhere better... Since I'm here I'll put it here but just ignore and I'll create an account and move to discuss when I can remember

> Aside question: Is there a better way to select block
> selections? Especially if I want it to be say only the second column in
> a Markdown table e.g.
>
> ```markdown
> | A | B | C |
> |---|---|---|
> | 1 | x | i |
> | 2 | y | j |
> | 3 | z | k |
> ```
>
> and my selection is `/\| B.+?z \|` (i.e. "| B" to "z |")? I normally
> just do `xs^` and use h/H etc. Such selections are very easy to make by
> just using `J` or similar, so for me are somewhat common.
