### PR TITLE
format.kak: Make sure Kakoune provides the envvars formatcmd needs

### DIFF
--- a/rc/tools/format.kak
+++ b/rc/tools/format.kak
@@ -16,7 +16,7 @@ define-command format-selections -docstring "Format the selections individually"
     }
     evaluate-commands -draft -no-hooks -save-regs 'e|' %{
         set-register e nop
-        set-register '|' %{
+        set-register '|' %exp{
             format_in="$(mktemp "${TMPDIR:-/tmp}"/kak-formatter.XXXXXX)"
             format_out="$(mktemp "${TMPDIR:-/tmp}"/kak-formatter.XXXXXX)"
 
@@ -29,6 +29,15 @@ define-command format-selections -docstring "Format the selections individually"
                 cat "$format_in"
             fi
             rm -f "$format_in" "$format_out"
+
+            # We want the format command to be literally present in this
+            # command, so that Kakoune will supply any any $kak_* variables
+            # it mentions, but we don't want to evaluate the command here
+            # so we'll tell the shell to exit before it gets to it.
+            # Just commenting it out would not be sufficient, since it might
+            # include newlines.
+            exit
+            %opt{formatcmd}
         }
         execute-keys '|<ret>'
         %reg{e}


### PR DESCRIPTION
When Kakoune executes a shell command, it scans the text for tokens like `kak_*` and if it finds any it recognises it adds them to the environment for the command (as described in `:doc expansions shell-expansions`). For example, if you select some text and type:

    |fold -w $kak_opt_autowrap_column<ret>

...then Kakoune sees `kak_opt_autowrap_column`, and exports the value of the `autowrap_column` option into the environment of the shell, which expands the variable reference then runs the command.

The `:format` command amounts to something like:

    |eval "$kak_opt_formatcmd"

...which means that Kakoune never sees "kak_opt_autowrap_column", so it never provides the value, so the shell winds up with a malformed command like "fold -w" which just causes an error.

To avoid this problem, as well as passing "$kak_opt_formatcmd" into the shell command, we also *append* it to the shell command where Kakoune can see it, guarded by an `exit` statement to prevent it from being processed.