### PR TITLE
corrected shell generated groovy highlighters and static words

### DIFF
--- a/rc/filetype/groovy.kak
+++ b/rc/filetype/groovy.kak
@@ -40,25 +40,27 @@ add-highlighter shared/groovy/code/numbers regex '\b[-+]?0x[A-Fa-f0-9_]+[.A-Fa-f
 add-highlighter shared/groovy/slashy_string region "\b/\w" "(?<!\\)\w/\b"   fill string
 
 evaluate-commands %sh{
-  keywords="as|assert|break|case|catch|class|const|continue|def|default"
-  keywords="${keywords}|do|else|enum|extends|finally|for|goto|if|implements|import|in"
-  keywords="${keywords}|instanceof|interface|new|package|return|super|switch|this|throw"
-  keywords="${keywords}|throws|trait|try|while"
-  builtins="true|false|null"
-  types="byte|char|short|int|long|BigInteger|float|double|BigDecimal|boolean"
+    keywords='
+      as assert break case catch class const continue def default
+      do else enum extends finally for goto if implements import in
+      instanceof interface new package return super switch this throw
+      throws trait try while
+    '
+    builtins='true false null println'
+    types='byte char short int long BigInteger float double BigDecimal boolean'
 
-  printf %s "
-    add-highlighter shared/groovy/code/keyword regex \b(${keywords})\b 0:keyword
-    add-highlighter shared/groovy/code/builtin regex \b(${builtins})\b 0:builtin
-    add-highlighter shared/groovy/code/types   regex \b(${types})\b    0:type
+    join() { sep=$2; eval set -- $1; IFS="$sep"; echo "$*"; }
 
-    declare-option str-list groovy_static_words \"${keywords}|${types}|${builtins}\"
-  "
+    printf %s\\n "add-highlighter shared/groovy/code/keyword regex \\b($(join "$keywords" '|'))\\b 0:keyword"
+    printf %s\\n "add-highlighter shared/groovy/code/builtin regex \\b($(join "$builtins" '|'))\\b 0:builtin"
+    printf %s\\n "add-highlighter shared/groovy/code/types   regex \\b($(join "$types" '|'))\\b    0:type"
+
+    printf %s\\n "declare-option str-list groovy_static_words $(join "$keywords $builtins $types" ' ')"
 }
 
 define-command -hidden groovy-insert-on-new-line %[
-        # copy // comments prefix and following white spaces
-        try %{ execute-keys -draft <semicolon><c-s>kx s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
+    # copy // comments prefix and following white spaces
+    try %{ execute-keys -draft <semicolon><c-s>kx s ^\h*\K/{2,}\h* <ret> y<c-o>P<esc> }
 ]
 
 define-command -hidden groovy-indent-on-new-line %~


### PR DESCRIPTION
when using groovy for the first time with kakoune, i noticed the static words were a bit odd, and println which is highlighted as a builtin in some default rc filetypes (like go) should be highlighted asweell, so i decided to redo the generated highlighters in a, in my opinion, more scalable way, using the same join() function defined in plenty of other highlighters (e.g.:c-family.kak)

before fix:
<img width="1047" height="654" alt="image" src="https://github.com/user-attachments/assets/d5f1ef6d-0b3e-4b27-8738-58e78e010038" />


after fix:
<img width="820" height="654" alt="image" src="https://github.com/user-attachments/assets/4167ead5-3dc2-40c6-9c54-b28c8a580a12" />
