### PR TITLE
feat(rc): detect .swiftinterface files as Swift

### DIFF
--- a/rc/filetype/swift.kak
+++ b/rc/filetype/swift.kak
@@ -2,7 +2,7 @@
 # MARK: - detection
 #
 
-hook global BufCreate .*\.(swift) %{
+hook global BufCreate .*\.(swift|swiftinterface) %{
     set-option buffer filetype swift
 }
 


### PR DESCRIPTION
- adds .swiftinterface extension to the Swift filetype hook
- .swiftinterface files are Swift module interface files generated by the compiler