### PR TITLE
fix: remove extraneous `select_line` declaration

### DIFF
--- a/src/selectors.hh
+++ b/src/selectors.hh
@@ -30,9 +30,6 @@ template<WordType word_type>
 Optional<Selection>
 select_to_previous_word(const Context& context, const Selection& selection);
 
-Optional<Selection>
-select_line(const Context& context, const Selection& selection);
-
 template<bool forward>
 Optional<Selection>
 select_matching(const Context& context, const Selection& selection);


### PR DESCRIPTION
Hi

The related definition was removed when the meaning of the `x` key was changed in commit https://github.com/mawww/kakoune/commit/ef8a11b3dbefb8a1222974a8c34e15fa006d56e0 (2022)