### PR TITLE
Change description of how <a-x> handles eol.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -431,8 +431,8 @@ See <<Appending>> below for instructions on extending (appending to) the current
  * `M`: extend selection to matching character
 
  * `x`: expand selections to contain full lines (including end-of-lines)
- * `<a-x>`: trim selections to only contain full lines (not including last
-            end-of-line)
+ * `<a-x>`: trim selections to only contain full lines (including
+            end-of-lines)
 
  * `%`: select whole buffer
 


### PR DESCRIPTION
I hope I got this right. I talked about `<a-x>` in #kakoune on libera.chat with a couple of others, and we couldn't figure out why the documentation said "not including last end-of-line". In fact, the last end-of-line is included in two senses:

- If I've selected a whole line except for the end-of-line, `<a-x>` discards that line.
- After pressing `<a-x>`, all ends-of-line are included.

This pull request is based just on what I observed and what `Screwtape` suggested on IRC. (Hopefully the fact that the description is closer to `x`'s description will make it more clear that `x` and `<a-x>` do very similar things.)