### PR TITLE
rc/filetype/gluon.kak: fix quoted strings mismatch

### DIFF
--- a/rc/filetype/gluon.kak
+++ b/rc/filetype/gluon.kak
@@ -94,7 +94,7 @@ define-command -hidden gluon-indent-on-new-line %~
         try %{ execute-keys -draft k : gluon-trim-indent <ret> }
         # indent after lines ending with (open) braces, =, ->, condition, rec,
         # or in
-        try %{ execute-keys -draft \; k x <a-k> (\(|\{|\[|=|->|\b(?:then|else|rec|in))$ <ret> j <a-gt> }
+        try %, execute-keys -draft \; k x <a-k> (\(|\{|\[|=|->|\b(?:then|else|rec|in))$ <ret> j <a-gt> ,
         # deindent closing brace(s) when after cursor
         try %< execute-keys -draft x <a-k> ^\h*[})\]] <ret> gh / \})\]] <ret> m <a-S> 1<a-&> >
     _


### PR DESCRIPTION
turns out the creator of this file relied on balancing out all brackets used in the `execute-keys` in... a comment:
https://github.com/mawww/kakoune/blob/21673744967c0ac5335915a40a6d25dfe16f4196/rc/filetype/gluon.kak#L91-L95

...*which* was accidentally stripped in a later update to this file, borking it.
https://github.com/mawww/kakoune/blob/c0e14b1cfd4f476927c72ef0d06d7353e51cc38b/rc/filetype/gluon.kak#L91

the developer who made the mistake only fixed it for the following line, and didn't notice the preceding line.
https://github.com/mawww/kakoune/blob/c0e14b1cfd4f476927c72ef0d06d7353e51cc38b/rc/filetype/gluon.kak#L89-L93

I replaced the braces with pretty much the first character I could think of that wasn't part of a matching set, or was within the string (the comma).

---

it's honestly surprising this got shipped in like this, but to be honest, this was a single change in [a really long PR](https://github.com/mawww/kakoune/pull/3620) to the editor support file of a *somewhat* niche programming language, so I'm not blaming them for missing it. if anything, this'll become a lesson for myself.

...yes I felt like writing an essay for this LMAO