### PR TITLE
feat: allow mapping keys to `combine` mode (`<a-z>`, `<a-Z>`)

### DIFF
--- a/doc/pages/modes.asciidoc
+++ b/doc/pages/modes.asciidoc
@@ -82,6 +82,13 @@ It aims at crafting semantic selections, often called *text-objects*.
 
 See object commands <<keys#object-selection,`:doc keys object-selection`>>.
 
+=== Combine mode
+
+Mode entered with `<a-z>` or `<a-Z>` keys.
+It aims at crafting ways to combine selections with ones in registers.
+
+See marks commands <<keys#marks,`:doc keys marks`>>.
+
 === User mode
 
 Mode entered with `<space>`. The user mode is empty by default and is the

--- a/rc/filetype/kakrc.kak
+++ b/rc/filetype/kakrc.kak
@@ -64,7 +64,7 @@ evaluate-commands %sh{
               unalias unmap unset-face unset-option update-option
               write write! write-all write-all-quit write-quit write-quit!"
     attributes="global buffer window current
-                normal insert prompt goto view user object
+                normal insert prompt goto view user object combine
                 number-lines show-matching show-whitespaces fill regex dynregex group flag-lines
                 ranges line column wrap ref regions region default-region replace-ranges"
     types="int bool str regex int-list str-list completions line-specs range-specs str-to-str-map"
@@ -112,7 +112,7 @@ define-command -hidden kak-indent-on-new-line %~
         try %{ execute-keys -draft k x <a-k> \%\w*[^\s\w]$ <ret> j <a-gt> }
         # deindent closing brace when after cursor
         try %_ execute-keys -draft -itersel x <a-k> ^\h*([>)}\]]) <ret> gh / <c-r>1 <ret> m <a-S> 1<a-&> _
-        # deindent closing char(s) 
+        # deindent closing char(s)
         try %{ execute-keys -draft -itersel x <a-k> ^\h*([^\s\w]) <ret> gh / <c-r>1 <ret> <a-?> <c-r>1 <ret> <a-T>% <a-k> \w*<c-r>1$ <ret> <a-S> 1<a-&> }
     =
 ~

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1591,14 +1591,15 @@ const CommandDesc echo_cmd = {
 
 KeymapMode parse_keymap_mode(StringView str, const KeymapManager::UserModeList& user_modes)
 {
-    if (prefix_match("normal", str)) return KeymapMode::Normal;
-    if (prefix_match("insert", str)) return KeymapMode::Insert;
-    if (prefix_match("menu", str))   return KeymapMode::Menu;
-    if (prefix_match("prompt", str)) return KeymapMode::Prompt;
-    if (prefix_match("goto", str))   return KeymapMode::Goto;
-    if (prefix_match("view", str))   return KeymapMode::View;
-    if (prefix_match("user", str))   return KeymapMode::User;
-    if (prefix_match("object", str)) return KeymapMode::Object;
+    if (prefix_match("normal", str))  return KeymapMode::Normal;
+    if (prefix_match("insert", str))  return KeymapMode::Insert;
+    if (prefix_match("menu", str))    return KeymapMode::Menu;
+    if (prefix_match("prompt", str))  return KeymapMode::Prompt;
+    if (prefix_match("goto", str))    return KeymapMode::Goto;
+    if (prefix_match("view", str))    return KeymapMode::View;
+    if (prefix_match("user", str))    return KeymapMode::User;
+    if (prefix_match("object", str))  return KeymapMode::Object;
+    if (prefix_match("combine", str)) return KeymapMode::Combine;
 
     auto it = find(user_modes, str);
     if (it == user_modes.end())
@@ -1608,7 +1609,7 @@ KeymapMode parse_keymap_mode(StringView str, const KeymapManager::UserModeList& 
     return (KeymapMode)(std::distance(user_modes.begin(), it) + offset);
 }
 
-static constexpr auto modes = make_array<StringView>({ "normal", "insert", "menu", "prompt", "goto", "view", "user", "object" });
+static constexpr auto modes = make_array<StringView>({ "normal", "insert", "menu", "prompt", "goto", "view", "user", "object", "combine" });
 
 const CommandDesc debug_cmd = {
     "debug",

--- a/src/keymap_manager.cc
+++ b/src/keymap_manager.cc
@@ -63,7 +63,7 @@ KeymapManager::KeyList KeymapManager::get_mapped_keys(KeymapMode mode) const
 
 void KeymapManager::add_user_mode(String user_mode_name)
 {
-    auto modes = {"normal", "insert", "prompt", "menu", "goto", "view", "user", "object"};
+    auto modes = {"normal", "insert", "prompt", "menu", "goto", "view", "user", "object", "combine"};
 
     if (contains(modes, user_mode_name))
         throw runtime_error(format("'{}' is already a regular mode", user_mode_name));

--- a/src/keymap_manager.hh
+++ b/src/keymap_manager.hh
@@ -20,6 +20,7 @@ enum class KeymapMode : char
     View,
     User,
     Object,
+    Combine,
     FirstUserMode,
 };
 

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -2074,41 +2074,42 @@ void combine_selections(Context& context, SelectionList list, Func func, StringV
     if (&context.buffer() != &list.buffer())
         throw runtime_error{"cannot combine selections from different buffers"};
 
-    on_next_key_with_autoinfo(context, "combine-selections", KeymapMode::None,
+    on_next_key_with_autoinfo(context, "combine-selections", KeymapMode::Combine,
                              [func, list](Key key, Context& context) mutable {
-                                 if (key == Key::Escape)
-                                     return;
+        if (key == Key::Escape)
+            return;
 
-                                 const auto op = key_to_combine_op(key);
-                                 ScopedSelectionEdition selection_edition{context};
-                                 auto& sels = context.selections();
-                                 list.update();
-                                 if (op == CombineOp::Append)
-                                 {
-                                     const auto main_index = list.size() + sels.main_index();
-                                     for (auto& sel : sels)
-                                         list.push_back(sel);
-                                     list.set_main_index(main_index);
-                                     list.sort_and_merge_overlapping();
-                                 }
-                                 else
-                                 {
-                                     if (list.size() != sels.size())
-                                         throw runtime_error{format("the two selection lists don't have the same number of elements ({} vs {})",
-                                                                    list.size(), sels.size())};
-                                     for (int i = 0; i < list.size(); ++i)
-                                         combine_selection(sels.buffer(), list[i], sels[i], op);
-                                     list.set_main_index(sels.main_index());
-                                 }
-                                 func(context, std::move(list));
-                             }, title.str(),
-                             "'a': append lists\n"
-                             "'u': union\n"
-                             "'i': intersection\n"
-                             "'<': select leftmost cursor\n"
-                             "'>': select rightmost cursor\n"
-                             "'+': select longest\n"
-                             "'-': select shortest\n");
+        const auto op = key_to_combine_op(key);
+        ScopedSelectionEdition selection_edition{context};
+        auto& sels = context.selections();
+        list.update();
+        if (op == CombineOp::Append)
+        {
+            const auto main_index = list.size() + sels.main_index();
+            for (auto& sel : sels)
+                list.push_back(sel);
+            list.set_main_index(main_index);
+            list.sort_and_merge_overlapping();
+        }
+        else
+        {
+            if (list.size() != sels.size())
+                throw runtime_error{format("the two selection lists don't have the same number of elements ({} vs {})",
+                                           list.size(), sels.size())};
+            for (int i = 0; i < list.size(); ++i)
+                combine_selection(sels.buffer(), list[i], sels[i], op);
+            list.set_main_index(sels.main_index());
+        }
+        func(context, std::move(list));
+    }, title.str(),
+    build_autoinfo_for_mapping(context, KeymapMode::Combine,
+        {{{'a'}, "append lists"},
+         {{'u'}, "union"},
+         {{'i'}, "intersection"},
+         {{'<'}, "select leftmost cursor"},
+         {{'>'}, "select rightmost cursor"},
+         {{'+'}, "select longest"},
+         {{'-'}, "select shortest"}}));
 }
 
 template<bool combine>


### PR DESCRIPTION
Hello

As described in https://github.com/mawww/kakoune/issues/3572 by @Screwtapello , along the years lots of people have experimented with new ways to combine selections beyond the operations currently available like union or intersection.

For example adding ways to make substraction, complement or (symmetric) difference.

Recently, it's getting steam again with attemps of using this set combinations to build code-folding systems.
https://discuss.kakoune.com/t/a-toy-code-folding-plugin/2864

This commit is quite conservative it what it offers for now.
It only lets users map new keys to a proper `combine` mode, as a way to better group custom commands around this topic.

The introduced changes follow the same pattern than `KeymapMode::Goto`, `KeymapMode::View` or `KeymapMode::Object`.

The diff looks unfortunately a big long but it's mostly just cosmetic re-indenting to be consistent with the aforementioned `KeymapModes`
The "real" meat of this commit is basically just `KeymapMode::None` → `KeymapMode::Combine` for `on_next_key_with_autoinfo` and `build_autoinfo_for_mapping`

Thanks