### PR TITLE
Fix Kakoune logo URL in README

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,6 +1,6 @@
-= image:{logo}[K,30,30,link="{website}",title="Kakoune logo by p0nce"] Kakoune image:{cirrus-img}[link="{cirrus-url}"] image:{srht-img}[link="{srht-url}"] image:{irc-img}[link="{irc-url}"]
+= image:{logo}[K,32,32,link="{website}",title="Kakoune logo by p0nce"] Kakoune image:{cirrus-img}[link="{cirrus-url}"] image:{srht-img}[link="{srht-url}"] image:{irc-img}[link="{irc-url}"]
 ifdef::env-github,env-browser[:outfilesuffix: .asciidoc]
-:logo: https://kakoune.org/img/kakoune_logo_full.png
+:logo: http://kakoune.org/img/kakoune_logo_32.png
 :website: https://kakoune.org
 :cirrus-img: https://api.cirrus-ci.com/github/mawww/kakoune.svg
 :cirrus-url: https://cirrus-ci.com/github/mawww/kakoune


### PR DESCRIPTION
Updated logo URL to point to the new image location.