### PR TITLE
feat(rc/odin): highlight byte

### DIFF
--- a/rc/filetype/odin.kak
+++ b/rc/filetype/odin.kak
@@ -90,7 +90,7 @@ evaluate-commands %sh{
            f16be f32be f64be
            complex32 complex64 complex128
            quaternion64 quaternion128 quaternion256
-           rune
+           byte rune
            string cstring
            rawptr
            typeid


### PR DESCRIPTION
It is technically [defined as an alias](https://github.com/odin-lang/Odin/blob/db635cab1e1e30b3b88556e22551bb8104f97b62/base/builtin/builtin.odin#L237), but I still think it should be treated as a builtin type.