### PR TITLE
Support running kakoune without a controlling /dev/tty terminal

### DIFF
--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -154,7 +154,9 @@ BufferIterator Buffer::iterator_at(BufferCoord coord) const
 
 BufferCoord Buffer::clamp(BufferCoord coord) const
 {
-    if (coord > back_coord())
+    if (coord.line < 0)
+        coord = BufferCoord{0, 0};
+    else if (coord > back_coord())
         coord = back_coord();
     kak_assert(coord.line >= 0 and coord.line < line_count());
     ByteCount max_col = std::max(0_byte, m_lines[coord.line].length() - 1);

--- a/src/main.cc
+++ b/src/main.cc
@@ -628,6 +628,19 @@ UniquePtr<UserInterface> create_local_ui(UIType ui_type)
     return ui;
 }
 
+// Give the terminal ui a fd 0 to read keys from, never the piped in one, which
+// is already consumed elsewhere.
+void replace_stdin_with_tty()
+{
+    int tty = open("/dev/tty", O_RDONLY);
+    if (tty < 0)
+        tty = open("/dev/null", O_RDONLY);
+    if (tty < 0)
+        return;
+    dup2(tty, 0);
+    close(tty);
+}
+
 int run_client(StringView session, StringView name, StringView client_init,
                Optional<BufferCoord> init_coord, UIType ui_type,
                bool suspend)
@@ -643,9 +656,7 @@ int run_client(StringView session, StringView name, StringView client_init,
         {
             // move stdin to another fd, and restore tty as stdin
             stdin_fd = dup(0);
-            int tty = open("/dev/tty", O_RDONLY);
-            dup2(tty, 0);
-            close(tty);
+            replace_stdin_with_tty();
         }
 
         EventManager event_manager;
@@ -802,9 +813,7 @@ int run_server(StringView session, StringView server_init,
         {
             // move stdin to another fd, and restore tty as stdin
             int fd = dup(0);
-            int tty = open("/dev/tty", O_RDONLY);
-            dup2(tty, 0);
-            close(tty);
+            replace_stdin_with_tty();
             create_fifo_buffer("*stdin*", fd, Buffer::Flags::None, AutoScroll::NotInitially);
         }
 

--- a/src/normal.cc
+++ b/src/normal.cc
@@ -277,7 +277,8 @@ void goto_commands(Context& context, NormalParams params)
                 if (context.has_window())
                 {
                     auto& window = context.window();
-                    auto line = window.position().line + window.dimensions().line - 1;
+                    // dimensions can be empty when the terminal size is unknown
+                    auto line = std::max(0_line, window.position().line + window.dimensions().line - 1);
                     select_coord<mode>(context, line);
                 }
                 break;

--- a/src/terminal_ui.cc
+++ b/src/terminal_ui.cc
@@ -655,10 +655,10 @@ void TerminalUI::check_resize(bool force)
 
     resize_pending = 0;
 
-    const int fd = open("/dev/tty", O_RDWR);
-    if (fd < 0)
-        return;
-    auto close_fd = OnScopeEnd([fd]{ ::close(fd); });
+    // With no controlling terminal, fall back to our output, which is a tty.
+    const int tty_fd = open("/dev/tty", O_RDWR);
+    auto close_fd = OnScopeEnd([tty_fd]{ if (tty_fd >= 0) ::close(tty_fd); });
+    const int fd = tty_fd >= 0 ? tty_fd : STDOUT_FILENO;
 
     DisplayCoord terminal_size{24_line, 80_col};
     if (winsize ws; ioctl(fd, TIOCGWINSZ, &ws) == 0 and ws.ws_row > 0 and ws.ws_col > 0)


### PR DESCRIPTION
This fixes issue when trying to run kakoune without controlling terminal (e.g. trying to run from within Claude Code in full-terminal mode).

Without the fix following crash happens:

```
Received SIGSEGV, exiting.
Callstack:
0   kak  Kakoune::Backtrace::Backtrace()
1   kak  Kakoune::(anonymous namespace)::signal_handler(int)
2   libsystem_platform.dylib  _sigtramp
3   kak  void Kakoune::select_coord<(Kakoune::SelectMode)1>(Kakoune::Context&, Kakoune::BufferCoord) + 76
4   kak  Kakoune::goto_commands<(Kakoune::SelectMode)1>(...)::'lambda'(Key, Context&)::operator()
5   kak  Kakoune::InputModes::NextKey::on_key(Kakoune::Key)
6   kak  Kakoune::InputHandler::handle_key(Kakoune::Key, bool)
7…  kak  execute-keys → context_wrap → CommandManager::execute → evaluate-commands
```

Fix resolves the issue, all tests are green.

## Reproduction

Run Claude Code, run any prompt, press Left Arrow (that backgrounds the process and shows the list or thread), select the thread and press Ctrl-g (open Editor).