### PR TITLE
Only apply highlights to visible portion of buffer

### DIFF
--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -1865,7 +1865,7 @@ public:
 
         auto display_range = display_buffer.range();
         const auto& buffer = context.context.buffer();
-        auto& regions = get_regions_for_range(buffer, range);
+        auto& regions = get_regions_for_range(buffer, display_range);
 
         auto begin = std::lower_bound(regions.begin(), regions.end(), display_range.begin,
                                       [](const Region& r, BufferCoord c) { return r.end < c; });


### PR DESCRIPTION
`cat src/*.cc src/*.hh > test.cc`
`perf record ./src/kak test.cc`

Before:   `81.36% Kakoune::RegionsHighlighter::MatchAdder::add(Kakoune::Range<Kakoune::LineCount>)`
After:  `0.36%  Kakoune::RegionsHighlighter::MatchAdder::add(Kakoune::Range<Kakoune::LineCount>)`

This noticeably improves performance in larger files.

All tests still pass.
