### PR TITLE
fix: remove extra `public` access specifier

### DIFF
--- a/src/display_buffer.hh
+++ b/src/display_buffer.hh
@@ -85,7 +85,6 @@ public:
                content() == other.content();
     }
 
-public:
     Face face;
 
 private:


### PR DESCRIPTION
Hi

The preceding lines of `DisplayAtom` are already in a `public` section