### PR TITLE
normal: make <c-o> always jump backward when snapshotting current selection

### DIFF
--- a/test/normal/jump/backward-dirty-middle/cmd
+++ b/test/normal/jump/backward-dirty-middle/cmd
@@ -1,0 +1,7 @@
+gj
+/bar<ret>
+/qux<ret>
+<c-o>
+h
+<c-o>
+aend<esc>

--- a/test/normal/jump/backward-dirty-middle/in
+++ b/test/normal/jump/backward-dirty-middle/in
@@ -1,0 +1,3 @@
+%(foo)
+bar
+qux

--- a/test/normal/jump/backward-dirty-middle/out
+++ b/test/normal/jump/backward-dirty-middle/out
@@ -1,0 +1,3 @@
+foo
+barend
+qux


### PR DESCRIPTION
`JumpList::backward` used to sometimes consume `<c-o>` without moving: when the current selection had diverged from the jump at `m_current`, we first pushed the current selection, then subtracted count.

With `count=1`, this landed on the freshly pushed entry itself, so `<c-o>` behaved like "save checkpoint" instead of "jump backward".

This was especially visible after going back into the middle of history, moving, then pressing `<c-o>` again: the first `<c-o>` could be a no-op from the user point of view.

Fix by treating the implicit push as an extra internal step: if we push current before jumping, move back by `count + 1`. This keeps the "preserve current position for `<c-i>`" behavior, while making `<c-o>` consistently perform an actual backward jump.

Add regression test: `test/normal/jump/backward-dirty-middle`

Fixes #5066