### PR TITLE
javascript.kak - Allow JSX Elements that begin with 0-9 or _ to be correctly highlighted

### DIFF
--- a/rc/filetype/javascript.kak
+++ b/rc/filetype/javascript.kak
@@ -169,7 +169,7 @@ define-command -hidden init-javascript-filetype -params 1 %~
     add-highlighter "shared/%arg{1}/shebang"       region ^#!  $                       fill meta
     add-highlighter "shared/%arg{1}/division" region '[\w\)\]]\K(/|(\h+/\s+))' '(?=\w)' group # Help Kakoune to better detect /…/ literals
     add-highlighter "shared/%arg{1}/regex"         region /    (?<!\\)(\\\\)*/[gimuy]* fill meta
-    add-highlighter "shared/%arg{1}/jsx"           region -recurse (?<![\w<])<[a-zA-Z>][\w:.-]* (?<![\w<])<[a-zA-Z>][\w:.-]*(?!\hextends)(?=[\s/>])(?!>\()) (</.*?>|/>) regions
+    add-highlighter "shared/%arg{1}/jsx"           region -recurse (?<![\w<])<[\w>][\w:.-]* (?<![\w<])<[\w>][\w:.-]*(?!\hextends)(?=[\s/>])(?!>\()) (</.*?>|/>) regions
 
     # Regular expression flags are: g → global match, i → ignore case, m → multi-lines, u → unicode, y → sticky
     # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
@@ -186,7 +186,7 @@ define-command -hidden init-javascript-filetype -params 1 %~
     # We inline a small XML highlighter here since it anyway need to recurse back up to the starting highlighter.
     # To make things simple we assume that jsx is always enabled.
 
-    add-highlighter "shared/%arg{1}/jsx/tag"  region -recurse <  <(?=[/a-zA-Z>]) (?<!=)> regions
+    add-highlighter "shared/%arg{1}/jsx/tag"  region -recurse <  <(?=[/\w>]) (?<!=)> regions
     add-highlighter "shared/%arg{1}/jsx/expr" region -recurse \{ \{             \}      ref %arg{1}
 
     add-highlighter "shared/%arg{1}/jsx/tag/base" default-region group


### PR DESCRIPTION
Previously highlighting would only work for elements named [a-zA-Z].  This allows for numbers and _ as well.

Before (note incorrect highlighting on line 14-16):
<img width="532" height="351" alt="Screenshot from 2025-11-24 12-34-00" src="https://github.com/user-attachments/assets/b9791671-2b72-41fd-928f-e856762ba244" />


After: 
<img width="536" height="350" alt="Screenshot from 2025-11-24 12-34-18" src="https://github.com/user-attachments/assets/c603dc9b-155a-4653-b7a2-09a7de01c6e5" />

