### PR TITLE
Add value expansion for macro recording state

### DIFF
--- a/doc/pages/expansions.asciidoc
+++ b/doc/pages/expansions.asciidoc
@@ -334,6 +334,9 @@ The following expansions are supported (with required context _in italics_):
     an inner selection, `to_begin` if the user wants to select to the
     beginning, and `to_end` if the user wants to select to the end
 
+*%val{recording_register}*::
+    the register being recorded to if currently recording a macro, empty when not recording
+
 *%val{register}*::
     _in `map` command <keys> parameter and `<a-;>` from the object menu_ +
     current register when the mapping was triggered

--- a/src/main.cc
+++ b/src/main.cc
@@ -258,6 +258,11 @@ const EnvVarDesc builtin_env_vars[] = { {
         { auto cursor = context.selections().main().cursor();
           return {to_string(context.buffer().distance({0,0}, cursor))}; }
     }, {
+        "recording_register", false,
+        [](StringView name, const Context& context) -> Vector<String>
+        { const char reg = context.client().input_handler().recording_reg();
+          return {reg ? String{static_cast<Codepoint>(reg)} : ""}; }
+    }, {
         "selection_desc", false,
         [](StringView name, const Context& context) -> Vector<String>
         { return {selection_to_string(ColumnType::Byte, context.buffer(), context.selections().main())}; }


### PR DESCRIPTION
I wanted to display whether a macro is being recorded in the status line, but I wanted it to be shorter than the `[recording (@)]` displayed by the `{{context_info}}` markup string that can be used in `modelinefmt`. I also did not want the other information present in `{{context_info}}`. Setting an option when pressing Q/q doesn't seem to work, because there is no "client" scope - so it either takes effect across clients, or doesn't keep when switching buffers while recording. Exposing this via a value expansion was very simple, as it is already tracked and just needed to be exposed. This allows me to display it in the status line.

Let me know if you have any concerns, and I'll see what can be done to address them.