### PR TITLE
filetype/jinja: fix triple { and } highlights

### DIFF
--- a/rc/filetype/jinja.kak
+++ b/rc/filetype/jinja.kak
@@ -27,9 +27,9 @@ add-highlighter shared/jinja/statement/ regex \b(do|extends|include)\b 0:keyword
 add-highlighter shared/jinja/statement/ regex \bignore\s+missing\b 0:meta
 add-highlighter shared/jinja/statement/ regex \bwith(out)?\s+context\b 0:meta
 
-add-highlighter shared/jinja/expression region '\{\{' '\}\}' group
+add-highlighter shared/jinja/expression region \{\{(?!\{) (?<!\})\}\} group
 add-highlighter shared/jinja/expression/ ref python
-add-highlighter shared/jinja/expression/ regex \{\{|\}\} 0:value
+add-highlighter shared/jinja/expression/ regex \{\{(?!\{)|(?<!\})\}\} 0:value
 add-highlighter shared/jinja/expression/filters regex \|\s*(abs|attr|batch|capitalize|center|default|dictsort|e|escape|filesizeformat|first|float|forceescape|format|groupby|indent|int|join|last|length|list|lower|map|max|min|pprint|random|reject|rejectattr|replace|reverse|round|safe|select|selectattr|slice|sort|string|striptags|sum|title|tojson|trim|truncate|unique|upper|urlencode|urlize|wordcount|wordwrap|xmlattr)\b 1:builtin
 
 ]


### PR DESCRIPTION
In case of three consecutive char, the wrong ones get highlighted. Using negative lookahead and negative lookbehind fix this.

example: 
<img width="645" height="236" alt="2026-03-10-19:33:26" src="https://github.com/user-attachments/assets/eada8c49-9749-4803-8884-ba84d3b992a2" />
