### PR TITLE
feat: add difference operators to combine mode (`a-z`, `a-Z`)

### DIFF
--- a/contrib/TRAMPOLINE
+++ b/contrib/TRAMPOLINE
@@ -42,7 +42,7 @@ using the built-in `:doc` command.
        .---,        described in this document are "editing primitives" that
        |esc|        have to be hit in normal mode, which is the default mode
        `---'        when you start the editor. To enter insert mode, hit the
-                    `i` key, and to leave it and return to normal mode, hit the 
+                    `i` key, and to leave it and return to normal mode, hit the
                     escape key.
 
 
@@ -322,7 +322,7 @@ using the built-in `:doc` command.
    | " |_. .---,    temporary search, one could make this primitive save the
    `---'  `| _ |    pattern to a different register, to preserve the default one,
            `---'    e.g., `"m*` to save the pattern to the `m` register, or even
-                    `"_*` to save the pattern to a "null" register, which does 
+                    `"_*` to save the pattern to a "null" register, which does
                     not store anything written to it.
 
                     ==[ CAPTURE GROUPS
@@ -373,11 +373,11 @@ using the built-in `:doc` command.
         .---,       expressions. To allow that, the save mark (`Z`) and append
         | Z |       mark (`<a-z>`) come in handy, as they respectively save
         `---'       the current selection to the mark register (`^`), and
-                    show a menu that allows appending the current selection
-.---, .---,         to the mark register upon hitting the `a` key. That way,
+                    show a menu that allows combining the current selection
+.---, .---,         to the mark register upon hitting the `u` key. That way,
 |alt|+| z |_.       it becomes possible to chain and save (append) several
 `---' `---'  `.---, selections made using completely different methods
-              | a | (select, split etc) without being forced to preserve
+              | u | (select, split etc) without being forced to preserve
               `---' them at all times.
         .---,
         | z |       Restoring a mark saved to the mark register using those

--- a/doc/pages/changelog.asciidoc
+++ b/doc/pages/changelog.asciidoc
@@ -5,6 +5,9 @@ To control the startup info message, see <<options#startup-info,`:doc options st
 This changelog contains major and/or breaking changes to Kakoune between
 released versions.
 
+* Combine mode, `<a-z>`, `<a-Z>`, now has distinct regular and pairwise operations.
+  Regular combinations now include: difference in both directions and symmetric difference.
+
 == Kakoune 2026.05.21
 
 * Support the `\N` escape sequence in regex (like in PCRE, matches `[^\n]`).
@@ -131,7 +134,7 @@ released versions.
   (See <<expansions#command-and-response-fifo,`:doc expansions command-and-response-fifo`>>)
 
 * Shell expansions only trim the last trailing newline instead of all of
-  them to make is possible to losslessly pass text through `%sh{...}`. 
+  them to make is possible to losslessly pass text through `%sh{...}`.
 
 * `set-option -remove` support for subtracting/removing from option values
 
@@ -171,7 +174,7 @@ released versions.
 * clients stdin is transferred to the server, making it possible
   to pipe into `kak -c <session>`
 
-* Faces can have an alpha channel, specified using the 
+* Faces can have an alpha channel, specified using the
   `rgba:RRGGBBAA` format.
 
 * replace-ranges highlighter now support empty and multi-lines ranges
@@ -181,7 +184,7 @@ released versions.
 
 * `*SetOption` hooks filter string will contain a value only for options
   of int/str/bool types to avoid performance issue with generating those
-  on more complex option types. 
+  on more complex option types.
 
 == Kakoune 2020.01.16
 
@@ -195,7 +198,7 @@ released versions.
 
 * Arrow keys and `<home>`, `<end>` are not normal mode commands
   anymore but default key mappings.
-  
+
 * `ModeChange` hook parameter now takes `push:` or `pop:` prefix,
   `InsertBegin`, `InsertEnd`, `NormalBegin` and `NormalEnd`
   were removed.
@@ -208,7 +211,7 @@ released versions.
 * `info` supports markup with the `-markup` switch
 
 * `rename-buffer` gained `-file` and `-scratch` switches
-  to support converting buffer types.  
+  to support converting buffer types.
 
 == Kakoune 2019.07.01
 

--- a/doc/pages/keys.asciidoc
+++ b/doc/pages/keys.asciidoc
@@ -511,22 +511,49 @@ Marks use the *^* register by default (See <<registers#,`:doc registers`>>)
 *<a-z>*, *<a-Z>*::
     *<a-z>* combines selections from the register with the current ones, whereas
     *<a-Z>* combines current selections with the ones in the register; a menu
-    is then displayed which waits for one of the following additional keys:
+    is then displayed which waits for one of the following additional keys.
 
-    *a*:::
-        append selections
+    In the mathematical set expressions below:
+
+    - *B* stands for "selections currently in the buffer"
+    - *R* stands for "selections currently in the register"
 
     *u*:::
-        keep a union of selections
+        keep the union of selections `B ∪ R`
 
     *i*:::
-        keep an intersection of selections
+        keep the intersection of selections `B ∩ R`
+
+    *b*:::
+        keep the buffer difference of selections `B \ R`
+
+    *r*:::
+        keep the register difference of selections `R \ B`
+
+    *s*:::
+        keep the symmetric difference of selections `B Δ R`
+
+    If the *<a-z>* or *<a-Z>* keys are preceded with the `count` *2*,
+    this time the combinations are performed *pairwise*.
+    (It implies the selections lists have the same length)
+
+    It means the first buffer selection will be combined with the first
+    register selection, the second buffer selection with the second register
+    selection and so on…
+
+    So for each pair:
+
+    *u*:::
+        select the union (gap included if they don't overlap)
+
+    *i*:::
+        select from intersection (gap included if they don't overlap)
 
     *<*:::
-        select the selection with the leftmost cursor for each pair
+        select the selection with the leftmost cursor
 
     *>*:::
-        select the selection with the rightmost cursor for each pair
+        select the selection with the rightmost cursor
 
     *+*:::
         select the longest selection

--- a/doc/pages/modes.asciidoc
+++ b/doc/pages/modes.asciidoc
@@ -87,6 +87,9 @@ See object commands <<keys#object-selection,`:doc keys object-selection`>>.
 Mode entered with `<a-z>` or `<a-Z>` keys.
 It aims at crafting ways to combine selections with ones in registers.
 
+If this mode is entered while the current `count` is `2`,
+combinations are performed "pairwise".
+
 See marks commands <<keys#marks,`:doc keys marks`>>.
 
 === User mode

--- a/rc/detection/modeline.kak
+++ b/rc/detection/modeline.kak
@@ -110,13 +110,13 @@ define-command -hidden modeline-parse-impl %{
 
 # Add the following function to a hook on BufOpenFile to automatically parse modelines
 # Select the first and last `modelines` lines in the buffer, only keep modelines
-# ref. options.txt (in vim `:help options`) : 2 forms of modelines: 
+# ref. options.txt (in vim `:help options`) : 2 forms of modelines:
 #   [text]{white}{vi:|vim:|ex:}[white]{options}
 #   [text]{white}{vi:|vim:|Vim:|ex:}[white]se[t] {options}:[text]
 define-command modeline-parse -docstring "Read and interpret vi-format modelines at the beginning/end of the buffer" %{
     try %{ evaluate-commands -draft -save-regs ^ %{
         execute-keys -save-regs "" gk %opt{modelines} JK x Z
-        execute-keys gj %opt{modelines} KJ x <a-z> a
+        execute-keys gj %opt{modelines} KJ x <a-z> u
         execute-keys s^\S*?\s+?\w+:\s?\N+<ret> x
         evaluate-commands -draft -itersel modeline-parse-impl
     } }

--- a/rc/filetype/clojure.kak
+++ b/rc/filetype/clojure.kak
@@ -200,20 +200,20 @@ define-command -hidden clojure-indent-on-new-line %{
     evaluate-commands -draft -save-regs '/"|^@iw' -itersel %{
         execute-keys -draft 'gk"iZ'
         try %{
-            execute-keys -draft '[bl"i<a-Z><gt>"wZ'
+            execute-keys -draft '[bl"i2<a-Z><gt>"wZ'
 
             try %{
                 # If a special form, indent another (indentwidth - 1) spaces
                 execute-keys -draft '"wze<a-K>[\s()\[\]\{\}]<ret><a-k>\A' %opt{clojure_special_indent_forms} '\z<ret>'
-                execute-keys -draft '"wze<a-L>s.{' %sh{printf $(( kak_opt_indentwidth - 1 ))} '}\K.*<ret><a-;>;"i<a-Z><gt>'
+                execute-keys -draft '"wze<a-L>s.{' %sh{printf $(( kak_opt_indentwidth - 1 ))} '}\K.*<ret><a-;>;"i2<a-Z><gt>'
             } catch %{
                 # If not special and parameter appears on line 1, indent to parameter
-                execute-keys -draft '"wz<a-K>[()[\]{}]<ret>e<a-K>[\s()\[\]\{\}]<ret><a-l>s\h\K[^\s].*<ret><a-;>;"i<a-Z><gt>'
+                execute-keys -draft '"wz<a-K>[()[\]{}]<ret>e<a-K>[\s()\[\]\{\}]<ret><a-l>s\h\K[^\s].*<ret><a-;>;"i2<a-Z><gt>'
             }
         }
-        try %{ execute-keys -draft '[rl"i<a-Z><gt>' }
-        try %{ execute-keys -draft '[Bl"i<a-Z><gt>' }
-        execute-keys -draft ';"i<a-z>a&,'
+        try %{ execute-keys -draft '[rl"i2<a-Z><gt>' }
+        try %{ execute-keys -draft '[Bl"i2<a-Z><gt>' }
+        execute-keys -draft ';"i<a-z>u&,'
     }
 }
 

--- a/rc/filetype/diff.kak
+++ b/rc/filetype/diff.kak
@@ -118,7 +118,7 @@ define-command \
                 evaluate-commands -itersel -save-regs 'ose/' %{
         try %{
             execute-keys '"oZgl<a-?>^diff <ret>;"sZ' 'Ge"eZ'
-            try %{ execute-keys '"sz?\n(?=diff )<ret>"e<a-Z><lt>' }
+            try %{ execute-keys '"sz?\n(?=diff )<ret>"e2<a-Z><lt>' }
             execute-keys '"ez'
         } catch %{
             execute-keys '"oz'
@@ -134,8 +134,8 @@ define-command \
     evaluate-commands -itersel -save-regs 'ose/' %{
         try %{
             execute-keys '"oZgl<a-?>^@@ <ret>;"sZ' 'Ge"eZ'
-            try %{ execute-keys '"sz?\n(?=diff )<ret>"e<a-Z><lt>' }
-            try %{ execute-keys '"sz?\n(?=@@ )<ret>"e<a-Z><lt>' }
+            try %{ execute-keys '"sz?\n(?=diff )<ret>"e2<a-Z><lt>' }
+            try %{ execute-keys '"sz?\n(?=@@ )<ret>"e2<a-Z><lt>' }
             execute-keys '"ez'
         } catch %{
             execute-keys '"oz'

--- a/rc/filetype/fennel.kak
+++ b/rc/filetype/fennel.kak
@@ -89,20 +89,20 @@ define-command -hidden fennel-indent-on-new-line %{
     evaluate-commands -draft -save-regs '/"|^@iw' -itersel %{
         execute-keys -draft 'gk"iZ'
         try %{
-            execute-keys -draft '[bl"i<a-Z><gt>"wZ'
+            execute-keys -draft '[bl"i2<a-Z><gt>"wZ'
 
             try %{
                 # If a special form, indent another (indentwidth - 1) spaces
                 execute-keys -draft '"wze<a-K>[\s()\[\]\{\}]<ret><a-k>\A' %opt{fennel_special_indent_forms} '\z<ret>'
-                execute-keys -draft '"wze<a-L>s.{' %sh{printf $(( kak_opt_indentwidth - 1 ))} '}\K.*<ret><a-;>;"i<a-Z><gt>'
+                execute-keys -draft '"wze<a-L>s.{' %sh{printf $(( kak_opt_indentwidth - 1 ))} '}\K.*<ret><a-;>;"i2<a-Z><gt>'
             } catch %{
                 # If not special and parameter appears on line 1, indent to parameter
-                execute-keys -draft '"wz<a-K>[()[\]{}]<ret>e<a-K>[\s()\[\]\{\}]<ret><a-l>s\h\K[^\s].*<ret><a-;>;"i<a-Z><gt>'
+                execute-keys -draft '"wz<a-K>[()[\]{}]<ret>e<a-K>[\s()\[\]\{\}]<ret><a-l>s\h\K[^\s].*<ret><a-;>;"i2<a-Z><gt>'
             }
         }
-        try %{ execute-keys -draft '[rl"i<a-Z><gt>' }
-        try %{ execute-keys -draft '[Bl"i<a-Z><gt>' }
-        execute-keys -draft ';"i<a-z>a&,'
+        try %{ execute-keys -draft '[rl"i2<a-Z><gt>' }
+        try %{ execute-keys -draft '[Bl"i2<a-Z><gt>' }
+        execute-keys -draft ';"i<a-z>u&,'
     }
 }
 

--- a/rc/filetype/janet.kak
+++ b/rc/filetype/janet.kak
@@ -60,19 +60,19 @@ define-command -hidden janet-indent-on-new-line %{
     evaluate-commands -draft -save-regs '/"|^@iw' -itersel %{
         execute-keys -draft 'gk"iZ'
         try %{
-            execute-keys -draft '[bl"i<a-Z><gt>"wZ'
+            execute-keys -draft '[bl"i2<a-Z><gt>"wZ'
 
             try %{
                 # If a special form, indent another j
-                execute-keys -draft '"wze<a-k>\A' %opt{janet_special_indent_forms} '\z<ret><a-L>s.\K.*<ret><a-;>;"i<a-Z><gt>'
+                execute-keys -draft '"wze<a-k>\A' %opt{janet_special_indent_forms} '\z<ret><a-L>s.\K.*<ret><a-;>;"i2<a-Z><gt>'
             } catch %{
                 # If not special and parameter appears on line 1, indent to parameter
-                execute-keys -draft '"wze<a-l>s\h\K[^\s].*<ret><a-;>;"i<a-Z><gt>'
+                execute-keys -draft '"wze<a-l>s\h\K[^\s].*<ret><a-;>;"i2<a-Z><gt>'
             }
         }
-        try %{ execute-keys -draft '[rl"i<a-Z><gt>' }
-        try %{ execute-keys -draft '[Bl"i<a-Z><gt>' }
-        execute-keys -draft '"i<a-z>a&,'
+        try %{ execute-keys -draft '[rl"i2<a-Z><gt>' }
+        try %{ execute-keys -draft '[Bl"i2<a-Z><gt>' }
+        execute-keys -draft '"i<a-z>u&,'
         # trim trailing whitespace on the previous line
         try %{ execute-keys -draft k : janet-trim-indent <ret> }
     }

--- a/rc/filetype/lisp.kak
+++ b/rc/filetype/lisp.kak
@@ -61,20 +61,20 @@ define-command -hidden lisp-indent-on-new-line %{
     evaluate-commands -draft -save-regs '/"|^@iw' -itersel %{
         execute-keys -draft 'gk"iZ'
         try %{
-            execute-keys -draft '[bl"i<a-Z><gt>"wZ'
+            execute-keys -draft '[bl"i2<a-Z><gt>"wZ'
 
             try %{
                 # If a special form, indent another (indentwidth - 1) spaces
                 execute-keys -draft '"wze<a-k>\A' %opt{lisp_special_indent_forms} '\z<ret>'
-                execute-keys -draft '"wze<a-L>s.{' %sh{printf $(( kak_opt_indentwidth - 1 ))} '}\K.*<ret><a-;>;"i<a-Z><gt>'
+                execute-keys -draft '"wze<a-L>s.{' %sh{printf $(( kak_opt_indentwidth - 1 ))} '}\K.*<ret><a-;>;"i2<a-Z><gt>'
             } catch %{
                 # If not "special" form and parameter appears on line 1, indent to parameter
-                execute-keys -draft '"wz<a-K>[()\[\]{}]<ret>e<a-l>s\h\K[^\s].*<ret><a-;>;"i<a-Z><gt>'
+                execute-keys -draft '"wz<a-K>[()\[\]{}]<ret>e<a-l>s\h\K[^\s].*<ret><a-;>;"i2<a-Z><gt>'
             }
         }
-        try %{ execute-keys -draft '[rl"i<a-Z><gt>' }
-        try %{ execute-keys -draft '[Bl"i<a-Z><gt>' }
-        execute-keys -draft ';"i<a-z>a&,'
+        try %{ execute-keys -draft '[rl"i2<a-Z><gt>' }
+        try %{ execute-keys -draft '[Bl"i2<a-Z><gt>' }
+        execute-keys -draft ';"i<a-z>u&,'
     }
 }
 

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -2010,9 +2010,8 @@ SelectionList read_selections_from_register(char reg, const Context& context)
     return selection_list_from_strings(buffer, ColumnType::Byte, content.subrange(1), timestamp, main);
 }
 
-enum class CombineOp
+enum class CombinePairwiseOp
 {
-    Append,
     Union,
     Intersect,
     SelectLeftmostCursor,
@@ -2021,46 +2020,45 @@ enum class CombineOp
     SelectShortest,
 };
 
-CombineOp key_to_combine_op(Key key)
+CombinePairwiseOp key_to_combine_pairwise_op(Key key)
 {
     switch (key.key)
     {
-        case 'a': return CombineOp::Append;
-        case 'u': return CombineOp::Union;
-        case 'i': return CombineOp::Intersect;
-        case '<': return CombineOp::SelectLeftmostCursor;
-        case '>': return CombineOp::SelectRightmostCursor;
-        case '+': return CombineOp::SelectLongest;
-        case '-': return CombineOp::SelectShortest;
+        case 'u': return CombinePairwiseOp::Union;
+        case 'i': return CombinePairwiseOp::Intersect;
+        case '<': return CombinePairwiseOp::SelectLeftmostCursor;
+        case '>': return CombinePairwiseOp::SelectRightmostCursor;
+        case '+': return CombinePairwiseOp::SelectLongest;
+        case '-': return CombinePairwiseOp::SelectShortest;
     }
-    throw runtime_error{format("no such combine operator: '{}'", key.key)};
+    throw runtime_error{format("no such combine pairwise operator: '{}'", key.key)};
 }
 
-void combine_selection(const Buffer& buffer, Selection& sel, const Selection& other, CombineOp op)
+void combine_selection_pairwise(const Buffer& buffer, Selection& sel, const Selection& other, CombinePairwiseOp op)
 {
     switch (op)
     {
-        case CombineOp::Union:
+        case CombinePairwiseOp::Union:
             sel.set(std::min(sel.min(), other.min()),
                     std::max(sel.max(), other.max()));
             break;
-        case CombineOp::Intersect:
+        case CombinePairwiseOp::Intersect:
             sel.set(std::max(sel.min(), other.min()),
                     std::min(sel.max(), other.max()));
             break;
-        case CombineOp::SelectLeftmostCursor:
+        case CombinePairwiseOp::SelectLeftmostCursor:
             if (sel.cursor() > other.cursor())
                 sel = other;
             break;
-        case CombineOp::SelectRightmostCursor:
+        case CombinePairwiseOp::SelectRightmostCursor:
             if (sel.cursor() < other.cursor())
                 sel = other;
             break;
-        case CombineOp::SelectLongest:
+        case CombinePairwiseOp::SelectLongest:
             if (char_length(buffer, sel) < char_length(buffer, other))
                 sel = other;
             break;
-        case CombineOp::SelectShortest:
+        case CombinePairwiseOp::SelectShortest:
             if (char_length(buffer, sel) > char_length(buffer, other))
                 sel = other;
             break;
@@ -2068,48 +2066,258 @@ void combine_selection(const Buffer& buffer, Selection& sel, const Selection& ot
     }
 }
 
+enum class CombineOp
+{
+    Union,
+    Intersect,
+    BufferDifference,
+    RegisterDifference,
+    SymmetricDifference,
+};
+
+CombineOp key_to_combine_op(Key key)
+{
+    switch (key.key)
+    {
+        case 'u': return CombineOp::Union;
+        case 'i': return CombineOp::Intersect;
+        case 'b': return CombineOp::BufferDifference;
+        case 'r': return CombineOp::RegisterDifference;
+        case 's': return CombineOp::SymmetricDifference;
+    }
+    throw runtime_error{format("no such combine operator: '{}'", key.key)};
+}
+
+enum class Overlap
+{
+    FIRST_ENTIRELY_BEFORE_SECOND,
+    FIRST_END_OVERLAPS_SECOND_BEGIN,
+    FIRST_ENTIRELY_AFTER_SECOND,
+    FIRST_BEGIN_OVERLAPS_SECOND_END,
+    FIRST_CONTAINS_SECOND,
+    FIRST_CONTAINED_BY_SECOND,
+    FIRST_EQUALS_SECOND,
+};
+
+Overlap compute_overlap(BufferCoord& min_a, BufferCoord& max_a, BufferCoord& min_b, BufferCoord& max_b) {
+  if ((max_a <=> min_b) == std::strong_ordering::less) return Overlap::FIRST_ENTIRELY_BEFORE_SECOND;
+  if ((min_a <=> max_b) == std::strong_ordering::greater) return Overlap::FIRST_ENTIRELY_AFTER_SECOND;
+
+  auto min = min_a <=> min_b;
+  auto max = max_a <=> max_b;
+
+  if (min == 0 and max == 0) return Overlap::FIRST_EQUALS_SECOND;
+  if (min <= 0 and max >= 0) return Overlap::FIRST_CONTAINS_SECOND;
+  if (min >= 0 and max <= 0) return Overlap::FIRST_CONTAINED_BY_SECOND;
+  if (min < 0) return Overlap::FIRST_END_OVERLAPS_SECOND_BEGIN;
+  if (min > 0) return Overlap::FIRST_BEGIN_OVERLAPS_SECOND_END;
+  kak_assert(false);
+}
+
+auto selections_union(SelectionList& sels, SelectionList& list) {
+    const auto main_index = list.size() + sels.main_index();
+    for (auto& sel : sels)
+        list.push_back(sel);
+    list.set_main_index(main_index);
+    list.sort_and_merge_overlapping();
+    return list;
+}
+
+auto selections_intersection(SelectionList& sels, SelectionList& list) {
+  Vector<Selection> res;
+  size_t i = 0, j = 0;
+
+  while (true) {
+    auto overlap = compute_overlap(sels[i].min(), sels[i].max(), list[j].min(), list[j].max());
+
+    if (overlap == Overlap::FIRST_CONTAINS_SECOND)
+      res.push_back(list[j]);
+    else if (overlap == Overlap::FIRST_CONTAINED_BY_SECOND or overlap == Overlap::FIRST_EQUALS_SECOND)
+      res.push_back(sels[i]);
+    else if (overlap == Overlap::FIRST_END_OVERLAPS_SECOND_BEGIN)
+      res.push_back({list[j].min(), sels[i].max()});
+    else if (overlap == Overlap::FIRST_BEGIN_OVERLAPS_SECOND_END)
+      res.push_back({sels[i].min(), list[j].max()});
+
+    auto last_i = i == sels.size() - 1;
+    auto last_j = j == list.size() - 1;
+    if (last_i and last_j)
+      break;
+    else if (last_i)
+      j++;
+    else if (last_j)
+      i++;
+    else if ((sels[i].max() <=> list[j].max()) >= 0)
+      j++;
+    else
+      i++;
+  }
+  return res;
+}
+
+auto selections_difference(Buffer& buffer, SelectionList& sels, SelectionList& list) {
+  Vector<Selection> res;
+  size_t i = 0, j = 0;
+  auto sels_min = sels[i].min();
+  auto sels_max = sels[i].max();
+  auto list_min = list[j].min();
+  auto list_max = list[j].max();
+
+  while (true) {
+    auto sels_adv = false;
+    auto list_adv = false;
+    auto overlap = compute_overlap(sels_min, sels_max, list_min, list_max);
+
+    if (overlap == Overlap::FIRST_ENTIRELY_BEFORE_SECOND) {
+      res.push_back({sels_min, sels_max});
+      sels_adv = true;
+    } else if (overlap == Overlap::FIRST_EQUALS_SECOND) {
+      sels_adv = true;
+      list_adv = true;
+    } else if (overlap == Overlap::FIRST_CONTAINS_SECOND) {
+      if ((sels_min <=> list_min) == std::strong_ordering::less) {
+        auto min = buffer.offset_coord(list_min, CharCount{-1}, 0);
+        res.push_back({sels_min, min});
+      }
+      if ((sels_max <=> list_max) == std::strong_ordering::greater)
+        sels_min = buffer.offset_coord(list_max, CharCount{1}, 0);
+      else
+        sels_adv = true;
+      list_adv = true;
+    } else if (overlap == Overlap::FIRST_END_OVERLAPS_SECOND_BEGIN) {
+      auto min = buffer.offset_coord(list_min, CharCount{-1}, 0);
+      res.push_back({sels_min, min});
+      sels_adv = true;
+    }
+    else if (overlap == Overlap::FIRST_ENTIRELY_AFTER_SECOND)
+      list_adv = true;
+    else if (overlap == Overlap::FIRST_CONTAINED_BY_SECOND)
+      sels_adv = true;
+    else if (overlap == Overlap::FIRST_BEGIN_OVERLAPS_SECOND_END) {
+      sels_min = buffer.offset_coord(list_max, CharCount{1}, 0);
+      list_adv = true;
+    }
+
+    if (sels_adv) {
+      i++;
+      if (i == sels.size()) {
+        break;
+      }
+      sels_min = sels[i].min();
+      sels_max = sels[i].max();
+    }
+    if (list_adv) {
+      j++;
+      if (j == list.size()) {
+        res.push_back({sels_min, sels_max});
+        i++;
+        while (i < sels.size()) {
+          res.push_back(sels[i]);
+          i++;
+        }
+        break;
+      }
+      list_min = list[j].min();
+      list_max = list[j].max();
+    }
+  }
+  return res;
+}
+
 template<typename Func>
-void combine_selections(Context& context, SelectionList list, Func func, StringView title)
+void combine_selections(Context& context, SelectionList list, Func func, bool pairwise, StringView title)
 {
     if (&context.buffer() != &list.buffer())
         throw runtime_error{"cannot combine selections from different buffers"};
 
     on_next_key_with_autoinfo(context, "combine-selections", KeymapMode::Combine,
-                             [func, list](Key key, Context& context) mutable {
+                             [func, list, pairwise](Key key, Context& context) mutable {
         if (key == Key::Escape)
             return;
 
-        const auto op = key_to_combine_op(key);
         ScopedSelectionEdition selection_edition{context};
         auto& sels = context.selections();
         list.update();
-        if (op == CombineOp::Append)
+
+        if (pairwise)
         {
-            const auto main_index = list.size() + sels.main_index();
-            for (auto& sel : sels)
-                list.push_back(sel);
-            list.set_main_index(main_index);
-            list.sort_and_merge_overlapping();
-        }
-        else
-        {
+            const auto op = key_to_combine_pairwise_op(key);
             if (list.size() != sels.size())
                 throw runtime_error{format("the two selection lists don't have the same number of elements ({} vs {})",
                                            list.size(), sels.size())};
             for (int i = 0; i < list.size(); ++i)
-                combine_selection(sels.buffer(), list[i], sels[i], op);
+                combine_selection_pairwise(sels.buffer(), list[i], sels[i], op);
             list.set_main_index(sels.main_index());
+        }
+        else
+        {
+            const auto op = key_to_combine_op(key);
+            switch (op) {
+                case CombineOp::Union:
+                    list = selections_union(sels, list);
+                    break;
+                case CombineOp::Intersect:
+                {
+                    auto intersections = selections_intersection(sels, list);
+                    if (intersections.empty())
+                        throw runtime_error("nothing selected");
+                    list = intersections;
+                    break;
+                }
+                case CombineOp::BufferDifference:
+                {
+                    auto differences = selections_difference(context.buffer(), sels, list);
+                    if (differences.empty())
+                        throw runtime_error("nothing selected");
+                    list = differences;
+                    break;
+                }
+                case CombineOp::RegisterDifference:
+                {
+                    auto differences = selections_difference(context.buffer(), list, sels);
+                    if (differences.empty())
+                        throw runtime_error("nothing selected");
+                    list = differences;
+                    break;
+                }
+                case CombineOp::SymmetricDifference:
+                {
+                    auto b_diffs = selections_difference(context.buffer(), sels, list);
+                    auto r_diffs = selections_difference(context.buffer(), list, sels);
+                    if (b_diffs.empty() and r_diffs.empty())
+                        throw runtime_error("nothing selected");
+                    if (b_diffs.empty())
+                        list = r_diffs;
+                    else if (r_diffs.empty())
+                        list = b_diffs;
+                    else
+                    {
+                        SelectionList buffer_diff {context.buffer(), b_diffs};
+                        SelectionList register_diff {context.buffer(), r_diffs};
+                        list = selections_union(buffer_diff, register_diff);
+                    }
+                    break;
+                }
+                default: kak_assert(false);
+            }
         }
         func(context, std::move(list));
     }, title.str(),
-    build_autoinfo_for_mapping(context, KeymapMode::Combine,
-        {{{'a'}, "append lists"},
-         {{'u'}, "union"},
-         {{'i'}, "intersection"},
+    pairwise
+    ? build_autoinfo_for_mapping(context, KeymapMode::Combine,
+        {{{'u'}, "pairwise union"},
+         {{'i'}, "pairwise intersection"},
          {{'<'}, "select leftmost cursor"},
          {{'>'}, "select rightmost cursor"},
          {{'+'}, "select longest"},
-         {{'-'}, "select shortest"}}));
+         {{'-'}, "select shortest"}})
+    : build_autoinfo_for_mapping(context, KeymapMode::Combine,
+        {{{'u'}, "union"},
+         {{'i'}, "intersection"},
+         {{'b'}, "buffer difference"},
+         {{'r'}, "register difference"},
+         {{'s'}, "symmetric difference"}})
+    );
 }
 
 template<bool combine>
@@ -2137,7 +2345,7 @@ void save_selections(Context& context, NormalParams params)
     if (combine and not empty)
     {
         ScopedSelectionEdition selection_edition{context};
-        combine_selections(context, read_selections_from_register(reg, context), save_to_reg, "combine selections to register");
+        combine_selections(context, read_selections_from_register(reg, context), save_to_reg, params.count == 2, "combine selections to register");
     }
     else
         save_to_reg(context, context.selections());
@@ -2166,7 +2374,7 @@ void restore_selections(Context& context, NormalParams params)
         set_selections(context, std::move(selections));
     }
     else
-        combine_selections(context, std::move(selections), set_selections, "combine selections from register");
+        combine_selections(context, std::move(selections), set_selections, params.count == 2, "combine selections from register");
 }
 
 void undo(Context& context, NormalParams params)

--- a/test/normal/combine-selections/rc
+++ b/test/normal/combine-selections/rc
@@ -1,0 +1,139 @@
+define-command assert-command-fails -params 1 %{
+    eval -save-regs e %{
+        reg e ''
+        try %{
+            exec %arg{1}
+            reg e 'quit! 1'
+        }
+        eval %reg{e}
+    }
+}
+
+define-command assert-selections-are -params 1 %{
+    eval %sh{
+        if [ "$1" != "$kak_quoted_selections" ]; then
+            printf 'quit! 1'
+        fi
+    }
+}
+
+define-command do-operation-and-check -params 2 %{
+    eval -draft %{
+        exec <a-z> %arg{1} <ret>
+        assert-selections-are %arg{2}
+    }
+}
+
+define-command set-buffer -params 1 %{
+    eval -save-regs t %{
+        reg dquote %arg{1}
+
+        exec '%R'
+        exec -draft '%s[()]<ret>d'
+        exec '%1s\{(.+?)\}<ret>'
+        exec -draft '<a-;>hd'
+        exec -draft 'ld'
+        reg t %val{selections_desc}
+
+        exec '%R'
+        exec -draft '%s[{}]<ret>d'
+        exec '%1s\((.+?)\)<ret>'
+        exec -draft '<a-;>hd'
+        exec -draft 'ld'
+
+        reg caret "%val{buffile}@%val{timestamp}@0" %reg{t}
+    }
+}
+
+set-buffer '(a)b{c}'
+do-operation-and-check u "'a' 'c'"
+assert-command-fails %{ '<a-z>i' }
+do-operation-and-check b "'a'"
+do-operation-and-check s "'a' 'c'"
+
+set-buffer '(ab{c})'
+do-operation-and-check u "'abc'"
+do-operation-and-check i "'c'"
+do-operation-and-check b "'ab'"
+do-operation-and-check s "'ab'"
+
+set-buffer '{(a)b}c'
+do-operation-and-check u "'ab'"
+do-operation-and-check i "'a'"
+assert-command-fails %{ '<a-z>b' }
+do-operation-and-check s "'b'"
+
+set-buffer '(a{b}c)'
+do-operation-and-check u "'abc'"
+do-operation-and-check i "'b'"
+do-operation-and-check b "'a' 'c'"
+do-operation-and-check s "'a' 'c'"
+
+set-buffer '{(a)(b)(c)}'
+do-operation-and-check u "'abc'"
+do-operation-and-check i "'a' 'b' 'c'"
+assert-command-fails %{ '<a-z>b' }
+assert-command-fails %{ '<a-z>s' }
+
+set-buffer '{a(b}c)'
+do-operation-and-check u "'abc'"
+do-operation-and-check i "'b'"
+do-operation-and-check b "'c'"
+do-operation-and-check s "'a' 'c'"
+
+set-buffer '({a}{b}{c})'
+do-operation-and-check u "'abc'"
+do-operation-and-check i "'a' 'b' 'c'"
+assert-command-fails %{ '<a-z>b' }
+assert-command-fails %{ '<a-z>s' }
+
+set-buffer '(foo bar)
+{abc def}'
+do-operation-and-check u "'foo bar' 'abc def'"
+assert-command-fails %{ '<a-z>i' }
+do-operation-and-check b "'foo bar'"
+do-operation-and-check s "'foo bar' 'abc def'"
+
+set-buffer '(foo) {bar}
+(abc) {def}'
+do-operation-and-check u "'foo' 'bar' 'abc' 'def'"
+assert-command-fails %{ '<a-z>i' }
+do-operation-and-check b "'foo' 'abc'"
+do-operation-and-check s "'foo' 'bar' 'abc' 'def'"
+
+set-buffer '{(foo) (bar)
+(abc) (def)}'
+do-operation-and-check u "'foo bar
+abc def'"
+do-operation-and-check i "'foo' 'bar' 'abc' 'def'"
+assert-command-fails %{ '<a-z>b' }
+do-operation-and-check s "' ' '
+' ' '"
+
+set-buffer '(foo bar
+{abc) de}'
+do-operation-and-check u "'foo bar
+abc de'"
+do-operation-and-check i "'abc'"
+do-operation-and-check b "'foo bar
+'"
+do-operation-and-check s "'foo bar
+' ' de'"
+
+set-buffer 'f{oo (ba}r ){ab}c (def)'
+do-operation-and-check u "'oo bar ' 'ab' 'def'"
+do-operation-and-check i "'ba'"
+do-operation-and-check b "'r ' 'def'"
+do-operation-and-check s "'oo ' 'r ' 'ab' 'def'"
+
+set-buffer '{f(oo)( b)a}(r {b)(a}z) {abc} (de{f) g}hi'
+do-operation-and-check u "'foo ba' 'r baz' 'abc' 'def g'"
+do-operation-and-check i "'oo' ' b' 'b' 'a' 'f'"
+do-operation-and-check b "'r ' 'z' 'de'"
+do-operation-and-check s "'f' 'a' 'r ' 'z' 'abc' 'de' ' g'"
+
+set-buffer '(abc)d(efg{hi)j(kl}{m}no){pq}rstu{vwxyz}ABCD(E{FG}HIJK)L({M}NO{P}QRSTUVW{X)(Y)Z}0{1}2{3}456789'
+do-operation-and-check u "'abc' 'efghijklmno' 'pq' 'vwxyz' 'EFGHIJK' 'MNOPQRSTUVWXYZ' '1' '3'"
+do-operation-and-check i "'hi' 'kl' 'm' 'FG' 'M' 'P' 'X' 'Y'"
+do-operation-and-check b "'abc' 'efg' 'no' 'E' 'HIJK' 'NO' 'QRSTUVW'"
+do-operation-and-check s "'abc' 'efg' 'j' 'no' 'pq' 'vwxyz' 'E' 'HIJK' 'NO' 'QRSTUVW' 'Z' '1' '3'"


### PR DESCRIPTION
Hello

## TL;DR:

Along the years, the "selections difference" operator has been requested multiple times on GitHub, on the forum, in IRC, in the vis editor… showing the strong interest of people for this feature. 

Non exhaustive lists:

- https://github.com/mawww/kakoune/issues/2850
- https://github.com/mawww/kakoune/issues/3560
- https://discuss.kakoune.com/t/selection-combining-operator-u-union-is-little-bit-misleading/724
- https://discuss.kakoune.com/t/selection-sets-do-mathematical-set-operations-on-selections/1728
- …

Lots of well-known Kakoune users have made attempts to write such feature in user-land during this period.
Various languages were used: @danr did it in Python, @Screwtapello in pure shell, @gustavo-hms in Lua and @occivink in Perl, again demonstrating that people enjoys these set operations.

Some users also demonstrated that set-operations are useful building blocks to implement more powerful [code folding features](https://discuss.kakoune.com/t/a-toy-code-folding-plugin/2864).

So here's my attempt to finally get in in the core itself!

I'd like to thank warmly all the people mentioned above. This contribution is definitely made on the "shoulders of these giants", especially the [implementation made by Occivink](https://github.com/occivink/kakoune-set-operations/blob/master/set-operations.kak) which served as the base for the translation C++ version in this commit. The challenge was indeed to port the 500 LOC perl version into a 250 LOC version C++ fitting into `normal.cc`.

---

Below are more explanations about design choices.

## Current situation

The current combine mode is a mixed bag of operations.
The majority of them are "pairwise", `a` (for append) being the only exception.
It's not always intuitive to understand what each operation does, especially the `u` and `i` which have surprising result when selections in a pair does not overlap. Also the "difference" operation(s) are missing.

## Goals

The first idea is to disambiguate the two groups of operations (regular vs pairwise) without introducing yet another key in normal mode. Here I suggest that by default, the combinations are made on full selections list. To get back to the "old" pairwise behavior, the `<a-z>` and `<a-Z>` needs to be prefixed with a count of `2`: `2<a-z>` and `2<a-Z>`.

The second thing to understand when we ask for a "difference operator" (also called "complement" in the litterature), is that there's not 1 but 3 "difference operator". So with union and intersection we have a grand total of 5 operations as depicted below:

<img width="379" height="257" alt="image" src="https://github.com/user-attachments/assets/97b2d318-6c70-41cf-b5a3-c8a35bfa5e45" />
<img width="220" height="160" alt="image" src="https://github.com/user-attachments/assets/78b1cd75-eb2f-4c3b-bd32-7ce2101eaabf" />

In the images above, the sets are called `A` and `B`, but for our understanding it's better to calls them `B` for selections currently in buffer and `R` for selections currently in the register.

When we say "difference" we sometimes want to keep the part of the selection list that is only in the buffer (`B \ R`), sometimes we wand to keep the part only in the register (`R \ B`) and sometimes both (`B Δ R`).

The pairwise operators are kept because they are already used in multiple scripts in the `rc` directory.

That's why we obtain the following mappings:

| | Before | After |
| - | ------- | ------ |
| union | `<a-z>a` | `<a-z>u` |
| intersection | | `<a-z>i` |
| buffer difference | | `<a-z>b` |
| register difference | | `<a-z>r` |
| symmetric difference | | `<a-z>s` |
| pairwise union (with gap) | `<a-z>u` | `2<a-z>u` |
| pairwise intersection (with gap) | `<a-z>i` | `2<a-z>i` |
| pairwise left most cursor | `<a-z><` | `2<a-z><` |
| pairwise right most cursor | `<a-z>>` | `2<a-z>>`  |
| pairwise shortest | `<a-z>-` | `2<a-z>-` |
| pairwise longest | `<a-z>+` | `2<a-z>+` |

In the code, I extracted the current "append" logic into a proper `selections_union` function. This is useful to implement the symmetric difference because it is the union of the buffer and register differences : `A Δ B = (A \ B) ∪ (B \ A)`

The C++ code is probably not the most elegant nor the most optimized performance wise but it can be refined, so @mawww don't hesitate to clean it / readjust it afterwards your Cpp-fu is obviously way better than mine.

For the testing scenario, I also reused the work done by occivink : https://github.com/occivink/kakoune-set-operations/blob/master/test.kak_ because the way he wrote tests are legible in one file instead of splitting in hard multiple files which is harder to follow.

## Future considerations

We may go deeper in optional future pull-requests. For instance, we could add the `<`, `>`, `-` and `+` operators in the non-pairwise mode. Also we may also want to introduce pairwise differences `2<a-z>b`, `2<a-z>r` and `2<a-z>s`. But I prefer keeping this PR not too long for now.

Thanks!  Don't hesitate to provide your feedback.
