### PR TITLE
share/kakrc: Preserve current colorscheme as an opt

### DIFF
--- a/share/kak/kakrc
+++ b/share/kak/kakrc
@@ -1,3 +1,7 @@
+declare-option -hidden \
+    -docstring "Exposes the most recent successfully set colorscheme name." \
+    str colorscheme_current '' 
+
 def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
     -shell-script-candidates %{
     find -L "${kak_runtime}/colors" "${kak_config}/colors" -type f -name '*\.kak' \
@@ -20,7 +24,7 @@ def -params 1 -docstring "colorscheme <name>: enable named colorscheme" \
     fi
 
     if [ -n "${filename}" ]; then
-        printf 'source %%{%s}' "${filename}"
+        printf 'source %%{%s}; set-option global colorscheme_current %%{%s}' "${filename}" "${1}"
     else
         echo "fail 'No such colorscheme ${1}.kak'"
     fi


### PR DESCRIPTION
This change defines a new option `current_colorscheme` and updates the `colorscheme` command to set current_colorscheme on successfully loading a colorscheme. It will allow programatic management of colorschemes based on the last-loaded colorscheme is. If a user sets their colorscheme by `source`-ing the file directly instead of using `colorscheme`, the opt will not be updated, making this opt specifically a convenience for users of the `colorscheme` command.

I have not seen a noticeable increase to startup time with this change when running kakoune with all standard lib in `val%{runtime}` and nothing in `val%{config}`. I tested this by running `time /path/to/development/kak/bin -n -e 'quit!'` repeatedly before and after the change.