### PR TITLE
Prevent ctags process stacking on stucked .tags.kaklock folder

### DIFF
--- a/rc/tools/ctags.kak
+++ b/rc/tools/ctags.kak
@@ -114,7 +114,7 @@ define-command ctags-generate -docstring 'Generate tag file asynchronously' %{
     nop %sh{ (
         trap - INT QUIT
         while ! mkdir .tags.kaklock 2>/dev/null; do sleep 1; done
-        trap 'rmdir .tags.kaklock' EXIT
+        trap 'rmdir .tags.kaklock' EXIT SIGTERM
 
         if ${kak_opt_ctagscmd} -f .tags.kaktmp ${kak_opt_ctagspaths}; then
             mv .tags.kaktmp tags

--- a/rc/tools/ctags.kak
+++ b/rc/tools/ctags.kak
@@ -126,7 +126,7 @@ define-command ctags-generate -docstring 'Generate tag file asynchronously' %{
     nop %sh{ (
         trap - INT QUIT
         while ! mkdir .tags.kaklock 2>/dev/null; do sleep 1; done
-        trap 'rmdir .tags.kaklock' EXIT
+        trap 'rmdir .tags.kaklock' EXIT SIGTERM
 
         if eval "${kak_opt_ctagscmd}" -f .tags.kaktmp ${kak_opt_ctagspaths}; then
             mv .tags.kaktmp tags


### PR DESCRIPTION
I'm not sure to fully understand what is causing this, but it happened to me multiple time. A new process get stuck on every buffer save, and I discover at the end of the day that a hundred of them are stucked.

At least let's try to remove the lock folder when starting Kakoune.