### PR TITLE
fix(rc/ctags): Use str-list for ctagspaths to allow multiple paths

### DIFF
--- a/rc/tools/ctags.kak
+++ b/rc/tools/ctags.kak
@@ -119,7 +119,7 @@ define-command ctags-disable-autoinfo -docstring "Disable automatically showing 
 
 declare-option -docstring "shell command used to generate tag files" \
     str ctagscmd "ctags -R --fields=+S"
-declare-option -docstring "path to the directory in which the tags file will be generated" str ctagspaths "."
+declare-option -docstring "path to the directories in which the tags file will be generated" str-list ctagspaths "."
 
 define-command ctags-generate -docstring 'Generate tag file asynchronously' %{
     echo -markup "{Information}launching tag generation in the background"


### PR DESCRIPTION
The ctags scripts appear to be set up to handle multiple source paths, but the `ctagspaths` option was a `str` instead of a `str-list`, preventing the use of this feature. I changed it to `str-list` and everything appears to work great.