### PR TITLE
chore: fix human readable binary operators

### DIFF
--- a/src/buffer_utils.cc
+++ b/src/buffer_utils.cc
@@ -22,7 +22,7 @@ namespace Kakoune
 void replace(Buffer& buffer, ArrayView<BufferRange> ranges, ConstArrayView<String> strings)
 {
     ForwardChangesTracker changes_tracker;
-    size_t timestamp  = buffer.timestamp();
+    size_t timestamp = buffer.timestamp();
     for (size_t index = 0; index < ranges.size(); ++index)
     {
         auto& range = ranges[index];
@@ -129,7 +129,7 @@ decltype(auto) parse_file(StringView filename, Func&& func)
     const char* end = pos + file.st.st_size;
 
     auto bom = ByteOrderMark::None;
-    if (file.st.st_size >= 3 && StringView{pos, 3_byte} == "\xEF\xBB\xBF")
+    if (file.st.st_size >= 3 and StringView{pos, 3_byte} == "\xEF\xBB\xBF")
     {
         bom = ByteOrderMark::Utf8;
         pos += 3;
@@ -357,7 +357,7 @@ Buffer* create_fifo_buffer(String name, int fd, Buffer::Flags flags, AutoScroll 
                     }
                     m_had_trailing_newline = have_trailing_newline;
                 }
-                while (++loop < max_loop  and fd_readable(fifo));
+                while (++loop < max_loop and fd_readable(fifo));
             }
 
             if (insert_begin)

--- a/src/client.cc
+++ b/src/client.cc
@@ -292,7 +292,7 @@ void Client::redraw_ifn()
 
     if (m_ui_pending & InfoShow and m_info.ui_anchor)
         m_ui->info_show(m_info.title, m_info.content, *m_info.ui_anchor,
-                        faces[(is_inline(m_info.style) || m_info.style == InfoStyle::MenuDoc)
+                        faces[(is_inline(m_info.style) or m_info.style == InfoStyle::MenuDoc)
                         ? "InlineInformation" : "Information"], m_info.style);
     if (m_ui_pending & InfoHide)
         m_ui->info_hide();

--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -143,7 +143,7 @@ ParseResult parse_quoted(ParseState& state, Delimiter delimiter)
         if (c == delimiter)
         {
             auto next = state.pos;
-            if (next == end || read(next, end) != delimiter)
+            if (next == end or read(next, end) != delimiter)
             {
                 if (str.empty())
                     return {String{String::NoCopy{}, {beg, cur}}, true};

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -176,7 +176,7 @@ static Completions complete_buffer_name(const Context& context, StringView prefi
 {
     struct RankedMatchAndBuffer : RankedMatch
     {
-        RankedMatchAndBuffer(RankedMatch  m, const Buffer* b)
+        RankedMatchAndBuffer(RankedMatch m, const Buffer* b)
             : RankedMatch{std::move(m)}, buffer{b} {}
 
         using RankedMatch::operator==;
@@ -601,7 +601,7 @@ void do_write_buffer(Context& context, Optional<String> filename, WriteFlags fla
     Buffer& buffer = context.buffer();
     const bool is_file = (bool)(buffer.flags() & Buffer::Flags::File);
 
-    if (not filename and !is_file)
+    if (not filename and not is_file)
         throw runtime_error("cannot write a non file buffer without a filename");
 
     const bool is_readonly = (bool)(context.buffer().flags() & Buffer::Flags::ReadOnly);
@@ -674,7 +674,7 @@ void write_all_buffers(const Context& context, bool sync = false, Optional<Write
         if ((buffer->flags() & Buffer::Flags::File) and
             ((buffer->flags() & Buffer::Flags::New) or
              buffer->is_modified())
-            and !(buffer->flags() & Buffer::Flags::ReadOnly))
+            and not (buffer->flags() & Buffer::Flags::ReadOnly))
         {
             auto method = write_method.value_or_compute([&] { return context.options()["writemethod"].get<WriteMethod>(); });
             auto flags = sync ? WriteFlags::Sync : WriteFlags::None;
@@ -1817,7 +1817,7 @@ const CommandDesc set_option_cmd = {
             return { 0_byte, params[1].length(),
                      GlobalScope::instance().option_registry().complete_option_name(params[1], pos_in_token),
                      Completions::Flags::Menu };
-        else if (token_to_complete == 2  and params[2].empty() and
+        else if (token_to_complete == 2 and params[2].empty() and
                  GlobalScope::instance().option_registry().option_exists(params[1]))
         {
             OptionManager& options = get_scope(params[0], context).options();

--- a/src/context.cc
+++ b/src/context.cc
@@ -335,7 +335,7 @@ void Context::forget_buffer(Buffer& buffer)
 
     if (&this->buffer() == &buffer)
     {
-        if (is_editing() && has_input_handler())
+        if (is_editing() and has_input_handler())
             input_handler().reset_normal_mode();
 
         auto last_buffer = this->last_buffer();

--- a/src/display_buffer.cc
+++ b/src/display_buffer.cc
@@ -148,7 +148,7 @@ DisplayLine::iterator DisplayLine::split(iterator it, ColumnCount count)
 DisplayLine::iterator DisplayLine::split(BufferCoord pos)
 {
     auto it = find_if(begin(), end(), [pos](const DisplayAtom& a) {
-        return (a.has_buffer_range() && a.begin() >= pos) ||
+        return (a.has_buffer_range() and a.begin() >= pos) or
                (a.type() == DisplayAtom::Range and a.end() > pos);
     });
     if (it == end() or it->begin() >= pos)
@@ -160,7 +160,7 @@ DisplayLine::iterator DisplayLine::insert(iterator it, DisplayAtom atom)
 {
     if (atom.has_buffer_range())
     {
-        m_range.begin  = std::min(m_range.begin, atom.begin());
+        m_range.begin = std::min(m_range.begin, atom.begin());
         m_range.end = std::max(m_range.end, atom.end());
     }
     return m_atoms.insert(it, std::move(atom));
@@ -170,7 +170,7 @@ DisplayAtom& DisplayLine::push_back(DisplayAtom atom)
 {
     if (atom.has_buffer_range())
     {
-        m_range.begin  = std::min(m_range.begin, atom.begin());
+        m_range.begin = std::min(m_range.begin, atom.begin());
         m_range.end = std::max(m_range.end, atom.end());
     }
     m_atoms.push_back(std::move(atom));
@@ -283,7 +283,7 @@ bool DisplayLine::trim_from(ColumnCount first_col, ColumnCount front, ColumnCoun
     it = begin();
     for (; it != end() and col_count > 0; ++it)
         col_count -= it->trim_end_to_length(col_count);
-    bool did_trim = it != end() && col_count == 0;
+    bool did_trim = it != end() and col_count == 0;
     m_atoms.erase(it, end());
 
     compute_range(true);
@@ -312,7 +312,7 @@ void DisplayBuffer::compute_range()
     m_range = init_range;
     for (auto& line : m_lines)
     {
-        m_range.begin  = std::min(line.range().begin, m_range.begin);
+        m_range.begin = std::min(line.range().begin, m_range.begin);
         m_range.end = std::max(line.range().end, m_range.end);
     }
     if (m_range == init_range)

--- a/src/display_buffer.hh
+++ b/src/display_buffer.hh
@@ -165,7 +165,7 @@ public:
 private:
     void compute_range(bool preserve_if_no_atoms = false);
     BufferRange m_range = { { INT_MAX, INT_MAX }, { INT_MIN, INT_MIN } };
-    AtomList  m_atoms;
+    AtomList m_atoms;
 };
 
 using DisplayLineList = Vector<DisplayLine>;

--- a/src/file.cc
+++ b/src/file.cc
@@ -103,7 +103,7 @@ String compact_path(StringView filename)
     String real_filename = real_path(filename);
 
     char cwd[1024];
-    if (!::getcwd(cwd, 1024))
+    if (not ::getcwd(cwd, 1024))
         throw runtime_error(format("unable to get the current working directory (errno: {})", ::strerror(errno)));
 
     String real_cwd = real_path(cwd) + "/";
@@ -144,7 +144,7 @@ StringView homedir()
 bool fd_readable(int fd)
 {
     kak_assert(fd >= 0);
-    fd_set  rfds;
+    fd_set rfds;
     FD_ZERO(&rfds);
     FD_SET(fd, &rfds);
 
@@ -155,7 +155,7 @@ bool fd_readable(int fd)
 bool fd_writable(int fd)
 {
     kak_assert(fd >= 0);
-    fd_set  wfds;
+    fd_set wfds;
     FD_ZERO(&wfds);
     FD_SET(fd, &wfds);
 
@@ -173,7 +173,7 @@ String read_fd(int fd, bool text)
         if (size == -1)
             throw file_access_error{fd, strerror(errno)};
 
-        if  (text)
+        if (text)
         {
             for (StringView data{buf, buf + size}; not data.empty();)
             {
@@ -414,7 +414,7 @@ String get_kak_binary_path()
     char buffer[2048];
 #if defined(__linux__) or defined(__CYGWIN__) or defined(__gnu_hurd__)
     ssize_t res = readlink("/proc/self/exe", buffer, 2048);
-    if (res != -1 && res < 2048) {
+    if (res != -1 and res < 2048) {
         buffer[res] = '\0';
         return buffer;
     }
@@ -446,7 +446,7 @@ String get_kak_binary_path()
     }
 #elif defined(__DragonFly__)
     ssize_t res = readlink("/proc/curproc/file", buffer, 2048);
-    if (res != -1 && res < 2048) {
+    if (res != -1 and res < 2048) {
         buffer[res] = '\0';
         return buffer;
     }
@@ -455,7 +455,7 @@ String get_kak_binary_path()
     return KAK_BIN_PATH;
 #elif defined(__sun__)
     ssize_t res = readlink("/proc/self/path/a.out", buffer, 2048);
-    if (res != -1 && res < 2048) {
+    if (res != -1 and res < 2048) {
         buffer[res] = '\0';
         return buffer;
     }

--- a/src/highlighters.cc
+++ b/src/highlighters.cc
@@ -1076,7 +1076,7 @@ private:
             const auto atom_face = last_line == current_line ? face_wrapped :
                 ((m_hl_cursor_line and is_cursor_line) ? face_absolute : face);
 
-            const auto& separator = is_cursor_line && last_line != current_line
+            const auto& separator = is_cursor_line and last_line != current_line
                                     ? m_cursor_separator : m_separator;
 
             line.insert(line.begin(), {buffer, atom_face});
@@ -1606,7 +1606,7 @@ private:
         {
             try
             {
-                if (!is_valid(buffer, range.first) or (!is_empty(range) and !is_valid(buffer, range.last)) or !is_fully_selected(sels, range))
+                if (not is_valid(buffer, range.first) or (not is_empty(range) and not is_valid(buffer, range.last)) or not is_fully_selected(sels, range))
                     continue;
                 auto end = is_empty(range) ? range.first : buffer.char_next(range.last);
                 replace_range(display_buffer, range.first, end,
@@ -1645,7 +1645,7 @@ private:
 
         for (auto& [range, spec] : range_and_faces.list)
         {
-            if (!is_valid(buffer, range.first) or (!is_empty(range) and !is_valid(buffer, range.last)) or !is_fully_selected(sels, range))
+            if (not is_valid(buffer, range.first) or (not is_empty(range) and not is_valid(buffer, range.last)) or not is_fully_selected(sels, range))
                 continue;
 
             auto last = is_empty(range) ? range.first : buffer.char_next(range.last);

--- a/src/hook_manager.cc
+++ b/src/hook_manager.cc
@@ -97,7 +97,7 @@ CandidateList HookManager::complete_hook_group(StringView prefix, ByteCount pos_
         auto container = list | transform([](const UniquePtr<HookData>& h) -> const String& { return h->group; });
         for (auto& c : complete(prefix, pos_in_token, container))
         {
-            if (!contains(res, c))
+            if (not contains(res, c))
                 res.push_back(c);
         }
     }

--- a/src/input_handler.cc
+++ b/src/input_handler.cc
@@ -503,14 +503,14 @@ void to_prev_word_begin(CharCount& pos, StringView line)
     {
         while (pos != 0_char and is_punctuation(line[pos]))
             --pos;
-        if (!is_punctuation(line[pos]))
+        if (not is_punctuation(line[pos]))
             ++pos;
     }
     else if (is_word<word_type>(line[pos]))
     {
         while (pos != 0_char and is_word<word_type>(line[pos]))
             --pos;
-        if (!is_word<word_type>(line[pos]))
+        if (not is_word<word_type>(line[pos]))
             ++pos;
      }
 }

--- a/src/insert_completer.cc
+++ b/src/insert_completer.cc
@@ -90,7 +90,7 @@ InsertCompletion complete_word(const SelectionList& sels,
     for (int i = 0; i < sels.size(); ++i)
     {
         int len = 0;
-        auto is_short_enough_word = [&] (Codepoint c) { return len++ < WordSplitter::max_word_len && is_word_pred(c); };
+        auto is_short_enough_word = [&] (Codepoint c) { return len++ < WordSplitter::max_word_len and is_word_pred(c); };
 
         Utf8It end{buffer.iterator_at(sels[i].cursor()), buffer};
         Utf8It begin = end-1;
@@ -115,7 +115,7 @@ InsertCompletion complete_word(const SelectionList& sels,
 
     struct RankedMatchAndBuffer : RankedMatch
     {
-        RankedMatchAndBuffer(RankedMatch  m, const Buffer* b)
+        RankedMatchAndBuffer(RankedMatch m, const Buffer* b)
             : RankedMatch{std::move(m)}, buffer{b} {}
 
         using RankedMatch::operator==;
@@ -174,7 +174,7 @@ InsertCompletion complete_word(const SelectionList& sels,
         if (not candidates.empty() and candidates.back().completion == m.candidate())
             return false;
         DisplayLine menu_entry;
-        if (other_buffers && m.buffer)
+        if (other_buffers and m.buffer)
         {
             const auto pad_len = longest + 1 - m.candidate().char_length();
             menu_entry.push_back({ m.candidate().str(), {} });
@@ -523,7 +523,7 @@ void InsertCompleter::reset()
 
 bool InsertCompleter::setup_ifn()
 {
-    if (!m_enabled)
+    if (not m_enabled)
         return false;
     if (not m_completions.is_valid())
     {

--- a/src/json_ui.cc
+++ b/src/json_ui.cc
@@ -263,7 +263,8 @@ void JsonUI::eval_json(const Value& json)
             for (auto& key : parse_keys(key_val.as<String>()))
                 m_on_key(key);
         }
-    }else if (method == "paste")
+    }
+    else if (method == "paste")
     {
         if (params.size() != 1 or not params[0].is_a<String>())
             throw invalid_rpc_request("paste requires a string parameter");

--- a/src/keys.cc
+++ b/src/keys.cc
@@ -33,7 +33,7 @@ static Key canonicalize_ifn(Key key)
             key.modifiers &= ~Key::Modifiers::Shift;
             key.key = to_upper(key.key);
         }
-        else if (key.key < 0xD800 || key.key > 0xDFFF)
+        else if (key.key < 0xD800 or key.key > 0xDFFF)
         {
             // Shift + any other printable character is not allowed.
             throw key_parse_error(format("Shift modifier only works on special keys and lowercase ASCII, not '{}'", key.key));

--- a/src/main.cc
+++ b/src/main.cc
@@ -636,7 +636,7 @@ int run_client(StringView session, StringView name, StringView client_init,
         // So only worry about making the tty your stdin if:
         // (a) ui_type is Terminal, *and*
         // (b) fd 0 is not interactive.
-        if (ui_type == UIType::Terminal && not isatty(0))
+        if (ui_type == UIType::Terminal and not isatty(0))
         {
             // move stdin to another fd, and restore tty as stdin
             stdin_fd = dup(0);
@@ -1129,7 +1129,7 @@ int main(int argc, char* argv[])
         {
             if (not name.empty() and name[0_byte] == '+')
             {
-                if (name == "+" or name  == "+:")
+                if (name == "+" or name == "+:")
                 {
                     client_init = client_init + "; exec gj";
                     continue;

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -969,7 +969,7 @@ void regex_prompt(Context& context, String prompt, char reg, RegexMode mode, Fun
                     return res;
 
                 int backslashes = 0;
-                for (auto bs = it; bs != s.begin() && *(bs-1) == '\\'; --bs)
+                for (auto bs = it; bs != s.begin() and *(bs-1) == '\\'; --bs)
                     ++backslashes;
                 return (backslashes % 2 == 1) ? res.substr(1_byte) : res;
             };

--- a/src/option_manager.hh
+++ b/src/option_manager.hh
@@ -41,7 +41,7 @@ public:
 private:
     String m_name;
     String m_docstring;
-    OptionFlags  m_flags;
+    OptionFlags m_flags;
 };
 
 class Option : public UseMemoryDomain<MemoryDomain::Options>

--- a/src/ranked_match.cc
+++ b/src/ranked_match.cc
@@ -47,7 +47,7 @@ static int count_word_boundaries_match(StringView candidate, StringView query)
     {
         const Codepoint c = *it;
         const bool is_word_boundary = prev == 0 or
-                                      (!is_word(prev, {}) and is_word(c, {})) or
+                                      (not is_word(prev, {}) and is_word(c, {})) or
                                       (is_lower(prev) and is_upper(c));
         prev = c;
 

--- a/src/remote.cc
+++ b/src/remote.cc
@@ -305,7 +305,7 @@ private:
         m_write_pos += res;
 
         if (cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
-            cmsg && cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS && cmsg->cmsg_len == CMSG_LEN(sizeof(int)))
+            cmsg and cmsg->cmsg_level == SOL_SOCKET and cmsg->cmsg_type == SCM_RIGHTS and cmsg->cmsg_len == CMSG_LEN(sizeof(int)))
         {
             m_ancillary_fd.map(close);
             memcpy(&m_ancillary_fd.emplace(), CMSG_DATA(cmsg), sizeof(int));
@@ -612,7 +612,7 @@ const String& session_directory()
         StringView xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
         if (not xdg_runtime_dir.empty())
         {
-            if (struct stat st; stat(xdg_runtime_dir.zstr(), &st) == 0 && st.st_uid == geteuid())
+            if (struct stat st; stat(xdg_runtime_dir.zstr(), &st) == 0 and st.st_uid == geteuid())
                 return format("{}/kakoune", xdg_runtime_dir);
             else
                 write_to_debug_buffer("XDG_RUNTIME_DIR does not exist or not owned by current user, using tmpdir");

--- a/src/selectors.cc
+++ b/src/selectors.cc
@@ -902,7 +902,7 @@ Vector<Selection> select_nested_paragraphs(const Context& context, int count, Ob
         {
             auto start = std::find_if(it, end, [&](char c) {return not is_eol(c); });
             int consecutive_eols = 0;
-            for  (it = start; it != end; ++it)
+            for (it = start; it != end; ++it)
             {
                 if (is_eol(*it))
                 {
@@ -1044,7 +1044,7 @@ select_lines(const Context& context, const Selection& selection)
 {
     auto& buffer = context.buffer();
     BufferCoord anchor = selection.anchor();
-    BufferCoord cursor  = selection.cursor();
+    BufferCoord cursor = selection.cursor();
     BufferCoord& to_line_start = anchor <= cursor ? anchor : cursor;
     BufferCoord& to_line_end = anchor <= cursor ? cursor : anchor;
 
@@ -1059,7 +1059,7 @@ trim_partial_lines(const Context& context, const Selection& selection)
 {
     auto& buffer = context.buffer();
     BufferCoord anchor = selection.anchor();
-    BufferCoord cursor  = selection.cursor();
+    BufferCoord cursor = selection.cursor();
     BufferCoord& to_line_start = anchor <= cursor ? anchor : cursor;
     BufferCoord& to_line_end = anchor <= cursor ? cursor : anchor;
 

--- a/src/string.cc
+++ b/src/string.cc
@@ -69,7 +69,7 @@ void String::Data::reserve(size_t new_capacity)
     if (current_capacity != 0 and new_capacity <= current_capacity)
         return;
 
-    if (!is_long() and new_capacity <= Short::capacity)
+    if (not is_long() and new_capacity <= Short::capacity)
         return;
 
     kak_assert(new_capacity <= Long::max_capacity);

--- a/src/terminal_ui.cc
+++ b/src/terminal_ui.cc
@@ -790,11 +790,11 @@ Optional<Key> TerminalUI::get_next_key()
             private_mode = c;
             c = next_char();
         }
-        for (int count = 0, subcount = 0; count < 16 and c >= 0x30 && c <= 0x3f; c = next_char())
+        for (int count = 0, subcount = 0; count < 16 and c >= 0x30 and c <= 0x3f; c = next_char())
         {
             if (isdigit(c))
                 params[count][subcount] = params[count][subcount] * 10 + c - '0';
-            else if (c == ':' && subcount < 3)
+            else if (c == ':' and subcount < 3)
                 ++subcount;
             else if (c == ';')
             {
@@ -1595,7 +1595,7 @@ void TerminalUI::set_ui_options(const Options& options)
 
     m_padding_char = find("terminal_padding_char").map([](StringView s) { return s.column_length() < 1 ? ' ' : s[0_char]; }).value_or(Codepoint{'~'});
     m_padding_fill = find("terminal_padding_fill").map(to_bool).value_or(false);
-    
+
     bool new_cursor_native = find("terminal_cursor_native").map(to_bool).value_or(false);
     if (new_cursor_native != m_cursor_native)
     {

--- a/src/utils.hh
+++ b/src/utils.hh
@@ -162,7 +162,7 @@ public:
     FunctionRef()
       : m_target{nullptr},
         m_invoker{[](void* target, Args... args) {
-            if constexpr (!std::is_same_v<Res, void>) return Res{};
+            if constexpr (not std::is_same_v<Res, void>) return Res{};
         }}
     {}
 


### PR DESCRIPTION
Hi

These remaining inconsistent binary operators were detected by `clang-tidy` with the following check option:

```
    CheckOptions:
      readability-operators-representation.BinaryOperators: "and;not;or;"
```

Not sure if this could be included in the CI pipeline somehow.