### PR TITLE
Improve autowrap paragraph formatting

### DIFF
--- a/rc/tools/autowrap.kak
+++ b/rc/tools/autowrap.kak
@@ -16,33 +16,33 @@ define-command -hidden autowrap-cursor %{ evaluate-commands -save-regs '/"|^@m' 
         execute-keys -draft "x<a-k>^[^\n]{%opt{autowrap_column},}[^\n]<ret>"
 
         try %{
-            reg m "%val{selections_desc}"
 
             ## if we're adding characters past the limit, just wrap them around
             execute-keys -draft "<a-h><a-k>.{%opt{autowrap_column}}\h*[^\s]*<ret>1s(\h+)[^\h]*\z<ret>c<ret>"
-        } catch %{
-            ## if we're adding characters in the middle of a sentence, use
-            ## the `fmtcmd` command to wrap the entire paragraph
-            evaluate-commands %sh{
-                if [ "${kak_opt_autowrap_format_paragraph}" = true ] \
-                    && [ -n "${kak_opt_autowrap_fmtcmd}" ]; then
-                    format_cmd=$(printf %s "${kak_opt_autowrap_fmtcmd}" \
-                                 | sed "s/%c/${kak_opt_autowrap_column}/g")
-                    printf %s "
-                        evaluate-commands -draft %{
-                            execute-keys '<a-]>px<a-j>|${format_cmd}<ret>'
-                            try %{ execute-keys s\h+$<ret> d }
-                        }
-                        select '${kak_main_reg_m}'
-                    "
-                fi
-            }
+        }
+
+        reg m "%val{selections_desc}"
+        ## if we're adding characters in the middle of a sentence, use
+        ## the `fmtcmd` command to wrap the entire paragraph
+        evaluate-commands %sh{
+            if [ "${kak_opt_autowrap_format_paragraph}" = true ] \
+                && [ -n "${kak_opt_autowrap_fmtcmd}" ]; then
+                format_cmd=$(printf %s "${kak_opt_autowrap_fmtcmd}" \
+                             | sed "s/%c/${kak_opt_autowrap_column}/g")
+                printf %s "
+                    evaluate-commands -draft %{
+                        execute-keys '<a-]>px<a-j>|${format_cmd}<ret>'
+                        try %{ execute-keys s\h+$<ret> d }
+                    }
+                    select '${kak_main_reg_m}'
+                "
+            fi
         }
     }
 } }
 
 define-command autowrap-enable -docstring "Automatically wrap the lines in which characters are inserted" %{
-    hook -group autowrap window InsertChar [^\n] autowrap-cursor
+    hook -group autowrap window InsertChar '[^\n ]' autowrap-cursor
 }
 
 define-command autowrap-disable -docstring "Disable automatic line wrapping" %{


### PR DESCRIPTION
To demonstrate my problem with the existing `autowrap_format_paragraph` option, try the following, bring a cursor to the end of one of the middle lines and type some text until it wraps. You will notice that a new line is created without running the `autowrap_fmtcmd` on the remainder of the text. The behaviour I expect is similar to what happens if you were to start typing in the middle of one of the lines.

```
echo "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eu convallis
neque. Phasellus varius efficitur lacus ut sodales. Aenean pellentesque ut dui
ut dapibus. Phasellus eros nisl, accumsan nec malesuada at, luctus aliquet
diam. Mauris ac velit quis felis pellentesque placerat. Vivamus condimentum
eget massa eget tempus. Duis luctus finibus tellus, quis lacinia metus
vestibulum a. Donec viverra ullamcorper dui in cursus. Donec sapien est,
aliquam vel velit nec, ultricies gravida ante. Etiam bibendum dui rhoncus,
pharetra augue id, venenatis lectus. Vestibulum pretium finibus nisi, quis
molestie est accumsan a. Sed id purus id ipsum consequat volutpat eu at
mi. Sed euismod tincidunt eros. Donec ac turpis eu eros condimentum laoreet
non ut neque. Quisque vel congue enim, id iaculis lectus. Quisque pretium,
metus id egestas auctor, ex elit sodales elit, a luctus turpis orci nec velit.
" | kak -e 'autowrap-enable; set-option window autowrap_format_paragraph yes'
```

I do not see why the try catch was used in the initial implementation.