### PR TITLE
tests: disable autorestore test if pathchk is not there (no coreutils)

### DIFF
--- a/test/tools/autorestore/autorestore/enabled
+++ b/test/tools/autorestore/autorestore/enabled
@@ -1,0 +1,2 @@
+#!/bin/sh
+command -v pathchk >/dev/null


### PR DESCRIPTION
Alternatively, we could run pathchk only if present. As this is an extra minor check over the backup file path.