### PR TITLE
Document -C commandline option in man page

### DIFF
--- a/doc/kak.1
+++ b/doc/kak.1
@@ -10,7 +10,7 @@
 .Op Fl d
 .Op Fl n
 .Op Fl ro
-.Op Fl c Ar session_id | Fl s Ar session_id
+.Op Fl c Ar session_id | Fl C Ar session_id | Fl s Ar session_id
 .Op Fl ui Ar ui_type
 .Op Fl e Ar command
 .Op Fl E Ar command
@@ -130,6 +130,11 @@ Send the commands written on the standard input to session
 .It Fl c Ar session_id
 Connect to the given session
 .Ar session_id .
+.
+.It Fl C Ar session_id
+Connect to the given session
+.Ar session_id 
+or create it if it does not exist.
 .
 .It Fl s Ar session_id
 Set the current session name to


### PR DESCRIPTION
Commit 7ee28e3e321f68a9dc842ea0ba70c1afa0412633 introduced `-C session_id` option to the cli but forgot to update the manpage.

You've already got my [copyright waiver](https://github.com/mawww/kakoune/commit/07000adb9bf659a879b8c272426e5c5201a7b0c1).