### PR TITLE
fix(client): refresh only if m_ui_pending is not empty

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -306,7 +306,9 @@ void Client::redraw_ifn()
     if (m_ui_pending & StatusLine)
         m_ui->draw_status(m_status_prompt, m_status_content, m_status_cursor_pos, m_mode_line, faces["StatusLine"]);
 
-    m_ui->refresh(m_ui_pending & Refresh);
+    if (m_ui_pending != 0)
+        m_ui->refresh(m_ui_pending & Refresh);
+
     m_ui_pending = 0;
 }
 


### PR DESCRIPTION
Fixes regression introduced in 551b20a where moving `generate_mode_line` after `update_display_buffer` removed the early return check. This caused `refresh` to be called even when no UI updates were needed, breaking tests that expected specific message sequences.

Fixes: 551b20a34aeab6e1736da42d9ae5b0356678a7f3