### PR TITLE
git.kak: improve "git commit" wrapper

### DIFF
--- a/rc/tools/blocking-editor-in-client
+++ b/rc/tools/blocking-editor-in-client
@@ -1,0 +1,50 @@
+die() {
+    printf "%s\n" "$*" >&2
+    exit 1
+}
+
+# Nested levels of kakoune single quote quoting
+kak_quote() {
+    level=${2:-1}
+    Q="'"
+    while [ ${level} -gt 1 ]; do
+        Q="${Q}${Q}"
+        level=$((${level} - 1))
+    done
+
+    printf "%s\n" "$1" | sed "s/'/${Q}${Q}/g; 1s/^/${Q}/; \$s/\$/${Q}/"
+}
+
+[ $# -eq 4 ] ||
+    die "usage: blocking-editor-in-client <fifo-dir> <kak-session> <kak-client> <filename>"
+
+fifo_dir="$1"
+kak_session="$2"
+kak_client="$3"
+filename="$4"
+response_fifo="${fifo_dir}/response_fifo" &&
+printf %s "
+    try '
+        eval -client ${kak_client} ''
+            edit $(kak_quote "${filename}" 3)
+            hook buffer BufWritePost .* ''''
+                echo -to-file $(kak_quote "${response_fifo}" 4) -end-of-line edited
+                remove-hooks buffer giteditor
+                delete-buffer
+            ''''
+            hook -group giteditor buffer BufClose .* ''''
+                echo -to-file $(kak_quote "${response_fifo}" 4) -end-of-line cancelled
+            ''''
+        ''
+    ' catch '
+        echo -to-file $(kak_quote "${response_fifo}" 2) -end-of-line failed
+    '" | kak -p "${kak_session}" ||
+        die "could not contact kak session ${kak_session}"
+# wait for the user to edit the commit message
+read status <"${response_fifo}"
+if [ "${status}" = cancelled ]; then
+    >"${fifo_dir}/cancelled"
+    die "editing cancelled"
+elif [ "${status}" != edited ]; then
+    die "could not open file '${filename}'"
+fi

--- a/rc/tools/git.kak
+++ b/rc/tools/git.kak
@@ -542,29 +542,42 @@ define-command -params 1.. \
     }
 
     commit() {
-        # Handle case where message needs not to be edited
-        if grep -E -q -e "-m|-F|-C|--message=.*|--file=.*|--reuse-message=.*|--no-edit|--fixup.*|--squash.*"; then
-            if git commit "$@" > /dev/null 2>&1; then
-                echo 'echo -markup "{Information}Commit succeeded"'
+        if ! fifo_dir="$(mktemp -d "${TMPDIR:-/tmp}/kak-git-commit-XXXXXX")" ||
+           ! mkfifo "${fifo_dir}/response_fifo"
+        then
+            echo "fail %{failed to run git commit (see *debug* buffer)}"
+            [ -n "${fifo_dir}" ] && rmdir "${fifo_dir}"
+            exit 1
+        fi
+        {
+            trap 'rm -r "${fifo_dir}"' EXIT
+            export GIT_EDITOR="$(git rev-parse --sq-quote \
+                "${KAKOUNE_POSIX_SHELL:-/bin/sh}" \
+                "${kak_runtime}/rc/tools/blocking-editor-in-client" \
+                "${fifo_dir}" "${kak_session}" "${kak_client}")"
+            failed=false
+            if err="$(git commit "$@" 2>&1)"; then
+                cmd="eval -try-client ${kak_client} %{
+                    echo -markup '{Information}Commit succeeded'
+                }"
+            elif [ -f "${fifo_dir}/cancelled" ]; then
+                cmd="eval -try-client ${kak_client} %{
+                    echo -markup '{Information}Commit cancelled'
+                }"
             else
-                echo 'fail Commit failed'
+                failed=true
+                cmd="eval -try-client ${kak_client} %{
+                    try %{
+                        edit! -fifo $(kakquote "${fifo_dir}/response_fifo") '*git-commit*'
+                    }
+                    echo -markup '{Error}Commit failed'
+                }"
             fi
-            exit
-        fi <<-EOF
-			$@
-		EOF
-
-        # fails, and generate COMMIT_EDITMSG
-        GIT_EDITOR='' EDITOR='' git commit "$@" > /dev/null 2>&1
-        msgfile="$(git rev-parse --git-dir)/COMMIT_EDITMSG"
-        printf %s "edit '$msgfile'
-              hook buffer BufWritePost '.*\Q$msgfile\E' %{ evaluate-commands %sh{
-                  if git commit -F '$msgfile' --cleanup=strip $* > /dev/null; then
-                     printf %s 'evaluate-commands -client $kak_client echo -markup %{{Information}Commit succeeded}; delete-buffer'
-                  else
-                     printf 'evaluate-commands -client %s fail Commit failed\n' "$kak_client"
-                  fi
-              } }"
+            printf %s "${cmd}" | kak -p "${kak_session}"
+            if [ ${failed} = true ]; then
+                printf %s "$err" >"${fifo_dir}/response_fifo"
+            fi
+        } 2>/dev/null 1>&2 </dev/null &
     }
 
     blame_jump() {


### PR DESCRIPTION
Improve the wrapper for `git commit` so that it runs `git commit` in the background with `GIT_EDITOR` set to a script that calls back into the kakoune session that started it. This stops kakoune prompting the user to edit the commit message when the commit cannot be created due to a failing `pre-commit` hook and avoids having to second guess which options ask the user to edit the message.