### PR TITLE
Implement paste method for JSON UI

### DIFF
--- a/doc/json_ui.asciidoc
+++ b/doc/json_ui.asciidoc
@@ -64,6 +64,7 @@ Here are the requests that can be written by the json ui on stdout:
 The requests that the json ui can interpret on stdin are:
 
 * keys(String key1, String key2...): keystrokes
+* paste(String content): paste content at selections
 * resize(int rows, int columns): notify ui resize
 * scroll(int amount, int line, int colum): scroll by given line amount, line and
   column relate to cursor position

--- a/src/json_ui.cc
+++ b/src/json_ui.cc
@@ -263,6 +263,12 @@ void JsonUI::eval_json(const Value& json)
             for (auto& key : parse_keys(key_val.as<String>()))
                 m_on_key(key);
         }
+    }else if (method == "paste")
+    {
+        if (params.size() != 1 or not params[0].is_a<String>())
+            throw invalid_rpc_request("paste requires a string parameter");
+        if (m_on_paste)
+            m_on_paste(params[0].as<String>());
     }
     else if (method == "mouse_move")
     {


### PR DESCRIPTION
Implements the `paste(String content)` method for JSON UI. The callback was already implemented, but there was no way to call it through the JSON interface.