### PR TITLE
fix(ci): prevent git tools deadlock in ci

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,11 +1,12 @@
 name: Makefile CI
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "main" ]
 jobs:
   build:
+    timeout-minutes: 10
     strategy:
       matrix:
         os: [ubuntu, macos]

--- a/test/tools/git/blame-in-diff/script
+++ b/test/tools/git/blame-in-diff/script
@@ -1,3 +1,4 @@
+cat <&4 >/dev/null &
 mkfifo fifo 2>/dev/null
 cat fifo
 # We should have jumped to the old version of line 2, assert on kak_selection.


### PR DESCRIPTION
- drain fifo in git blame test to prevent deadlock on Darwin
- added 10-minute timeout to prevent indefinite hanging in CI builds

That fix doesn't eliminate the deadlock completely, but it makes it less probable. From what I gathered, the reason it is only a Darwin problem, is the difference between fifo kernel buffer size (8kb vs 64kb) on Darwin and Linux, as well as heavy usage of fifos for bidirectional communication in git.kak.