### PR TITLE
zellij: use $ZELLIJ_PANE_ID to focus pane directly

### DIFF
--- a/rc/windowing/zellij.kak
+++ b/rc/windowing/zellij.kak
@@ -46,6 +46,8 @@ If no client is passed then the current one is used' \
 %{ evaluate-commands %sh{
     if [ $# -eq 1 ]; then
         printf "evaluate-commands -client '%s' focus" "$1"
+    elif [ -n "${kak_client_env_ZELLIJ_PANE_ID}" ]; then
+        zellij action focus-pane-id "${kak_client_env_ZELLIJ_PANE_ID}"
     elif [ -n "${kak_client_env_ZELLIJ}" ]; then
         output=$(mktemp -d "${TMPDIR:-/tmp}"/kak-zellij.XXXXXXXX)/dump-screen
         pane_count=0


### PR DESCRIPTION
This PR improves Zellij integration by using ZELLIJ_PANE_ID to focus the current pane directly, falling back to the old method if the variable is not set.

Changes:
- Check for ZELLIJ_PANE_ID first.
- If present, call `zellij action focus-pane-id`.
- Otherwise, keep existing behavior (dump-screen enumeration).