### PR TITLE
Updated the solarized term variants to use the default background

### DIFF
--- a/colors/solarized-dark-termcolors.kak
+++ b/colors/solarized-dark-termcolors.kak
@@ -26,7 +26,7 @@ face global bullet             yellow
 face global list               green
 
 # builtin
-face global Default            bright-blue,bright-black
+face global Default            bright-blue
 face global PrimarySelection   bright-black,blue+fg
 face global SecondarySelection bright-green,bright-cyan+fg
 face global PrimaryCursor      bright-black,bright-blue+fg
@@ -50,5 +50,5 @@ face global StatusLineValue    green
 face global StatusCursor       bright-yellow,bright-white
 face global Prompt             yellow+b
 face global MatchingChar       red,bright-green+b
-face global BufferPadding      bright-green,bright-black
+face global BufferPadding      bright-green
 face global Whitespace         blue+f

--- a/colors/solarized-light-termcolors.kak
+++ b/colors/solarized-light-termcolors.kak
@@ -26,7 +26,7 @@ face global bullet             yellow
 face global list               green
 
 # builtin
-face global Default            bright-yellow,bright-white
+face global Default            bright-yellow
 face global PrimarySelection   bright-white,blue+fg
 face global SecondarySelection bright-cyan,bright-green+fg
 face global PrimaryCursor      bright-white,bright-yellow+fg
@@ -50,5 +50,5 @@ face global StatusLineValue    green
 face global StatusCursor       bright-blue,bright-black
 face global Prompt             yellow+b
 face global MatchingChar       red,white+b
-face global BufferPadding      bright-cyan,bright-white
+face global BufferPadding      bright-cyan
 face global Whitespace         yellow+f


### PR DESCRIPTION
If the idea of these versions of the colorschemes is that they rely on the terminal emulator already being configured with the expected colors, then I figure it probably makes sense to not specify the background colors manually if they match what the expected value for the background is for a "compliant" solarized terminal.

This has the benefit of enabling transparancy for people with emulators that support that feature. The potential downside is that the theme may look incorrect if the terminal emulator doesn't follow the solarized pallete exactly (I think the defaults for the Windows Terminal don't), but that doesn't feel like Kakoune's problem, and besides, the non- termcolors variants still exist.