### PR TITLE
fix: `vfork` is deprecated on MacOS, use `fork` instead

### DIFF
--- a/src/shell_manager.cc
+++ b/src/shell_manager.cc
@@ -23,7 +23,7 @@
 #include <cstdlib>
 #include <errno.h>
 
-#if defined(__CYGWIN__)
+#if defined(__CYGWIN__) || defined(__APPLE__)
 #define vfork fork
 #endif
 


### PR DESCRIPTION
Compiling Kakoune on MacOS 26.5.2 yields this compilation warning:
```
src/shell_manager.cc:118:21: warning: 'vfork' is deprecated: Use posix_spawn or fork
      [-Wdeprecated-declarations]
  118 |     if (pid_t pid = vfork())
```

The description section of `man vfork` also relays the same message:
```
DESCRIPTION
     The vfork system call can be used to create new processes. As of macOS 12.0, this system
     call behaves identically to the fork(2) system call, except without calling any handlers
     registered with pthread_atfork(2).

     This system call is deprecated. In a future release, it may begin to return errors in all
     cases, or may be removed entirely.  It is extremely strongly recommended to replace all
     uses with fork(2) or, ideally, posix_spawn(3).
```

All this PR does is alias `vfork` to `fork` when building on Mac (`__APPLE__` is defined), similar to what we already do when building on Cygwin.