### PR TITLE
Fix manpath detection in tools/man.kak

### DIFF
--- a/rc/tools/man.kak
+++ b/rc/tools/man.kak
@@ -63,8 +63,11 @@ define-command -hidden -params ..3 man-impl %{ evaluate-commands %sh{
 
 define-command -params ..1 \
     -shell-script-candidates %{
-        find /usr/share/man/ $(printf %s "${MANPATH}" |
-            sed 's/:/ /') -name '*.[1-8]*' |
+        : "${MANPATH:="$(manpath)"}"
+        : "${MANPATH:=/usr/share/man}"
+        set -f
+        IFS=:
+        find $MANPATH -name '*.[1-8]*' |
             sed 's,^.*/\(.*\)\.\([1-8][a-zA-Z]*\).*$,\1(\2),'
     } \
     -docstring %{


### PR DESCRIPTION
The `manpath` binary is the preferred way to find the path for man pages with GNU man. This is relevant when `PATH` contains extra bin directories, but `MANPATH` is unset - `manpath` will find the corresponding `share/man` directories for each entry in `PATH`.