### PR TITLE
Add -back switch to arrange-buffers command

### DIFF
--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -12,6 +12,9 @@ released versions.
 * `enter-user-mode` support the `-count` and `-register` switches to forward
   those parameters to the underlying normal mode
 
+* `arrange-buffers -back` switch to arrange provided buffers to the back of
+  the buffer list.
+
 == Kakoune 2026.04.12
 
 * `finaleol` option to support writing files that do not end with an final

--- a/doc/pages/commands.asciidoc
+++ b/doc/pages/commands.asciidoc
@@ -25,6 +25,9 @@ of the file onto the filesystem
     given. Buffers that do not appear in the parameters will remain at the
     end of the list, keeping their current order.
 
+    *-back*:::
+        Move the named buffers to the back, rather than the fron, of the buffer list..
+
 *change-directory* [<directory>]::
     *alias* cd +
     change the current directory to *directory*, or the home directory if

--- a/src/buffer_manager.cc
+++ b/src/buffer_manager.cc
@@ -120,10 +120,10 @@ void BufferManager::clear_buffer_trash()
     m_buffer_trash.clear();
 }
 
-void BufferManager::arrange_buffers(ConstArrayView<String> first_ones)
+void BufferManager::arrange_buffers(ConstArrayView<String> buffers, bool to_back)
 {
     Vector<size_t> indices;
-    for (const auto& name : first_ones)
+    for (const auto& name : buffers)
     {
         auto filename = real_path(parse_filename(name));
         auto it = find_if(m_buffers, [&](auto& buf) { return buf->display_name() == name or (buf->flags() & Buffer::Flags::File and buf->filename() == filename); });
@@ -143,6 +143,9 @@ void BufferManager::arrange_buffers(ConstArrayView<String> first_ones)
         if (buf)
             res.push_back(std::move(buf));
     }
+    if (to_back)
+        std::rotate(res.begin(), res.begin() + indices.size(), res.end());
+
     m_buffers = std::move(res);
 }
 

--- a/src/buffer_manager.hh
+++ b/src/buffer_manager.hh
@@ -32,7 +32,7 @@ public:
     Buffer& get_buffer_matching(const FunctionRef<bool (Buffer&)>& filter);
 
     void make_latest(Buffer& buffer);
-    void arrange_buffers(ConstArrayView<String> first_ones);
+    void arrange_buffers(ConstArrayView<String> buffers, bool to_back);
 
     Buffer& get_first_buffer();
 

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -1103,7 +1103,10 @@ const CommandDesc arrange_buffers_cmd = {
     "arrange-buffers <buffer>...: reorder the buffers in the buffers list\n"
     "    the named buffers will be moved to the front of the buffer list, in the order given\n"
     "    buffers that do not appear in the parameters will remain at the end of the list, keeping their current order",
-    ParameterDesc{{}, ParameterDesc::Flags::None, 1},
+    ParameterDesc{
+        { { "back", { {}, "place the named buffers at the back, rather than the front, of the buffer list" } }, },
+        ParameterDesc::Flags::None, 1
+    },
     CommandFlags::None,
     CommandHelper{},
     [](const Context& context, CommandParameters params, size_t, ByteCount cursor_pos)
@@ -1112,7 +1115,8 @@ const CommandDesc arrange_buffers_cmd = {
     },
     [](const ParametersParser& parser, Context&, const ShellContext&)
     {
-        BufferManager::instance().arrange_buffers(parser.positionals_from(0));
+        const auto to_back = (bool)parser.get_switch("back");
+        BufferManager::instance().arrange_buffers(parser.positionals_from(0), to_back);
     }
 };
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -54,6 +54,7 @@ struct {
         0,
         "» support the {+b}\\N{} escape sequence in regex (matches {+b}[^\\n]{})\n"
         "» count and register forwarding to user modes\n"
+        "» back switch added for the arrange-buffers command\n"
     }, {
         20260412,
         "» {+u}finaleol{} option to preserve files with no final end-of-line\n"


### PR DESCRIPTION
Hi,

This is my first pull request on kakoune and github in general, so please correct me if i did something wrong.

I like using buffer-next and buffer-previous to move through buffers where the sequence in the buffer list is defined by when they where last accessed. This implies rearranging the buffer list whenever a buffer is accessed to place specific buffers at the back, rather than the front, of the buffer list, which is not something the arrange-buffer command support without modification.

This pull request adds a switch to the arrange-buffers command to control which end of the list specified buffers are placed at, preserving the current behavior as default.

To visualize this, the below configuration a workflow where the buffer-next and buffer-previous move through the history of accessed buffers, with "previous" mapping to "previously in time", consistent between opening of new buffers, and changing to an already opened buffer.
```
hook global WinDisplay .* %{ arrange-buffers -back %val{hook_param} }
map global goto p "<esc>\:buffer-previous<ret>" -docstring "next buffer"
map global goto n "<esc>\:buffer-next<ret>" -docstring "previous buffer"
```