### PR TITLE
Skip call to wcwidth for ascii in codepoint_width

### DIFF
--- a/src/unicode.hh
+++ b/src/unicode.hh
@@ -101,7 +101,7 @@ inline bool is_identifier(Codepoint c) noexcept
 
 inline ColumnCount codepoint_width(Codepoint c) noexcept
 {
-    if (c == '\n')
+    if (c < 0x80) [[likely]]
         return 1;
     const auto width = wcwidth((wchar_t)c);
     return width >= 0 ? width : 1;


### PR DESCRIPTION
`perf record kak src/commands.cc`, page down to bottom of file

wcwidth before:
- ~4-5%

wcwidth after:
- Does not appear in perf report

All tests continue to pass with `make test`
